### PR TITLE
Prevent "invalid access token" error when opening Mastodon while logged out

### DIFF
--- a/app/javascript/mastodon/reducers/slices/annual_report.ts
+++ b/app/javascript/mastodon/reducers/slices/annual_report.ts
@@ -62,7 +62,8 @@ export const checkAnnualReport = createAppThunk(
   `${annualReportSlice.name}/checkAnnualReport`,
   (_arg: unknown, { dispatch, getState }) => {
     const year = selectWrapstodonYear(getState());
-    if (!year) {
+    const me = getState().meta.get('me') as string;
+    if (!year || !me) {
       return;
     }
     void dispatch(fetchReportState());


### PR DESCRIPTION
Fixes #37253

### Changes proposed in this PR:
- DIsables the check for Wrapstodon when logged out, preventing the "Invalid access_token" error
