### PR TITLE
Fix Cmd/Ctrl + Enter in the composer triggering confirmation dialog action

### DIFF
--- a/app/javascript/mastodon/features/compose/components/compose_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/compose_form.jsx
@@ -102,6 +102,7 @@ class ComposeForm extends ImmutablePureComponent {
   handleKeyDownPost = (e) => {
     if (e.key.toLowerCase() === 'enter' && (e.ctrlKey || e.metaKey)) {
         this.handleSubmit();
+        e.preventDefault();
     }
     this.blurOnEscape(e);
   };


### PR DESCRIPTION
### Changes proposed in this PR:
- When a post is submitted via <kbd>Ctrl/Cmd</kbd> + <kbd>Enter</kbd>, and a confirmation dialog is supposed to be shown (e.g. if an image without Alt text is added to the composer, or a quote is added to a followers-only post), the confirmation dialog is immediately confirmed & its primary action is triggered