### PR TITLE
Remove the 2 PRs-per-hour Renovate limit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,6 @@
     'customManagers:dockerfileVersions',
     ':labels(dependencies)',
     ':prConcurrentLimitNone', // Remove limit for open PRs at any time.
-    ':prHourlyLimit2', // Rate limit PR creation to a maximum of two per hour.
     ':enableVulnerabilityAlertsWithLabel(security)',
   ],
   rebaseWhen: 'conflicted',


### PR DESCRIPTION
This is causing the once-a-week PRs (every monday morning) to not all be opened, because sometimes we have more than 2.