### PR TITLE
Fix theme-related Vite errors even when `theme_tokens` feature flag is disabled

### DIFF
--- a/config/vite/plugin-mastodon-themes.ts
+++ b/config/vite/plugin-mastodon-themes.ts
@@ -40,13 +40,15 @@ export function MastodonThemes(): Plugin {
 
       // Get all files mentioned in the themes.yml file.
       const themes = await loadThemesFromConfig(projectRoot);
+      const allThemes = {
+        ...themes,
+        default_theme_tokens: 'styles_new/application.scss',
+        'mastodon-light_theme_tokens': 'styles_new/mastodon-light.scss',
+        contract_theme_tokens: 'styles_new/contrast.scss',
+      };
 
-      for (const [themeName, themePath] of Object.entries(themes)) {
+      for (const [themeName, themePath] of Object.entries(allThemes)) {
         entrypoints[`themes/${themeName}`] = path.resolve(jsRoot, themePath);
-        entrypoints[`themes/${themeName}_theme_tokens`] = path.resolve(
-          jsRoot,
-          themePath.replace('styles/', 'styles_new/'),
-        );
       }
 
       return {

--- a/config/vite/plugin-mastodon-themes.ts
+++ b/config/vite/plugin-mastodon-themes.ts
@@ -44,7 +44,7 @@ export function MastodonThemes(): Plugin {
         ...themes,
         default_theme_tokens: 'styles_new/application.scss',
         'mastodon-light_theme_tokens': 'styles_new/mastodon-light.scss',
-        contract_theme_tokens: 'styles_new/contrast.scss',
+        contrast_theme_tokens: 'styles_new/contrast.scss',
       };
 
       for (const [themeName, themePath] of Object.entries(allThemes)) {


### PR DESCRIPTION
Fixes #36932

### Changes proposed in this PR:
- Fixes theme-related Vite errors even when `theme_tokens` feature flag is disabled, by only building the the new theme_tokens endpoints for our 3 statically known default themes
