### PR TITLE
Increase maximum height of media items on desktop

### DIFF
--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -10,6 +10,8 @@ html {
 
   --outline-focus-default: 2px solid var(--color-text-brand);
   --avatar-border-radius: 8px;
+  --max-media-height-small: 460px;
+  --max-media-height-large: 566px;
 
   // Variable for easily inverting directional UI elements,
   --text-x-direction: 1;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7165,7 +7165,18 @@ a.status-card {
     // The size of single images is determined by their
     // aspect-ratio, applied via inline style attribute
     width: initial;
-    max-height: 460px;
+
+    // Prevent extremely tall images from essentially becoming invisible
+    min-width: 120px;
+    max-height: var(--max-media-height-small);
+
+    @container (width > 500px) {
+      max-height: var(--max-media-height-large);
+    }
+
+    .detailed-status & {
+      max-height: calc(2 * var(--max-media-height-large));
+    }
   }
 
   &--layout-2 {
@@ -7500,13 +7511,17 @@ a.status-card {
   position: relative;
   color: var(--color-text-on-media);
   background: var(--color-bg-media);
-  max-height: 460px;
+  max-height: var(--max-media-height-small);
   border-radius: 8px;
   box-sizing: border-box;
   display: flex;
   outline: 1px solid var(--color-border-media);
   outline-offset: -1px;
   z-index: 2;
+
+  @container (width > 500px) {
+    max-height: var(--max-media-height-large);
+  }
 
   video {
     display: block;


### PR DESCRIPTION
Fixes #37128
Follow-up to #36966 and #37035 

### Changes proposed in this PR:
- Increases the maximum height of tall images and videos in timelines to 566px (this is the maximum width of images in our regular desktop layout, allowing square images to take up the full width of a post)
- Removes the maximum height for images in the post detail view, except for extremely tall images (see #37058 and #22993)
- Sets a minimum width for images, allowing extremely tall images to still be seen

### Screenshots

| Context | Before | After |
|--------|--------|--------|
| Timeline | <img width="598" height="632" alt="image" src="https://github.com/user-attachments/assets/5be99f8b-9679-4c71-8e62-9834348a2435" /> | <img width="598" height="734" alt="image" src="https://github.com/user-attachments/assets/a954c460-722e-4278-845b-796c4e406e2e" /> |
| Timeline | <img width="596" height="610" alt="image" src="https://github.com/user-attachments/assets/0cd0f07a-476c-49d4-b29f-d665c59cfa80" /> | <img width="596" height="717" alt="image" src="https://github.com/user-attachments/assets/141bb8e9-d633-4057-a51e-e477d14253c0" /> |
| Post detail view | <img width="606" height="762" alt="image" src="https://github.com/user-attachments/assets/f19fb0d2-b490-42c5-8258-afa98102791b" /> | <img width="603" height="1252" alt="image" src="https://github.com/user-attachments/assets/2cf08fce-5a1a-4c25-bc26-c30af819ced0" /> |
| Timeline | <img width="597" height="633" alt="image" src="https://github.com/user-attachments/assets/36d23be8-3f91-40d8-b820-ac46dacd0f98" /> | <img width="596" height="741" alt="image" src="https://github.com/user-attachments/assets/a861c2a9-0215-46c7-8a64-a22f40b64233" /> |