### PR TITLE
Fix badly visible focus outlines in composer

### DIFF
--- a/app/javascript/mastodon/features/compose/components/language_dropdown.tsx
+++ b/app/javascript/mastodon/features/compose/components/language_dropdown.tsx
@@ -399,9 +399,10 @@ export const LanguageDropdown: React.FC = () => {
   }
 
   return (
-    <div ref={targetRef}>
+    <>
       <button
         type='button'
+        ref={targetRef}
         title={intl.formatMessage(messages.changeLanguage)}
         aria-expanded={open}
         onClick={handleToggle}
@@ -438,6 +439,6 @@ export const LanguageDropdown: React.FC = () => {
           </div>
         )}
       </Overlay>
-    </div>
+    </>
   );
 };

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -926,6 +926,11 @@ body > [data-popper-placement] {
   text-overflow: ellipsis;
   white-space: nowrap;
 
+  &:focus-visible {
+    outline: var(--outline-focus-default);
+    outline-offset: 2px;
+  }
+
   &[disabled] {
     cursor: default;
     color: var(--color-text-disabled);

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -628,11 +628,6 @@ body > [data-popper-placement] {
     gap: 8px;
     margin: 8px;
     flex-wrap: wrap;
-
-    & > div {
-      overflow: hidden;
-      display: flex;
-    }
   }
 
   &__uploads {
@@ -772,7 +767,6 @@ body > [data-popper-placement] {
     align-items: center;
     flex: 1 1 auto;
     max-width: 100%;
-    overflow: hidden;
   }
 
   &__buttons {


### PR DESCRIPTION
Fixes #37143

### Changes proposed in this PR:
- Fixes invisible button focus outlines on the "post" and "post language" buttons
- Improves focus outlines for the `.dropdown-button` class to match that of regular buttons

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="308" height="251" alt="image" src="https://github.com/user-attachments/assets/d9b1b4a3-8040-4d6d-be46-1b99e1093d95" /> | <img width="305" height="250" alt="image" src="https://github.com/user-attachments/assets/1ef57a70-54b3-4e6d-8c13-5d2a42222d7a" /> |
| <img width="303" height="249" alt="image" src="https://github.com/user-attachments/assets/63512d49-d0f5-4351-b88c-002ea5eeaae1" /> | <img width="302" height="246" alt="image" src="https://github.com/user-attachments/assets/1b0db6fb-a70e-4470-ac7e-159cf97d366c" /> |