### PR TITLE
Ensure the boost button shows a numeric value

### DIFF
--- a/app/javascript/mastodon/components/status/boost_button.tsx
+++ b/app/javascript/mastodon/components/status/boost_button.tsx
@@ -118,6 +118,18 @@ const BoostOrQuoteMenu: FC<ReblogButtonProps> = ({ status, counters }) => {
   const statusId = status.get('id') as string;
   const wasBoosted = !!status.get('reblogged');
 
+  let count: number | undefined;
+  if (counters) {
+    count = 0;
+    // Ensure count is a valid integer.
+    if (Number.isInteger(status.get('reblogs_count'))) {
+      count += status.get('reblogs_count') as number;
+    }
+    if (Number.isInteger(status.get('quotes_count'))) {
+      count += status.get('quotes_count') as number;
+    }
+  }
+
   const showLoginPrompt = useCallback(() => {
     dispatch(
       openModal({
@@ -193,12 +205,7 @@ const BoostOrQuoteMenu: FC<ReblogButtonProps> = ({ status, counters }) => {
         )}
         icon='retweet'
         iconComponent={boostIcon}
-        counter={
-          counters
-            ? (status.get('reblogs_count') as number) +
-              (status.get('quotes_count') as number)
-            : undefined
-        }
+        counter={count}
         active={isReblogged}
       />
     </Dropdown>


### PR DESCRIPTION
Fixes #36799. This doesn't track down why the value is non-numeric, but prevents the boost counter from showing NaN.