### PR TITLE
Increase HTTP read timeout for expensive S3 batch delete operation

### DIFF
--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -112,10 +112,12 @@ class AttachmentBatch
     keys.each_slice(LIMIT) do |keys_slice|
       logger.debug { "Deleting #{keys_slice.size} objects" }
 
-      bucket.delete_objects(delete: {
-        objects: keys_slice.map { |key| { key: key } },
-        quiet: true,
-      })
+      with_overridden_timeout(bucket.client, 120) do
+        bucket.delete_objects(delete: {
+          objects: keys_slice.map { |key| { key: key } },
+          quiet: true,
+        })
+      end
     rescue => e
       retries += 1
 
@@ -132,6 +134,20 @@ class AttachmentBatch
 
   def bucket
     @bucket ||= records.first.public_send(@attachment_names.first).s3_bucket
+  end
+
+  # Currently, the aws-sdk-s3 gem does not offer a way to cleanly override the timeout
+  # per-request. So we change the client's config instead. As this client will likely
+  # be re-used for other jobs, restore its original configuration in an `ensure` block.
+  def with_overridden_timeout(s3_client, longer_read_timeout)
+    original_timeout = s3_client.config.http_read_timeout
+    s3_client.config.http_read_timeout = [original_timeout, longer_read_timeout].max
+
+    begin
+      yield
+    ensure
+      s3_client.config.http_read_timeout = original_timeout
+    end
   end
 
   def nullified_attributes


### PR DESCRIPTION
Re-do of #36971

To the best of my knowledge, there is nothing at the moment in the `aws-sdk-s3` gem to have per-request config overrides, so the cleanest way would be to instantiate a new S3 Client.

However, we do not instantiate our S3 Clients directly, we go through Paperclip for that, and it is pretty involved. In order to not duplicate a significant amount of logic from one of our dependencies, this PR mutates the config instead. As Paperclip manages clients per-thread, we should not run into any concurrency issue here, and we reset the config in an `ensure` block.