### PR TITLE
Fixes CDN domain loading

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -156,6 +156,14 @@ export const config: UserConfigFnPromise = async ({ mode, command }) => {
         },
       },
     },
+    experimental: {
+      /**
+       * Setting this causes Vite to not rely on the base config for import URLs,
+       * and instead uses import.meta.url, which is what we want for proper CDN support.
+       * @see https://github.com/mastodon/mastodon/pull/37310
+       */
+      renderBuiltUrl: () => undefined,
+    },
     worker: {
       format: 'es',
     },


### PR DESCRIPTION
Fixes #37274.

This works around some logic in Vite that is causing some assets to be loaded from the main domain instead of the CDN host.

To test:
- Create a production asset build with this PR.
- Have your production setup leverage the `CDN_HOST` env variable.
- Verify that all JS and CSS files are loaded from the CDN host instead of the main one.

In detail:
1. Vite generates [a preload function](https://github.com/vitejs/vite/blob/v7.1.1/packages/vite/src/node/plugins/importAnalysisBuild.ts#L76-L177) that replaces all dynamic imports with a wrapper function.
2. At build time, Vite checks for a relative base path or the `renderBuildUrl` experimental flag [here](https://github.com/vitejs/vite/blob/v7.1.1/packages/vite/src/node/plugins/importAnalysisBuild.ts#L199).
3. If either of those are set, a function called [`assetsURL`](https://github.com/vitejs/vite/blob/v7.1.1/packages/vite/src/node/plugins/importAnalysisBuild.ts#L111) is inserted that takes `import.meta.url` to generate the asset URL. If they are _not_ set, the function just concatenates the `base` path from the Vite config and the asset path.
5. However, [`renderBuildUrl`](https://vite.dev/guide/build#advanced-base-options) is also used for base URL generation, which we don't want to change. Therefore, the function needs to return `undefined` to [allow default behavior](https://github.com/vitejs/vite/blob/v7.1.1/packages/vite/src/node/build.ts#L1369) _except_ for `assetsURL`.