### PR TITLE
Rely on puma default environment setting

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -12,8 +12,7 @@ else
   bind "tcp://#{ENV.fetch('BIND', '127.0.0.1')}:#{ENV.fetch('PORT', 3000)}"
 end
 
-environment ENV.fetch('RAILS_ENV') { 'development' }
-workers     ENV.fetch('WEB_CONCURRENCY') { 2 }.to_i
+workers ENV.fetch('WEB_CONCURRENCY') { 2 }.to_i
 
 preload_app!
 


### PR DESCRIPTION
By default, puma/rails will pull an environment value from `RACK_ENV` and `RAILS_ENV`, so I think this line is superfluous (and no longer included in stock generated puma.rb)

Noticed while doing https://github.com/mastodon/mastodon/pull/36757

More possible stuff if anyone has an opinion:

- At some point the default threads changed from 5 to 3, and I think convention is to use a `RAILS_MAX_THREADS` env var so set min/max to same value ... we could change default, and/or adapt that environment var
- Persistent timeout defaults to 95, and will use `PUMA_PERSISTENT_TIMEOUT` env var by default. We could drop that line and rely on that env var - would need upgrade/docs/etc.
- Worker will use `WEB_CONCURRENCY` by default as well, but defaults to 1, not 2

Ref https://github.com/rails/rails/pull/52541