### PR TITLE
Remove stray Font Awesome styles

### DIFF
--- a/app/javascript/styles/mastodon/widgets.scss
+++ b/app/javascript/styles/mastodon/widgets.scss
@@ -47,10 +47,6 @@
       overflow: hidden;
       text-overflow: ellipsis;
 
-      .fa {
-        color: $darker-text-color;
-      }
-
       small {
         display: block;
         font-weight: 400;
@@ -62,7 +58,6 @@
 
     &.active h4 {
       &,
-      .fa,
       small,
       .trends__item__current {
         color: $primary-text-color;

--- a/app/javascript/styles_new/mastodon/widgets.scss
+++ b/app/javascript/styles_new/mastodon/widgets.scss
@@ -46,10 +46,6 @@
       overflow: hidden;
       text-overflow: ellipsis;
 
-      .fa {
-        color: var(--color-text-secondary);
-      }
-
       small {
         display: block;
         font-weight: 400;
@@ -61,7 +57,6 @@
 
     &.active h4 {
       &,
-      .fa,
       small,
       .trends__item__current {
         color: var(--color-text-primary);


### PR DESCRIPTION
There are no remaining uses of the "fa" class (used by Font Awesome, which Mastodon removed in v4.3.0) in the code base. This PR removes four remaining CSS rules related to that class.

You can test that these classes are unsused by running `git grep "\bfa\b"` and observing that every use of "fa" is neither CSS-related nor a class name.