### PR TITLE
Use thread support helper in concurrent insert tag spec

### DIFF
--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -275,15 +275,9 @@ RSpec.describe Tag do
       tag_name_upper = 'Rails'
       tag_name_lower = 'rails'
 
-      threads = []
-
-      2.times do |i|
-        threads << Thread.new do
-          described_class.find_or_create_by_names(i.zero? ? tag_name_upper : tag_name_lower)
-        end
+      multi_threaded_execution(2) do |index|
+        described_class.find_or_create_by_names(index.zero? ? tag_name_upper : tag_name_lower)
       end
-
-      threads.each(&:join)
 
       tags = described_class.where('lower(name) = ?', tag_name_lower.downcase)
       expect(tags.count).to eq(1)

--- a/spec/support/threading_helpers.rb
+++ b/spec/support/threading_helpers.rb
@@ -6,10 +6,10 @@ module ThreadingHelpers
   def multi_threaded_execution(thread_count)
     barrier = Concurrent::CyclicBarrier.new(thread_count)
 
-    threads = Array.new(thread_count) do
+    threads = Array.new(thread_count) do |index|
       Thread.new do
         barrier.wait
-        yield
+        yield(index)
       end
     end
 


### PR DESCRIPTION
Update the test for the concurrent tag insert to use the pre-existing `multi_threaded_execution` helper instead of doing its own local thread setup/join/etc. Also update that same helper to yield an index back to the running code (should not impact other existing usage, which will just ignore it) so we can keep the upper/lower value check approach in that spec.

Followup on https://github.com/mastodon/mastodon/pull/35797 and https://github.com/mastodon/mastodon/pull/35792 - and prep for handling `name` similarly in future PR.