### PR TITLE
Fix failing streaming Docker image builds

### DIFF
--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -86,7 +86,7 @@ WORKDIR /opt/mastodon
 
 # Copy Node package configuration files from build system to container
 COPY package.json yarn.lock .yarnrc.yml /opt/mastodon/
-COPY .yarn /opt/mastodon/.yarn
+# COPY .yarn /opt/mastodon/.yarn
 # Copy Streaming source code from build system to container
 COPY ./streaming /opt/mastodon/streaming
 

--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -86,7 +86,7 @@ WORKDIR /opt/mastodon
 
 # Copy Node package configuration files from build system to container
 COPY package.json yarn.lock .yarnrc.yml /opt/mastodon/
-# COPY .yarn /opt/mastodon/.yarn
+COPY .yarn* /opt/mastodon/
 # Copy Streaming source code from build system to container
 COPY ./streaming /opt/mastodon/streaming
 


### PR DESCRIPTION
#37161 removes the contents of `.yarn` which causes this copy operation to fail