### PR TITLE
(SCA) Mail delivery jobs are discarded on transient deserialization errors

### DIFF
--- a/config/initializers/mail_delivery_job.rb
+++ b/config/initializers/mail_delivery_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ActionMailer::MailDeliveryJob.class_eval do
-  discard_on ActiveJob::DeserializationError do |job, error|
+  discard_on ActiveJob::DeserializationError do |_job, error|
     raise error unless error.cause.is_a?(ActiveRecord::RecordNotFound)
   end
 end

--- a/config/initializers/mail_delivery_job.rb
+++ b/config/initializers/mail_delivery_job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 ActionMailer::MailDeliveryJob.class_eval do
-  discard_on ActiveJob::DeserializationError
+  discard_on ActiveJob::DeserializationError do |job, error|
+    raise error unless error.cause.is_a?(ActiveRecord::RecordNotFound)
+  end
 end


### PR DESCRIPTION
`The initializer discards all mail delivery jobs that encounter ActiveJob::DeserializationError, but this error wraps both permanent failures (deleted records) and transient failures (database connection timeouts, network issues).`