### PR TITLE
Change Wrapstodon switch from feature flag to admin setting

### DIFF
--- a/app/lib/annual_report.rb
+++ b/app/lib/annual_report.rb
@@ -17,7 +17,7 @@ class AnnualReport
   end
 
   def self.current_campaign
-    return unless Mastodon::Feature.wrapstodon_enabled?
+    return unless Setting.wrapstodon
 
     datetime = Time.now.utc
     datetime.year if datetime.month == 12 && (10..31).cover?(datetime.day)

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -44,6 +44,7 @@ class Form::AdminSettings
     local_topic_feed_access
     remote_topic_feed_access
     landing_page
+    wrapstodon
   ).freeze
 
   INTEGER_KEYS = %i(
@@ -66,6 +67,7 @@ class Form::AdminSettings
     require_invite_text
     captcha_enabled
     authorized_fetch
+    wrapstodon
   ).freeze
 
   UPLOAD_KEYS = %i(

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -110,5 +110,12 @@
               as: :boolean,
               wrapper: :with_label
 
+  %h4= t('admin.settings.discovery.wrapstodon')
+
+  .fields-group
+    = f.input :wrapstodon,
+              as: :boolean,
+              wrapper: :with_label
+
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -848,6 +848,7 @@ en:
         publish_statistics: Publish statistics
         title: Discovery
         trends: Trends
+        wrapstodon: Wrapstodon
       domain_blocks:
         all: To everyone
         disabled: To no one

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -111,6 +111,7 @@ en:
         thumbnail: A roughly 2:1 image displayed alongside your server information.
         trendable_by_default: Skip manual review of trending content. Individual items can still be removed from trends after the fact.
         trends: Trends show which posts, hashtags and news stories are gaining traction on your server.
+        wrapstodon: Offer local users to generate a playful summary of their Mastodon use during the year. This feature is available between the 10th and 31st of December of each year, and is offered to users who made at least one Public or Quiet Public post and used at least one hashtag within the year.
       form_challenge:
         current_password: You are entering a secure area
       imports:
@@ -312,6 +313,7 @@ en:
         thumbnail: Server thumbnail
         trendable_by_default: Allow trends without prior review
         trends: Enable trends
+        wrapstodon: Enable Wrapstodon
       interactions:
         must_be_follower: Block notifications from non-followers
         must_be_following: Block notifications from people you don't follow

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,6 +33,7 @@ defaults: &defaults
   captcha_enabled: false
   allow_referrer_origin: false
   landing_page: 'trends'
+  wrapstodon: true
 
 development:
   <<: *defaults

--- a/spec/requests/api/v1/annual_reports_spec.rb
+++ b/spec/requests/api/v1/annual_reports_spec.rb
@@ -85,6 +85,10 @@ RSpec.describe 'API V1 Annual Reports' do
       end
 
       context 'when the feature is not enabled' do
+        before do
+          Setting.wrapstodon = false
+        end
+
         it 'returns http success and ineligible status' do
           get '/api/v1/annual_reports/2025/state', headers: headers
 
@@ -99,7 +103,7 @@ RSpec.describe 'API V1 Annual Reports' do
         end
       end
 
-      context 'when the feature is enabled and time is within window', feature: :wrapstodon do
+      context 'when the feature is enabled and time is within window' do
         before do
           travel_to Time.utc(2025, 12, 20)
 
@@ -121,7 +125,7 @@ RSpec.describe 'API V1 Annual Reports' do
         end
       end
 
-      context 'when the feature is enabled but we are out of the time window', feature: :wrapstodon do
+      context 'when the feature is enabled but we are out of the time window' do
         before do
           travel_to Time.utc(2025, 6, 20)
 
@@ -168,7 +172,7 @@ RSpec.describe 'API V1 Annual Reports' do
     context 'with correct scope' do
       let(:scopes) { 'write:accounts' }
 
-      context 'when the feature is enabled and time is within window', feature: :wrapstodon do
+      context 'when the feature is enabled and time is within window' do
         before do
           travel_to Time.utc(2025, 12, 20)
 

--- a/spec/requests/api/v2/instance_spec.rb
+++ b/spec/requests/api/v2/instance_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Instances' do
       end
     end
 
-    context 'when wrapstodon is enabled', feature: :wrapstodon do
+    context 'when wrapstodon is enabled' do
       before do
         travel_to Time.utc(2025, 12, 20)
       end

--- a/spec/system/settings/applications_spec.rb
+++ b/spec/system/settings/applications_spec.rb
@@ -104,7 +104,12 @@ RSpec.describe 'Settings applications page' do
     let(:redis_pipeline_stub) { instance_double(Redis::PipelinedConnection, publish: nil) }
     let!(:access_token) { Fabricate(:accessible_access_token, application: application) }
 
-    before { stub_redis_pipeline }
+    before do
+      # Disable wrapstodon to avoid redis calls that we don't want to stub
+      Setting.wrapstodon = false
+
+      stub_redis_pipeline
+    end
 
     it 'destroys the record and tells the broader universe about that' do
       visit settings_applications_path


### PR DESCRIPTION
Enabled by default, can be disabled in the “Discovery” settings.

<img width="815" height="131" alt="image" src="https://github.com/user-attachments/assets/13b6bcd3-3de1-4331-933e-6b3be01f356c" />