### PR TITLE
Fixes display names not rendering with emojis

### DIFF
--- a/app/helpers/wrapstodon_helper.rb
+++ b/app/helpers/wrapstodon_helper.rb
@@ -9,7 +9,7 @@ module WrapstodonHelper
       scope_name: :current_user
     ).as_json
 
-    payload[:logged_in] = user_signed_in?
+    payload[:me] = current_account.id.to_s if user_signed_in?
 
     json_string = payload.to_json
 

--- a/app/helpers/wrapstodon_helper.rb
+++ b/app/helpers/wrapstodon_helper.rb
@@ -2,15 +2,19 @@
 
 module WrapstodonHelper
   def render_wrapstodon_share_data(report)
-    json = ActiveModelSerializers::SerializableResource.new(
+    payload = ActiveModelSerializers::SerializableResource.new(
       AnnualReportsPresenter.new([report]),
       serializer: REST::AnnualReportsSerializer,
       scope: nil,
       scope_name: :current_user
-    ).to_json
+    ).as_json
+
+    payload[:logged_in] = user_signed_in?
+
+    json_string = payload.to_json
 
     # rubocop:disable Rails/OutputSafety
-    content_tag(:script, json_escape(json).html_safe, type: 'application/json', id: 'wrapstodon-data')
+    content_tag(:script, json_escape(json_string).html_safe, type: 'application/json', id: 'wrapstodon-data')
     # rubocop:enable Rails/OutputSafety
   end
 end

--- a/app/javascript/entrypoints/wrapstodon.tsx
+++ b/app/javascript/entrypoints/wrapstodon.tsx
@@ -25,7 +25,7 @@ function loaded() {
 
   const initialState = JSON.parse(
     propsNode.textContent,
-  ) as ApiAnnualReportResponse & { logged_in: boolean };
+  ) as ApiAnnualReportResponse & { me?: string };
 
   const report = initialState.annual_reports[0];
   if (!report) {
@@ -37,7 +37,7 @@ function loaded() {
     hydrateStore({
       meta: {
         locale: document.documentElement.lang,
-        me: initialState.logged_in ? '1' : null,
+        me: initialState.me,
       },
       accounts: initialState.accounts,
     }),

--- a/app/javascript/entrypoints/wrapstodon.tsx
+++ b/app/javascript/entrypoints/wrapstodon.tsx
@@ -25,7 +25,7 @@ function loaded() {
 
   const initialState = JSON.parse(
     propsNode.textContent,
-  ) as ApiAnnualReportResponse;
+  ) as ApiAnnualReportResponse & { logged_in: boolean };
 
   const report = initialState.annual_reports[0];
   if (!report) {
@@ -35,7 +35,10 @@ function loaded() {
   // Set up store
   store.dispatch(
     hydrateStore({
-      meta: { locale: document.documentElement.lang },
+      meta: {
+        locale: document.documentElement.lang,
+        me: initialState.logged_in ? '1' : null,
+      },
       accounts: initialState.accounts,
     }),
   );

--- a/app/javascript/mastodon/features/annual_report/archetype.tsx
+++ b/app/javascript/mastodon/features/annual_report/archetype.tsx
@@ -12,6 +12,7 @@ import replier from '@/images/archetypes/replier.png';
 import space_elements from '@/images/archetypes/space_elements.png';
 import { Avatar } from '@/mastodon/components/avatar';
 import { Button } from '@/mastodon/components/button';
+import { DisplayName } from '@/mastodon/components/display_name';
 import { me } from '@/mastodon/initial_state';
 import type { Account } from '@/mastodon/models/account';
 import type {
@@ -137,9 +138,6 @@ export const Archetype: React.FC<{
     ? archetypeSelfDescriptions
     : archetypePublicDescriptions;
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- we specifically want to fallback if `display_name` is empty
-  const name = account?.display_name || account?.username;
-
   return (
     <div
       className={classNames(styles.box, styles.archetype)}
@@ -182,7 +180,9 @@ export const Archetype: React.FC<{
             <FormattedMessage
               id='annual_report.summary.archetype.title_public'
               defaultMessage="{name}'s archetype"
-              values={{ name }}
+              values={{
+                name: <DisplayName variant='simple' account={account} />,
+              }}
             />
           )}
         </h2>
@@ -199,7 +199,7 @@ export const Archetype: React.FC<{
         <p>
           {isRevealed ? (
             intl.formatMessage(descriptions[archetype], {
-              name,
+              name: <DisplayName variant='simple' account={account} />,
             })
           ) : (
             <FormattedMessage

--- a/app/javascript/mastodon/features/annual_report/index.tsx
+++ b/app/javascript/mastodon/features/annual_report/index.tsx
@@ -26,7 +26,7 @@ import { NewPosts } from './new_posts';
 
 const moduleClassNames = classNames.bind(styles);
 
-export const accountSelector = createAppSelector(
+const accountSelector = createAppSelector(
   [(state) => state.accounts, (state) => state.annualReport.report],
   (accounts, report) => {
     if (report?.schema_version === 2) {
@@ -103,7 +103,11 @@ export const AnnualReport: FC<{ context?: 'modal' | 'standalone' }> = ({
           {!!newFollowerCount && <Followers count={newFollowerCount} />}
           {!!newPostCount && <NewPosts count={newPostCount} />}
           {topHashtag && (
-            <MostUsedHashtag hashtag={topHashtag} context={context} />
+            <MostUsedHashtag
+              hashtag={topHashtag}
+              account={account}
+              context={context}
+            />
           )}
         </div>
         <Archetype report={report} account={account} context={context} />

--- a/app/javascript/mastodon/features/annual_report/index.tsx
+++ b/app/javascript/mastodon/features/annual_report/index.tsx
@@ -10,7 +10,6 @@ import classNames from 'classnames/bind';
 import { closeModal } from '@/mastodon/actions/modal';
 import { IconButton } from '@/mastodon/components/icon_button';
 import { LoadingIndicator } from '@/mastodon/components/loading_indicator';
-import { me } from '@/mastodon/initial_state';
 import {
   createAppSelector,
   useAppDispatch,
@@ -30,9 +29,6 @@ const moduleClassNames = classNames.bind(styles);
 export const accountSelector = createAppSelector(
   [(state) => state.accounts, (state) => state.annualReport.report],
   (accounts, report) => {
-    if (me) {
-      return accounts.get(me);
-    }
     if (report?.schema_version === 2) {
       return accounts.get(report.account_id);
     }

--- a/app/javascript/mastodon/features/annual_report/index.tsx
+++ b/app/javascript/mastodon/features/annual_report/index.tsx
@@ -27,7 +27,7 @@ import { NewPosts } from './new_posts';
 
 const moduleClassNames = classNames.bind(styles);
 
-const accountSelector = createAppSelector(
+export const accountSelector = createAppSelector(
   [(state) => state.accounts, (state) => state.annualReport.report],
   (accounts, report) => {
     if (me) {
@@ -107,11 +107,7 @@ export const AnnualReport: FC<{ context?: 'modal' | 'standalone' }> = ({
           {!!newFollowerCount && <Followers count={newFollowerCount} />}
           {!!newPostCount && <NewPosts count={newPostCount} />}
           {topHashtag && (
-            <MostUsedHashtag
-              hashtag={topHashtag}
-              name={account?.display_name}
-              context={context}
-            />
+            <MostUsedHashtag hashtag={topHashtag} context={context} />
           )}
         </div>
         <Archetype report={report} account={account} context={context} />

--- a/app/javascript/mastodon/features/annual_report/most_used_hashtag.tsx
+++ b/app/javascript/mastodon/features/annual_report/most_used_hashtag.tsx
@@ -2,15 +2,18 @@ import { FormattedMessage } from 'react-intl';
 
 import classNames from 'classnames';
 
+import { DisplayName } from '@/mastodon/components/display_name';
+import { useAppSelector } from '@/mastodon/store';
 import type { NameAndCount } from 'mastodon/models/annual_report';
 
+import { accountSelector } from '.';
 import styles from './index.module.scss';
 
 export const MostUsedHashtag: React.FC<{
   hashtag: NameAndCount;
-  name: string | undefined;
   context: 'modal' | 'standalone';
-}> = ({ hashtag, name, context }) => {
+}> = ({ hashtag, context }) => {
+  const account = useAppSelector(accountSelector);
   return (
     <div
       className={classNames(styles.box, styles.mostUsedHashtag, styles.content)}
@@ -25,20 +28,22 @@ export const MostUsedHashtag: React.FC<{
       <div className={styles.statExtraLarge}>#{hashtag.name}</div>
 
       <p>
-        {context === 'modal' ? (
+        {context === 'modal' && (
           <FormattedMessage
             id='annual_report.summary.most_used_hashtag.used_count'
             defaultMessage='You included this hashtag in {count, plural, one {one post} other {# posts}}.'
             values={{ count: hashtag.count }}
           />
-        ) : (
-          name && (
-            <FormattedMessage
-              id='annual_report.summary.most_used_hashtag.used_count_public'
-              defaultMessage='{name} included this hashtag in {count, plural, one {one post} other {# posts}}.'
-              values={{ count: hashtag.count, name }}
-            />
-          )
+        )}
+        {context !== 'modal' && account && (
+          <FormattedMessage
+            id='annual_report.summary.most_used_hashtag.used_count_public'
+            defaultMessage='{name} included this hashtag in {count, plural, one {one post} other {# posts}}.'
+            values={{
+              count: hashtag.count,
+              name: <DisplayName variant='simple' account={account} />,
+            }}
+          />
         )}
       </p>
     </div>

--- a/app/javascript/mastodon/features/annual_report/most_used_hashtag.tsx
+++ b/app/javascript/mastodon/features/annual_report/most_used_hashtag.tsx
@@ -3,17 +3,16 @@ import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 
 import { DisplayName } from '@/mastodon/components/display_name';
-import { useAppSelector } from '@/mastodon/store';
+import type { Account } from '@/mastodon/models/account';
 import type { NameAndCount } from 'mastodon/models/annual_report';
 
-import { accountSelector } from '.';
 import styles from './index.module.scss';
 
 export const MostUsedHashtag: React.FC<{
   hashtag: NameAndCount;
   context: 'modal' | 'standalone';
-}> = ({ hashtag, context }) => {
-  const account = useAppSelector(accountSelector);
+  account?: Account;
+}> = ({ hashtag, context, account }) => {
   return (
     <div
       className={classNames(styles.box, styles.mostUsedHashtag, styles.content)}

--- a/app/javascript/mastodon/features/annual_report/shared_page.tsx
+++ b/app/javascript/mastodon/features/annual_report/shared_page.tsx
@@ -3,12 +3,13 @@ import type { FC } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { IconLogo } from '@/mastodon/components/logo';
-import { me } from '@/mastodon/initial_state';
+import { useAppSelector } from '@/mastodon/store';
 
 import { AnnualReport } from './index';
 import classes from './shared_page.module.scss';
 
 export const WrapstodonSharedPage: FC = () => {
+  const isLoggedIn = useAppSelector((state) => !!state.meta.get('me'));
   return (
     <main className={classes.wrapper}>
       <AnnualReport />
@@ -23,7 +24,7 @@ export const WrapstodonSharedPage: FC = () => {
           <a href='https://joinmastodon.org'>
             <FormattedMessage id='footer.about' defaultMessage='About' />
           </a>
-          {!me && (
+          {!isLoggedIn && (
             <a href='https://joinmastodon.org/servers'>
               <FormattedMessage
                 id='annual_report.shared_page.sign_up'

--- a/app/views/wrapstodon/show.html.haml
+++ b/app/views/wrapstodon/show.html.haml
@@ -11,7 +11,6 @@
   = render 'og_description', account: @account
   = render 'og_image', report: @generated_annual_report
 
-  = render_initial_state
   = vite_typescript_tag 'wrapstodon.tsx', crossorigin: 'anonymous'
 
 - content_for :html_classes, 'theme-dark'


### PR DESCRIPTION
This fixes an issue with emojis not being rendered in display names and accounts not propagating correctly.

| No display name | Custom emoji display name |
| - | - |
| <img width="1200" height="1404" alt="Screenshot 2025-12-15 at 12 39 50" src="https://github.com/user-attachments/assets/56be60d3-6777-401a-8b99-8c9387a17f5d" /> | <img width="1186" height="1420" alt="Screenshot 2025-12-15 at 12 40 31" src="https://github.com/user-attachments/assets/88f40189-f736-4b51-b243-81575284cadf" /> |