### PR TITLE
Increase HTTP read timeout for expensive S3 batch delete operation

### DIFF
--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -112,10 +112,17 @@ class AttachmentBatch
     keys.each_slice(LIMIT) do |keys_slice|
       logger.debug { "Deleting #{keys_slice.size} objects" }
 
-      bucket.delete_objects(delete: {
-        objects: keys_slice.map { |key| { key: key } },
-        quiet: true,
-      })
+      bucket.delete_objects(
+        {
+          delete: {
+            objects: keys_slice.map { |key| { key: key } },
+            quiet: true,
+          },
+        },
+        {
+          http_read_timeout: [Paperclip::Attachment.default_options[:s3_options][:http_read_timeout], 120].max,
+        }
+      )
     rescue => e
       retries += 1
 


### PR DESCRIPTION
Untested as I don't have a S3 setup