### PR TITLE
Increase cache duration on public shared wrapstodon page

### DIFF
--- a/app/controllers/wrapstodon_controller.rb
+++ b/app/controllers/wrapstodon_controller.rb
@@ -12,7 +12,7 @@ class WrapstodonController < ApplicationController
   skip_before_action :require_functional!, only: :show, unless: :limited_federation_mode?
 
   def show
-    expires_in 10.seconds, public: true if current_account.nil?
+    expires_in 10.minutes, public: true if current_account.nil?
   end
 
   private


### PR DESCRIPTION
Increase cache duration from 10 seconds to 10 minutes.

This information is mostly immutable, reviewed by the user before sharing, and typically shared through a fediverse post, which will cause remote servers to fetch the page within a few minutes.