### PR TITLE
(SCA) Thread-unsafe shared @json in ActivityPub::Activity.factory misroutes activities

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -21,14 +21,13 @@ class ActivityPub::Activity
 
   class << self
     def factory(json, account, **)
-      @json = json
-      klass&.new(json, account, **)
+      klass(json)&.new(json, account, **)
     end
 
     private
 
-    def klass
-      case @json['type']
+    def klass(json)
+      case json['type']
       when 'Create'
         ActivityPub::Activity::Create
       when 'Announce'


### PR DESCRIPTION
`The factory method uses a class instance variable @json that is shared across all threads`