### PR TITLE
Emoji: Refresh custom emoji on new

### DIFF
--- a/app/javascript/mastodon/actions/importer/emoji.ts
+++ b/app/javascript/mastodon/actions/importer/emoji.ts
@@ -1,15 +1,25 @@
 import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
+import { loadCustomEmoji } from '@/mastodon/features/emoji';
 
 export async function importCustomEmoji(emojis: ApiCustomEmojiJSON[]) {
   const onlyLocalEmojis = emojis.filter(
-    // Remote emojis won't have this field, but we still want it for rendering old emojis.
+    // Remote emojis won't have this field.
     (emoji) => 'visible_in_picker' in emoji,
   );
   if (onlyLocalEmojis.length === 0) {
     return;
   }
 
-  const { putCustomEmojiData } =
+  // First, check if we already have them all.
+  const { searchCustomEmojisByShortcodes, clearEtag } =
     await import('@/mastodon/features/emoji/database');
-  await putCustomEmojiData(onlyLocalEmojis);
+  const existingEmojis = await searchCustomEmojisByShortcodes(
+    onlyLocalEmojis.map((emoji) => emoji.shortcode),
+  );
+
+  // If there's a mismatch, re-import all custom emojis.
+  if (existingEmojis.length < onlyLocalEmojis.length) {
+    await clearEtag('custom');
+    await loadCustomEmoji();
+  }
 }

--- a/app/javascript/mastodon/actions/importer/emoji.ts
+++ b/app/javascript/mastodon/actions/importer/emoji.ts
@@ -1,0 +1,15 @@
+import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
+
+export async function importCustomEmoji(emojis: ApiCustomEmojiJSON[]) {
+  const onlyLocalEmojis = emojis.filter(
+    // Remote emojis won't have this field, but we still want it for rendering old emojis.
+    (emoji) => 'visible_in_picker' in emoji,
+  );
+  if (onlyLocalEmojis.length === 0) {
+    return;
+  }
+
+  const { putCustomEmojiData } =
+    await import('@/mastodon/features/emoji/database');
+  await putCustomEmojiData(onlyLocalEmojis);
+}

--- a/app/javascript/mastodon/actions/importer/emoji.ts
+++ b/app/javascript/mastodon/actions/importer/emoji.ts
@@ -2,23 +2,20 @@ import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
 import { loadCustomEmoji } from '@/mastodon/features/emoji';
 
 export async function importCustomEmoji(emojis: ApiCustomEmojiJSON[]) {
-  const onlyLocalEmojis = emojis.filter(
-    // Remote emojis won't have this field.
-    (emoji) => 'visible_in_picker' in emoji,
-  );
-  if (onlyLocalEmojis.length === 0) {
+  if (emojis.length === 0) {
     return;
   }
 
   // First, check if we already have them all.
   const { searchCustomEmojisByShortcodes, clearEtag } =
     await import('@/mastodon/features/emoji/database');
+
   const existingEmojis = await searchCustomEmojisByShortcodes(
-    onlyLocalEmojis.map((emoji) => emoji.shortcode),
+    emojis.map((emoji) => emoji.shortcode),
   );
 
   // If there's a mismatch, re-import all custom emojis.
-  if (existingEmojis.length < onlyLocalEmojis.length) {
+  if (existingEmojis.length < emojis.length) {
     await clearEtag('custom');
     await loadCustomEmoji();
   }

--- a/app/javascript/mastodon/actions/importer/index.js
+++ b/app/javascript/mastodon/actions/importer/index.js
@@ -40,6 +40,10 @@ export function importFetchedAccounts(accounts) {
     if (account.moved) {
       processAccount(account.moved);
     }
+
+    if (account.emojis) {
+      importCustomEmoji(account.emojis);
+    }
   }
 
   accounts.forEach(processAccount);

--- a/app/javascript/mastodon/actions/importer/index.js
+++ b/app/javascript/mastodon/actions/importer/index.js
@@ -1,6 +1,7 @@
 import { createPollFromServerJSON } from 'mastodon/models/poll';
 
 import { importAccounts } from './accounts';
+import { importCustomEmoji } from './emoji';
 import { normalizeStatus } from './normalizer';
 import { importPolls } from './polls';
 
@@ -79,6 +80,10 @@ export function importFetchedStatuses(statuses, options = {}) {
 
       if (status.card) {
         status.card.authors.forEach(author => author.account && pushUnique(accounts, author.account));
+      }
+
+      if (status.emojis) {
+        importCustomEmoji(status.emojis);
       }
     }
 

--- a/app/javascript/mastodon/actions/importer/index.js
+++ b/app/javascript/mastodon/actions/importer/index.js
@@ -41,7 +41,7 @@ export function importFetchedAccounts(accounts) {
       processAccount(account.moved);
     }
 
-    if (account.emojis) {
+    if (account.emojis && account.username === account.acct) {
       importCustomEmoji(account.emojis);
     }
   }
@@ -86,7 +86,7 @@ export function importFetchedStatuses(statuses, options = {}) {
         status.card.authors.forEach(author => author.account && pushUnique(accounts, author.account));
       }
 
-      if (status.emojis) {
+      if (status.emojis && status.account.username === status.account.acct) {
         importCustomEmoji(status.emojis);
       }
     }

--- a/app/javascript/mastodon/actions/importer/normalizer.js
+++ b/app/javascript/mastodon/actions/importer/normalizer.js
@@ -2,6 +2,8 @@ import escapeTextContentForBrowser from 'escape-html';
 
 import { expandSpoilers } from '../../initial_state';
 
+import { importCustomEmoji } from './emoji';
+
 const domParser = new DOMParser();
 
 export function searchTextFromRawStatus (status) {
@@ -150,6 +152,10 @@ export function normalizeAnnouncement(announcement) {
   const normalAnnouncement = { ...announcement };
 
   normalAnnouncement.contentHtml = normalAnnouncement.content;
+
+  if (normalAnnouncement.emojis) {
+    importCustomEmoji(normalAnnouncement.emojis);
+  }
 
   return normalAnnouncement;
 }

--- a/app/javascript/mastodon/features/emoji/database.test.ts
+++ b/app/javascript/mastodon/features/emoji/database.test.ts
@@ -48,6 +48,19 @@ describe('emoji database', () => {
         customEmojiFactory(),
       );
     });
+
+    test('clears existing custom emoji if specified', async () => {
+      const { db } = await testGet();
+      await putCustomEmojiData([customEmojiFactory({ shortcode: 'emoji1' })]);
+      await putCustomEmojiData(
+        [customEmojiFactory({ shortcode: 'emoji2' })],
+        true,
+      );
+      await expect(db.get('custom', 'emoji1')).resolves.toBeUndefined();
+      await expect(db.get('custom', 'emoji2')).resolves.toEqual(
+        customEmojiFactory({ shortcode: 'emoji2' }),
+      );
+    });
   });
 
   describe('putLegacyShortcodes', () => {

--- a/app/javascript/mastodon/features/emoji/database.test.ts
+++ b/app/javascript/mastodon/features/emoji/database.test.ts
@@ -43,7 +43,7 @@ describe('emoji database', () => {
   describe('putCustomEmojiData', () => {
     test('loads custom emoji into indexedDB', async () => {
       const { db } = await testGet();
-      await putCustomEmojiData([customEmojiFactory()]);
+      await putCustomEmojiData({ emojis: [customEmojiFactory()] });
       await expect(db.get('custom', 'custom')).resolves.toEqual(
         customEmojiFactory(),
       );
@@ -51,11 +51,13 @@ describe('emoji database', () => {
 
     test('clears existing custom emoji if specified', async () => {
       const { db } = await testGet();
-      await putCustomEmojiData([customEmojiFactory({ shortcode: 'emoji1' })]);
-      await putCustomEmojiData(
-        [customEmojiFactory({ shortcode: 'emoji2' })],
-        true,
-      );
+      await putCustomEmojiData({
+        emojis: [customEmojiFactory({ shortcode: 'emoji1' })],
+      });
+      await putCustomEmojiData({
+        emojis: [customEmojiFactory({ shortcode: 'emoji2' })],
+        clear: true,
+      });
       await expect(db.get('custom', 'emoji1')).resolves.toBeUndefined();
       await expect(db.get('custom', 'emoji2')).resolves.toEqual(
         customEmojiFactory({ shortcode: 'emoji2' }),

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -161,11 +161,23 @@ export async function putEmojiData(emojis: UnicodeEmojiData[], locale: Locale) {
   await trx.done;
 }
 
-export async function putCustomEmojiData(emojis: CustomEmojiData[]) {
+export async function putCustomEmojiData(
+  emojis: CustomEmojiData[],
+  clear = false,
+) {
   const db = await loadDB();
   const trx = db.transaction('custom', 'readwrite');
+
+  // When importing from the API, clear everything first.
+  if (clear) {
+    await trx.store.clear();
+    log('Cleared existing custom emojis in database');
+  }
+
   await Promise.all(emojis.map((emoji) => trx.store.put(emoji)));
   await trx.done;
+
+  log('Imported %d custom emojis into database', emojis.length);
 }
 
 export async function putLegacyShortcodes(shortcodes: ShortcodesDataset) {
@@ -186,6 +198,13 @@ export async function putLatestEtag(etag: string, localeString: string) {
   const locale = toSupportedLocaleOrCustom(localeString);
   const db = await loadDB();
   await db.put('etags', etag, locale);
+}
+
+export async function clearEtag(localeString: string) {
+  const locale = toSupportedLocaleOrCustom(localeString);
+  const db = await loadDB();
+  await db.delete('etags', locale);
+  log('Cleared etag for %s', locale);
 }
 
 export async function loadEmojiByHexcode(

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -161,10 +161,13 @@ export async function putEmojiData(emojis: UnicodeEmojiData[], locale: Locale) {
   await trx.done;
 }
 
-export async function putCustomEmojiData(
-  emojis: CustomEmojiData[],
+export async function putCustomEmojiData({
+  emojis,
   clear = false,
-) {
+}: {
+  emojis: CustomEmojiData[];
+  clear?: boolean;
+}) {
   const db = await loadDB();
   const trx = db.transaction('custom', 'readwrite');
 

--- a/app/javascript/mastodon/features/emoji/loader.ts
+++ b/app/javascript/mastodon/features/emoji/loader.ts
@@ -76,7 +76,7 @@ export async function importCustomEmojiData() {
   if (!emojis) {
     return;
   }
-  await putCustomEmojiData(emojis);
+  await putCustomEmojiData(emojis, true);
   return emojis;
 }
 

--- a/app/javascript/mastodon/features/emoji/loader.ts
+++ b/app/javascript/mastodon/features/emoji/loader.ts
@@ -76,7 +76,7 @@ export async function importCustomEmojiData() {
   if (!emojis) {
     return;
   }
-  await putCustomEmojiData(emojis, true);
+  await putCustomEmojiData({ emojis, clear: true });
   return emojis;
 }
 


### PR DESCRIPTION
Fixes MAS-739.

Currently, we only try to load custom emoji on page load. However if a server adds new emoji since the initial load that means they aren't loaded until users refresh the page.

To fix that, this PR runs an import function on emojis inside statuses, accounts, and announcements that checks if there are any unknown local custom emoji. If there are some, it kicks off a refresh of the custom emoji data.

The code also now clears old custom emoji data when pulling a copy from the API. This is to handle an edge case where a server has deleted an emoji, so it doesn't try and render something that no longer exists.

Additionally, a bug is fixed where the emoji web worker variable was getting cleared even if it was working. This changes the logic so the variable is set only after a message is received from the worker.