### PR TITLE
Make settings-related database migrations more robust

### DIFF
--- a/db/migrate/20251002140103_migrate_timeline_preview_setting.rb
+++ b/db/migrate/20251002140103_migrate_timeline_preview_setting.rb
@@ -4,6 +4,8 @@ class MigrateTimelinePreviewSetting < ActiveRecord::Migration[8.0]
   class Setting < ApplicationRecord; end
 
   def up
+    Setting.reset_column_information
+
     setting = Setting.find_by(var: 'timeline_preview')
     return unless setting.present? && setting.attributes['value'].present?
 
@@ -12,7 +14,8 @@ class MigrateTimelinePreviewSetting < ActiveRecord::Migration[8.0]
     Setting.upsert_all(
       %w(local_live_feed_access remote_live_feed_access local_topic_feed_access remote_topic_feed_access).map do |var|
         { var: var, value: value ? "--- public\n" : "--- authenticated\n" }
-      end
+      end,
+      unique_by: index_exists?(:settings, [:thing_type, :thing_id, :var]) ? [:thing_type, :thing_id, :var] : :var
     )
   end
 

--- a/db/migrate/20251023210145_migrate_landing_page_setting.rb
+++ b/db/migrate/20251023210145_migrate_landing_page_setting.rb
@@ -4,6 +4,8 @@ class MigrateLandingPageSetting < ActiveRecord::Migration[8.0]
   class Setting < ApplicationRecord; end
 
   def up
+    Setting.reset_column_information
+
     setting = Setting.find_by(var: 'trends_as_landing_page')
     return unless setting.present? && setting.attributes['value'].present?
 
@@ -12,7 +14,8 @@ class MigrateLandingPageSetting < ActiveRecord::Migration[8.0]
     Setting.upsert({
       var: 'landing_page',
       value: value ? "--- trends\n" : "--- about\n",
-    })
+    },
+                   unique_by: index_exists?(:settings, [:thing_type, :thing_id, :var]) ? [:thing_type, :thing_id, :var] : :var)
   end
 
   def down; end


### PR DESCRIPTION
Fixes #37059

Unlike what the Rails documentation says, omitting `unique_by` in `upsert` calls doesn't make it skip duplicates across all unique indexes. Instead, it will pick the primary key, and fail because of the uniqueness constraint on other columns.

This PR uses `unique_by`, but uses different indexes depending on which ones exist in the database (since there are two possible upgrade paths).