### PR TITLE
Change wrapstodon 2025 to allow unlisted posts in top statuses

### DIFF
--- a/app/lib/annual_report/top_statuses.rb
+++ b/app/lib/annual_report/top_statuses.rb
@@ -5,8 +5,8 @@ class AnnualReport::TopStatuses < AnnualReport::Source
     {
       top_statuses: {
         by_reblogs: status_identifier(most_reblogged_status),
-        by_favourites: status_identifier(most_favourited_status),
-        by_replies: status_identifier(most_replied_status),
+        by_favourites: nil,
+        by_replies: nil,
       },
     }
   end

--- a/app/lib/annual_report/top_statuses.rb
+++ b/app/lib/annual_report/top_statuses.rb
@@ -12,7 +12,7 @@ class AnnualReport::TopStatuses < AnnualReport::Source
   end
 
   def eligible?
-    report_statuses.public_visibility.exists?
+    report_statuses.distributable_visibility.exists?
   end
 
   private
@@ -43,7 +43,7 @@ class AnnualReport::TopStatuses < AnnualReport::Source
 
   def base_scope
     report_statuses
-      .public_visibility
+      .distributable_visibility
       .joins(:status_stat)
   end
 end

--- a/spec/lib/annual_report/top_statuses_spec.rb
+++ b/spec/lib/annual_report/top_statuses_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe AnnualReport::TopStatuses do
           .to include(
             top_statuses: include(
               by_reblogs: reblogged_status.id.to_s,
-              by_favourites: favourited_status.id.to_s,
-              by_replies: replied_status.id.to_s
+              by_favourites: nil,
+              by_replies: nil
             )
           )
       end


### PR DESCRIPTION
This also changes the report to only include the most reblogged status, as that's the only one used on the client-side (I suspect the logic was to exclude 0-reblogs posts but that is not what it is doing).