### PR TITLE
Enable a custom image prefix for Mastodon image builds

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -21,15 +21,58 @@ jobs:
     outputs:
       prerelease: ${{ steps.version_vars.outputs.mastodon_version_prerelease }}
 
+  compute-prefix:
+    runs-on: ubuntu-latest
+    steps:
+      - id: repository_vars
+        env:
+          config_mastodon_image_name: ${{ vars.MASTODON_IMAGE_NAME }}
+          config_mastodon_streaming_image_name: ${{ vars.MASTODON_STREAMING_IMAGE_NAME }}
+        run: |
+          # If custom image names are configured, use them; otherwise, default to both
+          # Docker Hub (tootsuite) and GitHub Container Registry (ghcr.io) for wider distribution
+          if [ -n "$config_mastodon_image_name" ]; then
+            {
+              echo 'image_name<<EOF'
+              echo "$config_mastodon_image_name"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo 'image_name<<EOF'
+              echo 'tootsuite/mastodon'
+              echo 'ghcr.io/mastodon/mastodon'
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "$config_mastodon_streaming_image_name" ]; then
+            {
+              echo 'streaming_image_name<<EOF'
+              echo "$config_mastodon_streaming_image_name"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo 'streaming_image_name<<EOF'
+              echo 'tootsuite/mastodon-streaming'
+              echo 'ghcr.io/mastodon/mastodon-streaming'
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+    outputs:
+      image_name: ${{ steps.repository_vars.outputs.image_name }}
+      streaming_image_name: ${{ steps.repository_vars.outputs.streaming_image_name }}
+
   build-image:
-    needs: compute-suffix
+    needs: [compute-suffix, compute-prefix]
     uses: ./.github/workflows/build-container-image.yml
     with:
       file_to_build: Dockerfile
       cache: false
       push_to_images: |
-        tootsuite/mastodon
-        ghcr.io/mastodon/mastodon
+        ${{ needs.compute-prefix.outputs.image_name }}
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes
@@ -42,14 +85,13 @@ jobs:
     secrets: inherit
 
   build-image-streaming:
-    needs: compute-suffix
+    needs: [compute-suffix, compute-prefix]
     uses: ./.github/workflows/build-container-image.yml
     with:
       file_to_build: streaming/Dockerfile
       cache: false
       push_to_images: |
-        tootsuite/mastodon-streaming
-        ghcr.io/mastodon/mastodon-streaming
+        ${{ needs.compute-prefix.outputs.streaming_image_name }}
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes

--- a/.github/workflows/build-push-pr.yml
+++ b/.github/workflows/build-push-pr.yml
@@ -27,13 +27,46 @@ jobs:
       metadata: ${{ steps.version_vars.outputs.mastodon_version_metadata }}
       short_sha: ${{ steps.version_vars.outputs.mastodon_short_sha }}
 
+  compute-prefix:
+    runs-on: ubuntu-latest
+    steps:
+      - id: repository_vars
+        env:
+          config_mastodon_image_name: ${{ vars.MASTODON_IMAGE_NAME }}
+          config_mastodon_streaming_image_name: ${{ vars.MASTODON_STREAMING_IMAGE_NAME }}
+        run: |
+          # Compute image names, supporting multi-line values for custom configurations
+          if [ -n "$config_mastodon_image_name" ]; then
+            {
+              echo 'image_name<<EOF'
+              echo "$config_mastodon_image_name"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "image_name=ghcr.io/mastodon/mastodon" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "$config_mastodon_streaming_image_name" ]; then
+            {
+              echo 'streaming_image_name<<EOF'
+              echo "$config_mastodon_streaming_image_name"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "streaming_image_name=ghcr.io/mastodon/mastodon-streaming" >> "$GITHUB_OUTPUT"
+          fi
+
+    outputs:
+      image_name: ${{ steps.repository_vars.outputs.image_name }}
+      streaming_image_name: ${{ steps.repository_vars.outputs.streaming_image_name }}
+
   build-image:
-    needs: compute-suffix
+    needs: [compute-suffix, compute-prefix]
     uses: ./.github/workflows/build-container-image.yml
     with:
       file_to_build: Dockerfile
       push_to_images: |
-        ghcr.io/mastodon/mastodon
+        ${{ needs.compute-prefix.outputs.image_name }}
       version_metadata: ${{ needs.compute-suffix.outputs.metadata }}
       flavor: |
         latest=auto
@@ -43,12 +76,12 @@ jobs:
     secrets: inherit
 
   build-image-streaming:
-    needs: compute-suffix
+    needs: [compute-suffix, compute-prefix]
     uses: ./.github/workflows/build-container-image.yml
     with:
       file_to_build: streaming/Dockerfile
       push_to_images: |
-        ghcr.io/mastodon/mastodon-streaming
+        ${{ needs.compute-prefix.outputs.streaming_image_name }}
       version_metadata: ${{ needs.compute-suffix.outputs.metadata }}
       flavor: |
         latest=auto

--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -45,14 +45,57 @@ jobs:
             echo "is_latest_stable=false" >> "$GITHUB_OUTPUT"
           fi
 
+  compute-prefix:
+    runs-on: ubuntu-latest
+    steps:
+      - id: repository_vars
+        env:
+          config_mastodon_image_name: ${{ vars.MASTODON_IMAGE_NAME }}
+          config_mastodon_streaming_image_name: ${{ vars.MASTODON_STREAMING_IMAGE_NAME }}
+        run: |
+          # If custom image names are configured, use them; otherwise, default to both
+          # Docker Hub (tootsuite) and GitHub Container Registry (ghcr.io) for wider distribution
+          if [ -n "$config_mastodon_image_name" ]; then
+            {
+              echo 'image_name<<EOF'
+              echo "$config_mastodon_image_name"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo 'image_name<<EOF'
+              echo 'tootsuite/mastodon'
+              echo 'ghcr.io/mastodon/mastodon'
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "$config_mastodon_streaming_image_name" ]; then
+            {
+              echo 'streaming_image_name<<EOF'
+              echo "$config_mastodon_streaming_image_name"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo 'streaming_image_name<<EOF'
+              echo 'tootsuite/mastodon-streaming'
+              echo 'ghcr.io/mastodon/mastodon-streaming'
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+    outputs:
+      image_name: ${{ steps.repository_vars.outputs.image_name }}
+      streaming_image_name: ${{ steps.repository_vars.outputs.streaming_image_name }}
+
   build-image:
-    needs: check-latest-stable
+    needs: [check-latest-stable, compute-prefix]
     uses: ./.github/workflows/build-container-image.yml
     with:
       file_to_build: Dockerfile
       push_to_images: |
-        tootsuite/mastodon
-        ghcr.io/mastodon/mastodon
+        ${{ needs.compute-prefix.outputs.image_name }}
       # Do not use cache when building releases, so apt update is always ran and the release always contain the latest packages
       cache: false
       # Only tag with latest when ran against the latest stable branch
@@ -65,13 +108,12 @@ jobs:
     secrets: inherit
 
   build-image-streaming:
-    needs: check-latest-stable
+    needs: [check-latest-stable, compute-prefix]
     uses: ./.github/workflows/build-container-image.yml
     with:
       file_to_build: streaming/Dockerfile
       push_to_images: |
-        tootsuite/mastodon-streaming
-        ghcr.io/mastodon/mastodon-streaming
+        ${{ needs.compute-prefix.outputs.streaming_image_name }}
       # Do not use cache when building releases, so apt update is always ran and the release always contain the latest packages
       cache: false
       # Only tag with latest when ran against the latest stable branch

--- a/.github/workflows/build-security.yml
+++ b/.github/workflows/build-security.yml
@@ -18,15 +18,58 @@ jobs:
     outputs:
       prerelease: ${{ steps.version_vars.outputs.mastodon_version_prerelease }}
 
+  compute-prefix:
+    runs-on: ubuntu-latest
+    steps:
+      - id: repository_vars
+        env:
+          config_mastodon_image_name: ${{ vars.MASTODON_IMAGE_NAME }}
+          config_mastodon_streaming_image_name: ${{ vars.MASTODON_STREAMING_IMAGE_NAME }}
+        run: |
+          # If custom image names are configured, use them; otherwise, default to both
+          # Docker Hub (tootsuite) and GitHub Container Registry (ghcr.io) for wider distribution
+          if [ -n "$config_mastodon_image_name" ]; then
+            {
+              echo 'image_name<<EOF'
+              echo "$config_mastodon_image_name"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo 'image_name<<EOF'
+              echo 'tootsuite/mastodon'
+              echo 'ghcr.io/mastodon/mastodon'
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "$config_mastodon_streaming_image_name" ]; then
+            {
+              echo 'streaming_image_name<<EOF'
+              echo "$config_mastodon_streaming_image_name"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo 'streaming_image_name<<EOF'
+              echo 'tootsuite/mastodon-streaming'
+              echo 'ghcr.io/mastodon/mastodon-streaming'
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+    outputs:
+      image_name: ${{ steps.repository_vars.outputs.image_name }}
+      streaming_image_name: ${{ steps.repository_vars.outputs.streaming_image_name }}
+
   build-image:
-    needs: compute-suffix
+    needs: [compute-suffix, compute-prefix]
     uses: ./.github/workflows/build-container-image.yml
     with:
       file_to_build: Dockerfile
       cache: false
       push_to_images: |
-        tootsuite/mastodon
-        ghcr.io/mastodon/mastodon
+        ${{ needs.compute-prefix.outputs.image_name }}
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes
@@ -39,14 +82,13 @@ jobs:
     secrets: inherit
 
   build-image-streaming:
-    needs: compute-suffix
+    needs: [compute-suffix, compute-prefix]
     uses: ./.github/workflows/build-container-image.yml
     with:
       file_to_build: streaming/Dockerfile
       cache: false
       push_to_images: |
-        tootsuite/mastodon-streaming
-        ghcr.io/mastodon/mastodon-streaming
+        ${{ needs.compute-prefix.outputs.streaming_image_name }}
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes


### PR DESCRIPTION
This is a re-submission of #22057, but adapted for the new image build process. The purpose here is to allow forks of Mastodon to reuse the image build workflows but to push to their own ghcr.io image registry. No provision is made for logging in to alternate registries, for simplicity.

The outline is:
  - for `build-nightly`, `build-releases`, and `build-security`, it continues to build `tootsuite/mastodon*` and `ghcr.io/mastodon/mastodon*` images
  - for `build-push-pr` it builds just `ghcr.io/mastodon/mastodon*` images
  - if a fork provides their own `MASTODON_IMAGE_NAME` and `MASTODON_STREAMING_IMAGE_NAME` variable, those will be used in preference to the defaults.

The actions are running on https://github.com/wandering-shop/mastodon; you can check the outputs there to see the successful use of the new variables.