### PR TITLE
Update Mastodon link to point to 'about' page

### DIFF
--- a/app/javascript/mastodon/features/ui/components/link_footer.tsx
+++ b/app/javascript/mastodon/features/ui/components/link_footer.tsx
@@ -75,7 +75,7 @@ export const LinkFooter: React.FC<{
 
       <p>
         <strong>Mastodon</strong>:{' '}
-        <a href='https://joinmastodon.org' target='_blank' rel='noopener'>
+        <a href='https://joinmastodon.org/about' target='_blank' rel='noopener'>
           <FormattedMessage id='footer.about' defaultMessage='About' />
         </a>
         <DividingCircle />


### PR DESCRIPTION
This updates the Mastodon: About link in footer of Web interface to point to the Mastodon About page instead of the main joinmastodon landing page.