### PR TITLE
Emoji loading fixes

### DIFF
--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -5,11 +5,7 @@ import { openDB } from 'idb';
 
 import { EMOJI_DB_SHORTCODE_TEST } from './constants';
 import { toSupportedLocale, toSupportedLocaleOrCustom } from './locale';
-import type {
-  CustomEmojiData,
-  UnicodeEmojiData,
-  LocaleOrCustom,
-} from './types';
+import type { CustomEmojiData, UnicodeEmojiData, EtagTypes } from './types';
 import { emojiLogger } from './utils';
 
 interface EmojiDB extends LocaleTables, DBSchema {
@@ -32,7 +28,7 @@ interface EmojiDB extends LocaleTables, DBSchema {
     };
   };
   etags: {
-    key: LocaleOrCustom;
+    key: EtagTypes;
     value: string;
   };
 }
@@ -197,10 +193,9 @@ export async function putLegacyShortcodes(shortcodes: ShortcodesDataset) {
   await trx.done;
 }
 
-export async function putLatestEtag(etag: string, localeString: string) {
-  const locale = toSupportedLocaleOrCustom(localeString);
+export async function putLatestEtag(etag: string, name: EtagTypes) {
   const db = await loadDB();
-  await db.put('etags', etag, locale);
+  await db.put('etags', etag, name);
 }
 
 export async function clearEtag(localeString: string) {

--- a/app/javascript/mastodon/features/emoji/index.ts
+++ b/app/javascript/mastodon/features/emoji/index.ts
@@ -6,8 +6,6 @@ import type { EMOJI_DB_NAME_SHORTCODES, EMOJI_TYPE_CUSTOM } from './constants';
 import { toSupportedLocale } from './locale';
 import type { LocaleOrCustom } from './types';
 import { emojiLogger } from './utils';
-// eslint-disable-next-line import/default -- Importing via worker loader.
-import EmojiWorker from './worker?worker&inline';
 
 const userLocale = toSupportedLocale(initialState?.meta.locale ?? 'en');
 
@@ -18,13 +16,14 @@ const log = emojiLogger('index');
 // This is too short, but better to fallback quickly than wait.
 const WORKER_TIMEOUT = 1_000;
 
-export function initializeEmoji() {
+export async function initializeEmoji() {
   log('initializing emojis');
 
   // Create a temp worker, and assign it to the module-level worker once we know it's ready.
   let tempWorker: Worker | null = null;
   if (!worker && 'Worker' in window) {
     try {
+      const { default: EmojiWorker } = await import('./worker?worker&inline');
       tempWorker = new EmojiWorker();
     } catch (err) {
       console.warn('Error creating web worker:', err);

--- a/app/javascript/mastodon/features/emoji/index.ts
+++ b/app/javascript/mastodon/features/emoji/index.ts
@@ -64,7 +64,7 @@ async function fallbackLoad() {
   await loadCustomEmoji();
   const { importLegacyShortcodes } = await import('./loader');
   const shortcodes = await importLegacyShortcodes();
-  if (shortcodes.length) {
+  if (shortcodes?.length) {
     log('loaded %d legacy shortcodes', shortcodes.length);
   }
   await loadEmojiLocale(userLocale);

--- a/app/javascript/mastodon/features/emoji/index.ts
+++ b/app/javascript/mastodon/features/emoji/index.ts
@@ -1,8 +1,6 @@
-import type { Locale } from 'emojibase';
-
 import { initialState } from '@/mastodon/initial_state';
 
-import type { EMOJI_DB_NAME_SHORTCODES, EMOJI_TYPE_CUSTOM } from './constants';
+import type { EMOJI_DB_NAME_SHORTCODES } from './constants';
 import { toSupportedLocale } from './locale';
 import type { LocaleOrCustom } from './types';
 import { emojiLogger } from './utils';
@@ -71,14 +69,11 @@ async function fallbackLoad() {
 
 async function loadEmojiLocale(localeString: string) {
   const locale = toSupportedLocale(localeString);
-  const { importEmojiData, localeToEmojiPath, localeToShortcodesPath } =
-    await import('./loader');
+  const { importEmojiData } = await import('./loader');
 
   if (worker) {
-    const path = await localeToEmojiPath(locale);
-    const shortcodesPath = await localeToShortcodesPath(locale);
-    log('asking worker to load locale %s from %s', locale, path);
-    messageWorker(locale, path, shortcodesPath);
+    log('asking worker to load locale %s', locale);
+    messageWorker(locale);
   } else {
     const emojis = await importEmojiData(locale);
     if (emojis) {
@@ -100,16 +95,10 @@ export async function loadCustomEmoji() {
 }
 
 function messageWorker(
-  locale: typeof EMOJI_TYPE_CUSTOM | typeof EMOJI_DB_NAME_SHORTCODES,
-): void;
-function messageWorker(locale: Locale, path: string, shortcodes?: string): void;
-function messageWorker(
   locale: LocaleOrCustom | typeof EMOJI_DB_NAME_SHORTCODES,
-  path?: string,
-  shortcodes?: string,
 ) {
   if (!worker) {
     return;
   }
-  worker.postMessage({ locale, path, shortcodes });
+  worker.postMessage({ locale });
 }

--- a/app/javascript/mastodon/features/emoji/loader.ts
+++ b/app/javascript/mastodon/features/emoji/loader.ts
@@ -23,13 +23,7 @@ export async function importEmojiData(
 ) {
   const locale = toSupportedLocale(localeString);
 
-  // Validate the provided path.
-  if (path && !/^[/a-z]*\/packs\/assets\/compact-\w+\.json$/.test(path)) {
-    throw new Error(`Invalid path for emoji data: ${path}`);
-  } else {
-    // Otherwise get the path if not provided.
-    path ??= await localeToEmojiPath(locale);
-  }
+  path ??= await localeToEmojiPath(locale);
 
   const emojis = await fetchAndCheckEtag<CompactEmoji[]>(locale, path);
   if (!emojis) {
@@ -37,13 +31,7 @@ export async function importEmojiData(
   }
 
   const shortcodesData: ShortcodesDataset[] = [];
-  if (shortcodes) {
-    if (
-      typeof shortcodes === 'string' &&
-      !/^[/a-z]*\/packs\/assets\/shortcodes\/cldr\.json$/.test(shortcodes)
-    ) {
-      throw new Error(`Invalid path for shortcodes data: ${shortcodes}`);
-    }
+  if (typeof shortcodes === 'string') {
     const shortcodesPath =
       typeof shortcodes === 'string'
         ? shortcodes

--- a/app/javascript/mastodon/features/emoji/loader.ts
+++ b/app/javascript/mastodon/features/emoji/loader.ts
@@ -15,9 +15,18 @@ import {
 } from './database';
 import { toSupportedLocale, toValidEtagName } from './locale';
 import type { CustomEmojiData } from './types';
+import { emojiLogger } from './utils';
+
+const log = emojiLogger('loader');
 
 export async function importEmojiData(localeString: string, shortcodes = true) {
   const locale = toSupportedLocale(localeString);
+
+  log(
+    'importing emoji data for locale %s%s',
+    locale,
+    shortcodes ? ' and shortcodes' : '',
+  );
 
   const emojis = await fetchAndCheckEtag<CompactEmoji[]>(
     locale,
@@ -142,6 +151,7 @@ export async function fetchAndCheckEtag<ResultType extends object[] | object>(
   // Store the ETag for future requests
   const etag = response.headers.get('ETag');
   if (etag && checkEtag) {
+    log(`storing new etag for ${etagName}: ${etag}`);
     await putLatestEtag(etag, etagName);
   }
 

--- a/app/javascript/mastodon/features/emoji/locale.ts
+++ b/app/javascript/mastodon/features/emoji/locale.ts
@@ -33,7 +33,7 @@ export function toValidEtagName(input: string): EtagTypes {
 }
 
 function isSupportedLocale(locale: string): locale is Locale {
-  return SUPPORTED_LOCALES.includes(locale.toLowerCase() as Locale);
+  return SUPPORTED_LOCALES.includes(locale as Locale);
 }
 
 function isLocaleWithShortcodes(input: string): input is LocaleWithShortcodes {

--- a/app/javascript/mastodon/features/emoji/locale.ts
+++ b/app/javascript/mastodon/features/emoji/locale.ts
@@ -1,7 +1,8 @@
 import type { Locale } from 'emojibase';
 import { SUPPORTED_LOCALES } from 'emojibase';
 
-import type { LocaleOrCustom } from './types';
+import { EMOJI_DB_NAME_SHORTCODES, EMOJI_TYPE_CUSTOM } from './constants';
+import type { EtagTypes, LocaleOrCustom, LocaleWithShortcodes } from './types';
 
 export function toSupportedLocale(localeBase: string): Locale {
   const locale = localeBase.toLowerCase();
@@ -12,12 +13,35 @@ export function toSupportedLocale(localeBase: string): Locale {
 }
 
 export function toSupportedLocaleOrCustom(locale: string): LocaleOrCustom {
-  if (locale.toLowerCase() === 'custom') {
-    return 'custom';
+  if (locale.toLowerCase() === EMOJI_TYPE_CUSTOM) {
+    return EMOJI_TYPE_CUSTOM;
   }
   return toSupportedLocale(locale);
 }
 
+export function toValidEtagName(input: string): EtagTypes {
+  const lower = input.toLowerCase();
+  if (lower === EMOJI_TYPE_CUSTOM || lower === EMOJI_DB_NAME_SHORTCODES) {
+    return lower;
+  }
+
+  if (isLocaleWithShortcodes(lower)) {
+    return lower;
+  }
+
+  return toSupportedLocale(lower);
+}
+
 function isSupportedLocale(locale: string): locale is Locale {
   return SUPPORTED_LOCALES.includes(locale.toLowerCase() as Locale);
+}
+
+function isLocaleWithShortcodes(input: string): input is LocaleWithShortcodes {
+  const [baseLocale, shortcodes] = input.split('-');
+  return (
+    !!baseLocale &&
+    !!shortcodes &&
+    isSupportedLocale(baseLocale) &&
+    shortcodes === EMOJI_DB_NAME_SHORTCODES
+  );
 }

--- a/app/javascript/mastodon/features/emoji/render.ts
+++ b/app/javascript/mastodon/features/emoji/render.ts
@@ -4,12 +4,6 @@ import {
   EMOJI_TYPE_UNICODE,
   EMOJI_TYPE_CUSTOM,
 } from './constants';
-import {
-  loadEmojiByHexcode,
-  loadLegacyShortcodesByShortcode,
-  LocaleNotLoadedError,
-} from './database';
-import { importEmojiData } from './loader';
 import { emojiToUnicodeHex } from './normalize';
 import type {
   EmojiLoadedState,
@@ -121,6 +115,12 @@ export async function loadEmojiDataToState(
     return null;
   }
 
+  const {
+    loadLegacyShortcodesByShortcode,
+    loadEmojiByHexcode,
+    LocaleNotLoadedError,
+  } = await import('./database');
+
   // First, try to load the data from IndexedDB.
   try {
     const legacyCode = await loadLegacyShortcodesByShortcode(state.code);
@@ -155,6 +155,7 @@ export async function loadEmojiDataToState(
         state.code,
         locale,
       );
+      const { importEmojiData } = await import('./loader');
       await importEmojiData(locale); // Use this from the loader file as it can be awaited.
       return loadEmojiDataToState(state, locale, true);
     }

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -7,6 +7,7 @@ import type { CustomEmoji } from '@/mastodon/models/custom_emoji';
 import type { RequiredExcept } from '@/mastodon/utils/types';
 
 import type {
+  EMOJI_DB_NAME_SHORTCODES,
   EMOJI_MODE_NATIVE,
   EMOJI_MODE_NATIVE_WITH_FLAGS,
   EMOJI_MODE_TWEMOJI,
@@ -20,6 +21,11 @@ export type EmojiMode =
   | typeof EMOJI_MODE_TWEMOJI;
 
 export type LocaleOrCustom = Locale | typeof EMOJI_TYPE_CUSTOM;
+export type LocaleWithShortcodes = `${Locale}-shortcodes`;
+export type EtagTypes =
+  | LocaleOrCustom
+  | typeof EMOJI_DB_NAME_SHORTCODES
+  | LocaleWithShortcodes;
 
 export interface EmojiAppState {
   locales: Locale[];

--- a/app/javascript/mastodon/features/emoji/worker.ts
+++ b/app/javascript/mastodon/features/emoji/worker.ts
@@ -20,7 +20,7 @@ async function loadData(locale: string, path?: string) {
   if (locale === EMOJI_TYPE_CUSTOM) {
     importCount = (await importCustomEmojiData())?.length;
   } else if (locale === EMOJI_DB_NAME_SHORTCODES) {
-    importCount = (await importLegacyShortcodes()).length;
+    importCount = (await importLegacyShortcodes())?.length;
   } else if (path) {
     importCount = (await importEmojiData(locale, path))?.length;
   } else {

--- a/app/javascript/mastodon/features/emoji/worker.ts
+++ b/app/javascript/mastodon/features/emoji/worker.ts
@@ -8,24 +8,23 @@ import {
 addEventListener('message', handleMessage);
 self.postMessage('ready'); // After the worker is ready, notify the main thread
 
-function handleMessage(event: MessageEvent<{ locale: string; path?: string }>) {
+function handleMessage(event: MessageEvent<{ locale: string }>) {
   const {
-    data: { locale, path },
+    data: { locale },
   } = event;
-  void loadData(locale, path);
+  void loadData(locale);
 }
 
-async function loadData(locale: string, path?: string) {
+async function loadData(locale: string) {
   let importCount: number | undefined;
   if (locale === EMOJI_TYPE_CUSTOM) {
     importCount = (await importCustomEmojiData())?.length;
   } else if (locale === EMOJI_DB_NAME_SHORTCODES) {
     importCount = (await importLegacyShortcodes())?.length;
-  } else if (path) {
-    importCount = (await importEmojiData(locale, path))?.length;
   } else {
-    throw new Error('Path is required for loading locale emoji data');
+    importCount = (await importEmojiData(locale))?.length;
   }
+
   if (importCount) {
     self.postMessage(`loaded ${importCount} emojis into ${locale}`);
   }

--- a/app/javascript/mastodon/main.tsx
+++ b/app/javascript/mastodon/main.tsx
@@ -30,7 +30,7 @@ function main() {
     }
 
     const { initializeEmoji } = await import('./features/emoji/index');
-    initializeEmoji();
+    await initializeEmoji();
 
     const root = createRoot(mountNode);
     root.render(<Mastodon {...props} />);


### PR DESCRIPTION
This improves the emoji worker loading by removing the unnecessarily complicated technique of passing paths around from #36897. Instead, this relies on `import.meta.glob` with `eager: true`, which makes Vite actively insert the correct URLs into the final source instead of trying to do an `import()` which fails. This also removes the warnings from GitHub about user-controlled paths.

Also this adds a few more places to code split to fix Vite errors from another PR recently merged.