### PR TITLE
Fix ArgumentError of tootctl upgrade storage-schema

### DIFF
--- a/lib/mastodon/cli/upgrade.rb
+++ b/lib/mastodon/cli/upgrade.rb
@@ -123,12 +123,12 @@ module Mastodon::CLI
         progress.log("Moving #{previous_path} to #{upgraded_path}") if options[:verbose]
 
         begin
-          move_previous_to_upgraded
+          move_previous_to_upgraded(previous_path, upgraded_path)
         rescue => e
           progress.log(pastel.red("Error processing #{previous_path}: #{e}"))
           success = false
 
-          remove_directory
+          remove_directory(upgraded_path)
         end
       end
 


### PR DESCRIPTION
It seems that 2be48cf0 extracted move_previous_to_upgraded and remove_directory but actual arguments are missing.