### PR TITLE
(SCA) GroupedNotificationsPresenter crashes when sample_accounts includes nil (uniq(&:id))

### DIFF
--- a/app/presenters/grouped_notifications_presenter.rb
+++ b/app/presenters/grouped_notifications_presenter.rb
@@ -19,9 +19,9 @@ class GroupedNotificationsPresenter < ActiveModelSerializers::Model
   def accounts
     @accounts ||= begin
       if partial_avatars?
-        @grouped_notifications.map { |group| group.sample_accounts.first }.uniq(&:id)
+        @grouped_notifications.map { |group| group.sample_accounts.first }.compact.uniq(&:id)
       else
-        @grouped_notifications.flat_map(&:sample_accounts).uniq(&:id)
+        @grouped_notifications.flat_map(&:sample_accounts).compact.uniq(&:id)
       end
     end
   end
@@ -29,7 +29,7 @@ class GroupedNotificationsPresenter < ActiveModelSerializers::Model
   def partial_accounts
     @partial_accounts ||= begin
       if partial_avatars?
-        @grouped_notifications.flat_map { |group| group.sample_accounts[1...] }.uniq(&:id).filter { |account| accounts.exclude?(account) }
+        @grouped_notifications.flat_map { |group| group.sample_accounts[1...] }.compact.uniq(&:id).filter { |account| accounts.exclude?(account) }
       else
         []
       end

--- a/app/presenters/grouped_notifications_presenter.rb
+++ b/app/presenters/grouped_notifications_presenter.rb
@@ -19,7 +19,7 @@ class GroupedNotificationsPresenter < ActiveModelSerializers::Model
   def accounts
     @accounts ||= begin
       if partial_avatars?
-        @grouped_notifications.map { |group| group.sample_accounts.first }.compact.uniq(&:id)
+        @grouped_notifications.filter_map { |group| group.sample_accounts.first }.uniq(&:id)
       else
         @grouped_notifications.flat_map(&:sample_accounts).compact.uniq(&:id)
       end


### PR DESCRIPTION
Fixes `NoMethodError: undefined method `id' for nil:NilClass`.