### PR TITLE
Improve media modal swipe animation

### DIFF
--- a/app/javascript/mastodon/features/ui/components/media_modal.tsx
+++ b/app/javascript/mastodon/features/ui/components/media_modal.tsx
@@ -46,6 +46,8 @@ interface MediaModalProps {
   volume?: number;
 }
 
+const MIN_SWIPE_DISTANCE = 400;
+
 export const MediaModal: FC<MediaModalProps> = forwardRef<
   HTMLDivElement,
   MediaModalProps
@@ -70,7 +72,7 @@ export const MediaModal: FC<MediaModalProps> = forwardRef<
     const currentMedia = media.get(index);
 
     const [wrapperStyles, api] = useSpring(() => ({
-      x: index * -1 * window.innerWidth,
+      x: `-${index * 100}%`,
     }));
 
     const handleChangeIndex = useCallback(
@@ -83,7 +85,7 @@ export const MediaModal: FC<MediaModalProps> = forwardRef<
         setIndex(newIndex);
         setZoomedIn(false);
         if (animate) {
-          void api.start({ x: -1 * newIndex * window.innerWidth });
+          void api.start({ x: `-${newIndex * 100}%` });
         }
       },
       [api, media.size],
@@ -112,13 +114,18 @@ export const MediaModal: FC<MediaModalProps> = forwardRef<
 
     const bind = useDrag(
       ({ active, movement: [mx], direction: [xDir], cancel }) => {
-        if (active && Math.abs(mx) > window.innerWidth / 2) {
-          handleChangeIndex(index + (xDir > 0 ? -1 : 1));
+        // If dragging and swipe distance is enough, change the index.
+        if (
+          active &&
+          Math.abs(mx) > Math.min(window.innerWidth / 4, MIN_SWIPE_DISTANCE)
+        ) {
+          handleChangeIndex(index - xDir);
           cancel();
         }
-        const x = -1 * index * window.innerWidth + (active ? mx : 0);
+        // Set the x position via calc to ensure proper centering regardless of screen size.
+        const x = active ? mx : 0;
         void api.start({
-          x,
+          x: `calc(-${index * 100}% + ${x}px)`,
         });
       },
       { pointer: { capture: false } },


### PR DESCRIPTION
Fixes #36837.

This replaces the previous media modal logic which was used for announcements and pinned statuses. That logic checked for `swipeX` to animate between slides, but didn't follow the user's drag motion. The modal now takes a different approach that animates based on cursor location and window size.

The logic was taken from [here](https://codesandbox.io/p/sandbox/github/pmndrs/use-gesture/tree/main/demo/src/sandboxes/viewpager?file=%2Fsrc%2FApp.tsx%3A35%2C7) from the @use-gesture examples.

https://github.com/user-attachments/assets/12a2ba8b-c9ec-4221-972c-c0da0587afb4

