### PR TITLE
Fix mobile admin sidebar displaying under batch table toolbar

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -164,6 +164,7 @@ $content-width: 840px;
     width: 100%;
     max-width: $content-width;
     flex: 1 1 auto;
+    isolation: isolate;
   }
 
   @media screen and (max-width: ($content-width + $sidebar-width)) {


### PR DESCRIPTION
Fixes #37295

### Changes proposed in this PR:
- Prevent z-index conflict by forcing a separate stacking context on the `.content-wrapper` element

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="527" height="805" alt="image" src="https://github.com/user-attachments/assets/108e4610-42a2-423e-bb0c-d2a940adc481" /> | <img width="532" height="805" alt="image" src="https://github.com/user-attachments/assets/5dce72f0-22b1-4647-b393-4dc8ebbb696a" /> |