### PR TITLE
Remove unused `from_limited?` method from NotifyService

### DIFF
--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -61,10 +61,6 @@ class NotifyService < BaseService
       NotificationPermission.exists?(account: @recipient, from_account: @sender)
     end
 
-    def from_limited?
-      @sender.silenced? && not_following?
-    end
-
     def message?
       @notification.type == :mention
     end


### PR DESCRIPTION
The logic is now in the `blocked_by_limited_accounts_policy?` method further down the class.

Removed/converted in: https://github.com/mastodon/mastodon/commit/cbdd8edf68321b384d871855cd73b717ca394de2#diff-841aa2874fa08161a391e0286d725290ecd9b5967778b69802ff140066f2c655R168-R170