### PR TITLE
Suggest ES image version 7.17.29 in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   # es:
   #   restart: always
-  #   image: docker.elastic.co/elasticsearch/elasticsearch:7.17.4
+  #   image: docker.elastic.co/elasticsearch/elasticsearch:7.17.29
   #   environment:
   #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true"
   #     - "xpack.license.self_generated.type=basic"


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/33635

The docs repo as of now says:

> Mastodon is tested with Elasticsearch version 7. It should support OpenSearch, as well as Elasticsearch versions 6 and 8, but those setups are not officially supported.

...but presumably this line is leading people to run a specific version which has the concerns in linked issue.

Related: https://github.com/mastodon/documentation/pull/1795

Someone with more ES expertise than me should have an opinion like "yes, we can safely change the image and the data on the volume will be fine when it restarts with new version" sort of thing.

Separately -- the `elasticsearch-oss` image we use in the devcontainer is no longer maintained/updated, and is several years old and versions behind ... should we bump that up to parity with this?