### PR TITLE
Fix a typo in Finnish translation: suoksikkia -> suosikkia

### DIFF
--- a/app/javascript/mastodon/locales/fi.json
+++ b/app/javascript/mastodon/locales/fi.json
@@ -903,7 +903,7 @@
   "status.edited_x_times": "Muokattu {count, plural, one {{count} kerran} other {{count} kertaa}}",
   "status.embed": "Hanki upotuskoodi",
   "status.favourite": "Suosikki",
-  "status.favourites_count": "{count, plural, one {{counter} suosikki} other {{counter} suoksikkia}}",
+  "status.favourites_count": "{count, plural, one {{counter} suosikki} other {{counter} suosikkia}}",
   "status.filter": "Suodata tämä julkaisu",
   "status.history.created": "{name} loi {date}",
   "status.history.edited": "{name} muokkasi {date}",


### PR DESCRIPTION
A typo was introduced in the Finnish translation in commit 3f292e0f5be42c0ae757dcab827352f9e2aacabb. This fixes it.