### PR TITLE
Fix posts with edited out media attachments being returned in `/api/v1/accounts/:id/statuses?only_media=true`

### DIFF
--- a/app/lib/account_statuses_filter.rb
+++ b/app/lib/account_statuses_filter.rb
@@ -70,7 +70,7 @@ class AccountStatusesFilter
   end
 
   def only_media_scope
-    Status.joins(:media_attachments).merge(account.media_attachments).group(Status.arel_table[:id])
+    Status.without_empty_attachments.joins(:media_attachments).merge(account.media_attachments).group(Status.arel_table[:id])
   end
 
   def no_replies_scope

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -136,6 +136,7 @@ class Status < ApplicationRecord
   scope :tagged_with_none, lambda { |tag_ids|
     where('NOT EXISTS (SELECT * FROM statuses_tags forbidden WHERE forbidden.status_id = statuses.id AND forbidden.tag_id IN (?))', tag_ids)
   }
+  scope :without_empty_attachments, -> { where(ordered_media_attachment_ids: nil).or(where.not(ordered_media_attachment_ids: [])) }
 
   after_create_commit :trigger_create_webhooks
   after_update_commit :trigger_update_webhooks


### PR DESCRIPTION
I'm not sure about the performance impact of this change. In theory, it should be fine, but as the query is more complex, it is possible the query planner might pick a wrong plan in some cases.