### PR TITLE
Add dedicated user preferences for theme mode & contrast

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_account
   helper_method :current_session
   helper_method :current_theme
+  helper_method :prefers_contrast
   helper_method :single_user_mode?
   helper_method :use_seamless_external_login?
   helper_method :sso_account_settings
@@ -175,6 +176,10 @@ class ApplicationController < ActionController::Base
     return Setting.theme unless Themes.instance.names.include? current_user&.setting_theme
 
     current_user.setting_theme
+  end
+
+  def prefers_contrast
+    current_user.setting_prefers_contrast || 'default'
   end
 
   def respond_with_error(code)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,8 @@ class ApplicationController < ActionController::Base
   helper_method :current_account
   helper_method :current_session
   helper_method :current_theme
-  helper_method :prefers_contrast
+  helper_method :color_scheme
+  helper_method :contrast
   helper_method :single_user_mode?
   helper_method :use_seamless_external_login?
   helper_method :sso_account_settings
@@ -178,8 +179,23 @@ class ApplicationController < ActionController::Base
     current_user.setting_theme
   end
 
-  def prefers_contrast
-    current_user.setting_prefers_contrast || 'default'
+  def color_scheme
+    current = current_user&.setting_color_scheme
+    return current if current && current != 'auto'
+
+    return 'dark' if current_theme.include?('default') || current_theme.include?('contrast')
+    return 'light' if current_theme.include?('light')
+
+    'auto'
+  end
+
+  def contrast
+    current = current_user&.setting_contrast
+    return current if current && current != 'auto'
+
+    return 'high' if current_theme.include?('contrast')
+
+    'auto'
   end
 
   def respond_with_error(code)

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -716,6 +716,17 @@ code {
     }
   }
 
+  .horizontal-options .label_input__wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+
+    .radio,
+    .radio > label {
+      margin-bottom: 0;
+    }
+  }
+
   .status-card {
     contain: unset;
   }

--- a/app/models/concerns/user/has_settings.rb
+++ b/app/models/concerns/user/has_settings.rb
@@ -59,6 +59,10 @@ module User::HasSettings
     settings['theme']
   end
 
+  def setting_prefers_contrast
+    settings['web.prefers_contrast']
+  end
+
   def setting_display_media
     settings['web.display_media']
   end

--- a/app/models/concerns/user/has_settings.rb
+++ b/app/models/concerns/user/has_settings.rb
@@ -59,8 +59,12 @@ module User::HasSettings
     settings['theme']
   end
 
-  def setting_prefers_contrast
-    settings['web.prefers_contrast']
+  def setting_color_scheme
+    settings['web.color_scheme']
+  end
+
+  def setting_contrast
+    settings['web.contrast']
   end
 
   def setting_display_media

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -37,6 +37,7 @@ class UserSettings
     setting :display_media, default: 'default', in: %w(default show_all hide_all)
     setting :auto_play, default: false
     setting :emoji_style, default: 'auto', in: %w(auto native twemoji)
+    setting :prefers_contrast, default: 'default', in: %w(default high)
   end
 
   namespace :notification_emails do

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -37,7 +37,8 @@ class UserSettings
     setting :display_media, default: 'default', in: %w(default show_all hide_all)
     setting :auto_play, default: false
     setting :emoji_style, default: 'auto', in: %w(auto native twemoji)
-    setting :prefers_contrast, default: 'default', in: %w(default high)
+    setting :color_scheme, default: 'auto', in: %w(auto light dark)
+    setting :contrast, default: 'auto', in: %w(auto high)
   end
 
   namespace :notification_emails do

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{ lang: I18n.locale, class: html_classes, 'data-user-theme': current_theme.parameterize, 'data-prefers-contrast': prefers_contrast.parameterize }
+%html{ lang: I18n.locale, class: html_classes, 'data-user-theme': current_theme.parameterize, 'data-contrast': contrast.parameterize, 'data-mode': color_scheme.parameterize }
   %head
     %meta{ charset: 'utf-8' }/
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover' }/

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{ lang: I18n.locale, class: html_classes, 'data-user-theme': current_theme.parameterize }
+%html{ lang: I18n.locale, class: html_classes, 'data-user-theme': current_theme.parameterize, 'data-prefers-contrast': prefers_contrast.parameterize }
   %head
     %meta{ charset: 'utf-8' }/
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover' }/

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -32,22 +32,24 @@
                  wrapper: :with_label,
                  required: false
       - if Mastodon::Feature.new_theme_options_enabled?
-        = ff.input :'web.color_scheme',
-                   as: :radio_buttons,
-                   collection: %w(auto light dark),
-                   include_blank: false,
-                   label: I18n.t('simple_form.labels.defaults.setting_color_scheme'),
-                   label_method: ->(contrast) { I18n.t("color_scheme.#{contrast}", default: contrast) },
-                   wrapper: :with_label,
-                   required: false
-        = ff.input :'web.contrast',
-                   as: :radio_buttons,
-                   collection: %w(auto high),
-                   include_blank: false,
-                   label: I18n.t('simple_form.labels.defaults.setting_contrast'),
-                   label_method: ->(contrast) { I18n.t("contrast.#{contrast}", default: contrast) },
-                   wrapper: :with_label,
-                   required: false
+        .input.horizontal-options
+          = ff.input :'web.color_scheme',
+                     as: :radio_buttons,
+                     collection: %w(auto light dark),
+                     include_blank: false,
+                     label: I18n.t('simple_form.labels.defaults.setting_color_scheme'),
+                     label_method: ->(contrast) { I18n.t("color_scheme.#{contrast}", default: contrast) },
+                     wrapper: :with_label,
+                     required: false
+        .input.horizontal-options
+          = ff.input :'web.contrast',
+                     as: :radio_buttons,
+                     collection: %w(auto high),
+                     include_blank: false,
+                     label: I18n.t('simple_form.labels.defaults.setting_contrast'),
+                     label_method: ->(contrast) { I18n.t("contrast.#{contrast}", default: contrast) },
+                     wrapper: :with_label,
+                     required: false
 
   .fields-group
     = f.simple_fields_for :settings, current_user.settings do |ff|

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -29,7 +29,8 @@
                  include_blank: false,
                  label_method: ->(theme) { I18n.t("themes.#{theme}", default: theme) },
                  label: I18n.t('simple_form.labels.defaults.setting_theme'),
-                 wrapper: :with_label
+                 wrapper: :with_label,
+                 required: false
       - if Mastodon::Feature.new_theme_options_enabled?
         = ff.input :'web.color_scheme',
                    as: :radio_buttons,
@@ -56,7 +57,8 @@
                  hint: I18n.t('simple_form.hints.defaults.setting_emoji_style'),
                  label: I18n.t('simple_form.labels.defaults.setting_emoji_style'),
                  label_method: ->(emoji_style) { I18n.t("emoji_styles.#{emoji_style}", default: emoji_style) },
-                 wrapper: :with_label
+                 wrapper: :with_label,
+                 required: false
 
   - unless I18n.locale == :en
     .flash-message.translation-prompt
@@ -104,7 +106,8 @@
                  item_wrapper_tag: 'li',
                  label_method: ->(item) { t("simple_form.hints.defaults.setting_display_media_#{item}") },
                  label: I18n.t('simple_form.labels.defaults.setting_display_media'),
-                 wrapper: :with_floating_label
+                 wrapper: :with_floating_label,
+                 required: false
 
     .fields-group
       = ff.input :'web.use_blurhash',

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -29,15 +29,24 @@
                  include_blank: false,
                  label_method: ->(theme) { I18n.t("themes.#{theme}", default: theme) },
                  label: I18n.t('simple_form.labels.defaults.setting_theme'),
-                 wrapper: :with_label,
-                 required: false
-      = ff.input :'web.prefers_contrast',
-                 collection: %w(default high),
-                 include_blank: false,
-                 label: I18n.t('simple_form.labels.defaults.setting_prefers_contrast'),
-                 label_method: ->(contrast) { I18n.t("prefers_contrast.#{contrast}", default: contrast) },
-                 wrapper: :with_label,
-                 required: false
+                 wrapper: :with_label
+      - if Mastodon::Feature.new_theme_options_enabled?
+        = ff.input :'web.color_scheme',
+                   as: :radio_buttons,
+                   collection: %w(auto light dark),
+                   include_blank: false,
+                   label: I18n.t('simple_form.labels.defaults.setting_color_scheme'),
+                   label_method: ->(contrast) { I18n.t("color_scheme.#{contrast}", default: contrast) },
+                   wrapper: :with_label,
+                   required: false
+        = ff.input :'web.contrast',
+                   as: :radio_buttons,
+                   collection: %w(auto high),
+                   include_blank: false,
+                   label: I18n.t('simple_form.labels.defaults.setting_contrast'),
+                   label_method: ->(contrast) { I18n.t("contrast.#{contrast}", default: contrast) },
+                   wrapper: :with_label,
+                   required: false
 
   .fields-group
     = f.simple_fields_for :settings, current_user.settings do |ff|
@@ -47,8 +56,7 @@
                  hint: I18n.t('simple_form.hints.defaults.setting_emoji_style'),
                  label: I18n.t('simple_form.labels.defaults.setting_emoji_style'),
                  label_method: ->(emoji_style) { I18n.t("emoji_styles.#{emoji_style}", default: emoji_style) },
-                 wrapper: :with_label,
-                 required: false
+                 wrapper: :with_label
 
   - unless I18n.locale == :en
     .flash-message.translation-prompt
@@ -96,8 +104,7 @@
                  item_wrapper_tag: 'li',
                  label_method: ->(item) { t("simple_form.hints.defaults.setting_display_media_#{item}") },
                  label: I18n.t('simple_form.labels.defaults.setting_display_media'),
-                 wrapper: :with_floating_label,
-                 required: false
+                 wrapper: :with_floating_label
 
     .fields-group
       = ff.input :'web.use_blurhash',

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -31,6 +31,13 @@
                  label: I18n.t('simple_form.labels.defaults.setting_theme'),
                  wrapper: :with_label,
                  required: false
+      = ff.input :'web.prefers_contrast',
+                 collection: %w(default high),
+                 include_blank: false,
+                 label: I18n.t('simple_form.labels.defaults.setting_prefers_contrast'),
+                 label_method: ->(contrast) { I18n.t("prefers_contrast.#{contrast}", default: contrast) },
+                 wrapper: :with_label,
+                 required: false
 
   .fields-group
     = f.simple_fields_for :settings, current_user.settings do |ff|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1777,6 +1777,9 @@ en:
     other: Other
     posting_defaults: Posting defaults
     public_timelines: Public timelines
+  prefers_contrast:
+    default: Default
+    high: High
   privacy:
     hint_html: "<strong>Customize how you want your profile and your posts to be found.</strong> A variety of features in Mastodon can help you reach a wider audience when enabled. Take a moment to review these settings to make sure they fit your use case."
     privacy: Privacy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1319,6 +1319,13 @@ en:
     hint_html: "<strong>Tip:</strong> We won't ask you for your password again for the next hour."
     invalid_password: Invalid password
     prompt: Confirm password to continue
+  color_scheme:
+    auto: Auto
+    dark: Dark
+    light: Light
+  contrast:
+    auto: Auto
+    high: High
   crypto:
     errors:
       invalid_key: is not a valid Ed25519 or Curve25519 key
@@ -1777,9 +1784,6 @@ en:
     other: Other
     posting_defaults: Posting defaults
     public_timelines: Public timelines
-  prefers_contrast:
-    default: Default
-    high: High
   privacy:
     hint_html: "<strong>Customize how you want your profile and your posts to be found.</strong> A variety of features in Mastodon can help you reach a wider audience when enabled. Take a moment to review these settings to make sure they fit your use case."
     privacy: Privacy

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -254,6 +254,7 @@ en:
         setting_expand_spoilers: Always expand posts marked with content warnings
         setting_hide_network: Hide your social graph
         setting_missing_alt_text_modal: Warn me before posting media without alt text
+        setting_prefers_contrast: Contrast
         setting_quick_boosting: Enable quick boosting
         setting_reduce_motion: Reduce motion in animations
         setting_system_font_ui: Use system's default font

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -239,6 +239,8 @@ en:
         setting_always_send_emails: Always send e-mail notifications
         setting_auto_play_gif: Auto-play animated GIFs
         setting_boost_modal: Control boosting visibility
+        setting_color_scheme: Mode
+        setting_contrast: Contrast
         setting_default_language: Posting language
         setting_default_privacy: Posting visibility
         setting_default_quote_policy: Who can quote
@@ -254,7 +256,6 @@ en:
         setting_expand_spoilers: Always expand posts marked with content warnings
         setting_hide_network: Hide your social graph
         setting_missing_alt_text_modal: Warn me before posting media without alt text
-        setting_prefers_contrast: Contrast
         setting_quick_boosting: Enable quick boosting
         setting_reduce_motion: Reduce motion in animations
         setting_system_font_ui: Use system's default font


### PR DESCRIPTION
Fixes MAS-745
Fixes MAS-746

### Changes proposed in this PR:
- Adds new experimental feature flag `new_theme_options`, which adds the following settings to the Appearance user options page
  - "Mode": Allows selecting between "Auto", "Light", and "Dark"
  - "Contrast": Allows selecting between "Auto" and "High" (I'm still trying to figure out how to render this as a single checkbox)
- These options add new data attributes `data-mode` and `data-contrast` to the html element. When these are set to "Auto", for the time being they are populated based on the existing "Site theme" setting.
- No CSS changes were made in this PR


#### Next steps (in later PRs) will be:
1. Write a db migration to set these new preferences based on current theme selection
2. Actually change our CSS codebase into a single stylesheet that adjusts styling based on html attributes or media queries
3. Adapt theme selector to be hidden when no additional themes are available
4. Remove the feature flag

(Steps 1 and 2 can be done in any order.)

### Screenshots

> [!NOTE]
> This is a work-in-progress and does not reflect the intended final design

<img width="480" height="508" alt="image" src="https://github.com/user-attachments/assets/e296f386-1c63-498c-9881-390ae39f9e0a" />
