### PR TITLE
Left-align tall videos in posts, fix cut-off-video bug in Safari

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7698,9 +7698,7 @@ a.status-card {
   overflow: hidden;
   position: relative;
   background: $base-shadow-color;
-  width: 100%;
-  max-height: max(400px, 60vh);
-  margin-inline: auto;
+  max-height: 460px;
   border-radius: 8px;
   box-sizing: border-box;
   color: $white;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7698,14 +7698,13 @@ a.status-card {
   overflow: hidden;
   position: relative;
   background: $base-shadow-color;
-  max-width: 100%;
+  width: 100%;
   max-height: max(400px, 60vh);
   margin-inline: auto;
   border-radius: 8px;
   box-sizing: border-box;
   color: $white;
   display: flex;
-  align-items: center;
   outline: 1px solid var(--media-outline-color);
   outline-offset: -1px;
   z-index: 2;

--- a/app/javascript/styles_new/mastodon/components.scss
+++ b/app/javascript/styles_new/mastodon/components.scss
@@ -7491,9 +7491,7 @@ a.status-card {
   position: relative;
   color: var(--color-text-on-media);
   background: var(--color-bg-media);
-  width: 100%;
-  max-height: max(400px, 60vh);
-  margin-inline: auto;
+  max-height: 460px;
   border-radius: 8px;
   box-sizing: border-box;
   display: flex;

--- a/app/javascript/styles_new/mastodon/components.scss
+++ b/app/javascript/styles_new/mastodon/components.scss
@@ -7491,13 +7491,12 @@ a.status-card {
   position: relative;
   color: var(--color-text-on-media);
   background: var(--color-bg-media);
-  max-width: 100%;
+  width: 100%;
   max-height: max(400px, 60vh);
   margin-inline: auto;
   border-radius: 8px;
   box-sizing: border-box;
   display: flex;
-  align-items: center;
   outline: 1px solid var(--color-border-media);
   outline-offset: -1px;
   z-index: 2;


### PR DESCRIPTION
### Changes proposed in this PR:
- Left-aligns tall videos and limits their height to a fixed 460px rather than a dynamic size (a follow-up design tweak to #36966)
- Fixes a bug in Safari whereby the height of the video would be constrained, but the video would still take up the whole width, leading to the top and bottom parts being cut off

### Screenshots

| Context | **Before** | **After** |
|--------|--------|--------|
| Safari bug | <img width="614" height="706" alt="image" src="https://github.com/user-attachments/assets/b0598b91-867b-4f8c-8da1-c92004c3fab5" /> | <img width="619" height="689" alt="image" src="https://github.com/user-attachments/assets/b467bfdf-c30b-4e10-9747-83cb5fb0e5ec" /> |
| Design comparison | <img width="613" height="738" alt="image" src="https://github.com/user-attachments/assets/bbfc87f8-19d8-4d89-ac0b-b25ca9a206a4" /> | <img width="613" height="690" alt="image" src="https://github.com/user-attachments/assets/084bd256-b611-4979-a64e-5110af28c220" /> |
| Sensitive video | <img width="612" height="736" alt="image" src="https://github.com/user-attachments/assets/f3eda930-ce16-4155-8a12-244a2079fea5" /> | <img width="614" height="691" alt="image" src="https://github.com/user-attachments/assets/3b88871b-5a90-4b59-a8c4-65d1a68820ca" /> |

