### PR TITLE
Add `id` to collection serializers

### DIFF
--- a/app/serializers/rest/base_collection_serializer.rb
+++ b/app/serializers/rest/base_collection_serializer.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class REST::BaseCollectionSerializer < ActiveModel::Serializer
-  attributes :uri, :name, :description, :local, :sensitive, :discoverable,
-             :item_count, :created_at, :updated_at
+  attributes :id, :uri, :name, :description, :local, :sensitive,
+             :discoverable, :item_count, :created_at, :updated_at
 
   belongs_to :tag, serializer: REST::StatusSerializer::TagSerializer
+
+  def id
+    object.id.to_s
+  end
 
   def item_count
     object.respond_to?(:item_count) ? object.item_count : object.collection_items.count

--- a/spec/serializers/rest/base_collection_serializer_spec.rb
+++ b/spec/serializers/rest/base_collection_serializer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe REST::BaseCollectionSerializer do
   let(:tag) { Fabricate(:tag, name: 'discovery') }
   let(:collection) do
     Fabricate(:collection,
+              id: 2342,
               name: 'Exquisite follows',
               description: 'Always worth a follow',
               local: true,
@@ -26,6 +27,7 @@ RSpec.describe REST::BaseCollectionSerializer do
   it 'includes the relevant attributes' do
     expect(subject)
       .to include(
+        'id' => '2342',
         'name' => 'Exquisite follows',
         'description' => 'Always worth a follow',
         'local' => true,

--- a/spec/serializers/rest/collection_serializer_spec.rb
+++ b/spec/serializers/rest/collection_serializer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe REST::CollectionSerializer do
   let(:tag) { Fabricate(:tag, name: 'discovery') }
   let(:collection) do
     Fabricate(:collection,
+              id: 2342,
               name: 'Exquisite follows',
               description: 'Always worth a follow',
               local: true,
@@ -27,6 +28,7 @@ RSpec.describe REST::CollectionSerializer do
     expect(subject)
       .to include(
         'account' => an_instance_of(Hash),
+        'id' => '2342',
         'name' => 'Exquisite follows',
         'description' => 'Always worth a follow',
         'local' => true,


### PR DESCRIPTION
I initially had the idea that I might get away with not exposing these, but writing up all that we have so far, I realized this is not going to work out. So here they are.