### PR TITLE
(SCA) ScheduledStatus is destroyed before publish; unhandled PostStatusService errors cause permanent data loss

### DIFF
--- a/app/workers/publish_scheduled_status_worker.rb
+++ b/app/workers/publish_scheduled_status_worker.rb
@@ -15,12 +15,12 @@ class PublishScheduledStatusWorker
       options_with_objects(scheduled_status.params.with_indifferent_access)
     )
 
-    scheduled_status.destroy!  #Destroy AFTER successful posting
+    scheduled_status.destroy!
   rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid
     scheduled_status&.destroy!
     true
   rescue Mastodon::ValidationError, PostStatusService::UnexpectedMentionsError => e
-    raise e # Re-raise to let Sidekiq handle retries
+    raise e
   end
 
   def options_with_objects(options)


### PR DESCRIPTION
`The worker destroys the ScheduledStatus record before attempting to post the status, and if PostStatusService raises certain unhandled exceptions, the scheduled post is permanently lost.`