### PR TITLE
Hide domain for local emojis in admin

### DIFF
--- a/app/controllers/admin/custom_emojis_controller.rb
+++ b/app/controllers/admin/custom_emojis_controller.rb
@@ -5,6 +5,15 @@ module Admin
     def index
       authorize :custom_emoji, :index?
 
+      # If filtering by local emojis, remove by_domain filter.
+      params.delete(:by_domain) if params[:local].present?
+
+      # If filtering by domain, ensure remote filter is set.
+      if params[:by_domain].present?
+        params.delete(:local)
+        params[:remote] = '1'
+      end
+
       @custom_emojis = filtered_custom_emojis.eager_load(:local_counterpart).page(params[:page])
       @form          = Form::CustomEmojiBatch.new
     end

--- a/app/views/admin/custom_emojis/index.html.haml
+++ b/app/views/admin/custom_emojis/index.html.haml
@@ -9,15 +9,15 @@
   .filter-subset
     %strong= t('admin.accounts.location.title')
     %ul
-      %li= filter_link_to t('admin.accounts.location.all'), local: nil, remote: nil
+      %li= filter_link_to t('admin.accounts.location.all'), local: nil, remote: nil, by_domain: nil
       %li
         - if selected? local: '1', remote: nil
           = filter_link_to t('admin.accounts.location.local'), { local: nil, remote: nil }, { local: '1', remote: nil }
         - else
-          = filter_link_to t('admin.accounts.location.local'), local: '1', remote: nil
+          = filter_link_to t('admin.accounts.location.local'), local: '1', remote: nil, by_domain: nil
       %li
         - if selected? remote: '1', local: nil
-          = filter_link_to t('admin.accounts.location.remote'), { remote: nil, local: nil }, { remote: '1', local: nil }
+          = filter_link_to t('admin.accounts.location.remote'), { remote: nil, local: nil, by_domain: nil }, { remote: '1', local: nil }
         - else
           = filter_link_to t('admin.accounts.location.remote'), remote: '1', local: nil
 
@@ -27,6 +27,8 @@
       = form.hidden_field key, value: params[key] if params[key].present?
 
     - %i(shortcode by_domain).each do |key|
+      - next if key == :by_domain && params[:local] == '1'
+
       .input.string.optional
         = form.text_field key,
                           value: params[key],


### PR DESCRIPTION
Fixes #36566.

This fixes a bug with the custom emoji admin UI that allows a domain to be set while in local mode, which is mutually exclusive. With these changes, if a domain filter is set, it always shows as `remote`. Clicking on `all` or `local` also clears the domain filter. Also, the domain filter text input is hidden when looking at local emojis.

<img width="1704" height="892" alt="Screenshot 2025-12-01 at 14 40 23" src="https://github.com/user-attachments/assets/c6caff21-3e94-4704-b871-a1e07d04f60c" />
