### PR TITLE
Remove noreferrer from external links

### DIFF
--- a/app/javascript/mastodon/components/status/handled_link.tsx
+++ b/app/javascript/mastodon/components/status/handled_link.tsx
@@ -75,7 +75,7 @@ export const HandledLink: FC<HandledLinkProps & ComponentProps<'a'>> = ({
       title={href}
       className={classNames('unhandled-link', className)}
       target='_blank'
-      rel='noreferrer noopener'
+      rel='noopener'
       translate='no'
     >
       {children}


### PR DESCRIPTION
Fixes MAS-723.

This removes the explicit `noreferrer` from links in statuses in favor of the referrer policy managing that.