### PR TITLE
Update “Automatic post deletion” explanation text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1967,7 +1967,7 @@ en:
     enabled: Automatically delete old posts
     enabled_hint: Automatically deletes your posts once they reach a specified age threshold, unless they match one of the exceptions below
     exceptions: Exceptions
-    explanation: Automated deletion is performed with low priority. There may be a delay between reaching the threshold and being removed.
+    explanation: Automated deletion is performed with low priority. There may be a delay between reaching the age threshold and being removed.
     ignore_favs: Ignore favorites
     ignore_reblogs: Ignore boosts
     interaction_exceptions: Exceptions based on interactions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1967,11 +1967,11 @@ en:
     enabled: Automatically delete old posts
     enabled_hint: Automatically deletes your posts once they reach a specified age threshold, unless they match one of the exceptions below
     exceptions: Exceptions
-    explanation: Because deleting posts is an expensive operation, this is done slowly over time when the server is not otherwise busy. For this reason, your posts may be deleted a while after they reach the age threshold.
+    explanation: Automated deletion is performed with low priority. There may be a delay between reaching the threshold and being removed.
     ignore_favs: Ignore favorites
     ignore_reblogs: Ignore boosts
     interaction_exceptions: Exceptions based on interactions
-    interaction_exceptions_explanation: Note that there is no guarantee for posts to be deleted if they go below the favorite or boost threshold after having once gone over them.
+    interaction_exceptions_explanation: Posts which temporarily exceed the favorite or boost threshold may be retained even if they are later decreased.
     keep_direct: Keep direct messages
     keep_direct_hint: Doesn't delete any of your direct messages
     keep_media: Keep posts with media attachments


### PR DESCRIPTION
Just sort of a brevity/clarity tweak...

Before:
<img width="970" height="998" alt="Screenshot 2025-12-17 at 10 34 48" src="https://github.com/user-attachments/assets/f1a9f895-4727-42ac-a0c7-d99945db5601" />

After:
<img width="932" height="925" alt="Screenshot 2025-12-17 at 10 34 34" src="https://github.com/user-attachments/assets/be31d6f4-5a5f-4f89-bc3b-df7605f7beb6" />

I don't feel super-strongly about this *exact* improvement, but I do think there's room to tighten these up a bit with this or similar edit.