### PR TITLE
Change HTTP Signature verification status from 401 to 503 on temporary failure to get remote actor

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -72,10 +72,13 @@ module SignatureVerification
   rescue Mastodon::SignatureVerificationError => e
     fail_with! e.message
   rescue *Mastodon::HTTP_CONNECTION_ERRORS => e
+    @signature_verification_failure_code ||= 503
     fail_with! "Failed to fetch remote data: #{e.message}"
   rescue Mastodon::UnexpectedResponseError
+    @signature_verification_failure_code ||= 503
     fail_with! 'Failed to fetch remote data (got unexpected reply from server)'
   rescue Stoplight::Error::RedLight
+    @signature_verification_failure_code ||= 503
     fail_with! 'Fetching attempt skipped because of recent connection failure'
   end
 


### PR DESCRIPTION
When temporary failing to fetch a remote key (which can happen when interacting with a remote actor for the first time, or on each inbound request from implementations like GoToSocial which store keys with a distinct ID, see #37220), Mastodon currently returns a 401 error, which will cause the remote end to not retry delivery.

This can lead to messages not being delivered at all.

This PR changes it so that typically temporary issues raise a 503 error code instead of a 401 error code.