### PR TITLE
Upgrade Bundler from 4.0.1 to 4.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1093,4 +1093,4 @@ RUBY VERSION
   ruby 3.4.1p0
 
 BUNDLED WITH
-  4.0.1
+  4.0.2


### PR DESCRIPTION
Quick follow-up to https://github.com/mastodon/mastodon/pull/37191 to grab a few more Bundler fixes.

https://github.com/ruby/rubygems/blob/ca8ac9f1db634805c97c9f243cdc6c17690b6458/bundler/CHANGELOG.md#402-2025-12-17