### PR TITLE
Fix error page when logging out or boosting on mobile

### DIFF
--- a/app/javascript/mastodon/features/ui/components/modal_root.jsx
+++ b/app/javascript/mastodon/features/ui/components/modal_root.jsx
@@ -136,7 +136,7 @@ export default class ModalRoot extends PureComponent {
       <Base backgroundColor={backgroundColor} onClose={this.handleClose} ignoreFocus={ignoreFocus}>
         {visible && (
           <>
-            <BundleContainer fetchComponent={MODAL_COMPONENTS[type]} loading={this.renderLoading} error={this.renderError} renderDelay={200}>
+            <BundleContainer key={type} fetchComponent={MODAL_COMPONENTS[type]} loading={this.renderLoading} error={this.renderError} renderDelay={200}>
               {(SpecificComponent) => {
                 return <SpecificComponent {...props} onChangeBackgroundColor={this.setBackgroundColor} onClose={this.handleClose} ref={this.setModalRef} />;
               }}


### PR DESCRIPTION
Fixes #37024

### Changes proposed in this PR:
- Fixes an error caused by the refactor #36970, in particular [this change](https://github.com/mastodon/mastodon/pull/36970/commits/2edbfb0dd822773183862e5a163e467017d6a44f). I fixed it by adding the modal's name as a key to the `Bundle` component, causing the component to remount when the modal changes and preventing props from the previous modal being passed to the new one