### PR TITLE
(SCA) Unfollowed hashtag posts not removed when read-replica lags

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -220,7 +220,7 @@ class FeedManager
                     .tagged_with_none(TagFollow.where(account: into_account)
                                               .where.not(tag_id: from_tag.id)
                                               .pluck(:tag_id))
-  
+
     scope.select(:id, :reblog_of_id).reorder(nil).find_each do |status|
       remove_from_feed(:home, into_account.id, status, aggregate_reblogs: into_account.user&.aggregates_reblogs?)
     end

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -217,8 +217,10 @@ class FeedManager
                     .where(id: timeline_status_ids)
                     .where.not(account: into_account)
                     .where.not(account: into_account.following)
-                    .tagged_with_none(TagFollow.where(account: into_account).pluck(:tag_id))
-
+                    .tagged_with_none(TagFollow.where(account: into_account)
+                                              .where.not(tag_id: from_tag.id)
+                                              .pluck(:tag_id))
+  
     scope.select(:id, :reblog_of_id).reorder(nil).find_each do |status|
       remove_from_feed(:home, into_account.id, status, aggregate_reblogs: into_account.user&.aggregates_reblogs?)
     end


### PR DESCRIPTION
`With replication lag, posts from the unfollowed tag remain in the user's home feed indefinitely, whereas they should be removed immediately after unfollowing.`