### PR TITLE
Fix post navigation in single-column mode when Advanced UI is enabled

### DIFF
--- a/app/javascript/mastodon/features/ui/util/focusUtils.ts
+++ b/app/javascript/mastodon/features/ui/util/focusUtils.ts
@@ -1,5 +1,3 @@
-import { initialState } from '@/mastodon/initial_state';
-
 interface FocusColumnOptions {
   index?: number;
   focusItem?: 'first' | 'first-visible';
@@ -14,7 +12,10 @@ export function focusColumn({
   focusItem = 'first',
 }: FocusColumnOptions = {}) {
   // Skip the leftmost drawer in multi-column mode
-  const indexOffset = initialState?.meta.advanced_layout ? 1 : 0;
+  const isMultiColumnLayout = !!document.querySelector(
+    'body.layout-multiple-columns',
+  );
+  const indexOffset = isMultiColumnLayout ? 1 : 0;
 
   const column = document.querySelector(
     `.column:nth-child(${index + indexOffset})`,


### PR DESCRIPTION
### Changes proposed in this PR:

- When Advanced UI is enabled, but a post is shown in single-column mode ("Classic web interface"), the <kbd>J</kbd>, <kbd>K</kbd> and <kbd>1</kbd> hotkeys didn't work because they only looked at the user setting for Advanced UI rather than which layout is actually used. This change fixes that.