### PR TITLE
Remove rendering of custom emoji using the database

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -27,6 +27,7 @@ const config: StorybookConfig = {
       'oops.gif',
       'oops.png',
     ].map((path) => ({ from: `../public/${path}`, to: `/${path}` })),
+    { from: '../app/javascript/images/logo.svg', to: '/custom-emoji/logo.svg' },
   ],
   viteFinal(config) {
     // For an unknown reason, Storybook does not use the root

--- a/app/javascript/mastodon/components/emoji/emoji.stories.tsx
+++ b/app/javascript/mastodon/components/emoji/emoji.stories.tsx
@@ -2,6 +2,9 @@ import type { ComponentProps } from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+import { customEmojiFactory } from '@/testing/factories';
+
+import { CustomEmojiProvider } from './context';
 import { Emoji } from './index';
 
 type EmojiProps = ComponentProps<typeof Emoji> & {
@@ -34,7 +37,11 @@ const meta = {
     },
   },
   render(args) {
-    return <Emoji {...args} />;
+    return (
+      <CustomEmojiProvider emojis={[customEmojiFactory()]}>
+        <Emoji {...args} />
+      </CustomEmojiProvider>
+    );
   },
 } satisfies Meta<EmojiProps>;
 
@@ -47,11 +54,5 @@ export const Default: Story = {};
 export const CustomEmoji: Story = {
   args: {
     code: ':custom:',
-  },
-};
-
-export const LegacyEmoji: Story = {
-  args: {
-    code: ':copyright:',
   },
 };

--- a/app/javascript/mastodon/features/emoji/render.test.ts
+++ b/app/javascript/mastodon/features/emoji/render.test.ts
@@ -83,12 +83,8 @@ describe('stringToEmojiState', () => {
     });
   });
 
-  test('returns custom emoji state for valid custom emoji', () => {
-    expect(stringToEmojiState(':smile:')).toEqual({
-      type: 'custom',
-      code: 'smile',
-      data: undefined,
-    });
+  test('returns null for custom emoji without data', () => {
+    expect(stringToEmojiState(':smile:')).toBeNull();
   });
 
   test('returns custom emoji state with data when provided', () => {
@@ -108,7 +104,6 @@ describe('stringToEmojiState', () => {
 
   test('returns null for invalid emoji strings', () => {
     expect(stringToEmojiState('notanemoji')).toBeNull();
-    expect(stringToEmojiState(':invalid-emoji:')).toBeNull();
   });
 });
 
@@ -142,21 +137,13 @@ describe('loadEmojiDataToState', () => {
     });
   });
 
-  test('loads custom emoji data into state', async () => {
-    const dbCall = vi
-      .spyOn(db, 'loadCustomEmojiByShortcode')
-      .mockResolvedValueOnce(customEmojiFactory());
+  test('returns null for custom emoji without data', async () => {
     const customState = {
       type: 'custom',
       code: 'smile',
     } as const satisfies EmojiStateCustom;
     const result = await loadEmojiDataToState(customState, 'en');
-    expect(dbCall).toHaveBeenCalledWith('smile');
-    expect(result).toEqual({
-      type: 'custom',
-      code: 'smile',
-      data: customEmojiFactory(),
-    });
+    expect(result).toBeNull();
   });
 
   test('loads unicode data using legacy shortcode', async () => {
@@ -191,16 +178,6 @@ describe('loadEmojiDataToState', () => {
       code: '1F60A',
     } as const satisfies EmojiStateUnicode;
     const result = await loadEmojiDataToState(unicodeState, 'en');
-    expect(result).toBeNull();
-  });
-
-  test('returns null if custom emoji not found in database', async () => {
-    vi.spyOn(db, 'loadCustomEmojiByShortcode').mockResolvedValueOnce(undefined);
-    const customState = {
-      type: 'custom',
-      code: 'smile',
-    } as const satisfies EmojiStateCustom;
-    const result = await loadEmojiDataToState(customState, 'en');
     expect(result).toBeNull();
   });
 

--- a/app/javascript/testing/factories.ts
+++ b/app/javascript/testing/factories.ts
@@ -128,8 +128,8 @@ export function customEmojiFactory(
 ): CustomEmojiData {
   return {
     shortcode: 'custom',
-    static_url: 'emoji/custom/static',
-    url: 'emoji/custom',
+    static_url: '/custom-emoji/logo.svg',
+    url: '/custom-emoji/logo.svg',
     visible_in_picker: true,
     ...data,
   };


### PR DESCRIPTION
When rendering custom emoji, previously we used a lookup in IndexedDB. However, the API provides all needed information for custom emoji so a lookup is not needed. Additionally, doing a lookup means that remote servers can utilize local custom emoji, which isn't desirable.