### PR TITLE
Test SCA spec Update process_mentions_service_spec.rb

### DIFF
--- a/spec/services/process_mentions_service_spec.rb
+++ b/spec/services/process_mentions_service_spec.rb
@@ -7,6 +7,24 @@ RSpec.describe ProcessMentionsService do
 
   let(:account) { Fabricate(:account, username: 'alice') }
 
+  context 'when mentioning a domain-blocked ActivityPub account' do
+    let(:evil_user) { Fabricate(:account, username: 'eviluser', domain: 'evil.com', protocol: :activitypub, inbox_url: 'http://evil.com/inbox') }
+    let(:status) { Fabricate(:status, account: account, text: "Hello @#{evil_user.acct}", visibility: :public) }
+
+    before do
+      account.domain_blocks.create!(domain: 'evil.com')
+    end
+
+    it 'does not create a mention for the domain-blocked account' do
+      subject.call(status)
+
+      mentions = status.mentions.reload
+
+      expect(mentions.count).to eq(0)
+      expect(evil_user.mentions.where(status: status).count).to eq(0)
+    end
+  end
+
   context 'when mentions contain blocked accounts' do
     let(:non_blocked_account)          { Fabricate(:account) }
     let(:individually_blocked_account) { Fabricate(:account) }


### PR DESCRIPTION
```
Failures:

  1) ProcessMentionsService when mentioning a domain-blocked ActivityPub account does not create a mention for the domain-blocked account
     Failure/Error: expect(mentions.count).to eq(0)

       expected: 0
            got: 1

       (compared using ==)
     # ./spec/services/process_mentions_service_spec.rb:23:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:140:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.26.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/thor-1.4.0/lib/thor/command.rb:28:in `run'
     # ./vendor/bundle/ruby/3.2.0/gems/thor-1.4.0/lib/thor/invocation.rb:127:in `invoke_command'
     # ./vendor/bundle/ruby/3.2.0/gems/thor-1.4.0/lib/thor.rb:538:in `dispatch'
     # ./vendor/bundle/ruby/3.2.0/gems/thor-1.4.0/lib/thor/base.rb:584:in `start'

Finished in 7 minutes 35 seconds (files took 25.75 seconds to load)
6802 examples, 1 failure

Failed examples:

rspec ./spec/services/process_mentions_service_spec.rb:18 # ProcessMentionsService when mentioning a domain-blocked ActivityPub account does not create a mention for the domain-blocked account
```