### PR TITLE
Fix icon buttons animating when they haven't changed

### DIFF
--- a/app/javascript/mastodon/components/icon_button.tsx
+++ b/app/javascript/mastodon/components/icon_button.tsx
@@ -2,6 +2,8 @@ import { useCallback, forwardRef } from 'react';
 
 import classNames from 'classnames';
 
+import { usePrevious } from '../hooks/usePrevious';
+
 import { AnimatedNumber } from './animated_number';
 import type { IconProp } from './icon';
 import { Icon } from './icon';
@@ -91,12 +93,15 @@ export const IconButton = forwardRef<HTMLButtonElement, Props>(
       ...(active ? activeStyle : {}),
     };
 
+    const previousActive = usePrevious(active) ?? active;
+    const shouldAnimate = animate && active !== previousActive;
+
     const classes = classNames(className, 'icon-button', {
       active,
       disabled,
       inverted,
-      activate: animate && active,
-      deactivate: animate && !active,
+      activate: shouldAnimate && active,
+      deactivate: shouldAnimate && !active,
       overlayed: overlay,
       'icon-button--with-counter': typeof counter !== 'undefined',
     });


### PR DESCRIPTION
Fixes #36815

### Changes proposed in this PR:
- Fixes a regression caused by #36758 ([relevant commit](https://github.com/mastodon/mastodon/pull/36758/commits/2854256c2d6180e892f21d8c714ad031dafd1334)) that caused icon buttons with animated state changes to animate too frequently

### Screencaps

**Before**


https://github.com/user-attachments/assets/e06f600c-1112-4518-ad91-7c2a81fc4783



**After**

https://github.com/user-attachments/assets/c5f0f946-a1a0-475f-9b65-8e37acdfb498

