### PR TITLE
Fix streaming image build after removal of `.yarn`

### DIFF
--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -86,7 +86,6 @@ WORKDIR /opt/mastodon
 
 # Copy Node package configuration files from build system to container
 COPY package.json yarn.lock .yarnrc.yml /opt/mastodon/
-COPY .yarn /opt/mastodon/.yarn
 # Copy Streaming source code from build system to container
 COPY ./streaming /opt/mastodon/streaming
 


### PR DESCRIPTION
This directory was removed in #37161, causing build failures