### PR TITLE
Change Emoji in Wrapstodon footer 🐘

### DIFF
--- a/app/javascript/mastodon/features/annual_report/shared_page.tsx
+++ b/app/javascript/mastodon/features/annual_report/shared_page.tsx
@@ -16,8 +16,8 @@ export const WrapstodonSharedPage: FC = () => {
         <IconLogo className={classes.logo} />
         <FormattedMessage
           id='annual_report.shared_page.footer'
-          defaultMessage='Generated with {heart} by the Mastodon team'
-          values={{ heart: '♥' }}
+          defaultMessage='Generated with {emoji} by the Mastodon team'
+          values={{ emoji: '🐘' }}
         />
         <nav className={classes.nav}>
           <a href='https://joinmastodon.org'>

--- a/app/javascript/mastodon/features/annual_report/shared_page.tsx
+++ b/app/javascript/mastodon/features/annual_report/shared_page.tsx
@@ -16,8 +16,8 @@ export const WrapstodonSharedPage: FC = () => {
         <IconLogo className={classes.logo} />
         <FormattedMessage
           id='annual_report.shared_page.footer'
-          defaultMessage='Generated with {emoji} by the Mastodon team'
-          values={{ emoji: '🐘' }}
+          defaultMessage='Generated with {heart} by the Mastodon team'
+          values={{ heart: '🐘' }}
         />
         <nav className={classes.nav}>
           <a href='https://joinmastodon.org'>


### PR DESCRIPTION
### Changes proposed in this PR:
- Changes emoji in Wrapstodon footer from ❤️ to 🐘 

### Screenshots

<img width="646" height="273" alt="image" src="https://github.com/user-attachments/assets/f005fd0c-a539-46d0-979a-49621cb25044" />