### PR TITLE
Fix color contrast issues caused by new theme tokens

### DIFF
--- a/app/javascript/styles/mastodon-light/css_variables.scss
+++ b/app/javascript/styles/mastodon-light/css_variables.scss
@@ -39,6 +39,7 @@
     var(--color-text-brand)
   );
   --color-text-on-brand-base: var(--color-white);
+  --color-text-brand-on-inverted: var(--color-indigo-400);
   --color-text-error: var(--color-red-600);
   --color-text-on-error-base: var(--color-white);
   --color-text-warning: var(--color-yellow-600);

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10751,7 +10751,7 @@ noscript {
   box-sizing: border-box;
   font-size: 14px;
   color: var(--color-text-secondary);
-  background: var(--color-bg-tertiary);
+  background: var(--color-bg-secondary);
   border: 1px solid var(--color-border-primary);
   border-top: 0;
   border-radius: 0 0 8px 8px;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10267,7 +10267,7 @@ noscript {
   background: transparent;
   text-transform: uppercase;
   cursor: pointer;
-  color: var(--color-text-brand);
+  color: var(--color-text-brand-on-inverted);
   font-weight: 700;
   border-radius: 4px;
   padding: 0 4px;

--- a/app/javascript/styles/mastodon/css_variables.scss
+++ b/app/javascript/styles/mastodon/css_variables.scss
@@ -39,6 +39,7 @@
     var(--color-text-brand)
   );
   --color-text-on-brand-base: var(--color-white);
+  --color-text-brand-on-inverted: var(--color-indigo-600);
   --color-text-error: var(--color-red-500);
   --color-text-on-error-base: var(--color-white);
   --color-text-warning: var(--color-yellow-400);

--- a/app/javascript/styles/mastodon/css_variables.scss
+++ b/app/javascript/styles/mastodon/css_variables.scss
@@ -61,7 +61,7 @@
 
   // Neutrals
   --color-bg-primary: var(--color-grey-950);
-  --overlay-strength-secondary: 10%;
+  --overlay-strength-secondary: 8%;
   --color-bg-secondary-base: var(--color-indigo-200);
   --color-bg-secondary: #{utils.css-alpha(
       var(--color-bg-secondary-base),


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes these issues introduced by the new theme tokens:
   - Bad contrast of action in alerts
   - Secondary background shade in dark theme was a bit too bright compared with the pre-tokens dark theme
   - Use of the bg-tertiary token instead of bg-secondary in the "More from this user" panel on link preview cards

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="357" height="76" alt="image" src="https://github.com/user-attachments/assets/7edc8b2a-0757-4148-887f-beccb44b9ef6" /> | <img width="359" height="79" alt="image" src="https://github.com/user-attachments/assets/ebf9e182-88a9-4da5-a3da-c885b648ec9f" /> |
| <img width="583" height="172" alt="image" src="https://github.com/user-attachments/assets/4ea2b823-1d48-4f97-929d-ae2efbfdc16a" /> | <img width="585" height="177" alt="image" src="https://github.com/user-attachments/assets/c190a896-8bec-44b3-92a7-20127204039d" /> |
| <img width="309" height="408" alt="image" src="https://github.com/user-attachments/assets/d32d29c6-104a-46fd-9045-08b34684d541" /> | <img width="303" height="404" alt="image" src="https://github.com/user-attachments/assets/5f3299f2-a433-42d6-ac04-85ca8b27208a" /> |
