### PR TITLE
Improve `SessionActivation.activate` spec

### DIFF
--- a/app/models/session_activation.rb
+++ b/app/models/session_activation.rb
@@ -38,9 +38,7 @@ class SessionActivation < ApplicationRecord
     end
 
     def activate(**)
-      activation = create!(**)
-      purge_old
-      activation
+      create!(**).tap { purge_old }
     end
 
     def deactivate(id)

--- a/spec/models/session_activation_spec.rb
+++ b/spec/models/session_activation_spec.rb
@@ -39,20 +39,24 @@ RSpec.describe SessionActivation do
   end
 
   describe '.activate' do
-    let(:options) { { user: Fabricate(:user), session_id: '1' } }
+    let(:user) { Fabricate :user }
+    let!(:session_activation) { Fabricate :session_activation, user: }
 
-    it 'calls create! and purge_old' do
-      allow(described_class).to receive(:create!).with(**options)
-      allow(described_class).to receive(:purge_old)
-
-      described_class.activate(**options)
-
-      expect(described_class).to have_received(:create!).with(**options)
-      expect(described_class).to have_received(:purge_old)
+    around do |example|
+      original = Rails.configuration.x.max_session_activations
+      Rails.configuration.x.max_session_activations = 1
+      example.run
+      Rails.configuration.x.max_session_activations = original
     end
 
-    it 'returns an instance of SessionActivation' do
-      expect(described_class.activate(**options)).to be_a described_class
+    it 'creates a new activation and purges older ones' do
+      result = described_class.activate(user: user, session_id: '123')
+
+      expect(result)
+        .to be_a(described_class)
+        .and have_attributes(session_id: '123', user:)
+      expect { session_activation.reload }
+        .to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 


### PR DESCRIPTION
Previous spec stubbed out ... everything? ... and was asserting about what was called, not the expected results. Update that to assert on new record actually being created, and old one being destroyed (via configured max limit in spec).