### PR TITLE
Prevent vertical videos from overflowing the viewport

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7699,6 +7699,8 @@ a.status-card {
   position: relative;
   background: $base-shadow-color;
   max-width: 100%;
+  max-height: max(400px, 60vh);
+  margin-inline: auto;
   border-radius: 8px;
   box-sizing: border-box;
   color: $white;

--- a/app/javascript/styles_new/mastodon/components.scss
+++ b/app/javascript/styles_new/mastodon/components.scss
@@ -7492,6 +7492,8 @@ a.status-card {
   color: var(--color-text-on-media);
   background: var(--color-bg-media);
   max-width: 100%;
+  max-height: max(400px, 60vh);
+  margin-inline: auto;
   border-radius: 8px;
   box-sizing: border-box;
   display: flex;


### PR DESCRIPTION
Fixes #34457

### Changes proposed in this PR:
- Prevents vertical videos from overflowing the viewport by limiting their height to either 60% of the viewport or 400px, whichever is larger. When a video is limited in height like that, it might not fill the width of the post anymore and is centred inside of the post.

### Screencaps

**Before**

https://github.com/user-attachments/assets/42de0f31-6281-4d69-a97e-0c5d34f09f95

**After**

https://github.com/user-attachments/assets/c3e21410-58f7-41a5-b5d7-786f549469e7

