### PR TITLE
Skip followers synchronization for accounts with 25k followers or more

### DIFF
--- a/app/workers/activitypub/distribution_worker.rb
+++ b/app/workers/activitypub/distribution_worker.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class ActivityPub::DistributionWorker < ActivityPub::RawDistributionWorker
+  # Skip followers synchronization for accounts with a large number of followers,
+  # as this is expensive and people with very large amounts of followers
+  # necessarily have less control over them to begin with
+  MAX_FOLLOWERS_FOR_SYNCHRONIZATION = 25_000
+
   # Distribute a new status or an edit of a status to all the places
   # where the status is supposed to go or where it was interacted with
   def perform(status_id)
@@ -27,6 +32,6 @@ class ActivityPub::DistributionWorker < ActivityPub::RawDistributionWorker
   end
 
   def options
-    { 'synchronize_followers' => @status.private_visibility? }
+    { 'synchronize_followers' => @status.private_visibility? && @account.followers_count < MAX_FOLLOWERS_FOR_SYNCHRONIZATION }
   end
 end


### PR DESCRIPTION
Computing the followers synchronization hash can be pretty expensive, which isn't helped by PostgreSQL sometimes picking up a very inefficient query plan.

The more an account has followers, the more expensive the request is, even in best case scenarios, and the more an account has followers, the more likely PostgreSQL is to pick the very inefficient query plan.

This PR puts a cap on the number of followers, above which computation of the follower synchronization hash will be skipped.

This cap has been chosen to be 25k followers. A quick survey of mastodon.social database shows that most “locked” accounts have less than 1k followers, none of which has more than 20k followers, and only about a hundred accounts have more than 20k followers.