### PR TITLE
Revert "Increase HTTP read timeout for expensive S3 batch delete operation (#36971)"

### DIFF
--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -112,17 +112,10 @@ class AttachmentBatch
     keys.each_slice(LIMIT) do |keys_slice|
       logger.debug { "Deleting #{keys_slice.size} objects" }
 
-      bucket.delete_objects(
-        {
-          delete: {
-            objects: keys_slice.map { |key| { key: key } },
-            quiet: true,
-          },
-        },
-        {
-          http_read_timeout: [Paperclip::Attachment.default_options[:s3_options][:http_read_timeout], 120].max,
-        }
-      )
+      bucket.delete_objects(delete: {
+        objects: keys_slice.map { |key| { key: key } },
+        quiet: true,
+      })
     rescue => e
       retries += 1
 


### PR DESCRIPTION
This reverts commit a54334b7143a4483eb35b00e2331ccfcfb00b833.

Supersedes #36994 and fix an issue introduced in https://github.com/mastodon/mastodon/pull/36971