### PR TITLE
(SCA) ProcessMentionsService assign_mentions compares a string against a Set of objects

### DIFF
--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -75,7 +75,7 @@ class ProcessMentionsService < BaseService
       mentioned_account_ids = @current_mentions.map(&:account_id)
       blocked_account_ids = Set.new(@status.account.block_relationships.where(target_account_id: mentioned_account_ids).pluck(:target_account_id))
 
-      dropped_mentions, @current_mentions = @current_mentions.partition { |mention| blocked_account_ids.include?(mention.account_id) || blocked_domains.include?(mention.account.domain) }
+      dropped_mentions, @current_mentions = @current_mentions.partition { |mention| blocked_account_ids.include?(mention.account_id) || blocked_domains.include?(mention.account.domain&.downcase) }
       dropped_mentions.each(&:destroy)
     end
 

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -70,8 +70,8 @@ class ProcessMentionsService < BaseService
   def assign_mentions!
     # Make sure we never mention blocked accounts
     unless @current_mentions.empty?
-      mentioned_domains = @current_mentions.filter_map { |m| m.account.domain }.uniq
-      blocked_domains   = Set.new(mentioned_domains.empty? ? [] : AccountDomainBlock.where(account_id: @status.account_id, domain: mentioned_domains))
+      mentioned_domains = @current_mentions.filter_map { |m| m.account.domain&.downcase }.uniq
+      blocked_domains = Set.new(mentioned_domains.empty? ? [] : AccountDomainBlock.where(account_id: @status.account_id, domain: mentioned_domains).pluck(:domain).map!(&:downcase))
       mentioned_account_ids = @current_mentions.map(&:account_id)
       blocked_account_ids = Set.new(@status.account.block_relationships.where(target_account_id: mentioned_account_ids).pluck(:target_account_id))
 

--- a/spec/services/process_mentions_service_spec.rb
+++ b/spec/services/process_mentions_service_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe ProcessMentionsService do
 
     it 'does not create a mention for the domain-blocked account' do
       subject.call(status)
-
       mentions = status.mentions.reload
 
       expect(mentions.count).to eq(0)

--- a/spec/services/process_mentions_service_spec.rb
+++ b/spec/services/process_mentions_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ProcessMentionsService do
   subject { described_class.new }
 
-  let(:account) { Fabricate(:account, username: 'account') }
+  let(:account) { Fabricate(:account, username: 'alice') }
 
   context 'when mentioning a domain-blocked ActivityPub account' do
     let(:evil_user) { Fabricate(:account, username: 'eviluser', domain: 'evil.com', protocol: :activitypub, inbox_url: 'http://evil.com/inbox') }

--- a/spec/services/process_mentions_service_spec.rb
+++ b/spec/services/process_mentions_service_spec.rb
@@ -5,15 +5,14 @@ require 'rails_helper'
 RSpec.describe ProcessMentionsService do
   subject { described_class.new }
 
-  let(:account) { Fabricate(:account, username: 'alice') }
-  let(:alice) { Fabricate(:account, username: 'alice') }
+  let(:account) { Fabricate(:account, username: 'account') }
 
   context 'when mentioning a domain-blocked ActivityPub account' do
     let(:evil_user) { Fabricate(:account, username: 'eviluser', domain: 'evil.com', protocol: :activitypub, inbox_url: 'http://evil.com/inbox') }
-    let(:status) { Fabricate(:status, account: alice, text: "Hello @#{evil_user.acct}", visibility: :public) }
+    let(:status) { Fabricate(:status, account: account, text: "Hello @#{evil_user.acct}", visibility: :public) }
 
     before do
-      alice.domain_blocks.create!(domain: 'evil.com')
+      account.domain_blocks.create!(domain: 'evil.com')
     end
 
     it 'does not create a mention for the domain-blocked account' do


### PR DESCRIPTION
`The domain blocking filter in assign_mentions! creates a Set of AccountDomainBlock objects instead of domain strings.`

+ the lowercase is optional but I figure safe change.

Update: Noticed the SCA tool generated a test... the test does fail after testing on main and passes with this PR #37244 