### PR TITLE
(SCA) Tag timeline pagination drops filter params (any/all/none/remote)

### DIFF
--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Timelines::TagController < Api::V1::Timelines::TopicController
   before_action -> { authorize_if_got_token! :read, :'read:statuses' }
   before_action :load_tag
 
-  PERMITTED_PARAMS = %i(local limit only_media).freeze
+  PERMITTED_PARAMS = %i(any all none local remote limit only_media).freeze
 
   def show
     cache_if_unauthenticated!


### PR DESCRIPTION
`The PERMITTED_PARAMS constant is missing four query parameters (any, all, none, and remote) that are actually used by the controller. Users cannot reliably paginate through filtered hashtag timelines—filters are silently dropped after the first page, breaking the user experience and API contract.`

