### PR TITLE
Enable missing before actions in Collection API

### DIFF
--- a/app/controllers/api/v1_alpha/collections_controller.rb
+++ b/app/controllers/api/v1_alpha/collections_controller.rb
@@ -9,9 +9,9 @@ class Api::V1Alpha::CollectionsController < Api::BaseController
 
   before_action :check_feature_enabled
 
-  before_action -> { doorkeeper_authorize! :write, :'write:collections' }, only: [:create]
+  before_action -> { doorkeeper_authorize! :write, :'write:collections' }, only: [:create, :update, :destroy]
 
-  before_action :require_user!, only: [:create]
+  before_action :require_user!, only: [:create, :update, :destroy]
 
   before_action :set_collection, only: [:show, :update, :destroy]
 

--- a/spec/requests/api/v1_alpha/collections_spec.rb
+++ b/spec/requests/api/v1_alpha/collections_spec.rb
@@ -104,8 +104,6 @@ RSpec.describe 'Api::V1Alpha::Collections', feature: :collections do
     let(:collection) { Fabricate(:collection) }
     let(:params) { {} }
 
-    it_behaves_like 'forbidden for wrong scope', 'read:collections'
-
     context 'when user is not owner' do
       it 'returns http forbidden' do
         subject
@@ -123,6 +121,8 @@ RSpec.describe 'Api::V1Alpha::Collections', feature: :collections do
                   sensitive: true,
                   discoverable: false)
       end
+
+      it_behaves_like 'forbidden for wrong scope', 'read:collections'
 
       context 'with valid params' do
         let(:params) do
@@ -172,8 +172,6 @@ RSpec.describe 'Api::V1Alpha::Collections', feature: :collections do
 
     let(:collection) { Fabricate(:collection) }
 
-    it_behaves_like 'forbidden for wrong scope', 'read:collections'
-
     context 'when user is not owner' do
       it 'returns http forbidden' do
         subject
@@ -184,6 +182,8 @@ RSpec.describe 'Api::V1Alpha::Collections', feature: :collections do
 
     context 'when user is the owner' do
       let(:collection) { Fabricate(:collection, account: user.account) }
+
+      it_behaves_like 'forbidden for wrong scope', 'read:collections'
 
       it 'deletes the collection and returns http success' do
         collection


### PR DESCRIPTION
I plainly forgot these in #37110 and #37117.

In theory,  specs should have alerted me of this fact, but it turns out I put them in wrong context.

This fixes both issues.