### PR TITLE
Normalize `current_username` on account migration

### DIFF
--- a/app/models/account_migration.rb
+++ b/app/models/account_migration.rb
@@ -26,6 +26,7 @@ class AccountMigration < ApplicationRecord
   before_validation :set_followers_count
 
   normalizes :acct, with: ->(acct) { acct.strip.delete_prefix('@') }
+  normalizes :current_username, with: ->(value) { value.strip.delete_prefix('@') }
 
   validates :acct, presence: true, domain: { acct: true }
   validate :validate_migration_cooldown

--- a/spec/models/account_migration_spec.rb
+++ b/spec/models/account_migration_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe AccountMigration do
     describe 'acct' do
       it { is_expected.to normalize(:acct).from('  @username@domain  ').to('username@domain') }
     end
+
+    describe 'current_username' do
+      it { is_expected.to normalize(:current_username).from('  @username  ').to('username') }
+    end
   end
 
   describe 'Validations' do


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/discussions/36855

Further improvements:

- Update copy on that hint?
- Normalize even further, and allow for hostname as well?

I'm pretty sure this value is only ever accepted on this single migration form, and is only ever used internal to the model for string comparison to account username in scenario where the linked user account does not have an encrypted password present.