### PR TITLE
Unclosed connection leak when replacing pooled connection in SharedTimedStack.try_create

### DIFF
--- a/app/lib/connection_pool/shared_timed_stack.rb
+++ b/app/lib/connection_pool/shared_timed_stack.rb
@@ -70,6 +70,7 @@ class ConnectionPool::SharedTimedStack
     if @created == @max && !@queue.empty?
       throw_away_connection = @queue.pop
       @tagged_queue[throw_away_connection.site].delete(throw_away_connection)
+      throw_away_connection.close
       @create_block.call(preferred_tag)
     elsif @created != @max
       connection = @create_block.call(preferred_tag)

--- a/app/lib/connection_pool/shared_timed_stack.rb
+++ b/app/lib/connection_pool/shared_timed_stack.rb
@@ -70,8 +70,8 @@ class ConnectionPool::SharedTimedStack
     if @created == @max && !@queue.empty?
       throw_away_connection = @queue.pop
       @tagged_queue[throw_away_connection.site].delete(throw_away_connection)
-      throw_away_connection.close
       @create_block.call(preferred_tag)
+      throw_away_connection.close
     elsif @created != @max
       connection = @create_block.call(preferred_tag)
       @created += 1


### PR DESCRIPTION
`def flush` has the .close, and it's missing from the `def try_create`

Resulting in `consuming file descriptors`.

This was picked up by static code analysis, but the fix is mine... please validate