### PR TITLE
Downgrade sidekiq-unique-jobs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -821,7 +821,7 @@ GEM
     sidekiq-scheduler (6.0.1)
       rufus-scheduler (~> 3.2)
       sidekiq (>= 7.3, < 9)
-    sidekiq-unique-jobs (8.0.12)
+    sidekiq-unique-jobs (8.0.11)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 7.0.0, < 9.0.0)
       thor (>= 1.0, < 3.0)


### PR DESCRIPTION
This update introduced significant performance issues on mastodon.social. We still have to find out why exactly.