### PR TITLE
Fix filters not being applied to quotes in detailed view

### DIFF
--- a/app/javascript/mastodon/features/status/components/detailed_status.tsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.tsx
@@ -417,6 +417,7 @@ export const DetailedStatus: React.FC<{
               <QuotedStatus
                 quote={status.get('quote')}
                 parentQuotePostId={status.get('id')}
+                contextType='thread'
               />
             )}
           </>


### PR DESCRIPTION
Fixes #36840

Quotes in the detailed status were not given a filter context, thus not getting filtered at all. This now gives them the `thread` (or “Conversations”) context, applying filters accordingly.