### PR TITLE
Fix issues in new theme tokens

### DIFF
--- a/app/javascript/styles_new/mastodon/admin.scss
+++ b/app/javascript/styles_new/mastodon/admin.scss
@@ -122,7 +122,11 @@ $content-width: 840px;
         align-items: center;
         gap: 6px;
         padding: 15px;
-        color: var(--color-text-secondary);
+        color: color-mix(
+          in oklab,
+          var(--color-text-primary),
+          var(--color-text-secondary)
+        );
         text-decoration: none;
         transition: all 200ms linear;
         transition-property: color, background-color;

--- a/app/javascript/styles_new/mastodon/components.scss
+++ b/app/javascript/styles_new/mastodon/components.scss
@@ -4494,7 +4494,7 @@ a.status-card {
       z-index: 1;
       background: radial-gradient(
         ellipse,
-        rgb(from var(--color-bg-brand-softer-base) r g b / 23%) 0%,
+        rgb(from var(--color-bg-brand-base) r g b / 23%) 0%,
         transparent 60%
       );
     }

--- a/app/javascript/styles_new/mastodon/css_variables.scss
+++ b/app/javascript/styles_new/mastodon/css_variables.scss
@@ -87,7 +87,7 @@
       var(--color-bg-media-base),
       var(--color-bg-media-strength)
     )};
-  --color-bg-overlay: var(--color-bg-primary);
+  --color-bg-overlay: var(--color-black);
   --color-bg-disabled: var(--color-grey-700);
 
   // Brand

--- a/app/javascript/styles_new/mastodon/css_variables.scss
+++ b/app/javascript/styles_new/mastodon/css_variables.scss
@@ -79,7 +79,7 @@
 
   // Utility
   --color-bg-ambient: var(--color-bg-primary);
-  --color-bg-elevated: var(--color-grey-800);
+  --color-bg-elevated: var(--color-bg-primary);
   --color-bg-inverted: var(--color-grey-50);
   --color-bg-media-base: var(--color-black);
   --color-bg-media-strength: 65%;


### PR DESCRIPTION
Fixes #37007

### Changes proposed in this PR:
- Restores "new post glow":
    <img width="614" height="269" alt="image" src="https://github.com/user-attachments/assets/bb19c2ec-d90a-4739-9075-50356c6bb515" />
- Increases contrast of links in the admin navigation bar (now uses the same text colour as the main app navigation, a 50/50 mix of the primary and secondary text colour):
    <img width="597" height="486" alt="image" src="https://github.com/user-attachments/assets/1095b258-28ef-4ab8-863f-222f14d32473" />
- Reverts lighter background colour of dropdown menus in dark mode:
    <img width="230" height="184" alt="image" src="https://github.com/user-attachments/assets/246d61ce-53f5-459e-91cc-4b40388dfb17" />
- Darkens modal overlay in dark mode:
    <img width="528" height="339" alt="image" src="https://github.com/user-attachments/assets/8070a348-1f32-4e86-a9fc-f322e6420f6d" />
