### PR TITLE
Remove trailing variation selector code for legacy emojis

### DIFF
--- a/app/javascript/mastodon/features/emoji/normalize.test.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.test.ts
@@ -33,6 +33,7 @@ describe('emojiToUnicodeHex', () => {
     ['⚫', '26AB'],
     ['🖤', '1F5A4'],
     ['💀', '1F480'],
+    ['❤️', '2764'], // Checks for trailing variation selector removal.
     ['💂‍♂️', '1F482-200D-2642-FE0F'],
   ] as const)(
     'emojiToUnicodeHex converts %s to %s',

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -32,6 +32,12 @@ export function emojiToUnicodeHex(emoji: string): string {
       codes.push(code);
     }
   }
+
+  // Handles how Emojibase removes the variation selector for single code emojis.
+  // See: https://emojibase.dev/docs/spec/#merged-variation-selectors
+  if (codes.at(1) === VARIATION_SELECTOR_CODE && codes.length === 2) {
+    codes.pop();
+  }
   return hexNumbersToString(codes);
 }
 


### PR DESCRIPTION
Emojibase [trims the trailing variation selector code](https://emojibase.dev/docs/spec/#merged-variation-selectors) (`U+FE0F`) in it's dataset, as emoji like ❤️ often are provided without. This was making those emoji not found in the emoji database.

This PR trims trailing variation selector codes to match the Emojibase spec.

Also, if there is a trailing text variation selector code (`U+FE00`), instead of trying to look up the emoji the rendering system just exits early to allow for text rendering. For instance, this means characters like `❤` will render correctly.