### PR TITLE
Fix "no synchronous setting of state in effects" lint errors

### DIFF
--- a/app/javascript/mastodon/components/column_search_header.tsx
+++ b/app/javascript/mastodon/components/column_search_header.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect, useRef } from 'react';
+import { useCallback, useState, useRef } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -12,11 +12,15 @@ export const ColumnSearchHeader: React.FC<{
   const inputRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState('');
 
-  useEffect(() => {
+  // Reset the component when it turns from active to inactive.
+  // [More on this pattern](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)
+  const [previousActive, setPreviousActive] = useState(active);
+  if (active !== previousActive) {
+    setPreviousActive(active);
     if (!active) {
       setValue('');
     }
-  }, [active]);
+  }
 
   const handleChange = useCallback(
     ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {

--- a/app/javascript/mastodon/components/exit_animation_wrapper.tsx
+++ b/app/javascript/mastodon/components/exit_animation_wrapper.tsx
@@ -27,22 +27,23 @@ export const ExitAnimationWrapper: React.FC<{
    */
   children: (delayedIsActive: boolean) => React.ReactNode;
 }> = ({ isActive = false, delayMs = 500, withEntryDelay, children }) => {
-  const [delayedIsActive, setDelayedIsActive] = useState(false);
+  const [delayedIsActive, setDelayedIsActive] = useState(
+    isActive && !withEntryDelay,
+  );
 
   useEffect(() => {
-    if (isActive && !withEntryDelay) {
-      setDelayedIsActive(true);
+    const withDelay = !isActive || withEntryDelay;
 
-      return () => '';
-    } else {
-      const timeout = setTimeout(() => {
+    const timeout = setTimeout(
+      () => {
         setDelayedIsActive(isActive);
-      }, delayMs);
+      },
+      withDelay ? delayMs : 0,
+    );
 
-      return () => {
-        clearTimeout(timeout);
-      };
-    }
+    return () => {
+      clearTimeout(timeout);
+    };
   }, [isActive, delayMs, withEntryDelay]);
 
   if (!isActive && !delayedIsActive) {

--- a/app/javascript/mastodon/components/hover_card_controller.tsx
+++ b/app/javascript/mastodon/components/hover_card_controller.tsx
@@ -27,7 +27,6 @@ export const HoverCardController: React.FC = () => {
   const [setLeaveTimeout, cancelLeaveTimeout] = useTimeout();
   const [setEnterTimeout, cancelEnterTimeout, delayEnterTimeout] = useTimeout();
   const [setScrollTimeout] = useTimeout();
-  const location = useLocation();
 
   const handleClose = useCallback(() => {
     cancelEnterTimeout();
@@ -36,9 +35,12 @@ export const HoverCardController: React.FC = () => {
     setAnchor(null);
   }, [cancelEnterTimeout, cancelLeaveTimeout, setOpen, setAnchor]);
 
-  useEffect(() => {
+  const location = useLocation();
+  const [previousLocation, setPreviousLocation] = useState(location);
+  if (location !== previousLocation) {
+    setPreviousLocation(location);
     handleClose();
-  }, [handleClose, location]);
+  }
 
   useEffect(() => {
     let isScrolling = false;

--- a/app/javascript/mastodon/components/icon_button.tsx
+++ b/app/javascript/mastodon/components/icon_button.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, forwardRef } from 'react';
+import { useCallback, forwardRef } from 'react';
 
 import classNames from 'classnames';
 
@@ -55,23 +55,6 @@ export const IconButton = forwardRef<HTMLButtonElement, Props>(
     },
     buttonRef,
   ) => {
-    const [activate, setActivate] = useState(false);
-    const [deactivate, setDeactivate] = useState(false);
-
-    useEffect(() => {
-      if (!animate) {
-        return;
-      }
-
-      if (activate && !active) {
-        setActivate(false);
-        setDeactivate(true);
-      } else if (!activate && active) {
-        setActivate(true);
-        setDeactivate(false);
-      }
-    }, [setActivate, setDeactivate, animate, active, activate]);
-
     const handleClick: React.MouseEventHandler<HTMLButtonElement> = useCallback(
       (e) => {
         e.preventDefault();
@@ -112,8 +95,8 @@ export const IconButton = forwardRef<HTMLButtonElement, Props>(
       active,
       disabled,
       inverted,
-      activate,
-      deactivate,
+      activate: animate && active,
+      deactivate: animate && !active,
       overlayed: overlay,
       'icon-button--with-counter': typeof counter !== 'undefined',
     });

--- a/app/javascript/mastodon/containers/scroll_container/scroll_context.tsx
+++ b/app/javascript/mastodon/containers/scroll_container/scroll_context.tsx
@@ -86,6 +86,7 @@ export const ScrollContext: React.FC<ScrollContextProps> = ({
         ) =>
           // Hack to allow accessing scrollBehavior._stateStorage
           shouldUpdateScroll.call(
+            // eslint-disable-next-line react-hooks/immutability
             scrollBehavior,
             prevLocationContext,
             locationContext,

--- a/app/javascript/mastodon/features/annual_report/index.tsx
+++ b/app/javascript/mastodon/features/annual_report/index.tsx
@@ -31,15 +31,13 @@ export const AnnualReport: React.FC<{
   year: string;
 }> = ({ year }) => {
   const [response, setResponse] = useState<AnnualReportResponse | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const currentAccount = useAppSelector((state) =>
     me ? state.accounts.get(me) : undefined,
   );
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    setLoading(true);
-
     apiRequestGet<AnnualReportResponse>(`v1/annual_reports/${year}`)
       .then((data) => {
         dispatch(importFetchedStatuses(data.statuses));

--- a/app/javascript/mastodon/features/compose/components/language_dropdown.tsx
+++ b/app/javascript/mastodon/features/compose/components/language_dropdown.tsx
@@ -55,6 +55,8 @@ const getFrequentlyUsedLanguages = createSelector(
       .toArray(),
 );
 
+const isTextLongEnoughForGuess = (text: string) => text.length > 20;
+
 const LanguageDropdownMenu: React.FC<{
   value: string;
   guess?: string;
@@ -375,13 +377,26 @@ export const LanguageDropdown: React.FC = () => {
   );
 
   useEffect(() => {
-    if (text.length > 20) {
+    if (isTextLongEnoughForGuess(text)) {
       debouncedGuess(text, setGuess);
     } else {
       debouncedGuess.cancel();
-      setGuess('');
     }
   }, [text, setGuess]);
+
+  // Keeping track of the previous render's text length here
+  // to be able to reset the guess when the text length drops
+  // below the threshold needed to make a guess
+  const [wasLongText, setWasLongText] = useState(() =>
+    isTextLongEnoughForGuess(text),
+  );
+  if (wasLongText !== isTextLongEnoughForGuess(text)) {
+    setWasLongText(isTextLongEnoughForGuess(text));
+
+    if (wasLongText) {
+      setGuess('');
+    }
+  }
 
   return (
     <div ref={targetRef}>

--- a/app/javascript/mastodon/features/domain_blocks/index.tsx
+++ b/app/javascript/mastodon/features/domain_blocks/index.tsx
@@ -19,14 +19,12 @@ const messages = defineMessages({
 const Blocks: React.FC<{ multiColumn: boolean }> = ({ multiColumn }) => {
   const intl = useIntl();
   const [domains, setDomains] = useState<string[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [next, setNext] = useState<string | undefined>();
   const hasMore = !!next;
   const columnRef = useRef<ColumnRef>(null);
 
   useEffect(() => {
-    setLoading(true);
-
     void apiGetDomainBlocks()
       .then(({ domains, links }) => {
         const next = links.refs.find((link) => link.rel === 'next');
@@ -40,7 +38,7 @@ const Blocks: React.FC<{ multiColumn: boolean }> = ({ multiColumn }) => {
       .catch(() => {
         setLoading(false);
       });
-  }, [setLoading, setDomains, setNext]);
+  }, []);
 
   const handleLoadMore = useCallback(() => {
     setLoading(true);

--- a/app/javascript/mastodon/features/home_timeline/components/announcements/announcement.tsx
+++ b/app/javascript/mastodon/features/home_timeline/components/announcements/announcement.tsx
@@ -35,12 +35,17 @@ export const Announcement: FC<AnnouncementProps> = ({
   }, [active, id, dispatch, read]);
 
   // But visually show the announcement as read only when it goes out of view.
-  const [unread, setUnread] = useState(!read);
-  useEffect(() => {
-    if (!active && unread !== !read) {
-      setUnread(!read);
+  const [isRead, setIsRead] = useState(read);
+  const [previousActive, setPreviousActive] = useState(active);
+  if (active !== previousActive) {
+    setPreviousActive(active);
+
+    // This marks the announcement as read in the UI only after it
+    // went from active to inactive.
+    if (!active && isRead !== announcement.read) {
+      setIsRead(announcement.read);
     }
-  }, [active, unread, read]);
+  }
 
   return (
     <AnimateEmojiProvider>
@@ -63,7 +68,7 @@ export const Announcement: FC<AnnouncementProps> = ({
 
       <ReactionsBar reactions={announcement.reactions} id={announcement.id} />
 
-      {unread && <span className='announcements__unread' />}
+      {!isRead && <span className='announcements__unread' />}
     </AnimateEmojiProvider>
   );
 };

--- a/app/javascript/mastodon/features/home_timeline/components/announcements/announcement.tsx
+++ b/app/javascript/mastodon/features/home_timeline/components/announcements/announcement.tsx
@@ -35,15 +35,15 @@ export const Announcement: FC<AnnouncementProps> = ({
   }, [active, id, dispatch, read]);
 
   // But visually show the announcement as read only when it goes out of view.
-  const [isRead, setIsRead] = useState(read);
+  const [isVisuallyRead, setIsVisuallyRead] = useState(read);
   const [previousActive, setPreviousActive] = useState(active);
   if (active !== previousActive) {
     setPreviousActive(active);
 
     // This marks the announcement as read in the UI only after it
     // went from active to inactive.
-    if (!active && isRead !== announcement.read) {
-      setIsRead(announcement.read);
+    if (!active && isVisuallyRead !== read) {
+      setIsVisuallyRead(read);
     }
   }
 
@@ -68,7 +68,7 @@ export const Announcement: FC<AnnouncementProps> = ({
 
       <ReactionsBar reactions={announcement.reactions} id={announcement.id} />
 
-      {!isRead && <span className='announcements__unread' />}
+      {!isVisuallyRead && <span className='announcements__unread' />}
     </AnimateEmojiProvider>
   );
 };

--- a/app/javascript/mastodon/features/lists/members.tsx
+++ b/app/javascript/mastodon/features/lists/members.tsx
@@ -164,12 +164,11 @@ const ListMembers: React.FC<{
   const [searching, setSearching] = useState(false);
   const [accountIds, setAccountIds] = useState<string[]>([]);
   const [searchAccountIds, setSearchAccountIds] = useState<string[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!!id);
   const [mode, setMode] = useState<Mode>('remove');
 
   useEffect(() => {
     if (id) {
-      setLoading(true);
       dispatch(fetchList(id));
 
       void apiGetAccounts(id)

--- a/app/javascript/mastodon/features/navigation_panel/components/list_panel.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/components/list_panel.tsx
@@ -27,17 +27,15 @@ export const ListPanel: React.FC = () => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
   const lists = useAppSelector((state) => getOrderedLists(state));
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    setLoading(true);
-
     void dispatch(fetchLists()).then(() => {
       setLoading(false);
 
       return '';
     });
-  }, [dispatch, setLoading]);
+  }, [dispatch]);
 
   return (
     <CollapsiblePanel

--- a/app/javascript/mastodon/features/search/index.tsx
+++ b/app/javascript/mastodon/features/search/index.tsx
@@ -225,7 +225,7 @@ export const SearchResults: React.FC<{ multiColumn: boolean }> = ({
       />
 
       <div className='explore__search-header'>
-        <Search singleColumn initialValue={trimmedValue} />
+        <Search singleColumn initialValue={trimmedValue} key={trimmedValue} />
       </div>
 
       <div className='account__section-headline'>

--- a/app/javascript/mastodon/features/ui/components/domain_block_modal.tsx
+++ b/app/javascript/mastodon/features/ui/components/domain_block_modal.tsx
@@ -53,8 +53,6 @@ export const DomainBlockModal: React.FC<{
   }, [dispatch]);
 
   useEffect(() => {
-    setLoading(true);
-
     apiRequest<DomainBlockPreviewResponse>('GET', 'v1/domain_blocks/preview', {
       params: { domain },
       timeout: 5000,
@@ -68,7 +66,7 @@ export const DomainBlockModal: React.FC<{
         setPreview('error');
         setLoading(false);
       });
-  }, [setPreview, setLoading, domain]);
+  }, [domain]);
 
   return (
     <div className='modal-root__modal safety-action-modal' aria-live='polite'>

--- a/app/javascript/mastodon/features/ui/components/media_modal.tsx
+++ b/app/javascript/mastodon/features/ui/components/media_modal.tsx
@@ -66,6 +66,7 @@ export const MediaModal: FC<MediaModalProps> = forwardRef<
     _ref,
   ) => {
     const [index, setIndex] = useState(startIndex);
+    const [zoomedIn, setZoomedIn] = useState(false);
     const currentMedia = media.get(index);
 
     const handleChangeIndex = useCallback(
@@ -131,7 +132,6 @@ export const MediaModal: FC<MediaModalProps> = forwardRef<
       }
     }, []);
 
-    const [zoomedIn, setZoomedIn] = useState(false);
     const zoomable =
       currentMedia?.get('type') === 'image' &&
       ((currentMedia.getIn(['meta', 'original', 'width']) as number) >

--- a/app/javascript/mastodon/features/ui/hooks/useBreakpoint.tsx
+++ b/app/javascript/mastodon/features/ui/hooks/useBreakpoint.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useSyncExternalStore } from 'react';
 
 const breakpoints = {
   narrow: 479, // Device width under which horizontal space is constrained
@@ -9,25 +9,20 @@ const breakpoints = {
 type Breakpoint = keyof typeof breakpoints;
 
 export const useBreakpoint = (breakpoint: Breakpoint) => {
-  const [isMatching, setIsMatching] = useState(false);
+  const query = `(max-width: ${breakpoints[breakpoint]}px)`;
 
-  useEffect(() => {
-    const mediaWatcher = window.matchMedia(
-      `(max-width: ${breakpoints[breakpoint]}px)`,
-    );
+  const isMatching = useSyncExternalStore(
+    (callback) => {
+      const mediaWatcher = window.matchMedia(query);
 
-    setIsMatching(mediaWatcher.matches);
+      mediaWatcher.addEventListener('change', callback);
 
-    const handleChange = (e: MediaQueryListEvent) => {
-      setIsMatching(e.matches);
-    };
-
-    mediaWatcher.addEventListener('change', handleChange);
-
-    return () => {
-      mediaWatcher.removeEventListener('change', handleChange);
-    };
-  }, [breakpoint, setIsMatching]);
+      return () => {
+        mediaWatcher.removeEventListener('change', callback);
+      };
+    },
+    () => window.matchMedia(query).matches,
+  );
 
   return isMatching;
 };


### PR DESCRIPTION
Related to MAS-637
In preparation for #36702

### Changes proposed in this PR:
- Fixes all but one error related to setting state inside of effects as flagged by the latest `eslint-plugin-react-hooks`
- There should be no user-facing changes

If some of these changes look strange to you, they did to me, too! They're following the official React team advice around setting state during render that [you can read about here](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes).