### PR TITLE
Fix superfluous border & spacing in domains list on the Moderation > Federation page

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -327,9 +327,9 @@ $content-width: 840px;
       font-weight: 700;
       color: $primary-text-color;
       text-transform: none;
-      padding-bottom: 0;
+      padding-top: 0;
       margin-bottom: 0;
-      border-bottom: 0;
+      border-top: 0;
 
       .comment {
         display: block;

--- a/app/javascript/styles_new/mastodon/admin.scss
+++ b/app/javascript/styles_new/mastodon/admin.scss
@@ -319,9 +319,9 @@ $content-width: 840px;
       font-weight: 700;
       color: var(--color-text-primary);
       text-transform: none;
-      padding-bottom: 0;
+      padding-top: 0;
       margin-bottom: 0;
-      border-bottom: 0;
+      border-top: 0;
 
       .comment {
         display: block;


### PR DESCRIPTION
Fixes #36904

### Changes proposed in this PR:
- Fixes extra border and spacing in the domains list on the Moderation > Federation page, a regression introduced in #36496

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="832" height="451" alt="image" src="https://github.com/user-attachments/assets/c6990455-81e3-4aaa-bedd-41248e9ab6e8" /> | <img width="834" height="412" alt="image" src="https://github.com/user-attachments/assets/527811d9-25c3-4c81-94f8-82221fc8127b" /> |