### PR TITLE
Fix notifications page error in Tor browser

### DIFF
--- a/app/javascript/mastodon/components/status_action_bar/remove_quote_hint.module.css
+++ b/app/javascript/mastodon/components/status_action_bar/remove_quote_hint.module.css
@@ -1,0 +1,3 @@
+.inlineIcon {
+  vertical-align: middle;
+}

--- a/app/javascript/mastodon/components/status_action_bar/remove_quote_hint.tsx
+++ b/app/javascript/mastodon/components/status_action_bar/remove_quote_hint.tsx
@@ -12,6 +12,8 @@ import MoreHorizIcon from '@/material-icons/400-24px/more_horiz.svg?react';
 import { Button } from '../button';
 import { Icon } from '../icon';
 
+import classes from './remove_quote_hint.module.css';
+
 const DISMISSIBLE_BANNER_ID = 'notifications/remove_quote_hint';
 
 /**
@@ -92,7 +94,7 @@ export const RemoveQuoteHint: React.FC<{
                         id: 'status.more',
                         defaultMessage: 'More',
                       })}
-                      style={{ verticalAlign: 'middle' }}
+                      className={classes.inlineIcon}
                     />
                   ),
                 }}


### PR DESCRIPTION
Fixes #37200

### Changes proposed in this PR:
- Fixes a notifications page error in Tor browser caused by a setting an inline style on a not-rendered SVG element. Arguably this is more of a workaround for a bug in React