### PR TITLE
Fix deprecation warning in Vite

### DIFF
--- a/app/javascript/mastodon/features/emoji/loader.ts
+++ b/app/javascript/mastodon/features/emoji/loader.ts
@@ -80,10 +80,11 @@ async function fetchAndCheckEtag<ResultType extends object[]>(
   return data;
 }
 
-const modules = import.meta.glob(
+const modules = import.meta.glob<string>(
   '../../../../../node_modules/emojibase-data/**/compact.json',
   {
-    as: 'url',
+    query: '?url',
+    import: 'default',
   },
 );
 


### PR DESCRIPTION
With #36808, we used Vite glob imports to get module paths. However, the pattern we used is deprecated so is causing warnings with Vite. This swaps to the new syntax.