### PR TITLE
Fix bad contrast on disabled dropdown menu items

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2848,7 +2848,7 @@ a.account__display-name {
     cursor: default;
 
     &:focus {
-      color: rgb(from var(--color-text-disabled) r g b / 70%);
+      color: var(--color-text-on-disabled);
       background: var(--color-bg-disabled);
       outline: 0;
     }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3994,8 +3994,8 @@ a.account__display-name {
   box-sizing: border-box;
 
   &:hover,
-  &:focus,
-  &:active {
+  &:active,
+  &:focus-visible {
     color: var(--color-text-primary);
   }
 
@@ -4013,14 +4013,7 @@ a.account__display-name {
   }
 
   &--logo {
-    background: transparent;
     padding: 10px;
-
-    &:hover,
-    &:focus,
-    &:active {
-      background: transparent;
-    }
   }
 }
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Fix bad contrast on disabled-but-focused dropdown menu items (the contrast still isn't _high_ since it's disabled, but it's now predictable and controlled by the theme tokens so can be tweaked globally if needed)
- Changes main navigation link focus styles to `:focus-visible` for consistency

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="334" height="159" alt="image" src="https://github.com/user-attachments/assets/d854ac8e-90c3-4558-b1fe-0ed7be72c926" /> | <img width="332" height="171" alt="image" src="https://github.com/user-attachments/assets/aeb9c28a-c4dd-4b81-8171-9731ba900788" /> |