### PR TITLE
Fix error with remote tags including percent signs

### DIFF
--- a/app/javascript/mastodon/components/status/handled_link.tsx
+++ b/app/javascript/mastodon/components/status/handled_link.tsx
@@ -27,12 +27,14 @@ export const HandledLink: FC<HandledLinkProps & ComponentProps<'a'>> = ({
 }) => {
   // Handle hashtags
   if (
-    text.startsWith('#') ||
-    prevText?.endsWith('#') ||
-    text.startsWith('＃') ||
-    prevText?.endsWith('＃')
+    (text.startsWith('#') ||
+      prevText?.endsWith('#') ||
+      text.startsWith('＃') ||
+      prevText?.endsWith('＃')) &&
+    !text.includes('%')
   ) {
     const hashtag = text.slice(1).trim();
+
     return (
       <Link
         className={classNames('mention hashtag', className)}
@@ -69,7 +71,7 @@ export const HandledLink: FC<HandledLinkProps & ComponentProps<'a'>> = ({
   return (
     <a
       {...props}
-      href={href}
+      href={encodeURI(href)}
       title={href}
       className={classNames('unhandled-link', className)}
       target='_blank'


### PR DESCRIPTION
Fixes #36828.

as the backend doesn't handle percent signs anyway, this PR ensures tags with the `%` character is treated as an unhandled link, and the URI is encoded to open correctly.