### PR TITLE
Clarify hint for bootstrap account instructions

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -88,7 +88,7 @@ en:
         activity_api_enabled: Counts of locally published posts, active users, and new registrations in weekly buckets
         app_icon: WEBP, PNG, GIF or JPG. Overrides the default app icon on mobile devices with a custom icon.
         backups_retention_period: Users have the ability to generate archives of their posts to download later. When set to a positive value, these archives will be automatically deleted from your storage after the specified number of days.
-        bootstrap_timeline_accounts: These accounts will be pinned to the top of new users' follow recommendations.
+        bootstrap_timeline_accounts: These accounts will be pinned to the top of new users' follow recommendations. Provide a comma-separated list of accounts.
         closed_registrations_message: Displayed when sign-ups are closed
         content_cache_retention_period: All posts from other servers (including boosts and replies) will be deleted after the specified number of days, without regard to any local user interaction with those posts. This includes posts where a local user has marked it as bookmarks or favorites. Private mentions between users from different instances will also be lost and impossible to restore. Use of this setting is intended for special purpose instances and breaks many user expectations when implemented for general purpose use.
         custom_css: You can apply custom styles on the web version of Mastodon.


### PR DESCRIPTION
Fixes https://github.com/mastodon/mastodon/issues/36768

I couldn't find any other spot in the UI that talks about comma separated lists, but this more or less mirrors the about page privacy policy area, where the admin is encouraged to use Markdown.

<img width="842" height="202" alt="Screenshot 2025-11-06 at 15 06 12" src="https://github.com/user-attachments/assets/0d3cd065-7bcd-4e59-9ec5-6241b65c3781" />

<img width="853" height="207" alt="Screenshot 2025-11-06 at 15 06 00" src="https://github.com/user-attachments/assets/0b4e4b32-cfaa-4a05-8a20-460919195fbc" />

Possible followups:

- Validate the entry string format?
- Verify the actual accounts?
- Link to admin/docs or something?