### PR TITLE
Fix SignatureParser accepting duplicate parameters in HTTP Signature header

### DIFF
--- a/app/lib/signature_parser.rb
+++ b/app/lib/signature_parser.rb
@@ -28,6 +28,7 @@ class SignatureParser
       key = scanner[:key]
       # Detect a duplicate key
       raise Mastodon::SignatureVerificationError, 'Error parsing signature with duplicate keys' if params.key?(key)
+
       # This is not actually correct with regards to quoted pairs, but it's consistent
       # with our previous implementation, and good enough in practice.
       params[key] = scanner[:value] || scanner[:quoted_value][1...-1]

--- a/app/lib/signature_parser.rb
+++ b/app/lib/signature_parser.rb
@@ -27,8 +27,8 @@ class SignatureParser
     while scanner.skip(PARAM_RE)
       key = scanner[:key]
       # Detect a duplicate key
-      raise ParsingError if params.key?(key)
-
+      raise Mastodon::SignatureVerificationError, 'Error parsing signature with duplicate keys' if params.key?(key)
+    end
       # This is not actually correct with regards to quoted pairs, but it's consistent
       # with our previous implementation, and good enough in practice.
       params[key] = scanner[:value] || scanner[:quoted_value][1...-1]

--- a/app/lib/signature_parser.rb
+++ b/app/lib/signature_parser.rb
@@ -25,9 +25,13 @@ class SignatureParser
 
     # Use `skip` instead of `scan` as we only care about the subgroups
     while scanner.skip(PARAM_RE)
+      key = scanner[:key]
+      # Detect a duplicate key
+      raise ParsingError if params.key?(key)
+
       # This is not actually correct with regards to quoted pairs, but it's consistent
       # with our previous implementation, and good enough in practice.
-      params[scanner[:key]] = scanner[:value] || scanner[:quoted_value][1...-1]
+      params[key] = scanner[:value] || scanner[:quoted_value][1...-1]
 
       scanner.skip(/\s*/)
       return params if scanner.eos?

--- a/app/lib/signature_parser.rb
+++ b/app/lib/signature_parser.rb
@@ -28,7 +28,6 @@ class SignatureParser
       key = scanner[:key]
       # Detect a duplicate key
       raise Mastodon::SignatureVerificationError, 'Error parsing signature with duplicate keys' if params.key?(key)
-    end
       # This is not actually correct with regards to quoted pairs, but it's consistent
       # with our previous implementation, and good enough in practice.
       params[key] = scanner[:value] || scanner[:quoted_value][1...-1]


### PR DESCRIPTION
Detected by SCA, fix by myself. please validate.

`From [RFC 7235, Section 2.1](https://datatracker.ietf.org/doc/html/rfc7235#section-2.1): Authentication parameters are name=value pairs, where the name token is matched case-insensitively, and each parameter name MUST only occur once per challenge.`

ref: https://github.com/mastodon/mastodon/blob/628cbd2999564f8b7ec8e4ab35ec0126646712f2/app/lib/signed_request.rb#L91