### PR TITLE
Upgrade `rubocop-rails` from `2.33.4` to `2.34.2` and address related offenses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -773,7 +773,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.33.4)
+    rubocop-rails (2.34.2)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)

--- a/app/controllers/activitypub/inboxes_controller.rb
+++ b/app/controllers/activitypub/inboxes_controller.rb
@@ -39,7 +39,7 @@ class ActivityPub::InboxesController < ActivityPub::BaseController
     return @body if defined?(@body)
 
     @body = request.body.read
-    @body.force_encoding('UTF-8') if @body.present?
+    @body.presence&.force_encoding('UTF-8')
 
     request.body.rewind if request.body.respond_to?(:rewind)
 

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -275,7 +275,7 @@ class Request
   end
 
   if ::HTTP::Response.methods.include?(:body_with_limit) && !Rails.env.production?
-    abort 'HTTP::Response#body_with_limit is already defined, the monkey patch will not be applied'
+    raise 'HTTP::Response#body_with_limit is already defined, the monkey patch will not be applied'
   else
     class ::HTTP::Response
       include Request::ClientLimit

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 unless ENV.key?('RAILS_ENV')
-  abort <<~ERROR
+  abort <<~ERROR # rubocop:disable Rails/Exit
     The RAILS_ENV environment variable is not set.
 
     Please set it correctly depending on context:

--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -13,7 +13,7 @@
   value = ENV.fetch(key, '')
 
   if value.blank?
-    abort <<~MESSAGE
+    abort <<~MESSAGE # rubocop:disable Rails/Exit
 
       Mastodon now requires that these variables are set:
 
@@ -28,7 +28,7 @@
 
   next unless Rails.env.production? && value.end_with?('DO_NOT_USE_IN_PRODUCTION')
 
-  abort <<~MESSAGE
+  abort <<~MESSAGE # rubocop:disable Rails/Exit
 
     It looks like you are trying to run Mastodon in production with a #{key} value from the test environment.
 

--- a/config/initializers/deprecations.rb
+++ b/config/initializers/deprecations.rb
@@ -14,7 +14,7 @@ if ENV['REDIS_NAMESPACE']
     In addition, as REDIS_NAMESPACE is being used as a prefix for Elasticsearch, please do not forget to set ES_PREFIX to "#{ENV.fetch('REDIS_NAMESPACE')}".
   MESSAGE
 
-  abort message
+  abort message # rubocop:disable Rails/Exit
 end
 
 if ENV['MASTODON_USE_LIBVIPS'] == 'false'

--- a/config/initializers/vips.rb
+++ b/config/initializers/vips.rb
@@ -6,7 +6,7 @@ if Rails.configuration.x.use_vips
   require 'vips'
 
   unless Vips.at_least_libvips?(8, 13)
-    abort <<~ERROR.squish
+    abort <<~ERROR.squish # rubocop:disable Rails/Exit
       Incompatible libvips version (#{Vips.version_string}), please install libvips >= 8.13
     ERROR
   end


### PR DESCRIPTION
### Description

Upgrade `rubocop-rails` from `2.33.4` to `2.34.2` (latest) and address related offenses.

- https://github.com/rubocop/rubocop-rails/releases/tag/v2.34.0
- https://github.com/rubocop/rubocop-rails/releases/tag/v2.34.1
- https://github.com/rubocop/rubocop-rails/releases/tag/v2.34.2

Inspired by the following line in https://github.com/mastodon/mastodon/pull/37191.

> `Purposefully kept out rails, rubocop-rails, and connection_pool - which all need more work before update attempt.`

### References

- https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails/Presence
- https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails/Exit