### PR TITLE
Fix the translation of "Latvian"

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -100,7 +100,7 @@ module LanguagesHelper
     lo: ['Lao', 'ລາວ'].freeze,
     lt: ['Lithuanian', 'lietuvių kalba'].freeze,
     lu: ['Luba-Katanga', 'Tshiluba'].freeze,
-    lv: ['Latvian', 'latviešu valoda'].freeze,
+    lv: ['Latvian', 'Latviski'].freeze,
     mg: ['Malagasy', 'fiteny malagasy'].freeze,
     mh: ['Marshallese', 'Kajin M̧ajeļ'].freeze,
     mi: ['Māori', 'te reo Māori'].freeze,


### PR DESCRIPTION
"latviešu valoda" is also correct, but in the context of how it's used in Mastodon UI, "Latviski" fits in and sounds better