### PR TITLE
Allow increasing default sidekiq dead_max_jobs queue.

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
-:dead_max_jobs: 100_000
+:dead_max_jobs: <%= ENV.fetch('SIDEKIQ_DEADQUEUESIZE', 100_000) %>
 :concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 5) %>
 :queues:
   - [default, 8]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
-:dead_max_jobs: <%= ENV.fetch('SIDEKIQ_DEADQUEUESIZE', 100_000) %>
+:dead_max_jobs: <%= ENV.fetch('SIDEKIQ_DEADQUEUESIZE', 10_000) %>
 :concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 5) %>
 :queues:
   - [default, 8]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
-:dead_max_jobs: 100_000  # Default 10000
+:dead_max_jobs: 100_000
 :concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 5) %>
 :queues:
   - [default, 8]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,5 @@
 ---
+:dead_max_jobs: 100_000  # Default 10000
 :concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 5) %>
 :queues:
   - [default, 8]


### PR DESCRIPTION
Thanks @wild1145@mastodonapp.uk for the details.

My instance queue is always sitting at over the default, and I was unaware the value was tweakable.

Question: Should this default value be raised? 100_000 maybe?