### PR TITLE
Check "featureable" policy on creation of collections

### DIFF
--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -66,6 +66,6 @@ class AccountPolicy < ApplicationPolicy
   end
 
   def feature?
-    record.featureable? && !current_account.blocking?(record) && !record.blocking?(current_account)
+    record.featureable? && !current_account.blocking?(record) && !current_account.blocked_by?(record)
   end
 end

--- a/app/services/create_collection_service.rb
+++ b/app/services/create_collection_service.rb
@@ -2,9 +2,10 @@
 
 class CreateCollectionService
   def call(params, account)
-    account_ids = params.delete(:account_ids)
+    @account = account
+    @accounts_to_add = Account.find(params.delete(:account_ids) || [])
     @collection = Collection.new(params.merge({ account:, local: true }))
-    build_items(account_ids)
+    build_items
 
     @collection.save!
     @collection
@@ -12,14 +13,14 @@ class CreateCollectionService
 
   private
 
-  def build_items(account_ids)
-    return if account_ids.blank?
+  def build_items
+    return if @accounts_to_add.empty?
 
-    account_ids.each do |account_id|
-      account = Account.find(account_id)
-      raise Mastodon::NotPermittedError, I18n.t('accounts.errors.cannot_be_added_to_collections') unless AccountPolicy.new(@collection.account, account).feature?
+    @account.preload_relations!(@accounts_to_add.map(&:id))
+    @accounts_to_add.each do |account_to_add|
+      raise Mastodon::NotPermittedError, I18n.t('accounts.errors.cannot_be_added_to_collections') unless AccountPolicy.new(@account, account_to_add).feature?
 
-      @collection.collection_items.build(account:)
+      @collection.collection_items.build(account: account_to_add)
     end
   end
 end

--- a/app/services/create_collection_service.rb
+++ b/app/services/create_collection_service.rb
@@ -17,7 +17,8 @@ class CreateCollectionService
 
     account_ids.each do |account_id|
       account = Account.find(account_id)
-      # TODO: validate preferences
+      raise Mastodon::NotPermittedError, I18n.t('accounts.errors.cannot_be_added_to_collections') unless AccountPolicy.new(@collection.account, account).feature?
+
       @collection.collection_items.build(account:)
     end
   end

--- a/spec/services/create_collection_service_spec.rb
+++ b/spec/services/create_collection_service_spec.rb
@@ -30,9 +30,10 @@ RSpec.describe CreateCollectionService do
       end
 
       context 'when given account ids' do
-        let(:account_ids) do
-          Fabricate.times(2, :account).map { |a| a.id.to_s }
+        let(:accounts) do
+          Fabricate.times(2, :account)
         end
+        let(:account_ids) { accounts.map { |a| a.id.to_s } }
         let(:params) do
           base_params.merge(account_ids:)
         end
@@ -41,6 +42,18 @@ RSpec.describe CreateCollectionService do
           expect do
             subject.call(params, author)
           end.to change(CollectionItem, :count).by(2)
+        end
+
+        context 'when one account may not be added' do
+          before do
+            accounts.last.update(discoverable: false)
+          end
+
+          it 'raises an error' do
+            expect do
+              subject.call(params, author)
+            end.to raise_error(Mastodon::NotPermittedError)
+          end
         end
       end
 


### PR DESCRIPTION
Do not allow adding accounts that have explicitly not allowed this, analogous to `AddAccountToCollectionService`.

Also tries to optimize the number of database queries needed.