### PR TITLE
Align min/max values for confirm password with password

### DIFF
--- a/app/views/auth/passwords/edit.html.haml
+++ b/app/views/auth/passwords/edit.html.haml
@@ -16,7 +16,7 @@
                 wrapper: :with_label
     .fields-group
       = f.input :password_confirmation,
-                input_html: { 'aria-label': t('simple_form.labels.defaults.confirm_new_password'), autocomplete: 'new-password' },
+                input_html: { 'aria-label': t('simple_form.labels.defaults.confirm_new_password'), autocomplete: 'new-password', minlength: User.password_length.first, maxlength: User.password_length.last },
                 label: t('simple_form.labels.defaults.confirm_new_password'),
                 required: true,
                 wrapper: :with_label

--- a/app/views/auth/registrations/edit.html.haml
+++ b/app/views/auth/registrations/edit.html.haml
@@ -39,7 +39,7 @@
       .fields-row__column.fields-group.fields-row__column-6
         = f.input :password_confirmation,
                   disabled: current_account.suspended?,
-                  input_html: { 'aria-label': t('simple_form.labels.defaults.confirm_new_password'), autocomplete: 'new-password' },
+                  input_html: { 'aria-label': t('simple_form.labels.defaults.confirm_new_password'), autocomplete: 'new-password', minlength: User.password_length.first, maxlength: User.password_length.last },
                   label: t('simple_form.labels.defaults.confirm_new_password'),
                   wrapper: :with_label
 

--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -36,7 +36,7 @@
               wrapper: :with_label
     = f.input :password_confirmation,
               hint: false,
-              input_html: { 'aria-label': t('simple_form.labels.defaults.confirm_password'), autocomplete: 'new-password', maxlength: User.password_length.last },
+              input_html: { 'aria-label': t('simple_form.labels.defaults.confirm_password'), autocomplete: 'new-password', minlength: User.password_length.first, maxlength: User.password_length.last },
               placeholder: t('simple_form.labels.defaults.confirm_password'),
               required: true
     = f.input :confirm_password,


### PR DESCRIPTION
Seems at least harmless, and maybe useful, to align these?

Resolves https://github.com/mastodon/mastodon/issues/25390 (or at least, the resolvable portions of that)

Separately, as possible followup, we have this clientside validation - https://github.com/mastodon/mastodon/blob/main/app/javascript/entrypoints/public.tsx#L25-L32 - originally added as part of a username PR - https://github.com/mastodon/mastodon/pull/24546/files - where we could probably just rely on native browser validation, for at least the length portion?