### PR TITLE
Further clean up types for the `card` object

### DIFF
--- a/app/javascript/mastodon/api_types/statuses.ts
+++ b/app/javascript/mastodon/api_types/statuses.ts
@@ -45,7 +45,6 @@ export interface ApiPreviewCardJSON {
   type: string;
   author_name: string;
   author_url: string;
-  author_account?: ApiAccountJSON;
   provider_name: string;
   provider_url: string;
   html: string;

--- a/app/javascript/mastodon/api_types/statuses.ts
+++ b/app/javascript/mastodon/api_types/statuses.ts
@@ -41,8 +41,8 @@ export interface ApiPreviewCardJSON {
   url: string;
   title: string;
   description: string;
-  language: string;
-  type: string;
+  language: string | null;
+  type: 'video' | 'link';
   author_name: string;
   author_url: string;
   provider_name: string;
@@ -54,7 +54,7 @@ export interface ApiPreviewCardJSON {
   image_description: string;
   embed_url: string;
   blurhash: string;
-  published_at: string;
+  published_at: string | null;
   authors: ApiPreviewCardAuthorJSON[];
 }
 

--- a/app/javascript/mastodon/features/status/components/card.tsx
+++ b/app/javascript/mastodon/features/status/components/card.tsx
@@ -118,7 +118,7 @@ const Card: React.FC<CardProps> = ({ card, sensitive }) => {
       ? decodeIDNA(getHostname(card.get('url')))
       : card.get('provider_name');
   const interactive = card.get('type') === 'video';
-  const language = card.get('language') || '';
+  const language = card.get('language') ?? '';
   const hasImage = (card.get('image')?.length ?? 0) > 0;
   const largeImage =
     (hasImage && card.get('width') > card.get('height')) || interactive;
@@ -131,7 +131,11 @@ const Card: React.FC<CardProps> = ({ card, sensitive }) => {
         {card.get('published_at') && (
           <>
             {' '}
-            · <RelativeTimestamp timestamp={card.get('published_at')} />
+            ·{' '}
+            <RelativeTimestamp
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              timestamp={card.get('published_at')!}
+            />
           </>
         )}
       </span>

--- a/app/javascript/mastodon/models/status.ts
+++ b/app/javascript/mastodon/models/status.ts
@@ -7,8 +7,6 @@ export type { StatusVisibility } from 'mastodon/api_types/statuses';
 // Temporary until we type it correctly
 export type Status = Immutable.Map<string, unknown>;
 
-type CardShape = Required<ApiPreviewCardJSON>;
-
-export type Card = RecordOf<CardShape>;
+export type Card = RecordOf<ApiPreviewCardJSON>;
 
 export type MediaAttachment = Immutable.Map<string, unknown>;


### PR DESCRIPTION
### Changes proposed in this PR:
- Following #37022, further clean up the `Card` type:
   - Remove casting all fields as `required`
   - Remove obsolete `author_account` field
   - `language` and `published_at` can be `null`
   - `type` can only be `'link'` or `'video'`

Based on the preview card attributes in `link_detail_extractor.rb` it's possible that there might be two additional fields `image_remote_url` and `link_type`, but I wasn't able to make them appear in the frontend.