### PR TITLE
Experiment: Emoji picker

### DIFF
--- a/app/javascript/mastodon/components/emoji/picker/constants.ts
+++ b/app/javascript/mastodon/components/emoji/picker/constants.ts
@@ -1,9 +1,27 @@
+import { createContext, useContext } from 'react';
+
 import type { GroupKey, GroupMessage, SkinToneKey } from 'emojibase';
 import groupData from 'emojibase-data/meta/groups.json';
 
 import type { CustomEmojiData } from '@/mastodon/features/emoji/types';
 
-type CustomGroupMessage = Omit<GroupMessage, 'key'> & {
+export interface PickerContext {
+  skinTone: SkinTone;
+  hiddenGroups: string[];
+  recentlyUsed: string[];
+}
+
+const pickerContext = createContext<PickerContext>({
+  skinTone: 'default',
+  hiddenGroups: [],
+  recentlyUsed: [],
+});
+
+export const PickerContextProvider = pickerContext.Provider;
+
+export const usePickerContext = () => useContext(pickerContext);
+
+export type CustomGroupMessage = Omit<GroupMessage, 'key'> & {
   key: string;
 };
 

--- a/app/javascript/mastodon/components/emoji/picker/constants.ts
+++ b/app/javascript/mastodon/components/emoji/picker/constants.ts
@@ -1,4 +1,4 @@
-import type { GroupKey, GroupMessage } from 'emojibase';
+import type { GroupKey, GroupMessage, SkinToneKey } from 'emojibase';
 import groupData from 'emojibase-data/meta/groups.json';
 
 import type { CustomEmojiData } from '@/mastodon/features/emoji/types';
@@ -15,6 +15,17 @@ export const groupKeysToNumber = Object.fromEntries(
     Number(number),
   ]),
 );
+
+export type SkinTone = SkinToneKey | 'default';
+
+export const toneToEmoji: Record<SkinTone, string> = {
+  default: '👋',
+  dark: '👋🏿',
+  'medium-dark': '👋🏾',
+  medium: '👋🏽',
+  'medium-light': '👋🏼',
+  light: '👋🏻',
+};
 
 export const mockCustomGroups = [
   { key: 'blobcat', message: 'Blobcat', order: 1 },

--- a/app/javascript/mastodon/components/emoji/picker/constants.ts
+++ b/app/javascript/mastodon/components/emoji/picker/constants.ts
@@ -10,7 +10,8 @@ export interface PickerContext {
   hiddenGroups: string[];
   recentlyUsed: string[];
   favourites: string[];
-  setFavourite: (emojiCode: string) => void;
+  onSelect: (emojiCode: string) => void;
+  onFavourite: (emojiCode: string) => void;
 }
 
 const pickerContext = createContext<PickerContext>({
@@ -18,8 +19,11 @@ const pickerContext = createContext<PickerContext>({
   hiddenGroups: [],
   recentlyUsed: [],
   favourites: [],
-  setFavourite: () => {
-    throw new Error('setFavourite not implemented');
+  onSelect() {
+    throw new Error('onSelect not implemented');
+  },
+  onFavourite() {
+    throw new Error('onFavourite not implemented');
   },
 });
 

--- a/app/javascript/mastodon/components/emoji/picker/constants.ts
+++ b/app/javascript/mastodon/components/emoji/picker/constants.ts
@@ -1,4 +1,4 @@
-import type { GroupMessage } from 'emojibase';
+import type { GroupKey, GroupMessage } from 'emojibase';
 import groupData from 'emojibase-data/meta/groups.json';
 
 import type { CustomEmojiData } from '@/mastodon/features/emoji/types';
@@ -6,6 +6,8 @@ import type { CustomEmojiData } from '@/mastodon/features/emoji/types';
 type CustomGroupMessage = Omit<GroupMessage, 'key'> & {
   key: string;
 };
+
+export const groupsToHide: readonly GroupKey[] = ['component'];
 
 export const groupKeysToNumber = Object.fromEntries(
   Object.entries(groupData.groups).map(([number, key]) => [

--- a/app/javascript/mastodon/components/emoji/picker/constants.ts
+++ b/app/javascript/mastodon/components/emoji/picker/constants.ts
@@ -1,0 +1,72 @@
+import type { GroupMessage } from 'emojibase';
+import groupData from 'emojibase-data/meta/groups.json';
+
+import type { CustomEmojiData } from '@/mastodon/features/emoji/types';
+
+type CustomGroupMessage = Omit<GroupMessage, 'key'> & {
+  key: string;
+};
+
+export const groupKeysToNumber = Object.fromEntries(
+  Object.entries(groupData.groups).map(([number, key]) => [
+    key,
+    Number(number),
+  ]),
+);
+
+export const mockCustomGroups = [
+  { key: 'blobcat', message: 'Blobcat', order: 1 },
+  { key: 'lgbt', message: 'LGBTQ+', order: 2 },
+  { key: 'logos', message: 'Logos', order: 3 },
+] satisfies CustomGroupMessage[];
+
+export const mockCustomEmojis = [
+  {
+    shortcode: 'blobcat_heart',
+    url: 'https://pics.ishella.gay/custom_emojis/images/000/001/217/original/abede62a1fe634cf.png',
+    static_url:
+      'https://pics.ishella.gay/custom_emojis/images/000/001/217/static/abede62a1fe634cf.png',
+    visible_in_picker: true,
+    category: 'blobcat',
+  },
+  {
+    shortcode: 'blobcat_wave',
+    url: 'https://pics.ishella.gay/custom_emojis/images/000/001/250/original/f924277a36414906.png',
+    static_url:
+      'https://pics.ishella.gay/custom_emojis/images/000/001/250/static/f924277a36414906.png',
+    visible_in_picker: true,
+    category: 'blobcat',
+  },
+  {
+    shortcode: 'mastodon',
+    url: 'https://pics.ishella.gay/custom_emojis/images/000/025/993/original/56c38669cdca5d1c.png',
+    static_url:
+      'https://pics.ishella.gay/custom_emojis/images/000/025/993/static/56c38669cdca5d1c.png',
+    visible_in_picker: true,
+    category: 'mastodon',
+  },
+  {
+    shortcode: 'fediverse',
+    url: 'https://pics.ishella.gay/custom_emojis/images/000/001/198/original/b8041a4f365c4518.png',
+    static_url:
+      'https://pics.ishella.gay/custom_emojis/images/000/001/198/static/b8041a4f365c4518.png',
+    visible_in_picker: true,
+    category: 'logos',
+  },
+  {
+    shortcode: 'ace_heart',
+    url: 'https://pics.ishella.gay/custom_emojis/images/000/001/220/original/8689758e37a1bfbc.png',
+    static_url:
+      'https://pics.ishella.gay/custom_emojis/images/000/001/220/static/8689758e37a1bfbc.png',
+    visible_in_picker: true,
+    category: 'lgbt',
+  },
+  {
+    shortcode: 'nbi_heart',
+    url: 'https://pics.ishella.gay/custom_emojis/images/000/001/199/original/a06d788bce50f260.png',
+    static_url:
+      'https://pics.ishella.gay/custom_emojis/images/000/001/199/static/a06d788bce50f260.png',
+    visible_in_picker: true,
+    category: 'lgbt',
+  },
+] satisfies (CustomEmojiData & { category: string })[];

--- a/app/javascript/mastodon/components/emoji/picker/constants.ts
+++ b/app/javascript/mastodon/components/emoji/picker/constants.ts
@@ -10,6 +10,7 @@ export interface PickerContext {
   hiddenGroups: string[];
   recentlyUsed: string[];
   favourites: string[];
+  setFavourite: (emojiCode: string) => void;
 }
 
 const pickerContext = createContext<PickerContext>({
@@ -17,6 +18,9 @@ const pickerContext = createContext<PickerContext>({
   hiddenGroups: [],
   recentlyUsed: [],
   favourites: [],
+  setFavourite: () => {
+    throw new Error('setFavourite not implemented');
+  },
 });
 
 export const PickerContextProvider = pickerContext.Provider;

--- a/app/javascript/mastodon/components/emoji/picker/constants.ts
+++ b/app/javascript/mastodon/components/emoji/picker/constants.ts
@@ -69,6 +69,7 @@ export const mockCustomEmojis = [
       'https://pics.ishella.gay/custom_emojis/images/000/001/217/static/abede62a1fe634cf.png',
     visible_in_picker: true,
     category: 'blobcat',
+    tokens: ['blobcat', 'heart'],
   },
   {
     shortcode: 'blobcat_wave',
@@ -77,6 +78,7 @@ export const mockCustomEmojis = [
       'https://pics.ishella.gay/custom_emojis/images/000/001/250/static/f924277a36414906.png',
     visible_in_picker: true,
     category: 'blobcat',
+    tokens: ['blobcat', 'wave'],
   },
   {
     shortcode: 'mastodon',
@@ -85,6 +87,7 @@ export const mockCustomEmojis = [
       'https://pics.ishella.gay/custom_emojis/images/000/025/993/static/56c38669cdca5d1c.png',
     visible_in_picker: true,
     category: 'logos',
+    tokens: ['mastodon'],
   },
   {
     shortcode: 'fediverse',
@@ -93,6 +96,7 @@ export const mockCustomEmojis = [
       'https://pics.ishella.gay/custom_emojis/images/000/001/198/static/b8041a4f365c4518.png',
     visible_in_picker: true,
     category: 'logos',
+    tokens: ['fediverse'],
   },
   {
     shortcode: 'ace_heart',
@@ -101,6 +105,7 @@ export const mockCustomEmojis = [
       'https://pics.ishella.gay/custom_emojis/images/000/001/220/static/8689758e37a1bfbc.png',
     visible_in_picker: true,
     category: 'lgbt',
+    tokens: ['ace', 'heart'],
   },
   {
     shortcode: 'nbi_heart',
@@ -109,5 +114,6 @@ export const mockCustomEmojis = [
       'https://pics.ishella.gay/custom_emojis/images/000/001/199/static/a06d788bce50f260.png',
     visible_in_picker: true,
     category: 'lgbt',
+    tokens: ['nbi', 'heart'],
   },
 ] satisfies (CustomEmojiData & { category: string })[];

--- a/app/javascript/mastodon/components/emoji/picker/constants.ts
+++ b/app/javascript/mastodon/components/emoji/picker/constants.ts
@@ -9,12 +9,14 @@ export interface PickerContext {
   skinTone: SkinTone;
   hiddenGroups: string[];
   recentlyUsed: string[];
+  favourites: string[];
 }
 
 const pickerContext = createContext<PickerContext>({
   skinTone: 'default',
   hiddenGroups: [],
   recentlyUsed: [],
+  favourites: [],
 });
 
 export const PickerContextProvider = pickerContext.Provider;
@@ -74,7 +76,7 @@ export const mockCustomEmojis = [
     static_url:
       'https://pics.ishella.gay/custom_emojis/images/000/025/993/static/56c38669cdca5d1c.png',
     visible_in_picker: true,
-    category: 'mastodon',
+    category: 'logos',
   },
   {
     shortcode: 'fediverse',

--- a/app/javascript/mastodon/components/emoji/picker/emoji-picker.stories.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/emoji-picker.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
 
 import {
   importCustomEmojiData,
@@ -7,14 +8,18 @@ import {
 
 import { MockEmojiPicker } from './index';
 
+const onSelect = action('emoji selected');
+
 const meta = {
   title: 'Components/Emoji/EmojiPicker',
-  render() {
+  render(_args, { globals }) {
+    const locale = typeof globals.locale === 'string' ? globals.locale : 'en';
+
     void importCustomEmojiData();
-    void importEmojiData('en');
-    return <MockEmojiPicker />;
+    void importEmojiData(locale);
+    return <MockEmojiPicker onSelect={onSelect} />;
   },
-} satisfies Meta<typeof MockEmojiPicker>;
+} satisfies Meta;
 
 export default meta;
 

--- a/app/javascript/mastodon/components/emoji/picker/emoji-picker.stories.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/emoji-picker.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import {
+  importCustomEmojiData,
+  importEmojiData,
+} from '@/mastodon/features/emoji/loader';
+
+import { MockEmojiPicker } from './index';
+
+const meta = {
+  title: 'Components/Emoji/EmojiPicker',
+  render() {
+    void importCustomEmojiData();
+    void importEmojiData('en');
+    return <MockEmojiPicker />;
+  },
+} satisfies Meta<typeof MockEmojiPicker>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/app/javascript/mastodon/components/emoji/picker/emoji-picker.stories.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/emoji-picker.stories.tsx
@@ -12,6 +12,7 @@ import { toSupportedLocale } from '@/mastodon/features/emoji/locale';
 import { MockEmojiPicker } from './index';
 
 const onSelect = action('emoji selected');
+const onSkinToneChange = action('skin tone changed');
 
 const meta = {
   title: 'Components/Emoji/EmojiPicker',
@@ -34,7 +35,9 @@ const StoryComponent: FC<{ locale: string }> = ({ locale }) => {
   if (!loaded) {
     return null;
   }
-  return <MockEmojiPicker onSelect={onSelect} />;
+  return (
+    <MockEmojiPicker onSelect={onSelect} onSkinToneChange={onSkinToneChange} />
+  );
 };
 
 async function loadEmojiData(localeString: string) {

--- a/app/javascript/mastodon/components/emoji/picker/emoji-picker.stories.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/emoji-picker.stories.tsx
@@ -36,7 +36,21 @@ const StoryComponent: FC<{ locale: string }> = ({ locale }) => {
     return null;
   }
   return (
-    <MockEmojiPicker onSelect={onSelect} onSkinToneChange={onSkinToneChange} />
+    <div
+      style={{
+        resize: 'horizontal',
+        padding: '1rem',
+        border: '1px solid gray',
+        overflow: 'auto',
+        width: '400px',
+        minWidth: 'calc(250px + 2rem)',
+      }}
+    >
+      <MockEmojiPicker
+        onSelect={onSelect}
+        onSkinToneChange={onSkinToneChange}
+      />
+    </div>
   );
 };
 

--- a/app/javascript/mastodon/components/emoji/picker/emoji-picker.stories.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/emoji-picker.stories.tsx
@@ -1,3 +1,6 @@
+import type { FC } from 'react';
+import { useState } from 'react';
+
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { action } from 'storybook/actions';
 
@@ -14,12 +17,24 @@ const meta = {
   title: 'Components/Emoji/EmojiPicker',
   render(_args, { globals }) {
     const locale = typeof globals.locale === 'string' ? globals.locale : 'en';
-
-    void importCustomEmojiData();
-    void importEmojiData(locale);
-    return <MockEmojiPicker onSelect={onSelect} />;
+    return <StoryComponent locale={locale} />;
   },
 } satisfies Meta;
+
+const StoryComponent: FC<{ locale: string }> = ({ locale }) => {
+  const [loaded, setLoaded] = useState(false);
+
+  void Promise.all([importCustomEmojiData(), importEmojiData(locale)]).then(
+    () => {
+      setLoaded(true);
+    },
+  );
+
+  if (!loaded) {
+    return null;
+  }
+  return <MockEmojiPicker onSelect={onSelect} />;
+};
 
 export default meta;
 

--- a/app/javascript/mastodon/components/emoji/picker/emoji-picker.stories.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/emoji-picker.stories.tsx
@@ -1,13 +1,7 @@
 import type { FC } from 'react';
-import { useState } from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { CompactEmoji } from 'emojibase';
-import { flattenEmojiData } from 'emojibase';
 import { action } from 'storybook/actions';
-
-import { putEmojiData } from '@/mastodon/features/emoji/database';
-import { toSupportedLocale } from '@/mastodon/features/emoji/locale';
 
 import { MockEmojiPicker } from './index';
 
@@ -18,23 +12,11 @@ const meta = {
   title: 'Components/Emoji/EmojiPicker',
   render(_args, { globals }) {
     const locale = typeof globals.locale === 'string' ? globals.locale : 'en';
-    return <StoryComponent locale={locale} key={locale} />;
+    return <StoryComponent key={locale} />;
   },
 } satisfies Meta;
 
-const StoryComponent: FC<{ locale: string }> = ({ locale }) => {
-  const [loaded, setLoaded] = useState(false);
-
-  if (!loaded) {
-    void loadEmojiData(locale).then(() => {
-      action('emoji data loaded')(locale);
-      setLoaded(true);
-    });
-  }
-
-  if (!loaded) {
-    return null;
-  }
+const StoryComponent: FC = () => {
   return (
     <div
       style={{
@@ -53,15 +35,6 @@ const StoryComponent: FC<{ locale: string }> = ({ locale }) => {
     </div>
   );
 };
-
-async function loadEmojiData(localeString: string) {
-  const locale = toSupportedLocale(localeString);
-  const emojis = (await import(
-    `../../../../../../node_modules/emojibase-data/${locale}/compact.json`
-  )) as { default: CompactEmoji[] };
-  const flattenedEmojis = flattenEmojiData(emojis.default);
-  await putEmojiData(flattenedEmojis, locale);
-}
 
 export default meta;
 

--- a/app/javascript/mastodon/components/emoji/picker/group-button.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/group-button.tsx
@@ -1,0 +1,71 @@
+import type { FC, MouseEventHandler } from 'react';
+import { useCallback, useState, useEffect } from 'react';
+
+import classNames from 'classnames';
+
+import { loadUnicodeEmojiGroupIcon } from '@/mastodon/features/emoji/database';
+import { useEmojiAppState } from '@/mastodon/features/emoji/mode';
+import type { AnyEmojiData } from '@/mastodon/features/emoji/types';
+
+import { Emoji } from '..';
+
+import { mockCustomEmojis, groupKeysToNumber } from './constants';
+import classes from './styles.module.css';
+
+interface PickerGroupButtonProps {
+  onSelect: (key: string) => void;
+  group: string;
+  message: string;
+  disabled?: boolean;
+}
+
+export const PickerGroupButton: FC<PickerGroupButtonProps> = ({
+  onSelect,
+  message,
+  group,
+  disabled = false,
+}) => {
+  const handleClick: MouseEventHandler = useCallback(
+    (event) => {
+      event.preventDefault();
+      onSelect(group);
+    },
+    [onSelect, group],
+  );
+  const { currentLocale } = useEmojiAppState();
+  const [icon, setIcon] = useState<AnyEmojiData | null>(() => {
+    const emoji = mockCustomEmojis.find((emoji) => emoji.category === group);
+    return emoji ?? null;
+  });
+
+  useEffect(() => {
+    if (icon !== null) {
+      return;
+    }
+
+    if (group in groupKeysToNumber) {
+      const groupNum = groupKeysToNumber[group];
+      if (typeof groupNum !== 'undefined') {
+        void loadUnicodeEmojiGroupIcon(groupNum, currentLocale).then(setIcon);
+      }
+    }
+  }, [currentLocale, group, icon]);
+
+  return (
+    <li>
+      <button
+        type='button'
+        title={message}
+        onClick={handleClick}
+        className={classNames(classes.groupButton)}
+        disabled={disabled}
+      >
+        {icon && (
+          <Emoji
+            code={'unicode' in icon ? icon.unicode : `:${icon.shortcode}:`}
+          />
+        )}
+      </button>
+    </li>
+  );
+};

--- a/app/javascript/mastodon/components/emoji/picker/hooks.ts
+++ b/app/javascript/mastodon/components/emoji/picker/hooks.ts
@@ -1,12 +1,25 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { usePrevious } from '@dnd-kit/utilities';
 import type { MessagesDataset } from 'emojibase';
 import enMessages from 'emojibase-data/en/messages.json';
 
+import { loadEmojisByCodes } from '@/mastodon/features/emoji/database';
 import { useEmojiAppState } from '@/mastodon/features/emoji/mode';
+import type { AnyEmojiData } from '@/mastodon/features/emoji/types';
 
 import { groupsToHide } from './constants';
+
+export function useEmojisFromCodes(codes: string[]) {
+  const { currentLocale } = useEmojiAppState();
+  const [emojis, setEmojis] = useState<AnyEmojiData[] | null>(null);
+
+  useEffect(() => {
+    void loadEmojisByCodes(codes, currentLocale).then(setEmojis);
+  }, [codes, currentLocale]);
+
+  return emojis;
+}
 
 export function useLocaleMessages() {
   const { currentLocale } = useEmojiAppState();

--- a/app/javascript/mastodon/components/emoji/picker/hooks.ts
+++ b/app/javascript/mastodon/components/emoji/picker/hooks.ts
@@ -1,0 +1,40 @@
+import { useMemo, useState } from 'react';
+
+import { usePrevious } from '@dnd-kit/utilities';
+import type { MessagesDataset } from 'emojibase';
+import enMessages from 'emojibase-data/en/messages.json';
+
+import { useEmojiAppState } from '@/mastodon/features/emoji/mode';
+
+import { groupsToHide } from './constants';
+
+export function useLocaleMessages() {
+  const { currentLocale } = useEmojiAppState();
+  // This isn't needed in real life, as the current locale is only set on page load.
+  // However it Storybook can update the locale without a refresh.
+  const prevLocale = usePrevious(currentLocale);
+
+  const [messages, setMessages] = useState<MessagesDataset>(enMessages);
+  if (prevLocale !== currentLocale) {
+    // This is messy, but it's just for the mock picker.
+    import(
+      `../../../../../../node_modules/emojibase-data/${currentLocale}/messages.json`
+    )
+      .then((module: { default: MessagesDataset }) => {
+        setMessages(module.default);
+      })
+      .catch((err: unknown) => {
+        console.warn('fell back to en messages', err);
+      });
+  }
+
+  const groups = useMemo(
+    () => messages.groups.filter((group) => !groupsToHide.includes(group.key)),
+    [messages.groups],
+  );
+
+  return {
+    ...messages,
+    groups,
+  };
+}

--- a/app/javascript/mastodon/components/emoji/picker/index.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/index.tsx
@@ -85,30 +85,6 @@ export const MockEmojiPicker: FC<MockEmojiPickerProps> = ({
     });
   }, []);
 
-  const { currentLocale } = useEmojiAppState();
-  // This isn't needed in real life, as the current locale is only set on page load.
-  const prevLocale = usePrevious(currentLocale);
-  const [groups, setGroups] = useState<GroupMessage[]>([]);
-  if (prevLocale !== currentLocale) {
-    // This is messy, but it's just for the mock picker.
-    import(
-      `../../../../../../node_modules/emojibase-data/${currentLocale}/messages.json`
-    )
-      .then((module: { default: MessagesDataset }) => {
-        setGroups(
-          module.default.groups.filter(
-            (group) => !groupsToHide.includes(group.key),
-          ),
-        );
-      })
-      .catch((err: unknown) => {
-        console.warn('fell back to en messages', err);
-        setGroups(
-          messages.groups.filter((group) => !groupsToHide.includes(group.key)),
-        );
-      });
-  }
-
   return (
     <CustomEmojiProvider emojis={mockCustomEmojis}>
       <PickerContextProvider

--- a/app/javascript/mastodon/components/emoji/picker/index.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/index.tsx
@@ -16,7 +16,7 @@ import {
 } from './constants';
 import { PickerGroupButton } from './group-button';
 import { useLocaleMessages } from './hooks';
-import { PickerGroupList } from './list';
+import { PickerGroupCustomList, PickerGroupList } from './list';
 import { PickerSettings } from './settings';
 import classes from './styles.module.css';
 
@@ -70,9 +70,14 @@ export const MockEmojiPicker: FC<MockEmojiPickerProps> = ({
     );
   }, []);
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- TODO: Set up favourites management
+  const [favourites, setFavourites] = useState<string[]>(['🖤']);
+
   return (
     <CustomEmojiProvider emojis={mockCustomEmojis}>
-      <PickerContextProvider value={{ skinTone, hiddenGroups, recentlyUsed }}>
+      <PickerContextProvider
+        value={{ skinTone, hiddenGroups, favourites, recentlyUsed }}
+      >
         <div className={classes.wrapper}>
           {showSettings ? (
             <PickerSettings
@@ -135,7 +140,7 @@ const PickerMain: FC<
     searchInput.focus();
   }, []);
 
-  const { hiddenGroups } = usePickerContext();
+  const { hiddenGroups, favourites, recentlyUsed } = usePickerContext();
   const customGroups = useMemo(
     () => mockCustomGroups.filter(({ key }) => !hiddenGroups.includes(key)),
     [hiddenGroups],
@@ -159,6 +164,22 @@ const PickerMain: FC<
       </div>
 
       <div className={classes.main} ref={wrapperRef}>
+        {favourites.length > 0 && (
+          <PickerGroupCustomList
+            name='Favourites'
+            group='favourites'
+            onSelect={handleEmojiSelect}
+            emojiKeys={favourites}
+          />
+        )}
+        {recentlyUsed.length > 0 && (
+          <PickerGroupCustomList
+            name='Recently Used'
+            group='recent'
+            onSelect={handleEmojiSelect}
+            emojiKeys={recentlyUsed}
+          />
+        )}
         {customGroups.map((group) => (
           <PickerGroupList
             key={group.key}

--- a/app/javascript/mastodon/components/emoji/picker/index.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/index.tsx
@@ -95,11 +95,17 @@ export const MockEmojiPicker: FC<MockEmojiPickerProps> = ({
       `../../../../../../node_modules/emojibase-data/${currentLocale}/messages.json`
     )
       .then((module: { default: MessagesDataset }) => {
-        setGroups(module.default.groups);
+        setGroups(
+          module.default.groups.filter(
+            (group) => !groupsToHide.includes(group.key),
+          ),
+        );
       })
       .catch((err: unknown) => {
         console.warn('fell back to en messages', err);
-        setGroups(messages.groups);
+        setGroups(
+          messages.groups.filter((group) => !groupsToHide.includes(group.key)),
+        );
       });
   }
 

--- a/app/javascript/mastodon/components/emoji/picker/index.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/index.tsx
@@ -1,14 +1,13 @@
 import { useCallback, useState } from 'react';
 import type { FC, MouseEventHandler } from 'react';
 
+import type { GroupMessage, MessagesDataset } from 'emojibase';
 import messages from 'emojibase-data/en/messages.json';
 
 import { loadUnicodeEmojiGroupIcon } from '@/mastodon/features/emoji/database';
 import { useEmojiAppState } from '@/mastodon/features/emoji/mode';
-import type {
-  CustomEmojiData,
-  UnicodeEmojiData,
-} from '@/mastodon/features/emoji/types';
+import type { AnyEmojiData } from '@/mastodon/features/emoji/types';
+import { usePrevious } from '@/mastodon/hooks/usePrevious';
 import SettingsIcon from '@/material-icons/400-24px/settings.svg?react';
 
 import { Emoji } from '..';
@@ -20,9 +19,24 @@ import {
   mockCustomEmojis,
   mockCustomGroups,
 } from './constants';
+import { PickerGroupList } from './list';
 import classes from './styles.module.css';
 
-export const MockEmojiPicker: FC = () => {
+interface MockEmojiPickerProps {
+  onSelect?: (emojiCode: string) => void;
+}
+
+export const MockEmojiPicker: FC<MockEmojiPickerProps> = ({ onSelect }) => {
+  const handleEmojiSelect = useCallback(
+    (emoji: AnyEmojiData) => {
+      if (onSelect) {
+        const code =
+          'unicode' in emoji ? emoji.unicode : `:${emoji.shortcode}:`;
+        onSelect(code);
+      }
+    },
+    [onSelect],
+  );
   const handleGroupSelect = useCallback((key: string) => {
     // eslint-disable-next-line no-console
     console.log('Selected group:', key);
@@ -33,6 +47,24 @@ export const MockEmojiPicker: FC = () => {
     event.preventDefault();
     setShowSettings((prev) => !prev);
   }, []);
+
+  const { currentLocale } = useEmojiAppState();
+  // This isn't needed in real life, as the current locale is only set on page load.
+  const prevLocale = usePrevious(currentLocale);
+  const [groups, setGroups] = useState<GroupMessage[]>([]);
+  if (prevLocale !== currentLocale) {
+    // This is messy, but it's just for the mock picker.
+    import(
+      `../../../../../../node_modules/emojibase-data/${currentLocale}/messages.json`
+    )
+      .then((module: { default: MessagesDataset }) => {
+        setGroups(module.default.groups);
+      })
+      .catch((err: unknown) => {
+        console.warn('fell back to en messages', err);
+        setGroups(messages.groups);
+      });
+  }
 
   return (
     <CustomEmojiProvider emojis={mockCustomEmojis}>
@@ -51,7 +83,26 @@ export const MockEmojiPicker: FC = () => {
           />
         </div>
         {showSettings && <div className={classes.main}>Settings here</div>}
-        {!showSettings && <div className={classes.main} />}
+        {!showSettings && (
+          <div className={classes.main}>
+            {mockCustomGroups.map((group) => (
+              <PickerGroupList
+                key={group.key}
+                group={group.key}
+                name={group.message}
+                onSelect={handleEmojiSelect}
+              />
+            ))}
+            {groups.map((group) => (
+              <PickerGroupList
+                key={group.key}
+                group={group.key}
+                name={group.message}
+                onSelect={handleEmojiSelect}
+              />
+            ))}
+          </div>
+        )}
         <ul className={classes.nav}>
           {mockCustomGroups.map((group) => (
             <PickerNavButton
@@ -62,7 +113,7 @@ export const MockEmojiPicker: FC = () => {
             />
           ))}
           <li key='separator' className={classes.separator} />
-          {messages.groups.map((group) => (
+          {groups.map((group) => (
             <PickerNavButton
               key={group.key}
               onSelect={handleGroupSelect}
@@ -91,14 +142,12 @@ const PickerNavButton: FC<PickerNavProps> = ({ onSelect, message, group }) => {
     [onSelect, group],
   );
   const { currentLocale } = useEmojiAppState();
-  const [icon, setIcon] = useState<UnicodeEmojiData | CustomEmojiData | null>(
-    () => {
-      const emoji = mockCustomEmojis.find((emoji) => emoji.category === group);
-      return emoji ?? null;
-    },
-  );
+  const [icon, setIcon] = useState<AnyEmojiData | null>(() => {
+    const emoji = mockCustomEmojis.find((emoji) => emoji.category === group);
+    return emoji ?? null;
+  });
 
-  if (group in groupKeysToNumber) {
+  if (group in groupKeysToNumber && icon === null) {
     const groupNum = groupKeysToNumber[group];
     if (typeof groupNum !== 'undefined') {
       void loadUnicodeEmojiGroupIcon(groupNum, currentLocale).then(setIcon);

--- a/app/javascript/mastodon/components/emoji/picker/index.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FC, MouseEventHandler } from 'react';
 
 import classNames from 'classnames';
@@ -32,12 +32,7 @@ export const MockEmojiPicker: FC<MockEmojiPickerProps> = ({ onSelect }) => {
     [onSelect],
   );
 
-  const [showSettings, setShowSettings] = useState(false);
-  const handleSettingsClick: MouseEventHandler = useCallback((event) => {
-    event.preventDefault();
-    setShowSettings((prev) => !prev);
-  }, []);
-
+  const { groups } = useLocaleMessages();
   const wrapperRef = useRef<HTMLDivElement>(null);
   const handleGroupSelect = useCallback((key: string) => {
     const wrapper = wrapperRef.current;
@@ -57,7 +52,19 @@ export const MockEmojiPicker: FC<MockEmojiPickerProps> = ({ onSelect }) => {
     }
   }, []);
 
-  const { groups } = useLocaleMessages();
+  const searchRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    const searchInput = searchRef.current;
+    if (!searchInput) return;
+
+    searchInput.focus();
+  }, []);
+
+  const [showSettings, setShowSettings] = useState(false);
+  const handleSettingsClick: MouseEventHandler = useCallback((event) => {
+    event.preventDefault();
+    setShowSettings((prev) => !prev);
+  }, []);
 
   return (
     <CustomEmojiProvider emojis={mockCustomEmojis}>
@@ -67,6 +74,7 @@ export const MockEmojiPicker: FC<MockEmojiPickerProps> = ({ onSelect }) => {
             type='search'
             placeholder='Search emojis'
             className={classes.search}
+            ref={searchRef}
           />
           <IconButton
             icon='settings'

--- a/app/javascript/mastodon/components/emoji/picker/index.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/index.tsx
@@ -45,7 +45,7 @@ export const MockEmojiPicker: FC<MockEmojiPickerProps> = ({
     [onSkinToneChange],
   );
 
-  const [recentlyUsed, setRecentlyUsed] = useState<string[]>([
+  const [recentlyUsed, setRecentlyUsed] = useState([
     ':blobcat_heart:',
     ':mastodon:',
     '👍',
@@ -147,8 +147,7 @@ const PickerMain: FC<PickerMainProps> = ({ onSettingsClick }) => {
     searchInput.focus();
   }, []);
 
-  const pickerContext = usePickerContext();
-  const { hiddenGroups, favourites, recentlyUsed } = pickerContext;
+  const { hiddenGroups, favourites, recentlyUsed } = usePickerContext();
   const customGroups = useMemo(
     () => mockCustomGroups.filter(({ key }) => !hiddenGroups.includes(key)),
     [hiddenGroups],

--- a/app/javascript/mastodon/components/emoji/picker/index.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/index.tsx
@@ -85,6 +85,24 @@ export const MockEmojiPicker: FC<MockEmojiPickerProps> = ({
     });
   }, []);
 
+  const { currentLocale } = useEmojiAppState();
+  // This isn't needed in real life, as the current locale is only set on page load.
+  const prevLocale = usePrevious(currentLocale);
+  const [groups, setGroups] = useState<GroupMessage[]>([]);
+  if (prevLocale !== currentLocale) {
+    // This is messy, but it's just for the mock picker.
+    import(
+      `../../../../../../node_modules/emojibase-data/${currentLocale}/messages.json`
+    )
+      .then((module: { default: MessagesDataset }) => {
+        setGroups(module.default.groups);
+      })
+      .catch((err: unknown) => {
+        console.warn('fell back to en messages', err);
+        setGroups(messages.groups);
+      });
+  }
+
   return (
     <CustomEmojiProvider emojis={mockCustomEmojis}>
       <PickerContextProvider

--- a/app/javascript/mastodon/components/emoji/picker/index.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/index.tsx
@@ -16,6 +16,7 @@ import { CustomEmojiProvider } from '../context';
 
 import {
   groupKeysToNumber,
+  groupsToHide,
   mockCustomEmojis,
   mockCustomGroups,
 } from './constants';
@@ -58,11 +59,17 @@ export const MockEmojiPicker: FC<MockEmojiPickerProps> = ({ onSelect }) => {
       `../../../../../../node_modules/emojibase-data/${currentLocale}/messages.json`
     )
       .then((module: { default: MessagesDataset }) => {
-        setGroups(module.default.groups);
+        setGroups(
+          module.default.groups.filter(
+            (group) => !groupsToHide.includes(group.key),
+          ),
+        );
       })
       .catch((err: unknown) => {
         console.warn('fell back to en messages', err);
-        setGroups(messages.groups);
+        setGroups(
+          messages.groups.filter((group) => !groupsToHide.includes(group.key)),
+        );
       });
   }
 

--- a/app/javascript/mastodon/components/emoji/picker/index.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/index.tsx
@@ -70,13 +70,30 @@ export const MockEmojiPicker: FC<MockEmojiPickerProps> = ({
     );
   }, []);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- TODO: Set up favourites management
   const [favourites, setFavourites] = useState<string[]>(['🖤']);
+  const handleSetFavourite = useCallback((emojiCode: string) => {
+    const emojiKey = emojiCode;
+    setFavourites((prev) => {
+      const prevCodes = new Set(prev);
+      if (prevCodes.has(emojiKey)) {
+        prevCodes.delete(emojiKey);
+      } else {
+        prevCodes.add(emojiKey);
+      }
+      return Array.from(prevCodes);
+    });
+  }, []);
 
   return (
     <CustomEmojiProvider emojis={mockCustomEmojis}>
       <PickerContextProvider
-        value={{ skinTone, hiddenGroups, favourites, recentlyUsed }}
+        value={{
+          skinTone,
+          hiddenGroups,
+          favourites,
+          recentlyUsed,
+          setFavourite: handleSetFavourite,
+        }}
       >
         <div className={classes.wrapper}>
           {showSettings ? (

--- a/app/javascript/mastodon/components/emoji/picker/index.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/index.tsx
@@ -90,7 +90,20 @@ const PickerNavButton: FC<PickerNavProps> = ({ onSelect, message, group }) => {
     },
     [onSelect, group],
   );
-  const icon = useGroupIcon(group);
+  const { currentLocale } = useEmojiAppState();
+  const [icon, setIcon] = useState<UnicodeEmojiData | CustomEmojiData | null>(
+    () => {
+      const emoji = mockCustomEmojis.find((emoji) => emoji.category === group);
+      return emoji ?? null;
+    },
+  );
+
+  if (group in groupKeysToNumber) {
+    const groupNum = groupKeysToNumber[group];
+    if (typeof groupNum !== 'undefined') {
+      void loadUnicodeEmojiGroupIcon(groupNum, currentLocale).then(setIcon);
+    }
+  }
 
   return (
     <li>
@@ -109,23 +122,3 @@ const PickerNavButton: FC<PickerNavProps> = ({ onSelect, message, group }) => {
     </li>
   );
 };
-
-function useGroupIcon(groupKey: string) {
-  const { currentLocale } = useEmojiAppState();
-  const [icon, setIcon] = useState<UnicodeEmojiData | CustomEmojiData | null>(
-    () => {
-      const emoji = mockCustomEmojis.find(
-        (emoji) => emoji.category === groupKey,
-      );
-      return emoji ?? null;
-    },
-  );
-
-  if (groupKey in groupKeysToNumber) {
-    const group = groupKeysToNumber[groupKey];
-    if (typeof group !== 'undefined') {
-      void loadUnicodeEmojiGroupIcon(group, currentLocale).then(setIcon);
-    }
-  }
-  return icon;
-}

--- a/app/javascript/mastodon/components/emoji/picker/index.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/index.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useState } from 'react';
+import type { FC, MouseEventHandler } from 'react';
+
+import messages from 'emojibase-data/en/messages.json';
+
+import { loadUnicodeEmojiGroupIcon } from '@/mastodon/features/emoji/database';
+import { useEmojiAppState } from '@/mastodon/features/emoji/mode';
+import type {
+  CustomEmojiData,
+  UnicodeEmojiData,
+} from '@/mastodon/features/emoji/types';
+import SettingsIcon from '@/material-icons/400-24px/settings.svg?react';
+
+import { Emoji } from '..';
+import { IconButton } from '../../icon_button';
+import { CustomEmojiProvider } from '../context';
+
+import {
+  groupKeysToNumber,
+  mockCustomEmojis,
+  mockCustomGroups,
+} from './constants';
+import classes from './styles.module.css';
+
+export const MockEmojiPicker: FC = () => {
+  const handleGroupSelect = useCallback((key: string) => {
+    // eslint-disable-next-line no-console
+    console.log('Selected group:', key);
+  }, []);
+
+  const [showSettings, setShowSettings] = useState(false);
+  const handleSettingsClick: MouseEventHandler = useCallback((event) => {
+    event.preventDefault();
+    setShowSettings((prev) => !prev);
+  }, []);
+
+  return (
+    <CustomEmojiProvider emojis={mockCustomEmojis}>
+      <div className={classes.wrapper}>
+        <div className={classes.header}>
+          <input
+            type='search'
+            placeholder='Search emojis'
+            className={classes.search}
+          />
+          <IconButton
+            icon='settings'
+            iconComponent={SettingsIcon}
+            title='Picker settings'
+            onClick={handleSettingsClick}
+          />
+        </div>
+        {showSettings && <div className={classes.main}>Settings here</div>}
+        {!showSettings && <div className={classes.main} />}
+        <ul className={classes.nav}>
+          {mockCustomGroups.map((group) => (
+            <PickerNavButton
+              key={group.key}
+              onSelect={handleGroupSelect}
+              message={group.message}
+              group={group.key}
+            />
+          ))}
+          <li key='separator' className={classes.separator} />
+          {messages.groups.map((group) => (
+            <PickerNavButton
+              key={group.key}
+              onSelect={handleGroupSelect}
+              message={group.message}
+              group={group.key}
+            />
+          ))}
+        </ul>
+      </div>
+    </CustomEmojiProvider>
+  );
+};
+
+interface PickerNavProps {
+  onSelect: (key: string) => void;
+  group: string;
+  message: string;
+}
+
+const PickerNavButton: FC<PickerNavProps> = ({ onSelect, message, group }) => {
+  const handleClick: MouseEventHandler = useCallback(
+    (event) => {
+      event.preventDefault();
+      onSelect(group);
+    },
+    [onSelect, group],
+  );
+  const icon = useGroupIcon(group);
+
+  return (
+    <li>
+      <button
+        type='button'
+        title={message}
+        onClick={handleClick}
+        className={classes.groupButton}
+      >
+        {icon && (
+          <Emoji
+            code={'unicode' in icon ? icon.unicode : `:${icon.shortcode}:`}
+          />
+        )}
+      </button>
+    </li>
+  );
+};
+
+function useGroupIcon(groupKey: string) {
+  const { currentLocale } = useEmojiAppState();
+  const [icon, setIcon] = useState<UnicodeEmojiData | CustomEmojiData | null>(
+    () => {
+      const emoji = mockCustomEmojis.find(
+        (emoji) => emoji.category === groupKey,
+      );
+      return emoji ?? null;
+    },
+  );
+
+  if (groupKey in groupKeysToNumber) {
+    const group = groupKeysToNumber[groupKey];
+    if (typeof group !== 'undefined') {
+      void loadUnicodeEmojiGroupIcon(group, currentLocale).then(setIcon);
+    }
+  }
+  return icon;
+}

--- a/app/javascript/mastodon/components/emoji/picker/info.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/info.tsx
@@ -1,0 +1,65 @@
+import { useCallback } from 'react';
+import type { FC } from 'react';
+
+import { IconButton } from '@/mastodon/components/icon_button';
+import type { AnyEmojiData } from '@/mastodon/features/emoji/types';
+import CloseIcon from '@/material-icons/400-24px/close.svg?react';
+import StarFilledIcon from '@/material-icons/400-24px/star-fill.svg?react';
+import StarIcon from '@/material-icons/400-24px/star.svg?react';
+
+import { Emoji } from '..';
+
+import { usePickerContext } from './constants';
+import classes from './styles.module.css';
+import { emojiToKey } from './utils';
+
+interface PickerEmojiInfoProps {
+  emoji: AnyEmojiData;
+  onClose: () => void;
+}
+
+export const PickerEmojiInfo: FC<PickerEmojiInfoProps> = ({
+  emoji,
+  onClose,
+}) => {
+  const { onSelect, onFavourite, favourites } = usePickerContext();
+  const emojiKey = emojiToKey(emoji, false);
+  const handleSelect = useCallback(() => {
+    onSelect(emojiKey);
+  }, [emojiKey, onSelect]);
+  const handleFavourite = useCallback(() => {
+    onFavourite(emojiKey);
+  }, [emojiKey, onFavourite]);
+
+  const label = 'label' in emoji ? emoji.label : `:${emoji.shortcode}:`;
+  const isFavourite = favourites.includes(emojiKey);
+  return (
+    <div className={classes.info}>
+      <button
+        type='button'
+        onClick={handleSelect}
+        className={classes.infoEmoji}
+      >
+        <Emoji
+          code={'unicode' in emoji ? emoji.unicode : `:${emoji.shortcode}:`}
+          key={emojiKey}
+        />
+      </button>
+      <IconButton
+        icon='star'
+        iconComponent={isFavourite ? StarFilledIcon : StarIcon}
+        onClick={handleFavourite}
+        title={isFavourite ? 'Remove from favourites' : 'Add to favourites'}
+      />
+      <div className={classes.infoLabel}>
+        <p>{label}</p>
+      </div>
+      <IconButton
+        icon='close'
+        iconComponent={CloseIcon}
+        onClick={onClose}
+        title='Close info'
+      />
+    </div>
+  );
+};

--- a/app/javascript/mastodon/components/emoji/picker/list.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/list.tsx
@@ -1,17 +1,11 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { FC, MouseEventHandler } from 'react';
 
 import classNames from 'classnames';
 
-import { fromUnicodeToHexcode } from 'emojibase';
-
-import {
-  loadEmojiByHexcode,
-  loadUnicodeEmojiGroup,
-} from '@/mastodon/features/emoji/database';
+import { loadUnicodeEmojiGroup } from '@/mastodon/features/emoji/database';
 import { useEmojiAppState } from '@/mastodon/features/emoji/mode';
 import type { AnyEmojiData } from '@/mastodon/features/emoji/types';
-import { isCustomEmoji } from '@/mastodon/features/emoji/utils';
 import ArrowIcon from '@/material-icons/400-24px/arrow_drop_down.svg?react';
 
 import { Emoji } from '..';
@@ -21,6 +15,7 @@ import {
   mockCustomEmojis,
   usePickerContext,
 } from './constants';
+import { useEmojisFromCodes } from './hooks';
 import classes from './styles.module.css';
 import { emojiToKey } from './utils';
 
@@ -54,111 +49,10 @@ export const PickerGroupCustomList: FC<
   PickerGroupListProps & { emojiKeys: string[] }
 > = ({ emojiKeys, ...props }) => {
   // Start the state with any custom emojis we already have.
-  const [emojis, setEmojis] = useState<AnyEmojiData[] | null>(() => {
-    const customEmojis = mockCustomEmojis.filter((emoji) =>
-      emojiKeys.includes(`:${emoji.shortcode}:`),
-    );
-    return customEmojis.length > 0 ? customEmojis : null;
-  });
-
-  // Determine which missing keys are Unicode and which are custom.
-  const [missingUnicodeKeys, missingCustomKeys] = useMemo(() => {
-    const emojisToKeys = emojis?.map((e) => emojiToKey(e)) ?? [];
-    const unicodeKeys = emojiKeys
-      .filter((key) => !isCustomEmoji(key))
-      .map((code) => fromUnicodeToHexcode(code))
-      .filter((code) => !emojisToKeys.includes(code));
-    const customKeys = emojiKeys.filter(
-      (key) => isCustomEmoji(key) && !emojisToKeys.includes(key),
-    );
-    return [unicodeKeys, customKeys];
-  }, [emojiKeys, emojis]);
-
-  // Next, load all Unicode emojis.
-  const { currentLocale } = useEmojiAppState();
-  const [loading, setLoading] = useState(false); // Use to avoid duplicate loads.
-  if (missingUnicodeKeys.length > 0 && !loading) {
-    setLoading(true);
-
-    void Promise.all(
-      missingUnicodeKeys.map((code) => loadEmojiByHexcode(code, currentLocale)),
-    ).then((unicodeEmojis) => {
-      setEmojis((prevEmojis) => {
-        setLoading(false);
-        return mergeNewEmojis(
-          prevEmojis ?? [],
-          unicodeEmojis.filter((e) => !!e),
-          emojiKeys,
-        );
-      });
-    });
-  }
-
-  // Finally, load all custom emojis that haven't been loaded yet.
-  if (missingCustomKeys.length > 0) {
-    setEmojis((prevEmojis) => {
-      const newCustomEmojis = mockCustomEmojis.filter((emoji) =>
-        missingCustomKeys.includes(`:${emoji.shortcode}:`),
-      );
-      return mergeNewEmojis(prevEmojis ?? [], newCustomEmojis, emojiKeys);
-    });
-  }
-
-  // If there is an emoji but no key, remove it.
-  if (emojis !== null && emojis.length > emojiKeys.length) {
-    setEmojis(
-      (prevEmojis) =>
-        prevEmojis?.filter((emoji) => emojiKeys.includes(emojiToKey(emoji))) ??
-        [],
-    );
-  }
-
-  // Finally, load all custom emojis that haven't been loaded yet.
-  if (missingCustomKeys.length > 0) {
-    setEmojis((prevEmojis) => {
-      const newCustomEmojis = mockCustomEmojis.filter((emoji) =>
-        missingCustomKeys.includes(`:${emoji.shortcode}:`),
-      );
-      return mergeNewEmojis(prevEmojis ?? [], newCustomEmojis, emojiKeys);
-    });
-  }
-
-  // If there is an emoji but no key, remove it.
-  if (emojis !== null && emojis.length > emojiKeys.length) {
-    setEmojis(
-      (prevEmojis) =>
-        prevEmojis?.filter((emoji) => emojiKeys.includes(emojiToKey(emoji))) ??
-        [],
-    );
-  }
+  const emojis = useEmojisFromCodes(emojiKeys);
 
   return <PickerGroupListInner emojis={emojis} {...props} />;
 };
-
-function mergeNewEmojis(
-  currentEmojis: AnyEmojiData[],
-  newEmojis: AnyEmojiData[],
-  emojiKeys: string[],
-): AnyEmojiData[] {
-  if (newEmojis.length === 0) {
-    return currentEmojis;
-  }
-  const allEmojis = new Map([
-    ...currentEmojis.map(
-      (emoji) => [emojiToKey(emoji), emoji] satisfies [string, AnyEmojiData],
-    ),
-    ...newEmojis.map(
-      (emoji) => [emojiToKey(emoji), emoji] satisfies [string, AnyEmojiData],
-    ),
-  ]);
-
-  return (
-    emojiKeys
-      .map((key) => allEmojis.get(fromUnicodeToHexcode(key)))
-      // Discard any missing emojis.
-      .filter((e) => !!e)
-  );
-}
 
 const PickerGroupListInner: FC<
   PickerGroupListProps & { emojis: AnyEmojiData[] | null }

--- a/app/javascript/mastodon/components/emoji/picker/list.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/list.tsx
@@ -10,7 +10,6 @@ import {
   loadUnicodeEmojiGroup,
 } from '@/mastodon/features/emoji/database';
 import { useEmojiAppState } from '@/mastodon/features/emoji/mode';
-import { emojiToUnicodeHex } from '@/mastodon/features/emoji/normalize';
 import type { AnyEmojiData } from '@/mastodon/features/emoji/types';
 import { isCustomEmoji } from '@/mastodon/features/emoji/utils';
 import ArrowIcon from '@/material-icons/400-24px/arrow_drop_down.svg?react';

--- a/app/javascript/mastodon/components/emoji/picker/list.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/list.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useState } from 'react';
+import type { FC, MouseEventHandler } from 'react';
+
+import classNames from 'classnames';
+
+import { loadUnicodeEmojiGroup } from '@/mastodon/features/emoji/database';
+import { useEmojiAppState } from '@/mastodon/features/emoji/mode';
+import type { AnyEmojiData } from '@/mastodon/features/emoji/types';
+import ArrowIcon from '@/material-icons/400-24px/arrow_drop_down.svg?react';
+
+import { Emoji } from '..';
+
+import { groupKeysToNumber, mockCustomEmojis } from './constants';
+import classes from './styles.module.css';
+
+interface PickerGroupListProps {
+  group: string;
+  name: string;
+  onSelect: (emoji: AnyEmojiData) => void;
+}
+
+export const PickerGroupList: FC<PickerGroupListProps> = ({
+  group,
+  name,
+  onSelect,
+}) => {
+  const [emojis, setEmojis] = useState<AnyEmojiData[] | null>(() => {
+    const emojis = mockCustomEmojis.filter((emoji) => emoji.category === group);
+    return emojis.length > 0 ? emojis : null;
+  });
+
+  const { currentLocale } = useEmojiAppState();
+  if (group in groupKeysToNumber && emojis === null) {
+    const groupNum = groupKeysToNumber[group];
+    if (typeof groupNum !== 'undefined') {
+      void loadUnicodeEmojiGroup(groupNum, currentLocale).then(setEmojis);
+    }
+  }
+
+  const [isMinimized, setMinimized] = useState(false);
+  const handleToggleMinimize = useCallback(() => {
+    setMinimized((prev) => !prev);
+  }, []);
+
+  // Still loading emojis.
+  if (emojis === null) {
+    return null;
+  }
+
+  return (
+    <div tabIndex={-1}>
+      <h2
+        className={classNames(
+          classes.groupHeader,
+          isMinimized && classes.isMinimized,
+        )}
+      >
+        <button type='button' onClick={handleToggleMinimize}>
+          {name}
+          <ArrowIcon className={classes.groupHeaderArrow} />
+        </button>
+      </h2>
+      {!isMinimized && (
+        <ul className={classes.emojiGrid}>
+          {emojis.map((emoji) => (
+            <PickerListEmoji
+              key={'unicode' in emoji ? emoji.hexcode : emoji.shortcode}
+              emoji={emoji}
+              onClick={onSelect}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+interface PickerListEmojiProps {
+  emoji: AnyEmojiData;
+  onClick: (emoji: AnyEmojiData) => void;
+}
+
+const PickerListEmoji: FC<PickerListEmojiProps> = ({ emoji, onClick }) => {
+  const handleClick: MouseEventHandler = useCallback(() => {
+    onClick(emoji);
+  }, [emoji, onClick]);
+  return (
+    <li>
+      <button
+        type='button'
+        title={'unicode' in emoji ? emoji.label : `:${emoji.shortcode}:`}
+        onClick={handleClick}
+        className={classes.listButton}
+      >
+        <Emoji
+          code={'unicode' in emoji ? emoji.unicode : `:${emoji.shortcode}:`}
+        />
+      </button>
+    </li>
+  );
+};

--- a/app/javascript/mastodon/components/emoji/picker/list.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/list.tsx
@@ -124,6 +124,15 @@ export const PickerGroupCustomList: FC<
     });
   }
 
+  // If there is an emoji but no key, remove it.
+  if (emojis !== null && emojis.length > emojiKeys.length) {
+    setEmojis(
+      (prevEmojis) =>
+        prevEmojis?.filter((emoji) => emojiKeys.includes(emojiToKey(emoji))) ??
+        [],
+    );
+  }
+
   return <PickerGroupListInner emojis={emojis} {...props} />;
 };
 

--- a/app/javascript/mastodon/components/emoji/picker/list.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/list.tsx
@@ -55,7 +55,7 @@ export const PickerGroupList: FC<PickerGroupListProps> = ({
           isMinimized && classes.isMinimized,
         )}
       >
-        <button type='button' onClick={handleToggleMinimize}>
+        <button type='button' onClick={handleToggleMinimize} data-group={group}>
           {name}
           <ArrowIcon className={classes.groupHeaderArrow} />
         </button>

--- a/app/javascript/mastodon/components/emoji/picker/list.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/list.tsx
@@ -10,6 +10,7 @@ import {
   loadUnicodeEmojiGroup,
 } from '@/mastodon/features/emoji/database';
 import { useEmojiAppState } from '@/mastodon/features/emoji/mode';
+import { emojiToUnicodeHex } from '@/mastodon/features/emoji/normalize';
 import type { AnyEmojiData } from '@/mastodon/features/emoji/types';
 import { isCustomEmoji } from '@/mastodon/features/emoji/utils';
 import ArrowIcon from '@/material-icons/400-24px/arrow_drop_down.svg?react';

--- a/app/javascript/mastodon/components/emoji/picker/list.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/list.tsx
@@ -114,6 +114,16 @@ export const PickerGroupCustomList: FC<
     );
   }
 
+  // Finally, load all custom emojis that haven't been loaded yet.
+  if (missingCustomKeys.length > 0) {
+    setEmojis((prevEmojis) => {
+      const newCustomEmojis = mockCustomEmojis.filter((emoji) =>
+        missingCustomKeys.includes(`:${emoji.shortcode}:`),
+      );
+      return mergeNewEmojis(prevEmojis ?? [], newCustomEmojis, emojiKeys);
+    });
+  }
+
   return <PickerGroupListInner emojis={emojis} {...props} />;
 };
 

--- a/app/javascript/mastodon/components/emoji/picker/list.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/list.tsx
@@ -3,9 +3,15 @@ import type { FC, MouseEventHandler } from 'react';
 
 import classNames from 'classnames';
 
-import { loadUnicodeEmojiGroup } from '@/mastodon/features/emoji/database';
+import {
+  loadUnicodeEmojiGroup,
+  searchEmojisByHexcodes,
+} from '@/mastodon/features/emoji/database';
 import { useEmojiAppState } from '@/mastodon/features/emoji/mode';
+import { emojiToUnicodeHex } from '@/mastodon/features/emoji/normalize';
 import type { AnyEmojiData } from '@/mastodon/features/emoji/types';
+import { isCustomEmoji } from '@/mastodon/features/emoji/utils';
+import { usePrevious } from '@/mastodon/hooks/usePrevious';
 import ArrowIcon from '@/material-icons/400-24px/arrow_drop_down.svg?react';
 
 import { Emoji } from '..';
@@ -21,8 +27,7 @@ interface PickerGroupListProps {
 
 export const PickerGroupList: FC<PickerGroupListProps> = ({
   group,
-  name,
-  onSelect,
+  ...props
 }) => {
   const [emojis, setEmojis] = useState<AnyEmojiData[] | null>(() => {
     const emojis = mockCustomEmojis.filter((emoji) => emoji.category === group);
@@ -37,13 +42,79 @@ export const PickerGroupList: FC<PickerGroupListProps> = ({
     }
   }
 
+  return <PickerGroupListInner group={group} emojis={emojis} {...props} />;
+};
+
+export const PickerGroupCustomList: FC<
+  PickerGroupListProps & { emojiKeys: string[] }
+> = ({ emojiKeys, ...props }) => {
+  // Start the state with any custom emojis we already have.
+  const [emojis, setEmojis] = useState<AnyEmojiData[] | null>(() => {
+    const customEmojis = mockCustomEmojis.filter((emoji) =>
+      emojiKeys.includes(`:${emoji.shortcode}:`),
+    );
+    return customEmojis.length > 0 ? customEmojis : null;
+  });
+
+  // Next, load all Unicode emojis.
+  const { currentLocale } = useEmojiAppState();
+  const prevKeyCount = usePrevious(emojiKeys.length) ?? null;
+  if (
+    prevKeyCount === null ||
+    (prevKeyCount !== emojiKeys.length &&
+      (emojis === null || emojis.length < emojiKeys.length))
+  ) {
+    // Convert to Unicode hex codes.
+    const unicodeKeys = emojiKeys
+      .filter((key) => !isCustomEmoji(key))
+      .map((code) => emojiToUnicodeHex(code));
+    if (unicodeKeys.length === 0) {
+      return;
+    }
+    void searchEmojisByHexcodes(unicodeKeys, currentLocale).then(
+      (unicodeEmojis) => {
+        if (emojis?.length === emojiKeys.length) {
+          return;
+        }
+        // Combine custom and Unicode emojis based on the original key order.
+        setEmojis((prevEmojis) => {
+          const combinedEmojis = prevEmojis ?? [];
+
+          return (
+            emojiKeys
+              .map((key) => {
+                if (isCustomEmoji(key)) {
+                  return combinedEmojis.find(
+                    (e) => 'shortcode' in e && e.shortcode === key.slice(1, -1),
+                  );
+                }
+                return (
+                  unicodeEmojis.find(
+                    (e) => e.hexcode === emojiToUnicodeHex(key),
+                  ) ?? null
+                );
+              })
+              // Discard any unknown emojis.
+              .filter((e): e is AnyEmojiData => !!e)
+          );
+        });
+      },
+    );
+  }
+
+  return <PickerGroupListInner emojis={emojis} {...props} />;
+};
+
+const PickerGroupListInner: FC<
+  PickerGroupListProps & { emojis: AnyEmojiData[] | null }
+> = ({ group, name, onSelect, emojis }) => {
   const [isMinimized, setMinimized] = useState(false);
   const handleToggleMinimize = useCallback(() => {
     setMinimized((prev) => !prev);
   }, []);
 
-  // Still loading emojis.
-  if (emojis === null) {
+  // If loaded and there are no emojis, don't render the group at all.
+  if (emojis !== null && emojis.length === 0) {
     return null;
   }
 
@@ -60,7 +131,7 @@ export const PickerGroupList: FC<PickerGroupListProps> = ({
           <ArrowIcon className={classes.groupHeaderArrow} />
         </button>
       </h2>
-      {!isMinimized && (
+      {!isMinimized && emojis !== null && (
         <ul className={classes.emojiGrid}>
           {emojis.map((emoji) => (
             <PickerListEmoji

--- a/app/javascript/mastodon/components/emoji/picker/settings.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/settings.tsx
@@ -1,28 +1,43 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { ChangeEventHandler, FC } from 'react';
 
+import { IconButton } from '@/mastodon/components/icon_button';
 import CloseIcon from '@/material-icons/400-24px/close.svg?react';
 
-import { IconButton } from '../../icon_button';
+import { Emoji } from '..';
 
-import type { SkinTone } from './constants';
-import { toneToEmoji } from './constants';
+import type { CustomGroupMessage, SkinTone } from './constants';
+import {
+  mockCustomEmojis,
+  mockCustomGroups,
+  toneToEmoji,
+  usePickerContext,
+} from './constants';
 import { useLocaleMessages } from './hooks';
 import classes from './styles.module.css';
 
 interface PickerSettingsProps {
   onClose: () => void;
   onSkinToneChange?: (skinTone: SkinTone) => void;
+  onClearRecentlyUsed: () => void;
+  onToggleHiddenGroup: (group: string) => void;
 }
 
 export const PickerSettings: FC<PickerSettingsProps> = ({
   onClose,
   onSkinToneChange,
+  onToggleHiddenGroup,
+  onClearRecentlyUsed,
 }) => {
+  const [editHidden, setEditHidden] = useState(false);
+  const handleEditHiddenClick = useCallback(() => {
+    setEditHidden((prev) => !prev);
+  }, []);
+
   return (
     <>
       <div className={classes.header}>
-        <h2 className={classes.headerTitle}>Emoji Picker Settings</h2>
+        <h2>Emoji Picker Settings</h2>
         <IconButton
           icon='close'
           iconComponent={CloseIcon}
@@ -31,10 +46,25 @@ export const PickerSettings: FC<PickerSettingsProps> = ({
         />
       </div>
       <div className={classes.settings}>
-        <fieldset>
-          <legend>Skin tone</legend>
-          <SkinToneSelector onSkinToneChange={onSkinToneChange} />
-        </fieldset>
+        {!editHidden ? (
+          <>
+            <fieldset>
+              <legend>Skin tone</legend>
+              <SkinToneSelector onSkinToneChange={onSkinToneChange} />
+            </fieldset>
+            <button type='button' onClick={handleEditHiddenClick}>
+              Edit hidden groups
+            </button>
+            <button type='button' onClick={onClearRecentlyUsed}>
+              Reset recently used
+            </button>
+          </>
+        ) : (
+          <HiddenGroupsSelector
+            onClose={handleEditHiddenClick}
+            onToggleHiddenGroup={onToggleHiddenGroup}
+          />
+        )}
       </div>
     </>
   );
@@ -80,5 +110,59 @@ const SkinToneSelector: FC<Pick<PickerSettingsProps, 'onSkinToneChange'>> = ({
         />
       ))}
     </div>
+  );
+};
+
+const HiddenGroupsSelector: FC<
+  Pick<PickerSettingsProps, 'onToggleHiddenGroup'> & { onClose: () => void }
+> = ({ onClose, onToggleHiddenGroup }) => {
+  return (
+    <fieldset>
+      <legend className={classes.hiddenGroupHeader}>
+        <span>Uncheck to hide groups</span>
+        <button type='button' onClick={onClose}>
+          Go back
+        </button>
+      </legend>
+      <ul>
+        {mockCustomGroups.map((group) => (
+          <HiddenGroupItem
+            group={group}
+            key={group.key}
+            onToggleHiddenGroup={onToggleHiddenGroup}
+          />
+        ))}
+      </ul>
+    </fieldset>
+  );
+};
+
+const HiddenGroupItem: FC<
+  Pick<PickerSettingsProps, 'onToggleHiddenGroup'> & {
+    group: CustomGroupMessage;
+  }
+> = ({ group, onToggleHiddenGroup }) => {
+  const groupEmoji = useMemo(
+    () => mockCustomEmojis.find((e) => e.category === group.key),
+    [group],
+  );
+  const handleToggle = useCallback(() => {
+    onToggleHiddenGroup(group.key);
+  }, [onToggleHiddenGroup, group.key]);
+
+  const { hiddenGroups } = usePickerContext();
+
+  return (
+    <li key={group.key}>
+      <label className={classes.hiddenGroupItem}>
+        <input
+          type='checkbox'
+          onChange={handleToggle}
+          checked={!hiddenGroups.includes(group.key)}
+        />
+        <Emoji code={`:${groupEmoji?.shortcode}:`} />
+        {group.message}
+      </label>
+    </li>
   );
 };

--- a/app/javascript/mastodon/components/emoji/picker/settings.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/settings.tsx
@@ -1,0 +1,36 @@
+import type { FC } from 'react';
+
+import type { SkinToneKey } from 'emojibase';
+
+import { useLocaleMessages } from './hooks';
+import classes from './styles.module.css';
+
+const toneToEmoji: Record<SkinToneKey, string> = {
+  light: '👋🏻',
+  'medium-light': '👋🏼',
+  medium: '👋🏽',
+  'medium-dark': '👋🏾',
+  dark: '👋🏿',
+};
+
+export const PickerSettings: FC = () => {
+  const { skinTones } = useLocaleMessages();
+  return (
+    <div className={classes.main}>
+      <h1>Emoji Settings</h1>
+      <label>
+        <select>
+          <option value='default' title='Default skin tone'>
+            👋
+          </option>
+          {skinTones.map((tone) => (
+            <option key={tone.key} value={tone.key} title={tone.message}>
+              {toneToEmoji[tone.key]}
+            </option>
+          ))}
+        </select>{' '}
+        Skin tone
+      </label>
+    </div>
+  );
+};

--- a/app/javascript/mastodon/components/emoji/picker/settings.tsx
+++ b/app/javascript/mastodon/components/emoji/picker/settings.tsx
@@ -1,36 +1,84 @@
-import type { FC } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import type { ChangeEventHandler, FC } from 'react';
 
-import type { SkinToneKey } from 'emojibase';
+import CloseIcon from '@/material-icons/400-24px/close.svg?react';
 
+import { IconButton } from '../../icon_button';
+
+import type { SkinTone } from './constants';
+import { toneToEmoji } from './constants';
 import { useLocaleMessages } from './hooks';
 import classes from './styles.module.css';
 
-const toneToEmoji: Record<SkinToneKey, string> = {
-  light: '👋🏻',
-  'medium-light': '👋🏼',
-  medium: '👋🏽',
-  'medium-dark': '👋🏾',
-  dark: '👋🏿',
+interface PickerSettingsProps {
+  onClose: () => void;
+  onSkinToneChange?: (skinTone: SkinTone) => void;
+}
+
+export const PickerSettings: FC<PickerSettingsProps> = ({
+  onClose,
+  onSkinToneChange,
+}) => {
+  return (
+    <>
+      <div className={classes.header}>
+        <h2 className={classes.headerTitle}>Emoji Picker Settings</h2>
+        <IconButton
+          icon='close'
+          iconComponent={CloseIcon}
+          title='Close settings'
+          onClick={onClose}
+        />
+      </div>
+      <div className={classes.settings}>
+        <fieldset>
+          <legend>Skin tone</legend>
+          <SkinToneSelector onSkinToneChange={onSkinToneChange} />
+        </fieldset>
+      </div>
+    </>
+  );
 };
 
-export const PickerSettings: FC = () => {
+const SkinToneSelector: FC<Pick<PickerSettingsProps, 'onSkinToneChange'>> = ({
+  onSkinToneChange,
+}) => {
+  const [skinTone, setSkinTone] = useState<SkinTone>('default');
   const { skinTones } = useLocaleMessages();
+  const toneMessages = useMemo(() => {
+    return Object.entries(toneToEmoji).map(([key, emoji]) => ({
+      key,
+      emoji,
+      message: skinTones.find((tone) => tone.key === key)?.message ?? key,
+    }));
+  }, [skinTones]);
+
+  const handleSkinToneChange: ChangeEventHandler<HTMLInputElement> =
+    useCallback(
+      (event) => {
+        const tone = event.currentTarget.value;
+        if (tone === 'default' || tone in toneToEmoji) {
+          setSkinTone(tone as SkinTone);
+          onSkinToneChange?.(tone as SkinTone);
+        }
+      },
+      [onSkinToneChange],
+    );
+
   return (
-    <div className={classes.main}>
-      <h1>Emoji Settings</h1>
-      <label>
-        <select>
-          <option value='default' title='Default skin tone'>
-            👋
-          </option>
-          {skinTones.map((tone) => (
-            <option key={tone.key} value={tone.key} title={tone.message}>
-              {toneToEmoji[tone.key]}
-            </option>
-          ))}
-        </select>{' '}
-        Skin tone
-      </label>
+    <div className={classes.skinTonesWrapper}>
+      {toneMessages.map((tone) => (
+        <input
+          type='radio'
+          name='skin-tone'
+          key={tone.key}
+          value={tone.key}
+          title={tone.message}
+          checked={skinTone === tone.key}
+          onChange={handleSkinToneChange}
+          data-emoji={tone.emoji}
+        />
+      ))}
     </div>
   );
 };

--- a/app/javascript/mastodon/components/emoji/picker/styles.module.css
+++ b/app/javascript/mastodon/components/emoji/picker/styles.module.css
@@ -63,6 +63,7 @@
 
 .main {
   grid-area: 2 / 2 / 3 / 3;
+  position: relative;
 }
 
 .groupHeader {
@@ -158,6 +159,40 @@
   height: 1px;
   background-color: gray;
   flex-shrink: 0;
+}
+
+.info {
+  --emoji-size: 3rem;
+
+  position: sticky;
+  bottom: -0.5rem;
+  left: -0.5rem;
+  margin: -0.5rem;
+  width: calc(100% + 1rem);
+  background-color: lightgray;
+  padding: 0.5rem 0.5rem 0 0;
+  display: flex;
+  align-items: start;
+  gap: 0.5rem;
+
+  > button {
+    color: gray;
+  }
+}
+
+.infoEmoji {
+  width: var(--emoji-size);
+  height: var(--emoji-size);
+  font-size: calc(var(--emoji-size) - 1rem);
+
+  > img {
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.infoLabel {
+  flex-grow: 1;
 }
 
 .settings {

--- a/app/javascript/mastodon/components/emoji/picker/styles.module.css
+++ b/app/javascript/mastodon/components/emoji/picker/styles.module.css
@@ -1,18 +1,15 @@
 .wrapper {
-  --max-width: 20rem;
-  --col-count: 6;
-
   display: grid;
   gap: 0.5rem;
   grid-template-rows: auto 1fr;
-  grid-template-columns: 2rem minmax(10rem, calc(var(--max-width) - 4rem));
+  grid-template-columns: 2rem auto;
   background-color: lightgray;
   padding: 0.5rem;
   border-radius: 0.25rem;
   width: 100%;
-  max-width: var(--max-width);
   max-height: 50vh;
   box-sizing: border-box;
+  min-width: 250px;
 
   :global(.emojione) {
     margin: 0;
@@ -97,7 +94,7 @@
 
 .emojiGrid {
   display: grid;
-  grid-template-columns: repeat(var(--col-count), 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(2rem, 1fr));
   gap: 0.5rem;
 }
 

--- a/app/javascript/mastodon/components/emoji/picker/styles.module.css
+++ b/app/javascript/mastodon/components/emoji/picker/styles.module.css
@@ -157,11 +157,6 @@
   height: 2rem;
   border-radius: 50%;
   border: 1px solid gray;
-
-  .settingsNav & {
-    opacity: 0.5;
-    pointer-events: none;
-  }
 }
 
 .separator {

--- a/app/javascript/mastodon/components/emoji/picker/styles.module.css
+++ b/app/javascript/mastodon/components/emoji/picker/styles.module.css
@@ -1,0 +1,72 @@
+.wrapper {
+  --max-width: 20rem;
+
+  display: grid;
+  gap: 0.5rem;
+  grid-template-rows: auto 1fr;
+  grid-template-columns: 2rem minmax(10rem, calc(var(--max-width) - 4rem));
+  background-color: lightgray;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  width: 100%;
+  max-width: var(--max-width);
+  max-height: 50vh;
+  box-sizing: border-box;
+
+  * {
+    box-sizing: border-box;
+  }
+}
+
+.header {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  grid-area: 1 / 1 / 1 / 3;
+
+  svg {
+    color: gray;
+  }
+}
+
+.search {
+  flex-grow: 1;
+  appearance: none;
+  border: 1px solid gray;
+  border-radius: 0.25rem;
+  height: 100%;
+  padding: 0.25rem 0.5rem;
+}
+
+.main {
+  grid-area: 2 / 2 / 3 / 3;
+  border-radius: 0.25rem;
+  background-color: whitesmoke;
+  overflow: hidden auto;
+  scrollbar-width: thin;
+  padding: 0.5rem;
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  grid-area: 2 / 1 / 3 / 1;
+  overflow: hidden scroll;
+  scrollbar-width: none;
+}
+
+.groupButton {
+  border-radius: 50%;
+  aspect-ratio: 1;
+  border: 1px solid gray;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+}
+
+.separator {
+  height: 1px;
+  background-color: gray;
+  flex-shrink: 0;
+}

--- a/app/javascript/mastodon/components/emoji/picker/styles.module.css
+++ b/app/javascript/mastodon/components/emoji/picker/styles.module.css
@@ -157,6 +157,11 @@
   height: 2rem;
   border-radius: 50%;
   border: 1px solid gray;
+
+  .settingsNav & {
+    opacity: 0.5;
+    pointer-events: none;
+  }
 }
 
 .separator {

--- a/app/javascript/mastodon/components/emoji/picker/styles.module.css
+++ b/app/javascript/mastodon/components/emoji/picker/styles.module.css
@@ -63,6 +63,10 @@
   width: 2rem;
   height: 2rem;
   padding: 0;
+
+  > * {
+    pointer-events: none;
+  }
 }
 
 .separator {

--- a/app/javascript/mastodon/components/emoji/picker/styles.module.css
+++ b/app/javascript/mastodon/components/emoji/picker/styles.module.css
@@ -71,7 +71,7 @@
   margin-bottom: 0.5rem;
   transition: opacity 0.1s ease;
 
-  &:not(.isMinimized):hover {
+  &:hover {
     opacity: 0.7;
   }
 
@@ -85,10 +85,6 @@
     align-items: center;
     width: 100%;
   }
-}
-
-.groupHeader.isMinimized {
-  opacity: 0.5;
 }
 
 .groupHeaderArrow {

--- a/app/javascript/mastodon/components/emoji/picker/styles.module.css
+++ b/app/javascript/mastodon/components/emoji/picker/styles.module.css
@@ -1,5 +1,6 @@
 .wrapper {
   --max-width: 20rem;
+  --col-count: 6;
 
   display: grid;
   gap: 0.5rem;
@@ -92,7 +93,7 @@
 
 .emojiGrid {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(var(--col-count), 1fr);
   gap: 0.5rem;
 }
 
@@ -145,6 +146,11 @@
   height: 2rem;
   border-radius: 50%;
   border: 1px solid gray;
+
+  .settingsNav & {
+    opacity: 0.5;
+    pointer-events: none;
+  }
 }
 
 .separator {

--- a/app/javascript/mastodon/components/emoji/picker/styles.module.css
+++ b/app/javascript/mastodon/components/emoji/picker/styles.module.css
@@ -25,14 +25,23 @@
   gap: 0.5rem;
   align-items: center;
   grid-area: 1 / 1 / 1 / 3;
+  color: gray;
 
-  svg {
-    color: gray;
+  .search,
+  h2 {
+    flex-grow: 1;
+  }
+
+  h2 {
+    font-size: 1.25em;
+  }
+
+  button {
+    color: inherit;
   }
 }
 
 .search {
-  flex-grow: 1;
   appearance: none;
   border: 1px solid gray;
   border-radius: 0.25rem;
@@ -163,17 +172,14 @@
   }
 }
 
-.headerTitle {
-  flex-grow: 1;
-  color: gray;
-  font-size: 1.25em;
-}
-
 .skinTonesWrapper {
+  --max-button-size: 3rem;
+
   display: flex;
   gap: 0.5rem;
   justify-content: space-between;
   font-size: 1.5rem;
+  max-width: calc(var(--max-button-size) * 6 + 0.5rem * 5);
 
   input {
     appearance: none;
@@ -188,7 +194,8 @@
     border: 1px solid gray;
     line-height: 100%;
     cursor: pointer;
-    min-width: 2.5em;
+    width: 100%;
+    max-width: var(--max-button-size);
   }
 
   input:checked {
@@ -202,4 +209,29 @@
     font-size: 1.5em;
     line-height: 1;
   }
+}
+
+.hiddenGroupHeader {
+  display: flex;
+  gap: 0.5rem;
+  width: 100%;
+
+  span {
+    flex-grow: 1;
+  }
+
+  button {
+    font-size: 0.75em;
+  }
+}
+
+.hiddenGroupItem {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  cursor: pointer;
+  margin-bottom: 0.25rem;
+  background: lightgray;
+  border-radius: 0.25rem;
+  padding: 0.25rem;
 }

--- a/app/javascript/mastodon/components/emoji/picker/styles.module.css
+++ b/app/javascript/mastodon/components/emoji/picker/styles.module.css
@@ -49,6 +49,86 @@
   overflow: hidden auto;
   scrollbar-width: thin;
   padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.groupHeader {
+  font-size: 1rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  transition: opacity 0.1s ease;
+
+  &:not(.isMinimized):hover {
+    opacity: 0.7;
+  }
+
+  button {
+    appearance: none;
+    border: none;
+    background-color: transparent;
+    padding: 0;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+  }
+}
+
+.groupHeader.isMinimized {
+  opacity: 0.5;
+}
+
+.groupHeaderArrow {
+  transition: transform 0.1s ease;
+  width: 1rem;
+  height: 1rem;
+}
+
+.isMinimized .groupHeaderArrow {
+  transform: rotate(-90deg);
+}
+
+.emojiGrid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.5rem;
+}
+
+.listButton,
+.groupButton {
+  aspect-ratio: 1;
+  padding: 0;
+  appearance: none;
+  display: block;
+
+  > * {
+    pointer-events: none;
+  }
+}
+
+.listButton {
+  border: none;
+  background-color: transparent;
+  font-size: 1.5rem;
+  text-align: center;
+  width: 100%;
+  border-radius: 5px;
+  transition: background-color 0.1s ease;
+
+  &:hover {
+    background-color: gray;
+  }
+
+  > img {
+    padding: 5px;
+  }
+
+  > * {
+    width: 100%;
+    height: 100%;
+  }
 }
 
 .nav {
@@ -61,16 +141,10 @@
 }
 
 .groupButton {
-  border-radius: 50%;
-  aspect-ratio: 1;
-  border: 1px solid gray;
   width: 2rem;
   height: 2rem;
-  padding: 0;
-
-  > * {
-    pointer-events: none;
-  }
+  border-radius: 50%;
+  border: 1px solid gray;
 }
 
 .separator {

--- a/app/javascript/mastodon/components/emoji/picker/styles.module.css
+++ b/app/javascript/mastodon/components/emoji/picker/styles.module.css
@@ -15,6 +15,10 @@
     margin: 0;
   }
 
+  :global(.emojione) {
+    margin: 0;
+  }
+
   * {
     box-sizing: border-box;
   }

--- a/app/javascript/mastodon/components/emoji/picker/styles.module.css
+++ b/app/javascript/mastodon/components/emoji/picker/styles.module.css
@@ -43,8 +43,8 @@
   padding: 0.25rem 0.5rem;
 }
 
-.main {
-  grid-area: 2 / 2 / 3 / 3;
+.main,
+.settings {
   border-radius: 0.25rem;
   background-color: whitesmoke;
   overflow: hidden auto;
@@ -53,6 +53,10 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.main {
+  grid-area: 2 / 2 / 3 / 3;
 }
 
 .groupHeader {
@@ -146,15 +150,59 @@
   height: 2rem;
   border-radius: 50%;
   border: 1px solid gray;
-
-  .settingsNav & {
-    opacity: 0.5;
-    pointer-events: none;
-  }
 }
 
 .separator {
   height: 1px;
   background-color: gray;
   flex-shrink: 0;
+}
+
+.settings {
+  grid-area: 2 / 1 / 3 / 3;
+
+  legend {
+    margin-bottom: 0.5rem;
+  }
+}
+
+.headerTitle {
+  flex-grow: 1;
+  color: gray;
+  font-size: 1.25em;
+}
+
+.skinTonesWrapper {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+  font-size: 1.5rem;
+
+  input {
+    appearance: none;
+    background: none;
+    margin: 0;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    border: 1px solid gray;
+    line-height: 100%;
+    cursor: pointer;
+    min-width: 2.5em;
+  }
+
+  input:checked {
+    border-color: black;
+    background-color: lightgray;
+  }
+
+  input::before {
+    content: attr(data-emoji);
+    display: block;
+    font-size: 1.5em;
+    line-height: 1;
+  }
 }

--- a/app/javascript/mastodon/components/emoji/picker/styles.module.css
+++ b/app/javascript/mastodon/components/emoji/picker/styles.module.css
@@ -13,6 +13,10 @@
   max-height: 50vh;
   box-sizing: border-box;
 
+  :global(.emojione) {
+    margin: 0;
+  }
+
   * {
     box-sizing: border-box;
   }

--- a/app/javascript/mastodon/components/emoji/picker/utils.ts
+++ b/app/javascript/mastodon/components/emoji/picker/utils.ts
@@ -1,0 +1,8 @@
+import type { AnyEmojiData } from '@/mastodon/features/emoji/types';
+
+export function emojiToKey(emoji: AnyEmojiData, hexcode = true): string {
+  if ('shortcode' in emoji) {
+    return `:${emoji.shortcode}:`;
+  }
+  return hexcode ? emoji.hexcode : emoji.unicode;
+}

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -312,21 +312,11 @@ export async function loadUnicodeEmojiGroupIcon(
 ) {
   const locale = toLoadedLocale(localeString);
   const db = await loadDB();
-  const trx = db.transaction(locale);
-  const index = trx.store.index('group');
-  let first: UnicodeEmojiData | null = null;
-  for await (const cursor of index.iterate(group)) {
-    if (!first) {
-      first = cursor.value;
-    } else if (
-      cursor.value.order &&
-      first.order &&
-      cursor.value.order < first.order
-    ) {
-      first = cursor.value;
-    }
-  }
-  return first;
+  const trx = db.transaction(locale, 'readonly');
+  const index = trx.store.index('groupOrder');
+  const range = IDBKeyRange.bound([group, 0], [group, Number.MAX_SAFE_INTEGER]);
+  const cursor = await index.openCursor(range);
+  return cursor?.value ?? null;
 }
 
 // Private functions

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -296,6 +296,29 @@ export async function loadLatestEtag(localeString: string) {
   return etag ?? null;
 }
 
+export async function loadUnicodeEmojiGroupIcon(
+  group: number,
+  localeString: string,
+) {
+  const locale = toLoadedLocale(localeString);
+  const db = await loadDB();
+  const trx = db.transaction(locale);
+  const index = trx.store.index('group');
+  let first: UnicodeEmojiData | null = null;
+  for await (const cursor of index.iterate(group)) {
+    if (!first) {
+      first = cursor.value;
+    } else if (
+      cursor.value.order &&
+      first.order &&
+      cursor.value.order < first.order
+    ) {
+      first = cursor.value;
+    }
+  }
+  return first;
+}
+
 // Private functions
 
 async function syncLocales(db: Database) {

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -296,6 +296,16 @@ export async function loadLatestEtag(localeString: string) {
   return etag ?? null;
 }
 
+export async function loadUnicodeEmojiGroup(
+  group: number,
+  localeString: string,
+) {
+  const locale = toLoadedLocale(localeString);
+  const db = await loadDB();
+  const emojis = await db.getAllFromIndex(locale, 'group', group);
+  return emojis.toSorted(({ order: a = 0 }, { order: b = 0 }) => a - b);
+}
+
 export async function loadUnicodeEmojiGroupIcon(
   group: number,
   localeString: string,

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -18,7 +18,7 @@ import {
   transformEmojiData,
 } from './normalize';
 import type { AnyEmojiData, EtagTypes } from './types';
-import { emojiLogger } from './utils';
+import { emojiLogger, isCustomEmoji } from './utils';
 
 const loadedLocales = new Set<Locale>();
 
@@ -265,6 +265,18 @@ export async function searchCustomEmojisByShortcodes(shortcodes: string[]) {
     IDBKeyRange.bound(sortedCodes.at(0), sortedCodes.at(-1)),
   );
   return results.filter((emoji) => shortcodes.includes(emoji.shortcode));
+}
+
+export async function loadEmojisByCodes(codes: string[], localeString: string) {
+  const locale = await toLoadedLocale(localeString);
+  const results = await Promise.all(
+    codes.map((code) =>
+      isCustomEmoji(code)
+        ? loadCustomEmojiByShortcode(code)
+        : loadEmojiByHexcode(code, locale),
+    ),
+  );
+  return results.filter((emoji): emoji is AnyEmojiData => !!emoji);
 }
 
 export async function loadLegacyShortcodesByShortcode(shortcode: string) {

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -300,9 +300,10 @@ export async function loadUnicodeEmojiGroup(
   group: number,
   localeString: string,
 ) {
-  const locale = toLoadedLocale(localeString);
+  const locale = await toLoadedLocale(localeString);
   const db = await loadDB();
-  const emojis = await db.getAllFromIndex(locale, 'group', group);
+  const range = IDBKeyRange.bound([group, 0], [group, Number.MAX_SAFE_INTEGER]);
+  const emojis = await db.getAllFromIndex(locale, 'groupOrder', range);
   return emojis.toSorted(({ order: a = 0 }, { order: b = 0 }) => a - b);
 }
 
@@ -310,7 +311,7 @@ export async function loadUnicodeEmojiGroupIcon(
   group: number,
   localeString: string,
 ) {
-  const locale = toLoadedLocale(localeString);
+  const locale = await toLoadedLocale(localeString);
   const db = await loadDB();
   const trx = db.transaction(locale, 'readonly');
   const index = trx.store.index('groupOrder');

--- a/app/javascript/testing/api.ts
+++ b/app/javascript/testing/api.ts
@@ -1,8 +1,5 @@
-import type { CompactEmoji } from 'emojibase';
 import { http, HttpResponse } from 'msw';
 import { action } from 'storybook/actions';
-
-import { toSupportedLocale } from '@/mastodon/features/emoji/locale';
 
 import { customEmojiFactory, relationshipsFactory } from './factories';
 
@@ -47,21 +44,6 @@ export const mockHandlers = {
     action('fetching custom emoji data')();
     return HttpResponse.json([customEmojiFactory()]);
   }),
-  emojiData: http.get<{ locale: string }>(
-    '/packs-dev/emoji/:locale.json',
-    async ({ params }) => {
-      const locale = toSupportedLocale(params.locale);
-      action('fetching emoji data')(locale);
-      const { default: data } = (await import(
-        /* @vite-ignore */
-        `emojibase-data/${locale}/compact.json`
-      )) as {
-        default: CompactEmoji[];
-      };
-
-      return HttpResponse.json([data]);
-    },
-  ),
 };
 
 export const unhandledRequestHandler = ({ url }: Request) => {

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -43,7 +43,7 @@ module.exports = {
       },
     },
     {
-      'files': ['app/javascript/**/*.module.scss', 'app/javascript/**/*.module.css'],
+      files: ['app/javascript/**/*.module.scss', 'app/javascript/**/*.module.css'],
       rules: {
         'selector-pseudo-class-no-unknown': [
           true,

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -43,13 +43,13 @@ module.exports = {
       },
     },
     {
-      files: ['app/javascript/**/*.module.scss'],
+      'files': ['app/javascript/**/*.module.scss', 'app/javascript/**/*.module.css'],
       rules: {
         'selector-pseudo-class-no-unknown': [
           true,
           { ignorePseudoClasses: ['global'] },
-        ]
+        ],
       }
-    },
+    }
   ],
 };


### PR DESCRIPTION
⚠️ DO NOT MERGE! ⚠️

Fixes MAS-645.

This is an experiment for mocking a basic emoji picker utilizing the work in 4.5. This is not final and not for production: the styles are all wrong and all functionality is not implemented.

[Click here](https://684157922c67cb435d550a35-hinopvytam.chromatic.com/?path=/story/components-emoji-emojipicker--default) to view the interactive component inside Storybook.

Current features:
- Shows quick emoji group sidebar that allows scrolling to a specific group.
- Groups have default icon selected.
- Groups can be minimized to get them out of the way.
- Settings area with skin tone picker.
- Auto-focus search input on mount.

<img width="668" height="674" alt="Screenshot 2025-11-13 at 16 20 35" src="https://github.com/user-attachments/assets/37c1dd2b-b13d-4058-9057-1d56a463a06e" />

<img width="650" height="658" alt="Screenshot 2025-11-13 at 16 29 46" src="https://github.com/user-attachments/assets/2b38f429-a53a-445e-aea3-d46ddf759b19" />
