### PR TITLE
normalized_domain in domain_blocking

### DIFF
--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -160,7 +160,7 @@ module Account::Interactions
 
   def domain_blocking?(other_domain)
     preloaded_relation(:domain_blocking_by_domain, other_domain) do
-      domain_blocks.exists?(domain: other_domain)
+      domain_blocks.exists?(domain: normalized_domain(other_domain))
     end
   end
 


### PR DESCRIPTION
Match the normalized_domain() method used by the matching `unblock_domain`.

```
  def unblock_domain!(other_domain)
    block = domain_blocks.find_by(domain: normalized_domain(other_domain))
    block&.destroy
  end
```