### PR TITLE
Increase OCR spec timeout from 10 to 20 seconds to improve CI stability

### DIFF
--- a/spec/system/ocr_spec.rb
+++ b/spec/system/ocr_spec.rb
@@ -28,6 +28,6 @@ RSpec.describe 'OCR', :attachment_processing, :inline_jobs, :js, :streaming do
 
     click_on('Add text from image')
 
-    expect(page).to have_css('#description', text: /Hello Mastodon\s*/, wait: 10)
+    expect(page).to have_css('#description', text: /Hello Mastodon\s*/, wait: 20)
   end
 end


### PR DESCRIPTION
Seemingly since the upgraded of the the JS OCR library, tesseract, from 6.0.0 to [7.0.0](https://github.com/naptha/tesseract.js/releases/tag/v7.0.0) in December of 2025 (https://github.com/mastodon/mastodon/pull/37246), the OCR spec has been failing pretty frequently, _seemingly_ due to timeouts.
- https://github.com/mastodon/mastodon/actions/runs/20723506415/job/59493505558 (unrelated PR)
- https://github.com/mastodon/mastodon/actions/runs/20720328712/job/59482300932 (main)
- https://github.com/mastodon/mastodon/actions/runs/20719568049/job/59479993200 (main)
- https://github.com/mastodon/mastodon/actions/runs/20719568049/job/59479993145 (main)

Ideally there would be a better solution but for now we need CI stability. We can revert this change once we have a better solution. Maybe a future dependency bump, introducing capybara-lockstep, or something else will help.

Previous little discussion here: https://github.com/mastodon/mastodon/pull/37345#issuecomment-3711539183.