### PR TITLE
Adjust Chromatic to run conditionally

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,27 +5,45 @@ on:
     branches-ignore:
       - renovate/*
       - stable-*
-    paths:
-      - 'package.json'
-      - 'yarn.lock'
-      - '**/*.js'
-      - '**/*.jsx'
-      - '**/*.ts'
-      - '**/*.tsx'
-      - '**/*.css'
-      - '**/*.scss'
-      - '.github/workflows/chromatic.yml'
 
 jobs:
-  chromatic:
-    name: Run Chromatic
+  pathcheck:
+    name: Check for relevant changes
     runs-on: ubuntu-latest
-    if: github.repository == 'mastodon/mastodon'
+    outputs:
+      src_changed: ${{ steps.filter.outputs.src }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'package.json'
+              - 'yarn.lock'
+              - '**/*.js'
+              - '**/*.jsx'
+              - '**/*.ts'
+              - '**/*.tsx'
+              - '**/*.css'
+              - '**/*.scss'
+              - '.github/workflows/chromatic.yml'
+
+  chromatic:
+    name: Run Chromatic
+    runs-on: ubuntu-latest
+    needs: pathcheck
+    if: github.repository == 'mastodon/mastodon' && needs.pathcheck.outputs.src == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
       - name: Set up Javascript environment
         uses: ./.github/actions/setup-javascript
 
@@ -39,3 +57,4 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           zip: true
           storybookBuildDir: 'storybook-static'
+          exitZeroOnChanges: false # Fail workflow if changes are found

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -59,3 +59,4 @@ jobs:
           zip: true
           storybookBuildDir: 'storybook-static'
           exitZeroOnChanges: false # Fail workflow if changes are found
+          autoAcceptChanges: 'main' # Auto-accept changes on main branch only

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,4 +1,6 @@
 name: 'Chromatic'
+permissions:
+  contents: read
 
 on:
   push:
@@ -11,7 +13,7 @@ jobs:
     name: Check for relevant changes
     runs-on: ubuntu-latest
     outputs:
-      src_changed: ${{ steps.filter.outputs.src }}
+      changed: ${{ steps.filter.outputs.src }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -37,7 +39,7 @@ jobs:
     name: Run Chromatic
     runs-on: ubuntu-latest
     needs: pathcheck
-    if: github.repository == 'mastodon/mastodon' && needs.pathcheck.outputs.src == 'true'
+    if: github.repository == 'mastodon/mastodon' && needs.pathcheck.outputs.changed == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -53,7 +55,6 @@ jobs:
       - name: Run Chromatic
         uses: chromaui/action@v13
         with:
-          # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           zip: true
           storybookBuildDir: 'storybook-static'


### PR DESCRIPTION
Because GH Actions cannot have a required job with a path filter, this adjusts Chromatic to always run but depend on another job that checks the paths. This also makes Chromatic fail if there's changes that need to be accepted, and auto-accept changes on the `main` branch.