### PR TITLE
Group classes in media proxy `rescue_from` declaration

### DIFF
--- a/app/controllers/media_proxy_controller.rb
+++ b/app/controllers/media_proxy_controller.rb
@@ -11,9 +11,7 @@ class MediaProxyController < ApplicationController
   before_action :authenticate_user!, if: :limited_federation_mode?
   before_action :set_media_attachment
 
-  rescue_from ActiveRecord::RecordInvalid, with: :not_found
-  rescue_from Mastodon::UnexpectedResponseError, with: :not_found
-  rescue_from Mastodon::NotPermittedError, with: :not_found
+  rescue_from ActiveRecord::RecordInvalid, Mastodon::NotPermittedError, Mastodon::UnexpectedResponseError, with: :not_found
   rescue_from(*Mastodon::HTTP_CONNECTION_ERRORS, with: :internal_server_error)
 
   def show


### PR DESCRIPTION
Small style thing.

Matches format used on the line below, and (as far as I can tell) every other usage of `rescue_from` in the app.

Possible that some of this predates being able to send multiple? (though maybe that was always possible...)