### PR TITLE
Remove unneeded type check on Status in `og_image` partial

### DIFF
--- a/app/views/statuses/_og_image.html.haml
+++ b/app/views/statuses/_og_image.html.haml
@@ -1,6 +1,6 @@
-- if activity.is_a?(Status) && (activity.non_sensitive_with_media? || (activity.with_media? && Setting.preview_sensitive_media))
+- if status.non_sensitive_with_media? || (status.with_media? && Setting.preview_sensitive_media)
   - player_card = false
-  - activity.ordered_media_attachments.each do |media|
+  - status.ordered_media_attachments.each do |media|
     - if media.image?
       = opengraph 'og:image', full_asset_url(media.file.url(:original))
       = opengraph 'og:image:type', media.file_content_type

--- a/app/views/statuses/show.html.haml
+++ b/app/views/statuses/show.html.haml
@@ -20,6 +20,6 @@
   = opengraph 'profile:username', acct(@account)[1..]
 
   = render 'og_description', activity: @status
-  = render 'og_image', activity: @status, account: @account
+  = render 'og_image', status: @status, account: @account
 
 = render 'shared/web_app'


### PR DESCRIPTION
The type check here goes back to when "Stream Entries" could be passed in, but hasnt been needed in quite some time.

Remove the check, rename the local var to reflect that it's always a status now.