### PR TITLE
Store key identifier of actors whose key is in a separate document

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -98,7 +98,7 @@ module SignatureVerification
     if key_id.start_with?('acct:')
       stoplight_wrapper.run { ResolveAccountService.new.call(key_id.delete_prefix('acct:'), suppress_errors: false) }
     elsif !ActivityPub::TagManager.instance.local_uri?(key_id)
-      account   = ActivityPub::TagManager.instance.uri_to_actor(key_id)
+      account   = ActivityPub::TagManager.instance.key_uri_to_actor(key_id)
       account ||= stoplight_wrapper.run { ActivityPub::FetchRemoteKeyService.new.call(key_id, suppress_errors: false) }
       account
     end

--- a/app/lib/activitypub/linked_data_signature.rb
+++ b/app/lib/activitypub/linked_data_signature.rb
@@ -19,7 +19,7 @@ class ActivityPub::LinkedDataSignature
 
     return unless type == 'RsaSignature2017'
 
-    creator = ActivityPub::TagManager.instance.uri_to_actor(creator_uri)
+    creator = ActivityPub::TagManager.instance.key_uri_to_actor(creator_uri)
     creator = ActivityPub::FetchRemoteKeyService.new.call(creator_uri) if creator&.public_key.blank?
 
     return if creator.nil?

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -264,6 +264,10 @@ class ActivityPub::TagManager
     uri_to_resource(uri, Account)
   end
 
+  def key_uri_to_actor(uri)
+    Account.find_by(uri: uri.split('#').first) || Account.find_by(public_key_id: uri)
+  end
+
   def uri_to_resource(uri, klass)
     return if uri.nil?
 

--- a/app/services/activitypub/fetch_remote_key_service.rb
+++ b/app/services/activitypub/fetch_remote_key_service.rb
@@ -32,7 +32,7 @@ class ActivityPub::FetchRemoteKeyService < BaseService
   private
 
   def find_actor(uri, prefetched_body, suppress_errors)
-    actor   = ActivityPub::TagManager.instance.uri_to_actor(uri)
+    actor   = ActivityPub::TagManager.instance.key_uri_to_actor(uri)
     actor ||= ActivityPub::FetchRemoteActorService.new.call(uri, prefetched_body: prefetched_body, suppress_errors: suppress_errors)
     actor
   end


### PR DESCRIPTION
Some implementations (e.g. GoToSocial) have their actor's key as a separate document identifier (as opposed to a fragment in Mastodon's case).

Since Mastodon does not store the key ID, it is unable to lookup the corresponding actor from database. Instead, it requests the remote document and figures out the actor from there, but this has two issues:
- it causes an extra request to the originating server on each inbound delivery
- may fail with HTTP 401 on temporary issues, dropping messages altogether

This PR is early work in progress to address that by storing the ID once it is verified.