### PR TITLE
Fix compose autosuggest always lowercasing token

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_input.jsx
+++ b/app/javascript/mastodon/components/autosuggest_input.jsx
@@ -28,7 +28,7 @@ const textAtCursorMatchesToken = (str, caretPosition, searchTokens) => {
     return [null, null];
   }
 
-  word = word.trim().toLowerCase();
+  word = word.trim();
 
   if (word.length > 0) {
     return [left + 1, word];

--- a/app/javascript/mastodon/components/autosuggest_textarea.jsx
+++ b/app/javascript/mastodon/components/autosuggest_textarea.jsx
@@ -29,7 +29,7 @@ const textAtCursorMatchesToken = (str, caretPosition) => {
     return [null, null];
   }
 
-  word = word.trim().toLowerCase();
+  word = word.trim();
 
   if (word.length > 0) {
     return [left + 1, word];


### PR DESCRIPTION
#36103 intended to change the behavior of hashtag completion by keeping the already-written part case intact.

Because the already-written part was actually lowercased before reaching that code, the effect was that the already-written part was always lowercased.

This PR removes the early lowercasing, although I'm not quite sure why it was there in the first place.

This may not be the perfect solution either (see https://github.com/mastodon/mastodon/issues/36912#issuecomment-3541795754), but it should be a clear improvement over the current behavior (which respects neither the casing of the suggestion, nor that of what was typed).