### PR TITLE
Fix error when visiting non-public hashtag timelines

### DIFF
--- a/app/javascript/mastodon/features/hashtag_timeline/components/hashtag_header.tsx
+++ b/app/javascript/mastodon/features/hashtag_timeline/components/hashtag_header.tsx
@@ -197,13 +197,16 @@ export const HashtagHeader: React.FC<{
             />
           )}
 
-          <Button
-            onClick={handleFollow}
-            text={intl.formatMessage(
-              tag.following ? messages.unfollowHashtag : messages.followHashtag,
-            )}
-            disabled={!signedIn}
-          />
+          {signedIn && (
+            <Button
+              onClick={handleFollow}
+              text={intl.formatMessage(
+                tag.following
+                  ? messages.unfollowHashtag
+                  : messages.followHashtag,
+              )}
+            />
+          )}
         </div>
       </div>
 

--- a/app/javascript/mastodon/features/ui/containers/status_list_container.js
+++ b/app/javascript/mastodon/features/ui/containers/status_list_container.js
@@ -40,10 +40,10 @@ const makeMapStateToProps = () => {
   const getStatusIds = makeGetStatusIds();
   const getPendingStatusIds = makeGetStatusIds(true);
 
-  const mapStateToProps = (state, { timelineId }) => ({
+  const mapStateToProps = (state, { timelineId, initialLoadingState = true }) => ({
     statusIds: getStatusIds(state, { type: timelineId }),
     lastId:    state.getIn(['timelines', timelineId, 'items'])?.last(),
-    isLoading: state.getIn(['timelines', timelineId, 'isLoading'], true),
+    isLoading: state.getIn(['timelines', timelineId, 'isLoading'], initialLoadingState),
     isPartial: state.getIn(['timelines', timelineId, 'isPartial'], false),
     hasMore:   state.getIn(['timelines', timelineId, 'hasMore']),
     numPending: getPendingStatusIds(state, { type: timelineId }).size,

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -357,6 +357,7 @@
   "empty_column.notification_requests": "All clear! There is nothing here. When you receive new notifications, they will appear here according to your settings.",
   "empty_column.notifications": "You don't have any notifications yet. When other people interact with you, you will see it here.",
   "empty_column.public": "There is nothing here! Write something publicly, or manually follow users from other servers to fill it up",
+  "error.no_hashtag_feed_access": "Join or log in to view and follow this hashtag.",
   "error.unexpected_crash.explanation": "Due to a bug in our code or a browser compatibility issue, this page could not be displayed correctly.",
   "error.unexpected_crash.explanation_addons": "This page could not be displayed correctly. This error is likely caused by a browser add-on or automatic translation tools.",
   "error.unexpected_crash.next_steps": "Try refreshing the page. If that does not help, you may still be able to use Mastodon through a different browser or native app.",


### PR DESCRIPTION
Fixes MAS-639

### Changes proposed in this PR:
- Fixes authentication error when opening a hashtag timeline when the setting "Access to hashtag and link feeds featuring local posts" is set to "Authenticated users only"
- Changes the empty state copy in this scenario to "Join or log in to view and follow this hashtag."
- Hides the "Follow hashtag" button when logged out

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="1216" height="714" alt="image" src="https://github.com/user-attachments/assets/25246d76-9a06-4e46-8463-a6378bf9efe5" /> | <img width="1214" height="715" alt="image" src="https://github.com/user-attachments/assets/54f872ab-8a79-4ea5-b039-a6612bb0a421" /> |