### PR TITLE
Upgrade bundler from 4.0.2 to 4.0.3 and sync Gemfile.lock Ruby version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1091,7 +1091,7 @@ DEPENDENCIES
   xorcist (~> 1.1)
 
 RUBY VERSION
-  ruby 3.4.1p0
+  ruby 3.4.8
 
 BUNDLED WITH
-  4.0.2
+  4.0.3


### PR DESCRIPTION
### Description

Upgrades `bundler` from 4.0.2 to [4.0.3](https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.3), the latest version and the version included in [Ruby 4.0.0](https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/). ~Additionally upgrades a few other gems. This is somewhat a preparatory PR for supporting Ruby 4.0.0 based on my experience upgrading another Rails app. For example, I ran into needed latest `brakeman`. Hence the upgrade in here. The other upgrades: `aws-sdk-s3` is [required](https://github.com/mastodon/mastodon/actions/runs/20510443432/job/58930832191?pr=37345) in order to address a [security advisory](https://github.com/aws/aws-sdk-ruby/security/advisories/GHSA-2xgq-q749-89fq) and `debug` and `irb` are simply nice to have.~

Additionally updated the Ruby version in the `Gemfile.lock` to match the version in `.ruby-version`.

Inspired by and follow up to
- https://github.com/mastodon/mastodon/pull/37191
- https://github.com/mastodon/mastodon/pull/37283

### :tophat: :tophat: :tophat: 

<img width="3840" height="2096" alt="Screenshot From 2026-01-02 16-58-52" src="https://github.com/user-attachments/assets/a7883fe9-b4cf-40ea-bcff-ec4c8c6a3dfc" />
<img width="3840" height="2096" alt="Screenshot From 2026-01-02 16-59-35" src="https://github.com/user-attachments/assets/c3f3a56b-a5b9-42b6-ac65-f7475edf6a2a" />