### PR TITLE
Collections: Add missing validations for boolean columns

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -27,6 +27,9 @@ class Collection < ApplicationRecord
 
   validates :name, presence: true
   validates :description, presence: true
+  validates :local, inclusion: [true, false]
+  validates :sensitive, inclusion: [true, false]
+  validates :discoverable, inclusion: [true, false]
   validates :uri, presence: true, if: :remote?
   validates :original_number_of_items,
             presence: true,

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe Collection do
 
     it { is_expected.to validate_presence_of(:description) }
 
+    it { is_expected.to_not allow_value(nil).for(:local) }
+
+    it { is_expected.to_not allow_value(nil).for(:sensitive) }
+
+    it { is_expected.to_not allow_value(nil).for(:discoverable) }
+
     context 'when collection is remote' do
       subject { Fabricate.build :collection, local: false }
 


### PR DESCRIPTION
As explained [here](https://github.com/mastodon/mastodon/pull/36977#discussion_r2549747534), I deliberately omitted default values for the three boolean attributes in `Collection`. But I failed to add a matching validation.

This adds those missing validations, making sure a value is provided for these attributes.