### PR TITLE
Reduce haml-lint `LineLength` configuration to 240

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -10,6 +10,6 @@ linters:
   MiddleDot:
     enabled: true
   LineLength:
-    max: 300
+    max: 280 # Override default value of 80 inherited from rubocop
   ViewLength:
     max: 200 # Override default value of 100 inherited from rubocop

--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -10,6 +10,6 @@ linters:
   MiddleDot:
     enabled: true
   LineLength:
-    max: 280 # Override default value of 80 inherited from rubocop
+    max: 260 # Override default value of 80 inherited from rubocop
   ViewLength:
     max: 200 # Override default value of 100 inherited from rubocop

--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -10,6 +10,6 @@ linters:
   MiddleDot:
     enabled: true
   LineLength:
-    max: 260 # Override default value of 80 inherited from rubocop
+    max: 250 # Override default value of 80 inherited from rubocop
   ViewLength:
     max: 200 # Override default value of 100 inherited from rubocop

--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -10,6 +10,6 @@ linters:
   MiddleDot:
     enabled: true
   LineLength:
-    max: 250 # Override default value of 80 inherited from rubocop
+    max: 240 # Override default value of 80 inherited from rubocop
   ViewLength:
     max: 200 # Override default value of 100 inherited from rubocop

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -18,4 +18,12 @@ module RegistrationHelper
   def ip_blocked?(remote_ip)
     IpBlock.severity_sign_up_block.containing(remote_ip.to_s).exists?
   end
+
+  def terms_agreement_label
+    if TermsOfService.live.exists?
+      t('auth.user_agreement_html', privacy_policy_path: privacy_policy_path, terms_of_service_path: terms_of_service_path)
+    else
+      t('auth.user_privacy_agreement_html', privacy_policy_path: privacy_policy_path)
+    end
+  end
 end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -23,6 +23,16 @@ module SettingsHelper
       )
   end
 
+  def author_attribution_name(account)
+    return if account.nil?
+
+    link_to(root_url, class: 'story__details__shared__author-link') do
+      safe_join(
+        [image_tag(account.avatar.url, class: 'account__avatar', size: 16, alt: ''), tag.bdi(display_name(account))]
+      )
+    end
+  end
+
   def session_device_icon(session)
     device = session.detection.device
 

--- a/app/views/admin/announcements/previews/show.html.haml
+++ b/app/views/admin/announcements/previews/show.html.haml
@@ -18,5 +18,12 @@
 %hr.spacer/
 
 .content__heading__actions
-  = link_to t('admin.terms_of_service.preview.send_preview', email: current_user.email), admin_announcement_test_path(@announcement), method: :post, class: 'button button-secondary'
-  = link_to t('admin.terms_of_service.preview.send_to_all', count: @user_count, display_count: number_with_delimiter(@user_count)), admin_announcement_distribution_path(@announcement), method: :post, class: 'button', data: { confirm: t('admin.reports.are_you_sure') }
+  = link_to t('admin.terms_of_service.preview.send_preview', email: current_user.email),
+            admin_announcement_test_path(@announcement),
+            class: 'button button-secondary',
+            method: :post
+  = link_to t('admin.terms_of_service.preview.send_to_all', count: @user_count, display_count: number_with_delimiter(@user_count)),
+            admin_announcement_distribution_path(@announcement),
+            class: 'button',
+            data: { confirm: t('admin.reports.are_you_sure') },
+            method: :post

--- a/app/views/admin/terms_of_service/previews/show.html.haml
+++ b/app/views/admin/terms_of_service/previews/show.html.haml
@@ -16,5 +16,12 @@
 %hr.spacer/
 
 .content__heading__actions
-  = link_to t('admin.terms_of_service.preview.send_preview', email: current_user.email), admin_terms_of_service_test_path(@terms_of_service), method: :post, class: 'button button-secondary'
-  = link_to t('admin.terms_of_service.preview.send_to_all', count: @user_count, display_count: number_with_delimiter(@user_count)), admin_terms_of_service_distribution_path(@terms_of_service), method: :post, class: 'button', data: { confirm: t('admin.reports.are_you_sure') }
+  = link_to t('admin.terms_of_service.preview.send_preview', email: current_user.email),
+            admin_terms_of_service_test_path(@terms_of_service),
+            class: 'button button-secondary',
+            method: :post
+  = link_to t('admin.terms_of_service.preview.send_to_all', count: @user_count, display_count: number_with_delimiter(@user_count)),
+            admin_terms_of_service_distribution_path(@terms_of_service),
+            class: 'button',
+            data: { confirm: t('admin.reports.are_you_sure') },
+            method: :post

--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -79,7 +79,7 @@
   .fields-group
     = f.input :agreement,
               as: :boolean,
-              label: TermsOfService.live.exists? ? t('auth.user_agreement_html', privacy_policy_path: privacy_policy_path, terms_of_service_path: terms_of_service_path) : t('auth.user_privacy_agreement_html', privacy_policy_path: privacy_policy_path),
+              label: terms_agreement_label,
               required: false,
               wrapper: :with_label
 

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -93,9 +93,15 @@
     %h4= t 'appearance.boosting_preferences'
 
     .fields-group
-      = ff.input :'web.reblog_modal', wrapper: :with_label, hint: I18n.t('simple_form.hints.defaults.setting_boost_modal'), label: I18n.t('simple_form.labels.defaults.setting_boost_modal')
+      = ff.input :'web.reblog_modal',
+                 hint: I18n.t('simple_form.hints.defaults.setting_boost_modal'),
+                 label: I18n.t('simple_form.labels.defaults.setting_boost_modal'),
+                 wrapper: :with_label
     .fields-group
-      = ff.input :'web.quick_boosting', wrapper: :with_label, hint: t('simple_form.hints.defaults.setting_quick_boosting_html', boost_icon: material_symbol('repeat'), options_icon: material_symbol('more_horiz')), label: I18n.t('simple_form.labels.defaults.setting_quick_boosting')
+      = ff.input :'web.quick_boosting',
+                 hint: t('simple_form.hints.defaults.setting_quick_boosting_html', boost_icon: material_symbol('repeat'), options_icon: material_symbol('more_horiz')),
+                 label: I18n.t('simple_form.labels.defaults.setting_quick_boosting'),
+                 wrapper: :with_label
     .flash-message.hidden-on-touch-devices= t('appearance.boosting_preferences_info_html', icon: material_symbol('repeat'))
 
     %h4= t 'appearance.sensitive_content'

--- a/app/views/settings/verifications/show.html.haml
+++ b/app/views/settings/verifications/show.html.haml
@@ -51,7 +51,7 @@
           %strong.status-card__title= t('author_attribution.example_title')
       .more-from-author
         = logo_as_symbol(:icon)
-        = t('author_attribution.more_from_html', name: link_to(root_url, class: 'story__details__shared__author-link') { image_tag(@account.avatar.url, class: 'account__avatar', width: 16, height: 16, alt: '') + tag.bdi(display_name(@account)) })
+        = t('author_attribution.more_from_html', name: author_attribution_name(@account))
 
   %h4= t('verification.here_is_how')
 
@@ -65,7 +65,10 @@
   %p.lead= t('author_attribution.then_instructions')
 
   .fields-group
-    = f.input :attribution_domains, as: :text, wrapper: :with_block_label, input_html: { value: @account.attribution_domains.join("\n"), placeholder: "example1.com\nexample2.com\nexample3.com", rows: 4, autocapitalize: 'none', autocorrect: 'off' }
+    = f.input :attribution_domains,
+              as: :text,
+              input_html: { value: @account.attribution_domains.join("\n"), placeholder: "example1.com\nexample2.com\nexample3.com", rows: 4, autocapitalize: 'none', autocorrect: 'off' },
+              wrapper: :with_block_label
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/user_mailer/confirmation_instructions.html.haml
+++ b/app/views/user_mailer/confirmation_instructions.html.haml
@@ -10,7 +10,9 @@
           %td.email-inner-card-td.email-prose
             %p= t @resource.approved? ? 'devise.mailer.confirmation_instructions.explanation' : 'devise.mailer.confirmation_instructions.explanation_when_pending', host: site_hostname
             - if @resource.created_by_application
-              = render 'application/mailer/button', text: t('devise.mailer.confirmation_instructions.action_with_app', app: @resource.created_by_application.name), url: confirmation_url(@resource, confirmation_token: @token, redirect_to_app: 'true')
+              = render 'application/mailer/button',
+                       text: t('devise.mailer.confirmation_instructions.action_with_app', app: @resource.created_by_application.name),
+                       url: confirmation_url(@resource, confirmation_token: @token, redirect_to_app: 'true')
             - else
               = render 'application/mailer/button', text: t('devise.mailer.confirmation_instructions.action'), url: confirmation_url(@resource, confirmation_token: @token)
             %p= t 'devise.mailer.confirmation_instructions.extra_html', terms_path: about_more_url, policy_path: privacy_policy_url


### PR DESCRIPTION
It'd be great to eventually get this in line with the override below (ie, 2x the default ... 160), but that would currently be pretty high churn. As a first pass, drop to 240 - which is pretty straightforward.