### PR TITLE
[SCA] Destroyed accounts’ statuses are not removed from Elasticsearch PublicStatusesIndex

### DIFF
--- a/app/workers/remove_from_public_statuses_index_worker.rb
+++ b/app/workers/remove_from_public_statuses_index_worker.rb
@@ -10,6 +10,6 @@ class RemoveFromPublicStatusesIndexWorker
 
     account.remove_from_public_statuses_index!
   rescue ActiveRecord::RecordNotFound
-    true
+    PublicStatusesIndex.filter(term: { account_id: account_id }).delete_all
   end
 end


### PR DESCRIPTION
`app/workers/remove_from_public_statuses_index_worker.rb`
```
def perform(account_id)
  account = Account.find(account_id)  # Raises RecordNotFound for destroyed accounts

  return if account.indexable?

  account.remove_from_public_statuses_index!
rescue ActiveRecord::RecordNotFound
  true  # Silently returns without removing from index
end
```