### PR TITLE
Remove required field markers from unclearable fields in user preferences

### DIFF
--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -29,7 +29,8 @@
                  include_blank: false,
                  label_method: ->(theme) { I18n.t("themes.#{theme}", default: theme) },
                  label: I18n.t('simple_form.labels.defaults.setting_theme'),
-                 wrapper: :with_label
+                 wrapper: :with_label,
+                 required: false
 
   .fields-group
     = f.simple_fields_for :settings, current_user.settings do |ff|
@@ -39,7 +40,8 @@
                  hint: I18n.t('simple_form.hints.defaults.setting_emoji_style'),
                  label: I18n.t('simple_form.labels.defaults.setting_emoji_style'),
                  label_method: ->(emoji_style) { I18n.t("emoji_styles.#{emoji_style}", default: emoji_style) },
-                 wrapper: :with_label
+                 wrapper: :with_label,
+                 required: false
 
   - unless I18n.locale == :en
     .flash-message.translation-prompt
@@ -87,7 +89,8 @@
                  item_wrapper_tag: 'li',
                  label_method: ->(item) { t("simple_form.hints.defaults.setting_display_media_#{item}") },
                  label: I18n.t('simple_form.labels.defaults.setting_display_media'),
-                 wrapper: :with_floating_label
+                 wrapper: :with_floating_label,
+                 required: false
 
     .fields-group
       = ff.input :'web.use_blurhash',

--- a/app/views/settings/preferences/notifications/show.html.haml
+++ b/app/views/settings/preferences/notifications/show.html.haml
@@ -40,4 +40,5 @@
                      include_blank: false,
                      label_method: ->(setting) { I18n.t("simple_form.labels.notification_emails.software_updates.#{setting}") },
                      label: I18n.t('simple_form.labels.notification_emails.software_updates.label'),
-                     wrapper: :with_label
+                     wrapper: :with_label,
+                     required: false


### PR DESCRIPTION
### Changes proposed in this PR:
- Removes the asterisks denoting required fields in the user preferences for fields that can't be left empty and that are fine to leave as is

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="838" height="412" alt="image" src="https://github.com/user-attachments/assets/e56df50a-5ab6-4d10-90b0-242d060e9daf" /> | <img width="831" height="390" alt="image" src="https://github.com/user-attachments/assets/11862095-e3c7-411d-beb6-20594dade19c" /> |
| <img width="506" height="323" alt="image" src="https://github.com/user-attachments/assets/fd1bb623-9706-4633-afe2-1717b0a3a1da" /> | <img width="498" height="325" alt="image" src="https://github.com/user-attachments/assets/fe63803e-0030-4399-b851-fe6217d64509" /> |
| <img width="348" height="299" alt="image" src="https://github.com/user-attachments/assets/338c63cf-f8ba-4d34-a192-8e4d55e6d8a3" /> | <img width="359" height="294" alt="image" src="https://github.com/user-attachments/assets/d37cfeea-f801-4eee-9788-2d3e4800842a" /> |