### PR TITLE
Remove unused time series details from 2025 annual report

### DIFF
--- a/spec/lib/annual_report/time_series_spec.rb
+++ b/spec/lib/annual_report/time_series_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AnnualReport::TimeSeries do
         expect(subject.generate)
           .to include(
             time_series: match(
-              include(followers: 0, following: 0, month: 1, statuses: 0)
+              include(followers: 0, month: 12, statuses: 0)
             )
           )
       end
@@ -37,7 +37,7 @@ RSpec.describe AnnualReport::TimeSeries do
         expect(subject.generate)
           .to include(
             time_series: match(
-              include(followers: 1, following: 1, month: 1, statuses: 1)
+              include(followers: 1, month: 12, statuses: 1)
             )
           )
       end


### PR DESCRIPTION
Removes some more unused data from the 2025 report.

The goal is to not store or expose things we don't use, and have reports generated marginally faster.

This keeps the “time series” name and structure despite being a single-value record in order to keep compatibility with reports generated before the change as far as our front-end is concerned (some admins have already started generating wrapstodon reports with the non-finalized 2025 schema).