### PR TITLE
Rely on locale for options order in DOB input

### DIFF
--- a/app/inputs/date_of_birth_input.rb
+++ b/app/inputs/date_of_birth_input.rb
@@ -1,31 +1,49 @@
 # frozen_string_literal: true
 
 class DateOfBirthInput < SimpleForm::Inputs::Base
-  OPTIONS = [
-    { autocomplete: 'bday-year', maxlength: 4, pattern: '[0-9]+', placeholder: 'YYYY' }.freeze,
-    { autocomplete: 'bday-month', maxlength: 2, pattern: '[0-9]+', placeholder: 'MM' }.freeze,
-    { autocomplete: 'bday-day', maxlength: 2, pattern: '[0-9]+', placeholder: 'DD' }.freeze,
-  ].freeze
+  OPTIONS = {
+    day: { autocomplete: 'bday-day', maxlength: 2, pattern: '[0-9]+', placeholder: 'DD' },
+    month: { autocomplete: 'bday-month', maxlength: 2, pattern: '[0-9]+', placeholder: 'MM' },
+    year: { autocomplete: 'bday-year', maxlength: 4, pattern: '[0-9]+', placeholder: 'YYYY' },
+  }.freeze
 
   def input(wrapper_options = nil)
     merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
     merged_input_options[:inputmode] = 'numeric'
 
-    values = (object.public_send(attribute_name) || '').to_s.split('-')
-
-    safe_join(2.downto(0).map do |index|
-      options = merged_input_options.merge(OPTIONS[index]).merge id: generate_id(index), 'aria-label': I18n.t("simple_form.labels.user.date_of_birth_#{index + 1}i"), value: values[index]
-      @builder.text_field("#{attribute_name}(#{index + 1}i)", options)
-    end)
+    safe_join(
+      ordered_options.map do |option|
+        options = merged_input_options
+          .merge(OPTIONS[option])
+          .merge(
+            id: generate_id(option),
+            'aria-label': I18n.t("simple_form.labels.user.date_of_birth_#{param_for(option)}"),
+            value: values[option]
+          )
+        @builder.text_field("#{attribute_name}(#{param_for(option)})", options)
+      end
+    )
   end
 
   def label_target
-    "#{attribute_name}_3i"
+    "#{attribute_name}_#{param_for(ordered_options.first)}"
   end
 
   private
 
-  def generate_id(index)
-    "#{object_name}_#{attribute_name}_#{index + 1}i"
+  def ordered_options
+    I18n.t('date.order').map(&:to_sym)
+  end
+
+  def generate_id(option)
+    "#{object_name}_#{attribute_name}_#{param_for(option)}"
+  end
+
+  def param_for(option)
+    "#{ActionView::Helpers::DateTimeSelector::POSITION[option]}i"
+  end
+
+  def values
+    Date._parse((object.public_send(attribute_name) || '').to_s).transform_keys(mon: :month, mday: :day)
   end
 end


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/36039 which has some background.

This diff winds up looking a lot more complex than the actual change ... but some refactor to the constant and methods was needed to make this make sense. The key change is using `date.order` from I18n data to determine the locale-appropriate order of the Y/M/D elements in the input.

In current main (after linked PR merged), we see:

<img width="565" height="319" alt="dob-current-main" src="https://github.com/user-attachments/assets/ce9d42a8-bfe4-45be-9354-72a0464c942b" />

In this branch, relying on locale order:

<img width="568" height="303" alt="dob-branch-order" src="https://github.com/user-attachments/assets/fb0e7762-349d-4911-a231-93285c4bc1a2" />

The underlying markup on each item stays the same so they pass the controller the correct value; just the order changes (default en locale is in YYYY-MM-DD order).

All that said, a more appealing solution would be to delete the custom input entirely, and use `as: :date` in the form ... but I don't know the full history of why the custom input was made in the first place (not explained in original PR adding DOB stuff), or if there's something especially desirable about the fields vs default selects? If removed entirely, it would look like other date dropdowns (TOS draft, for example):

<img width="521" height="283" alt="dob-use-date" src="https://github.com/user-attachments/assets/03103874-5f7f-4945-a29a-5b4810952db5" />
