### PR TITLE
Fix outdated link target for “locked” warning

### DIFF
--- a/app/javascript/mastodon/features/compose/components/warning.tsx
+++ b/app/javascript/mastodon/features/compose/components/warning.tsx
@@ -31,7 +31,7 @@ export const Warning = () => {
           defaultMessage='Your account is not {locked}. Anyone can follow you to view your follower-only posts.'
           values={{
             locked: (
-              <a href='/settings/profile'>
+              <a href='/settings/privacy#account_unlocked'>
                 <FormattedMessage
                   id='compose_form.lock_disclaimer.lock'
                   defaultMessage='locked'


### PR DESCRIPTION
See #37324 for context. Not marked as fixing it, because the copy would probably need updating as well.