### PR TITLE
Fix URI generation for reblogs by accounts with numerical AP ids

### DIFF
--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -50,7 +50,7 @@ class ActivityPub::TagManager
       context_url(target) unless target.parent_account_id.nil? || target.parent_status_id.nil?
     when :note, :comment, :activity
       if target.account.numeric_ap_id?
-        return activity_ap_account_status_url(target.account, target) if target.reblog?
+        return activity_ap_account_status_url(target.account.id, target) if target.reblog?
 
         ap_account_status_url(target.account.id, target)
       else

--- a/spec/lib/activitypub/tag_manager_spec.rb
+++ b/spec/lib/activitypub/tag_manager_spec.rb
@@ -128,6 +128,28 @@ RSpec.describe ActivityPub::TagManager do
             .to eq("#{host_prefix}/ap/users/#{status.account.id}/statuses/#{status.id}")
         end
       end
+
+      context 'with a reblog' do
+        let(:status) { Fabricate(:status, account:, reblog: Fabricate(:status)) }
+
+        context 'when using a numeric ID based scheme' do
+          let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+
+          it 'returns a string starting with web domain and with the expected path' do
+            expect(subject.uri_for(status))
+              .to eq("#{host_prefix}/ap/users/#{status.account.id}/statuses/#{status.id}/activity")
+          end
+        end
+
+        context 'when using the legacy username based scheme' do
+          let(:account) { Fabricate(:account, id_scheme: :username_ap_id) }
+
+          it 'returns a string starting with web domain and with the expected path' do
+            expect(subject.uri_for(status))
+              .to eq("#{host_prefix}/users/#{status.account.username}/statuses/#{status.id}/activity")
+          end
+        end
+      end
     end
 
     context 'with a remote status' do


### PR DESCRIPTION
This can be overlooked so easily as 99% of time passing a model to a URL-helper is equivalent with passing its ID. Of course it is a different thing when said model overwrites `#to_param`, which is the case here.

I pondered if maybe `#to_param` could be made to behave better here, but that would break all non-AP links :frowning: 

So I went for the easy fix for now and added tests to at least make sure it does not happen again here.