### PR TITLE
Limit height of tall images in posts

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7373,6 +7373,13 @@ a.status-card {
   grid-template-rows: 1fr 1fr;
   gap: 2px;
 
+  &--layout-1 {
+    // The size of single images is determined by their
+    // aspect-ratio, applied via inline style attribute
+    width: initial;
+    max-height: 460px;
+  }
+
   &--layout-2 {
     & > .media-gallery__item:nth-child(1) {
       border-end-end-radius: 0;

--- a/app/javascript/styles_new/mastodon/components.scss
+++ b/app/javascript/styles_new/mastodon/components.scss
@@ -7159,6 +7159,13 @@ a.status-card {
   grid-template-rows: 1fr 1fr;
   gap: 2px;
 
+  &--layout-1 {
+    // The size of single images is determined by their
+    // aspect-ratio, applied via inline style attribute
+    width: initial;
+    max-height: 460px;
+  }
+
   &--layout-2 {
     & > .media-gallery__item:nth-child(1) {
       border-end-end-radius: 0;


### PR DESCRIPTION
Fixes #22993

### Changes proposed in this PR:
- Limits the height of single images in posts to a maximum of 460px. We'll apply the same treatment to videos, in a follow-up PR

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="616" height="790" alt="image" src="https://github.com/user-attachments/assets/0f76930f-57e4-45dc-a67d-1f46cbb8e6cb" /> | <img width="616" height="653" alt="image" src="https://github.com/user-attachments/assets/4c545ac1-8f5a-4590-98a9-265398829828" /> |