### PR TITLE
trustworthy_attribution - Bounce bad URIs

### DIFF
--- a/app/services/activitypub/fetch_remote_status_service.rb
+++ b/app/services/activitypub/fetch_remote_status_service.rb
@@ -60,6 +60,7 @@ class ActivityPub::FetchRemoteStatusService < BaseService
 
   def trustworthy_attribution?(uri, attributed_to)
     return false if uri.nil? || attributed_to.nil?
+    return false if unsupported_uri_scheme?(uri) || unsupported_uri_scheme?(attributed_to)
 
     Addressable::URI.parse(uri).normalized_host.casecmp(Addressable::URI.parse(attributed_to).normalized_host).zero?
   end


### PR DESCRIPTION
Detected by SCA. Fix by myself. Please validate.

This is assuming the uri and attributed_to is always a `https://` reference and never something like a bearcap or similar.