### PR TITLE
Update keyboard shortcut description for direct mentions

### DIFF
--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -517,7 +517,7 @@
   "keyboard_shortcuts.column": "Focus column",
   "keyboard_shortcuts.compose": "Focus compose textarea",
   "keyboard_shortcuts.description": "Description",
-  "keyboard_shortcuts.direct": "to open private mentions column",
+  "keyboard_shortcuts.direct": "Open private mentions column",
   "keyboard_shortcuts.down": "Move down in the list",
   "keyboard_shortcuts.enter": "Open post",
   "keyboard_shortcuts.favourite": "Favorite post",


### PR DESCRIPTION
The string value for the private mentions shortcut stands out as being in a different format to the rest, this small edit fixes that for consistency. Screenshot attached to show the issue that we are resolving.

<img width="773" height="1390" alt="Screenshot From 2025-12-26 11-25-57" src="https://github.com/user-attachments/assets/428c0679-f06c-4895-81c8-d1296b21f33e" />
