### PR TITLE
Fix quote cancel button not appearing after edit then delete-and-redraft

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -146,6 +146,7 @@ class Status extends ImmutablePureComponent {
     'hidden',
     'unread',
     'pictureInPicture',
+    'onQuoteCancel',
   ];
 
   state = {


### PR DESCRIPTION
## Summary

Fixes #37060

When editing a quote post, the X button to remove the quote is correctly hidden (since you can't remove a quote when editing). However, if you then choose 'delete and re-draft', the X button should appear since you're now creating a new post, not editing.

## Problem

The Status component extends \ImmutablePureComponent\ and uses an \updateOnProps\ array to specify which props should trigger re-renders. The \onQuoteCancel\ prop was not included in this array.

When transitioning from edit mode to redraft mode:
- During edit: \onQuoteCancel = undefined\ (X button hidden, as expected)
- After redraft: \onQuoteCancel = handleQuoteCancel\ (X button should appear)

But since \onQuoteCancel\ wasn't in \updateOnProps\, the component didn't detect this prop change and didn't re-render to show the X button.

## Solution

Add \onQuoteCancel\ to the \updateOnProps\ array so the Status component properly re-renders when the cancel handler becomes available.

## Testing

1. Create a quote post
2. Click Edit on your quote post
3. Notice the X button is not shown (expected - can't remove quote when editing)
4. Click 'Delete and Re-draft'
5. **Before fix:** X button still not shown
6. **After fix:** X button appears, allowing you to remove the quote