### PR TITLE
Fix quoting overwriting current content warning

### DIFF
--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -341,8 +341,8 @@ export const composeReducer = (state = initialState, action) => {
     const isDirect = state.get('privacy') === 'direct';
     return state
       .set('quoted_status_id', isDirect ? null : status.get('id'))
-      .set('spoiler', status.get('sensitive'))
-      .set('spoiler_text', status.get('spoiler_text'))
+      .update('spoiler', spoiler => (spoiler) || !!status.get('spoiler_text'))
+      .update('spoiler_text', (spoiler_text) => spoiler_text || status.get('spoiler_text'))
       .update('privacy', (visibility) => {
         if (['public', 'unlisted'].includes(visibility) && status.get('visibility') === 'private') {
           return 'private';


### PR DESCRIPTION
When quoting a post, we purposefully carry over the content warning (that then can be edited by the user).

However, the current code overwrites any content warning that is being currently written, possibly removing it entirely if the quoted post has no content warning.

This is an issue when the user quotes after starting to compose the reply, and it is especially an issue with the “copy-link-to-paste” flow.

This PR simply makes it so that, if the compose form currently has a content warning, quoting leaves it untouched.