### PR TITLE
Fix scroll shift caused by fetch-all-replies alerts

### DIFF
--- a/app/javascript/mastodon/features/status/components/refresh_controller.tsx
+++ b/app/javascript/mastodon/features/status/components/refresh_controller.tsx
@@ -295,7 +295,7 @@ export const RefreshController: React.FC<{
   if (loadingState === 'loading') {
     return (
       <div
-        className='load-more load-gap'
+        className='load-more load-more--large'
         aria-busy
         aria-live='polite'
         aria-label={intl.formatMessage(messages.loadingInitial)}

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3181,20 +3181,21 @@ a.account__display-name {
 }
 
 .column__alert {
+  --alert-height: 54px;
+
   position: sticky;
   bottom: 0;
   z-index: 10;
   box-sizing: border-box;
   display: grid;
+  grid-template-rows: minmax(var(--alert-height), max-content);
+  align-items: end;
   width: 100%;
   max-width: 360px;
   padding: 1rem;
   margin: auto auto 0;
   overflow: clip;
-
-  &:empty {
-    padding: 0;
-  }
+  pointer-events: none;
 
   @media (max-width: #{$mobile-menu-breakpoint - 1}) {
     // Compensate for mobile menubar
@@ -3205,6 +3206,7 @@ a.account__display-name {
     // Make all nested alerts occupy the same space
     // rather than stack
     grid-area: 1 / 1;
+    pointer-events: initial;
   }
 }
 
@@ -4484,13 +4486,19 @@ a.status-card {
   box-sizing: border-box;
   text-decoration: none;
 
-  &:hover {
-    background: var(--on-surface-color);
+  &--large {
+    padding-block: 32px;
   }
 
-  &:focus-visible {
-    outline: 2px solid $ui-button-focus-outline-color;
-    outline-offset: -2px;
+  &:is(button) {
+    &:hover {
+      background: var(--on-surface-color);
+    }
+
+    &:focus-visible {
+      outline: 2px solid $ui-button-focus-outline-color;
+      outline-offset: -2px;
+    }
   }
 
   .icon {


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes shifting scroll position as fetch-all-replies alerts are shown or hidden, by reserving some amount of space at the bottom of threads
- Also makes the load-more indicator taller at the end of threads (to match the height of the alert container), and suppresses its background colour change on hover as it's not interactive

### Screencaps

**Before**

https://github.com/user-attachments/assets/7bfa494d-2721-455e-8b35-f9f19833554a

**After**

https://github.com/user-attachments/assets/36a3ff46-8c7d-4c3f-8089-2ed4164dd650

