### PR TITLE
Fixes YouTube embeds

### DIFF
--- a/app/javascript/mastodon/features/status/components/card.tsx
+++ b/app/javascript/mastodon/features/status/components/card.tsx
@@ -48,8 +48,10 @@ const handleIframeUrl = (html: string, url: string, providerName: string) => {
     iframeUrl.searchParams.set('autoplay', '1');
     iframeUrl.searchParams.set('auto_play', '1');
 
-    if (startTime && providerName === 'YouTube')
-      iframeUrl.searchParams.set('start', startTime);
+    if (providerName === 'YouTube') {
+      iframeUrl.searchParams.set('start', startTime ?? '');
+      iframe.referrerPolicy = 'strict-origin-when-cross-origin';
+    }
 
     iframe.src = iframeUrl.href;
 


### PR DESCRIPTION
Fixes #36643.
Fixes MAS-640.

This changes the referrer policy for just YouTube embeds so they work again.