### PR TITLE
Add stub story for `StatusQuoteManager` / `Status` component

### DIFF
--- a/app/javascript/mastodon/components/status_quoted.stories.tsx
+++ b/app/javascript/mastodon/components/status_quoted.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { accountFactoryState, statusFactoryState } from '@/testing/factories';
+
+import type { StatusQuoteManagerProps } from './status_quoted';
+import { StatusQuoteManager } from './status_quoted';
+
+const meta = {
+  title: 'Components/Status/StatusQuoteManager',
+  render(args) {
+    return <StatusQuoteManager {...args} />;
+  },
+  args: {
+    id: '1',
+  },
+  parameters: {
+    state: {
+      accounts: {
+        '1': accountFactoryState({ id: '1', acct: 'hashtaguser' }),
+      },
+      statuses: {
+        '1': statusFactoryState({
+          id: '1',
+          text: 'Hello world!',
+        }),
+      },
+    },
+  },
+} satisfies Meta<StatusQuoteManagerProps>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/app/javascript/mastodon/components/status_quoted.tsx
+++ b/app/javascript/mastodon/components/status_quoted.tsx
@@ -4,19 +4,18 @@ import { FormattedMessage } from 'react-intl';
 
 import type { Map as ImmutableMap } from 'immutable';
 
+import { fetchRelationships } from 'mastodon/actions/accounts';
+import { revealAccount } from 'mastodon/actions/accounts_typed';
+import { fetchStatus } from 'mastodon/actions/statuses';
 import { LearnMoreLink } from 'mastodon/components/learn_more_link';
 import StatusContainer from 'mastodon/containers/status_container';
 import { domain } from 'mastodon/initial_state';
 import type { Account } from 'mastodon/models/account';
 import type { Status } from 'mastodon/models/status';
+import { makeGetStatusWithExtraInfo } from 'mastodon/selectors';
+import { getAccountHidden } from 'mastodon/selectors/accounts';
 import type { RootState } from 'mastodon/store';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
-
-import { fetchRelationships } from '../actions/accounts';
-import { revealAccount } from '../actions/accounts_typed';
-import { fetchStatus } from '../actions/statuses';
-import { makeGetStatusWithExtraInfo } from '../selectors';
-import { getAccountHidden } from '../selectors/accounts';
 
 import { Button } from './button';
 
@@ -333,7 +332,7 @@ export const QuotedStatus: React.FC<QuotedStatusProps> = ({
   );
 };
 
-interface StatusQuoteManagerProps {
+export interface StatusQuoteManagerProps {
   id: string;
   contextType?: string;
   [key: string]: unknown;

--- a/app/javascript/testing/factories.ts
+++ b/app/javascript/testing/factories.ts
@@ -76,7 +76,7 @@ export const statusFactory: FactoryFunction<ApiStatusJSON> = ({
   mentions: [],
   tags: [],
   emojis: [],
-  contentHtml: '<p>This is a test status.</p>',
+  contentHtml: data.text ?? '<p>This is a test status.</p>',
   ...data,
 });
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Adds a minuscule stub story for the `StatusQuoteManager` component, which is the highest-level building block of our standalone `Status` component. Not much there in terms of documentation and I've left it sitting right in the `/components` folder for now, but it's a start.

### Screenshots

<img width="889" height="534" alt="image" src="https://github.com/user-attachments/assets/ff08f9b4-1b01-4980-a6ee-1d963ec25d0a" />
