### PR TITLE
Use `normalizes` for tag name attribute

### DIFF
--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -39,6 +39,6 @@ class Api::V1::TagsController < Api::BaseController
   def set_or_create_tag
     return not_found unless Tag::HASHTAG_NAME_RE.match?(params[:id])
 
-    @tag = Tag.find_normalized(params[:id]) || Tag.new(name: Tag.normalize(params[:id]), display_name: params[:id])
+    @tag = Tag.find_normalized(params[:id]) || Tag.new(name: params[:id], display_name: params[:id])
   end
 end

--- a/app/models/featured_tag.rb
+++ b/app/models/featured_tag.rb
@@ -26,7 +26,7 @@ class FeaturedTag < ApplicationRecord
 
   normalizes :name, with: ->(name) { name.strip.delete_prefix('#') }
 
-  scope :by_name, ->(name) { joins(:tag).where(tag: { name: HashtagNormalizer.new.normalize(name) }) }
+  scope :by_name, ->(name) { joins(:tag).where(tag: { name: }) }
 
   before_validation :set_tag
 

--- a/app/services/tag_search_service.rb
+++ b/app/services/tag_search_service.rb
@@ -39,7 +39,7 @@ class TagSearchService < BaseService
   def ensure_exact_match(results)
     return results unless @offset.nil? || @offset.zero?
 
-    normalized_query = Tag.normalize(@query)
+    normalized_query = Tag.normalize_value_for(:name, @query)
     exact_match = results.find { |tag| tag.name.downcase == normalized_query }
     exact_match ||= Tag.find_normalized(normalized_query)
     unless exact_match.nil?

--- a/spec/models/featured_tag_spec.rb
+++ b/spec/models/featured_tag_spec.rb
@@ -93,24 +93,22 @@ RSpec.describe FeaturedTag do
   end
 
   describe '#display_name' do
-    subject { Fabricate.build :featured_tag, name: name, tag: tag }
+    subject { featured_tag.display_name }
 
-    context 'with a name value present' do
-      let(:name) { 'Test' }
+    let(:featured_tag) { Fabricate.build :featured_tag, name: name, tag: tag }
+
+    context 'with a name value present on the featured tag' do
+      let(:name) { 'FeaturedTagName' }
       let(:tag) { nil }
 
-      it 'uses name value' do
-        expect(subject.display_name).to eq('Test')
-      end
+      it { is_expected.to eq('FeaturedTagName') }
     end
 
-    context 'with a missing name value but a present tag' do
+    context 'with a missing name value but a present linked tag' do
       let(:name) { nil }
-      let(:tag) { Fabricate.build :tag, name: 'Tester' }
+      let(:tag) { Fabricate.build :tag, display_name: 'LinkedTagDisplayName' }
 
-      it 'uses name value' do
-        expect(subject.display_name).to eq('Tester')
-      end
+      it { is_expected.to eq('LinkedTagDisplayName') }
     end
   end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -40,26 +40,40 @@ RSpec.describe Tag do
       I18n.t('tags.does_not_match_previous_name')
     end
 
-    it 'invalid with #' do
-      expect(described_class.new(name: '#hello_world')).to_not be_valid
+    describe 'when skipping normalizations' do
+      subject { described_class.new }
+
+      before { subject.attributes[:name] = name }
+
+      context 'with a # in string' do
+        let(:name) { '#hello_world' }
+
+        it { is_expected.to_not be_valid }
+      end
+
+      context 'with a . in string' do
+        let(:name) { '.abcdef123' }
+
+        it { is_expected.to_not be_valid }
+      end
+
+      context 'with a space in string' do
+        let(:name) { 'hello world' }
+
+        it { is_expected.to_not be_valid }
+      end
     end
 
-    it 'invalid with .' do
-      expect(described_class.new(name: '.abcdef123')).to_not be_valid
-    end
-
-    it 'invalid with spaces' do
-      expect(described_class.new(name: 'hello world')).to_not be_valid
-    end
-
-    it 'valid with ａｅｓｔｈｅｔｉｃ' do
-      expect(described_class.new(name: 'ａｅｓｔｈｅｔｉｃ')).to be_valid
-    end
+    it { is_expected.to allow_value('ａｅｓｔｈｅｔｉｃ').for(:name) }
   end
 
   describe 'Normalizations' do
     it { is_expected.to normalize(:display_name).from('#HelloWorld').to('HelloWorld') }
     it { is_expected.to normalize(:display_name).from('Hello❤️World').to('HelloWorld') }
+
+    it { is_expected.to normalize(:name).from('#hello_world').to('hello_world') }
+    it { is_expected.to normalize(:name).from('hello world').to('helloworld') }
+    it { is_expected.to normalize(:name).from('.abcdef123').to('abcdef123') }
   end
 
   describe 'HASHTAG_RE' do
@@ -210,7 +224,7 @@ RSpec.describe Tag do
       upcase_string   = 'abcABCａｂｃＡＢＣやゆよ'
       downcase_string = 'abcabcａｂｃａｂｃやゆよ'
 
-      tag = Fabricate(:tag, name: HashtagNormalizer.new.normalize(downcase_string))
+      tag = Fabricate(:tag, name: downcase_string)
       expect(described_class.find_normalized(upcase_string)).to eq tag
     end
   end
@@ -239,7 +253,7 @@ RSpec.describe Tag do
       upcase_string   = 'abcABCａｂｃＡＢＣやゆよ'
       downcase_string = 'abcabcａｂｃａｂｃやゆよ'
 
-      tag = Fabricate(:tag, name: HashtagNormalizer.new.normalize(downcase_string))
+      tag = Fabricate(:tag, name: downcase_string)
       expect(described_class.matches_name(upcase_string)).to eq [tag]
     end
 
@@ -254,7 +268,7 @@ RSpec.describe Tag do
       upcase_string   = 'abcABCａｂｃＡＢＣやゆよ'
       downcase_string = 'abcabcａｂｃａｂｃやゆよ'
 
-      tag = Fabricate(:tag, name: HashtagNormalizer.new.normalize(downcase_string))
+      tag = Fabricate(:tag, name: downcase_string)
       expect(described_class.matching_name(upcase_string)).to eq [tag]
     end
   end


### PR DESCRIPTION
Followup on https://github.com/mastodon/mastodon/pull/35797

I had a larger WIP branch, but reduced and tried to limit this to the minimum set of changes to enable the switch to `normalizes` approach.

Notes / Future ideas:

- There are some spots/queries which do an explicit call of that class method but which could probably be rearranged to implicitly use it ... but as noted, trying to keep this minimal
- Sort of a side issue to this PR, but the signature of `HashtagNormalizer.new.normalize(str)` is sort of odd? ... as opposed to either a) make it a class method `HashtagNormalizer.normalize(str)` and skip the `new`, b) change to `HashtagNormalizer.new(str).normalize` or something - not a huge deal at all, but noticed while doing this
- The `find_or_create_by_names` method was sort of busy already and remains so after this change. Could pretty easily pull out methods for a) "build array of normalized values", b) the "match or create with rescue" portion. The former might be awkward by itself and better in a query class, the latter would be totally reasonable as standalone class method that this could call. I'd be happy to do one/both of those as follows up, or roll into here if desired (I have both in a [WIP branch](https://github.com/mastodon/mastodon/compare/main...mjankowski:tags-normalize-exp?expand=1#diff-175888239adc2b81ed2e4e82f0ee0663be0677f376e1aa1d9151baa69596e546R122-R134), but wanted to keep this one simple)
- I suspect there are some places now which are effectively "double normalizing" the value, based on how `find_normalized` previously worked. This is harmless - but also pointless. Could review those code paths and simplify some of the finding/matching/searching stuff as well.