### PR TITLE
Ensure all pages have a solid background color

### DIFF
--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -1,5 +1,10 @@
 @use 'variables' as *;
 
+html {
+  color: var(--color-text-primary);
+  background: var(--color-bg-ambient);
+}
+
 html.has-modal {
   &,
   body {


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes an issue whereby some pages like the app authorisation page can become unreadable when viewed in a mobile web view. This only happens when the theme that's selected in Mastodon differs from the current device theme.
   
   The issue is caused by pages with the `.modal-layout` class having a semi-transparent background color on the `body` element. Since Mastodon's `html` element was previously not assigned a background color, it'd fallback to the system theme's background color (pure white or black), which could cause readability issues when Mastodon's theme was the opposite.