### PR TITLE
Emoji: Adds search

### DIFF
--- a/app/javascript/mastodon/components/emoji/index.tsx
+++ b/app/javascript/mastodon/components/emoji/index.tsx
@@ -88,7 +88,10 @@ export const Emoji: FC<EmojiProps> = ({
     );
   }
 
-  const src = unicodeHexToUrl(state.code, appState.darkTheme);
+  const src = unicodeHexToUrl({
+    unicodeHex: state.code,
+    ...appState,
+  });
 
   return (
     <img

--- a/app/javascript/mastodon/features/emoji/constants.ts
+++ b/app/javascript/mastodon/features/emoji/constants.ts
@@ -15,6 +15,8 @@ export const SKIN_TONE_CODES = [
   0x1f3ff, // Dark skin tone
 ] as const;
 
+export const EMOJI_MIN_TOKEN_LENGTH = 2;
+
 // Emoji rendering modes. A mode is what we are using to render emojis, a style is what the user has selected.
 export const EMOJI_MODE_NATIVE = 'native';
 export const EMOJI_MODE_NATIVE_WITH_FLAGS = 'native-flags';

--- a/app/javascript/mastodon/features/emoji/database.test.ts
+++ b/app/javascript/mastodon/features/emoji/database.test.ts
@@ -6,8 +6,6 @@ import { EMOJI_DB_SHORTCODE_TEST } from './constants';
 import {
   putEmojiData,
   loadEmojiByHexcode,
-  searchEmojisByHexcodes,
-  searchEmojisByTag,
   testClear,
   testGet,
   putCustomEmojiData,
@@ -95,90 +93,6 @@ describe('emoji database', () => {
     test('returns undefined if not found', async () => {
       await putEmojiData([], 'en');
       await expect(loadEmojiByHexcode('test', 'en')).resolves.toBeUndefined();
-    });
-  });
-
-  describe('searchEmojisByHexcodes', () => {
-    const data = [
-      unicodeEmojiFactory({ hexcode: 'not a number' }),
-      unicodeEmojiFactory({ hexcode: '1' }),
-      unicodeEmojiFactory({ hexcode: '2' }),
-      unicodeEmojiFactory({ hexcode: '3' }),
-      unicodeEmojiFactory({ hexcode: 'another not a number' }),
-    ];
-    beforeEach(async () => {
-      await putEmojiData(data, 'en');
-    });
-    test('finds emoji in consecutive range', async () => {
-      const actual = await searchEmojisByHexcodes(['1', '2', '3'], 'en');
-      expect(actual).toHaveLength(3);
-    });
-
-    test('finds emoji in split range', async () => {
-      const actual = await searchEmojisByHexcodes(['1', '3'], 'en');
-      expect(actual).toHaveLength(2);
-      expect(actual).toContainEqual(data.at(1));
-      expect(actual).toContainEqual(data.at(3));
-    });
-
-    test('finds emoji with non-numeric range', async () => {
-      const actual = await searchEmojisByHexcodes(
-        ['3', 'not a number', '1'],
-        'en',
-      );
-      expect(actual).toHaveLength(3);
-      expect(actual).toContainEqual(data.at(0));
-      expect(actual).toContainEqual(data.at(1));
-      expect(actual).toContainEqual(data.at(3));
-    });
-
-    test('not found emoji are not returned', async () => {
-      const actual = await searchEmojisByHexcodes(['not found'], 'en');
-      expect(actual).toHaveLength(0);
-    });
-
-    test('only found emojis are returned', async () => {
-      const actual = await searchEmojisByHexcodes(
-        ['another not a number', 'not found'],
-        'en',
-      );
-      expect(actual).toHaveLength(1);
-      expect(actual).toContainEqual(data.at(4));
-    });
-  });
-
-  describe('searchEmojisByTag', () => {
-    const data = [
-      unicodeEmojiFactory({ hexcode: 'test1', tags: ['test 1'] }),
-      unicodeEmojiFactory({
-        hexcode: 'test2',
-        tags: ['test 2', 'something else'],
-      }),
-      unicodeEmojiFactory({ hexcode: 'test3', tags: ['completely different'] }),
-    ];
-    beforeEach(async () => {
-      await putEmojiData(data, 'en');
-    });
-    test('finds emojis with tag', async () => {
-      const actual = await searchEmojisByTag('test 1', 'en');
-      expect(actual).toHaveLength(1);
-      expect(actual).toContainEqual(data.at(0));
-    });
-
-    test('finds emojis starting with tag', async () => {
-      const actual = await searchEmojisByTag('test', 'en');
-      expect(actual).toHaveLength(2);
-      expect(actual).not.toContainEqual(data.at(2));
-    });
-
-    test('does not find emojis ending with tag', async () => {
-      const actual = await searchEmojisByTag('else', 'en');
-      expect(actual).toHaveLength(0);
-    });
-
-    test('finds nothing with invalid tag', async () => {
-      const actual = await searchEmojisByTag('not found', 'en');
-      expect(actual).toHaveLength(0);
     });
   });
 

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -74,7 +74,7 @@ export async function search({
 
   log('searching for tokens %o in locale %s', queryTokens, locale);
 
-  // Create an array of
+  // Create an array of emoji results
   const db = await loadDB();
   const resultArrays: Map<string, AnyEmojiData>[] = [];
   for (let i = 0; i < queryTokens.length; i++) {

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -71,6 +71,10 @@ export async function search({
     log('no tokens extracted from query "%s"', query);
     return [];
   }
+  const lastToken = queryTokens.at(-1);
+  if (!lastToken) {
+    throw new Error('Missing tokens from query');
+  }
 
   log('searching for tokens %o in locale %s', queryTokens, locale);
 
@@ -118,10 +122,6 @@ export async function search({
       .values(),
   );
 
-  const lastToken = queryTokens.at(-1);
-  if (!lastToken) {
-    throw new Error('Missing tokens from query');
-  }
   results.sort((a, b) => {
     // Checks if a or b has the last token exactly, or only a prefix.
     const aHasToken = a.tokens.includes(lastToken);
@@ -156,8 +156,8 @@ export async function search({
     results.length,
     time.duration,
   );
-  if (count > 0) {
-    return results.slice(0, count);
+  if (limit > 0) {
+    return results.slice(0, limit);
   }
   return results;
 }

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -54,11 +54,11 @@ const loadDB = (() => {
 export async function search({
   query,
   locale: localeString,
-  count = 0,
+  limit = 0,
 }: {
   query: string;
   locale: string;
-  count?: number;
+  limit?: number;
 }) {
   performance.mark('emoji-search-start');
 

--- a/app/javascript/mastodon/features/emoji/db-schema.ts
+++ b/app/javascript/mastodon/features/emoji/db-schema.ts
@@ -1,0 +1,178 @@
+import { SUPPORTED_LOCALES } from 'emojibase';
+import type { Locale } from 'emojibase';
+import { openDB } from 'idb';
+import type {
+  DBSchema,
+  IDBPDatabase,
+  IDBPObjectStore,
+  IDBPTransaction,
+  IndexNames,
+  StoreNames,
+} from 'idb';
+
+import type { CustomEmojiData, EtagTypes, UnicodeEmojiData } from './types';
+import { emojiLogger } from './utils';
+
+const log = emojiLogger('database');
+
+interface EmojiDB extends LocaleTables, DBSchema {
+  custom: {
+    key: string;
+    value: CustomEmojiData;
+    indexes: {
+      category: string;
+    };
+  };
+  shortcodes: {
+    key: string;
+    value: {
+      hexcode: string;
+      shortcodes: string[];
+    };
+    indexes: {
+      shortcodes: string[];
+    };
+  };
+  etags: {
+    key: EtagTypes;
+    value: string;
+  };
+}
+
+interface LocaleTable {
+  key: string;
+  value: UnicodeEmojiData;
+  indexes: {
+    shortcodes: string[];
+    groupOrder: [number, number];
+    tokens: string[];
+    skinHexcodes: string[];
+  };
+}
+type LocaleTables = Record<Locale, LocaleTable>;
+
+type Transaction<Mode extends IDBTransactionMode = 'versionchange'> =
+  IDBPTransaction<EmojiDB, StoreNames<EmojiDB>[], Mode>;
+
+export type Database = IDBPDatabase<EmojiDB>;
+
+const SCHEMA_VERSION = 2;
+
+export async function openEmojiDB() {
+  const db = await openDB<EmojiDB>('mastodon-emoji', SCHEMA_VERSION, {
+    upgrade(database, oldVersion, newVersion, trx) {
+      if (!database.objectStoreNames.contains('custom')) {
+        database.createObjectStore('custom', {
+          keyPath: 'shortcode',
+          autoIncrement: false,
+        });
+      }
+      maybeAddIndex({ trx, storeName: 'custom', indexName: 'category' });
+
+      if (!database.objectStoreNames.contains('etags')) {
+        database.createObjectStore('etags');
+      }
+
+      SUPPORTED_LOCALES.forEach((locale) => {
+        createLocaleTable(locale, database, trx);
+      });
+
+      const shortcodeTable = database.objectStoreNames.contains('shortcodes')
+        ? trx.objectStore('shortcodes')
+        : database.createObjectStore('shortcodes', {
+            keyPath: 'hexcode',
+            autoIncrement: false,
+          });
+      maybeAddIndex({
+        trx,
+        storeName: 'shortcodes',
+        indexName: 'shortcodes',
+        options: { multiEntry: true },
+      });
+      deleteOldIndexes(shortcodeTable, ['hexcode']);
+
+      log(
+        'Upgraded emoji database from version %d to %d',
+        oldVersion,
+        newVersion,
+      );
+    },
+    blocked(currentVersion, blockedVersion) {
+      log(
+        'Emoji database upgrade from version %d to %d is blocked',
+        currentVersion,
+        blockedVersion,
+      );
+    },
+    blocking(currentVersion, blockedVersion) {
+      log(
+        'Emoji database upgrade from version %d is blocking upgrade to %d',
+        currentVersion,
+        blockedVersion,
+      );
+    },
+  });
+
+  return db;
+}
+
+function maybeAddIndex<StoreName extends StoreNames<EmojiDB>>({
+  trx,
+  storeName,
+  indexName,
+  keys,
+  options,
+}: {
+  trx: Transaction;
+  storeName: StoreName;
+  indexName: IndexNames<EmojiDB, StoreName>;
+  keys?: string | string[];
+  options?: IDBIndexParameters;
+}) {
+  const store = trx.objectStore(storeName);
+  if (!store.indexNames.contains(indexName)) {
+    store.createIndex(indexName, keys ?? indexName, options);
+  }
+}
+
+function createLocaleTable(
+  locale: Locale,
+  database: Database,
+  trx: Transaction,
+) {
+  const localeTable = database.objectStoreNames.contains(locale)
+    ? trx.objectStore(locale)
+    : database.createObjectStore(locale, {
+        keyPath: 'hexcode',
+        autoIncrement: false,
+      });
+
+  // Added in version 2.
+  if (!localeTable.indexNames.contains('shortcodes')) {
+    localeTable.createIndex('shortcodes', 'shortcodes', {
+      multiEntry: true,
+    });
+  }
+
+  // Changed in version 3.
+  const oldIndexes = ['group', 'order', 'tag', 'label'] as const;
+  deleteOldIndexes(localeTable, oldIndexes);
+
+  localeTable.createIndex('groupOrder', ['group', 'order']);
+  localeTable.createIndex('tokens', 'tokens', { multiEntry: true });
+  localeTable.createIndex('skinHexcodes', 'skinHexcodes', {
+    multiEntry: true,
+  });
+}
+
+function deleteOldIndexes(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Type is too complex, so only any works here.
+  table: IDBPObjectStore<any, any, any, 'versionchange'>,
+  indexes: readonly string[],
+) {
+  for (const index of indexes) {
+    if (table.indexNames.contains(index)) {
+      table.deleteIndex(index);
+    }
+  }
+}

--- a/app/javascript/mastodon/features/emoji/db-schema.ts
+++ b/app/javascript/mastodon/features/emoji/db-schema.ts
@@ -20,6 +20,7 @@ interface EmojiDB extends LocaleTables, DBSchema {
     key: string;
     value: CustomEmojiData;
     indexes: {
+      tokens: string[];
       category: string;
     };
   };
@@ -68,6 +69,12 @@ export async function openEmojiDB() {
         });
       }
       maybeAddIndex({ trx, storeName: 'custom', indexName: 'category' });
+      maybeAddIndex({
+        trx,
+        storeName: 'custom',
+        indexName: 'tokens',
+        options: { multiEntry: true },
+      });
 
       if (!database.objectStoreNames.contains('etags')) {
         database.createObjectStore('etags');

--- a/app/javascript/mastodon/features/emoji/loader.ts
+++ b/app/javascript/mastodon/features/emoji/loader.ts
@@ -1,10 +1,5 @@
-import { flattenEmojiData } from 'emojibase';
-import type {
-  CompactEmoji,
-  FlatCompactEmoji,
-  Locale,
-  ShortcodesDataset,
-} from 'emojibase';
+import { joinShortcodes } from 'emojibase';
+import type { CompactEmoji, Locale, ShortcodesDataset } from 'emojibase';
 
 import {
   putEmojiData,
@@ -28,7 +23,7 @@ export async function importEmojiData(localeString: string, shortcodes = true) {
     shortcodes ? ' and shortcodes' : '',
   );
 
-  const emojis = await fetchAndCheckEtag<CompactEmoji[]>({
+  let emojis = await fetchAndCheckEtag<CompactEmoji[]>({
     etagString: locale,
     path: localeToEmojiPath(locale),
   });
@@ -49,12 +44,10 @@ export async function importEmojiData(localeString: string, shortcodes = true) {
     }
   }
 
-  const flattenedEmojis: FlatCompactEmoji[] = flattenEmojiData(
-    emojis,
-    shortcodesData,
-  );
-  await putEmojiData(flattenedEmojis, locale);
-  return flattenedEmojis;
+  emojis = joinShortcodes(emojis, shortcodesData);
+
+  await putEmojiData(emojis, locale);
+  return emojis;
 }
 
 export async function importCustomEmojiData() {

--- a/app/javascript/mastodon/features/emoji/locale.ts
+++ b/app/javascript/mastodon/features/emoji/locale.ts
@@ -32,6 +32,13 @@ export function toValidEtagName(input: string): EtagTypes {
   return toSupportedLocale(lower);
 }
 
+export function localeToSegmenter(locale: Locale): Intl.Segmenter | null {
+  if (typeof Intl.Segmenter === 'function') {
+    return new Intl.Segmenter(locale, { granularity: 'word' });
+  }
+  return null;
+}
+
 function isSupportedLocale(locale: string): locale is Locale {
   return SUPPORTED_LOCALES.includes(locale as Locale);
 }

--- a/app/javascript/mastodon/features/emoji/mode.ts
+++ b/app/javascript/mastodon/features/emoji/mode.ts
@@ -2,6 +2,7 @@
 // See: https://github.com/nolanlawson/emoji-picker-element/blob/master/src/picker/utils/testColorEmojiSupported.js
 
 import { createAppSelector, useAppSelector } from '@/mastodon/store';
+import { assetHost } from '@/mastodon/utils/config';
 import { isDevelopment } from '@/mastodon/utils/environment';
 import { isDarkMode } from '@/mastodon/utils/theme';
 
@@ -29,6 +30,7 @@ export function useEmojiAppState(): EmojiAppState {
     locales: [locale],
     mode,
     darkTheme: isDarkMode(),
+    assetHost,
   };
 }
 

--- a/app/javascript/mastodon/features/emoji/normalize.test.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.test.ts
@@ -4,11 +4,7 @@ import { basename, resolve } from 'path';
 import { flattenEmojiData } from 'emojibase';
 import unicodeRawEmojis from 'emojibase-data/en/data.json';
 
-import {
-  twemojiToUnicodeInfo,
-  unicodeToTwemojiHex,
-  emojiToUnicodeHex,
-} from './normalize';
+import { unicodeToTwemojiHex, emojiToUnicodeHex } from './normalize';
 
 const emojiSVGFiles = await readdir(
   // This assumes tests are run from project root
@@ -53,27 +49,4 @@ describe('unicodeToTwemojiHex', () => {
     const result = unicodeToTwemojiHex(hexcode);
     expect(svgFileNamesWithoutBorder).toContain(result);
   });
-});
-
-describe('twemojiToUnicodeInfo', () => {
-  const unicodeCodeSet = new Set(unicodeEmojis.map((emoji) => emoji.hexcode));
-
-  test.concurrent.for(svgFileNamesWithoutBorder)(
-    'verifying SVG file %s maps to Unicode emoji',
-    (svgFileName, { expect }) => {
-      assert(!!svgFileName);
-      const result = twemojiToUnicodeInfo(svgFileName);
-      const hexcode = typeof result === 'string' ? result : result.unqualified;
-      if (!hexcode) {
-        // No hexcode means this is a special case like the Shibuya 109 emoji
-        expect(result).toHaveProperty('label');
-        return;
-      }
-      assert(!!hexcode);
-      expect(
-        unicodeCodeSet.has(hexcode),
-        `${hexcode} (${svgFileName}) not found`,
-      ).toBeTruthy();
-    },
-  );
 });

--- a/app/javascript/mastodon/features/emoji/normalize.test.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.test.ts
@@ -4,7 +4,7 @@ import { basename, resolve } from 'path';
 import { flattenEmojiData } from 'emojibase';
 import unicodeRawEmojis from 'emojibase-data/en/data.json';
 
-import { unicodeToTwemojiHex, emojiToUnicodeHex } from './normalize';
+import { unicodeToTwemojiHex } from './normalize';
 
 const emojiSVGFiles = await readdir(
   // This assumes tests are run from project root
@@ -21,23 +21,6 @@ const svgFileNamesWithoutBorder = svgFileNames.filter(
 );
 
 const unicodeEmojis = flattenEmojiData(unicodeRawEmojis);
-
-describe('emojiToUnicodeHex', () => {
-  test.concurrent.for([
-    ['🎱', '1F3B1'],
-    ['🐜', '1F41C'],
-    ['⚫', '26AB'],
-    ['🖤', '1F5A4'],
-    ['💀', '1F480'],
-    ['❤️', '2764'], // Checks for trailing variation selector removal.
-    ['💂‍♂️', '1F482-200D-2642-FE0F'],
-  ] as const)(
-    'emojiToUnicodeHex converts %s to %s',
-    ([emoji, hexcode], { expect }) => {
-      expect(emojiToUnicodeHex(emoji)).toBe(hexcode);
-    },
-  );
-});
 
 describe('unicodeToTwemojiHex', () => {
   test.concurrent.for(

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -186,15 +186,13 @@ export function cleanExtraEmojis(extraEmojis?: CustomEmojiMapArg) {
   return extraEmojis;
 }
 
-// Private functions
-
 /**
  * Tokenizes an input string into words, using Intl.Segmenter if available.
  * @param input Any input string.
  * @param segmenter Segmenter, if available.
  * @returns Array of tokens in lowercase.
  */
-function extractTokens(
+export function extractTokens(
   input: string,
   segmenter: Intl.Segmenter | null,
 ): string[] {
@@ -208,14 +206,14 @@ function extractTokens(
     for (const { isWordLike, segment } of segmenter.segment(
       input.replaceAll('_', ' '), // Handle underscores from shortcodes.
     )) {
-      if (isWordLike && segment.length > EMOJI_MIN_TOKEN_LENGTH) {
+      if (isWordLike && segment.length >= EMOJI_MIN_TOKEN_LENGTH) {
         tokens.push(segment.toLowerCase());
       }
     }
   } else {
     // Fallback to simple splitting.
     input.split(/[\s_-]+/).forEach((word) => {
-      if (/\w/.test(word) && word.length > EMOJI_MIN_TOKEN_LENGTH) {
+      if (/\w/.test(word) && word.length >= EMOJI_MIN_TOKEN_LENGTH) {
         tokens.push(word.toLowerCase());
       }
     });

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -1,5 +1,7 @@
 import { isList } from 'immutable';
 
+import { fromHexcodeToCodepoint } from 'emojibase';
+
 import { assetHost } from '@/mastodon/utils/config';
 
 import {
@@ -13,31 +15,14 @@ import {
 } from './constants';
 import { toSupportedLocale } from './locale';
 import type { CustomEmojiMapArg, ExtraCustomEmojiMap } from './types';
-import { hexNumbersToString, hexStringToNumbers } from './utils';
+import { emojiToUnicodeHex } from './utils';
 
 // Misc codes that have special handling
 const EYE_CODE = 0x1f441;
 const SPEECH_BUBBLE_CODE = 0x1f5e8;
 
-export function emojiToUnicodeHex(emoji: string): string {
-  const codes: number[] = [];
-  for (const char of emoji) {
-    const code = char.codePointAt(0);
-    if (code !== undefined) {
-      codes.push(code);
-    }
-  }
-
-  // Handles how Emojibase removes the variation selector for single code emojis.
-  // See: https://emojibase.dev/docs/spec/#merged-variation-selectors
-  if (codes.at(1) === VARIATION_SELECTOR_CODE && codes.length === 2) {
-    codes.pop();
-  }
-  return hexNumbersToString(codes);
-}
-
 export function unicodeToTwemojiHex(unicodeHex: string): string {
-  const codes = hexStringToNumbers(unicodeHex);
+  const codes = fromHexcodeToCodepoint(unicodeHex);
   const normalizedCodes: number[] = [];
   for (let i = 0; i < codes.length; i++) {
     const code = codes[i];
@@ -59,14 +44,15 @@ export function unicodeToTwemojiHex(unicodeHex: string): string {
     normalizedCodes.push(code);
   }
 
-  return hexNumbersToString(normalizedCodes, 0).toLowerCase();
+  return normalizedCodes
+    .map((code) => code.toString(16))
+    .join('-')
+    .toLowerCase();
 }
 
-export const CODES_WITH_DARK_BORDER =
-  EMOJIS_WITH_DARK_BORDER.map(emojiToUnicodeHex);
+const CODES_WITH_DARK_BORDER = EMOJIS_WITH_DARK_BORDER.map(emojiToUnicodeHex);
 
-export const CODES_WITH_LIGHT_BORDER =
-  EMOJIS_WITH_LIGHT_BORDER.map(emojiToUnicodeHex);
+const CODES_WITH_LIGHT_BORDER = EMOJIS_WITH_LIGHT_BORDER.map(emojiToUnicodeHex);
 
 export function unicodeHexToUrl(unicodeHex: string, darkMode: boolean): string {
   const normalizedHex = unicodeToTwemojiHex(unicodeHex);

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -3,6 +3,8 @@ import { isList } from 'immutable';
 import type { CompactEmoji, SkinTone } from 'emojibase';
 import { fromHexcodeToCodepoint } from 'emojibase';
 
+import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
+
 import {
   VARIATION_SELECTOR_CODE,
   KEYCAP_CODE,
@@ -13,6 +15,7 @@ import {
   EMOJI_MIN_TOKEN_LENGTH,
 } from './constants';
 import type {
+  CustomEmojiData,
   CustomEmojiMapArg,
   ExtraCustomEmojiMap,
   UnicodeEmojiData,
@@ -84,6 +87,19 @@ export function transformEmojiData(
   }
 
   return res;
+}
+
+export function transformCustomEmojiData(
+  emoji: ApiCustomEmojiJSON,
+): CustomEmojiData {
+  const tokens = emoji.shortcode
+    .split('_')
+    .filter((word) => word.length >= EMOJI_MIN_TOKEN_LENGTH)
+    .map((word) => word.toLowerCase());
+  return {
+    ...emoji,
+    tokens,
+  };
 }
 
 export function skinHexcodeToEmoji(

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -3,8 +3,6 @@ import { isList } from 'immutable';
 import type { CompactEmoji, SkinTone } from 'emojibase';
 import { fromHexcodeToCodepoint } from 'emojibase';
 
-import { assetHost } from '@/mastodon/utils/config';
-
 import {
   VARIATION_SELECTOR_CODE,
   KEYCAP_CODE,
@@ -136,10 +134,18 @@ const CODES_WITH_DARK_BORDER = EMOJIS_WITH_DARK_BORDER.map(emojiToUnicodeHex);
 
 const CODES_WITH_LIGHT_BORDER = EMOJIS_WITH_LIGHT_BORDER.map(emojiToUnicodeHex);
 
-export function unicodeHexToUrl(unicodeHex: string, darkMode: boolean): string {
+export function unicodeHexToUrl({
+  unicodeHex,
+  darkTheme,
+  assetHost,
+}: {
+  unicodeHex: string;
+  darkTheme: boolean;
+  assetHost: string;
+}): string {
   const normalizedHex = unicodeToTwemojiHex(unicodeHex);
   let url = `${assetHost}/emoji/${normalizedHex}`;
-  if (darkMode && CODES_WITH_LIGHT_BORDER.includes(normalizedHex)) {
+  if (darkTheme && CODES_WITH_LIGHT_BORDER.includes(normalizedHex)) {
     url += '_border';
   }
   if (CODES_WITH_DARK_BORDER.includes(normalizedHex)) {

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -67,8 +67,6 @@ export function unicodeHexToUrl(unicodeHex: string, darkMode: boolean): string {
   return url;
 }
 
-let segmenter: Intl.Segmenter | null = null;
-
 /**
  * Tokenizes an input string into words, using Intl.Segmenter if available.
  * @param input Any input string.
@@ -84,7 +82,7 @@ export function extractTokens(input: string, localeString: string): string[] {
   // Prefer to use Intl.Segmenter if available for better locale support.
   if (typeof Intl.Segmenter === 'function') {
     const locale = toSupportedLocale(localeString);
-    segmenter ??= new Intl.Segmenter(locale, { granularity: 'word' });
+    const segmenter = new Intl.Segmenter(locale, { granularity: 'word' });
 
     for (const { isWordLike, segment } of segmenter.segment(
       input.replaceAll('_', ' '), // Handle underscores from shortcodes.

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -5,9 +5,6 @@ import { assetHost } from '@/mastodon/utils/config';
 import {
   VARIATION_SELECTOR_CODE,
   KEYCAP_CODE,
-  GENDER_FEMALE_CODE,
-  GENDER_MALE_CODE,
-  SKIN_TONE_CODES,
   EMOJIS_WITH_DARK_BORDER,
   EMOJIS_WITH_LIGHT_BORDER,
   EMOJIS_REQUIRING_INVERSION_IN_LIGHT_MODE,
@@ -16,15 +13,11 @@ import {
 } from './constants';
 import { toSupportedLocale } from './locale';
 import type { CustomEmojiMapArg, ExtraCustomEmojiMap } from './types';
+import { hexNumbersToString, hexStringToNumbers } from './utils';
 
 // Misc codes that have special handling
-const SKIER_CODE = 0x26f7;
-const CHRISTMAS_TREE_CODE = 0x1f384;
-const MR_CLAUS_CODE = 0x1f385;
 const EYE_CODE = 0x1f441;
-const LEVITATING_PERSON_CODE = 0x1f574;
 const SPEECH_BUBBLE_CODE = 0x1f5e8;
-const MS_CLAUS_CODE = 0x1f936;
 
 export function emojiToUnicodeHex(emoji: string): string {
   const codes: number[] = [];
@@ -107,7 +100,9 @@ export function extractTokens(input: string, localeString: string): string[] {
     const locale = toSupportedLocale(localeString);
     segmenter ??= new Intl.Segmenter(locale, { granularity: 'word' });
 
-    for (const { isWordLike, segment } of segmenter.segment(input)) {
+    for (const { isWordLike, segment } of segmenter.segment(
+      input.replaceAll('_', ' '), // Handle underscores from shortcodes.
+    )) {
       if (isWordLike && segment.length > EMOJI_MIN_TOKEN_LENGTH) {
         tokens.push(segment.toLowerCase());
       }
@@ -121,78 +116,6 @@ export function extractTokens(input: string, localeString: string): string[] {
     });
   }
   return tokens;
-}
-
-interface TwemojiSpecificEmoji {
-  unqualified?: string;
-  gender?: number;
-  skin?: number;
-  label?: string;
-}
-
-// Normalize man/woman to male/female
-const GENDER_CODES_MAP: Record<number, number> = {
-  [GENDER_FEMALE_CODE]: GENDER_FEMALE_CODE,
-  [GENDER_MALE_CODE]: GENDER_MALE_CODE,
-  // These are man/woman markers, but are used for gender sometimes.
-  [0x1f468]: GENDER_MALE_CODE,
-  [0x1f469]: GENDER_FEMALE_CODE,
-};
-
-const TWEMOJI_SPECIAL_CASES: Record<string, string | TwemojiSpecificEmoji> = {
-  '1F441-200D-1F5E8': '1F441-FE0F-200D-1F5E8-FE0F', // Eye in speech bubble
-  // An emoji that was never ported to the Unicode standard.
-  // See: https://emojipedia.org/shibuya
-  E50A: { label: 'Shibuya 109' },
-};
-
-export function twemojiToUnicodeInfo(
-  twemojiHex: string,
-): TwemojiSpecificEmoji | string {
-  const specialCase = TWEMOJI_SPECIAL_CASES[twemojiHex.toUpperCase()];
-  if (specialCase) {
-    return specialCase;
-  }
-  const codes = hexStringToNumbers(twemojiHex);
-  let gender: undefined | number;
-  let skin: undefined | number;
-  for (const code of codes) {
-    if (!gender && code in GENDER_CODES_MAP) {
-      gender = GENDER_CODES_MAP[code];
-    } else if (!skin && code in SKIN_TONE_CODES) {
-      skin = code;
-    }
-
-    // Exit if we have both skin and gender
-    if (skin && gender) {
-      break;
-    }
-  }
-
-  let mappedCodes: unknown[] = codes;
-
-  if (codes.at(-1) === CHRISTMAS_TREE_CODE && codes.length >= 3 && gender) {
-    // Twemoji uses the christmas tree with a ZWJ for Mr. and Mrs. Claus,
-    // but in Unicode that only works for Mx. Claus.
-    const START_CODE =
-      gender === GENDER_FEMALE_CODE ? MS_CLAUS_CODE : MR_CLAUS_CODE;
-    mappedCodes = [START_CODE, skin];
-  } else if (codes.at(-1) === KEYCAP_CODE && codes.length === 2) {
-    // For key emoji, insert the variation selector
-    mappedCodes = [codes[0], VARIATION_SELECTOR_CODE, KEYCAP_CODE];
-  } else if (
-    (codes.at(0) === SKIER_CODE || codes.at(0) === LEVITATING_PERSON_CODE) &&
-    codes.length > 1
-  ) {
-    // Twemoji offers more gender and skin options for the skier and levitating person emoji.
-    return {
-      unqualified: hexNumbersToString([codes.at(0)]),
-      skin,
-      gender,
-    };
-  }
-
-  return hexNumbersToString(mappedCodes);
 }
 
 export function emojiToInversionClassName(emoji: string): string | null {
@@ -224,21 +147,4 @@ export function cleanExtraEmojis(extraEmojis?: CustomEmojiMapArg) {
       );
   }
   return extraEmojis;
-}
-
-function hexStringToNumbers(hexString: string): number[] {
-  return hexString
-    .split('-')
-    .map((code) => Number.parseInt(code, 16))
-    .filter((code) => !Number.isNaN(code));
-}
-
-function hexNumbersToString(codes: unknown[], padding = 4): string {
-  return codes
-    .filter(
-      (code): code is number =>
-        typeof code === 'number' && code > 0 && !Number.isNaN(code),
-    )
-    .map((code) => code.toString(16).padStart(padding, '0').toUpperCase())
-    .join('-');
 }

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -12,7 +12,9 @@ import {
   EMOJIS_WITH_LIGHT_BORDER,
   EMOJIS_REQUIRING_INVERSION_IN_LIGHT_MODE,
   EMOJIS_REQUIRING_INVERSION_IN_DARK_MODE,
+  EMOJI_MIN_TOKEN_LENGTH,
 } from './constants';
+import { toSupportedLocale } from './locale';
 import type { CustomEmojiMapArg, ExtraCustomEmojiMap } from './types';
 
 // Misc codes that have special handling
@@ -84,6 +86,41 @@ export function unicodeHexToUrl(unicodeHex: string, darkMode: boolean): string {
   }
   url += '.svg';
   return url;
+}
+
+let segmenter: Intl.Segmenter | null = null;
+
+/**
+ * Tokenizes an input string into words, using Intl.Segmenter if available.
+ * @param input Any input string.
+ * @param localeString Locale string to use for segmentation.
+ * @returns Array of tokens in lowercase.
+ */
+export function extractTokens(input: string, localeString: string): string[] {
+  if (!input.trim()) {
+    return [];
+  }
+  const tokens: string[] = [];
+
+  // Prefer to use Intl.Segmenter if available for better locale support.
+  if (typeof Intl.Segmenter === 'function') {
+    const locale = toSupportedLocale(localeString);
+    segmenter ??= new Intl.Segmenter(locale, { granularity: 'word' });
+
+    for (const { isWordLike, segment } of segmenter.segment(input)) {
+      if (isWordLike && segment.length > EMOJI_MIN_TOKEN_LENGTH) {
+        tokens.push(segment.toLowerCase());
+      }
+    }
+  } else {
+    // Fallback to simple splitting.
+    input.split(/[\s_-]+/).forEach((word) => {
+      if (/\w/.test(word) && word.length > EMOJI_MIN_TOKEN_LENGTH) {
+        tokens.push(word.toLowerCase());
+      }
+    });
+  }
+  return tokens;
 }
 
 interface TwemojiSpecificEmoji {

--- a/app/javascript/mastodon/features/emoji/render.ts
+++ b/app/javascript/mastodon/features/emoji/render.ts
@@ -4,7 +4,6 @@ import {
   EMOJI_TYPE_UNICODE,
   EMOJI_TYPE_CUSTOM,
 } from './constants';
-import { emojiToUnicodeHex } from './normalize';
 import type {
   EmojiLoadedState,
   EmojiMode,
@@ -16,6 +15,7 @@ import type {
 import {
   anyEmojiRegex,
   emojiLogger,
+  emojiToUnicodeHex,
   isCustomEmoji,
   isUnicodeEmoji,
   stringHasUnicodeFlags,
@@ -140,12 +140,7 @@ export async function loadEmojiDataToState(
     }
 
     // If not found, assume it's not an emoji and return null.
-    log(
-      'Could not find emoji %s of type %s for locale %s',
-      state.code,
-      state.type,
-      locale,
-    );
+    log('Could not find emoji %s for locale %s', state.code, locale);
     return null;
   } catch (err: unknown) {
     // If the locale is not loaded, load it and retry once.

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -32,6 +32,7 @@ export interface EmojiAppState {
   currentLocale: Locale;
   mode: EmojiMode;
   darkTheme: boolean;
+  assetHost: string;
 }
 
 export type CustomEmojiData = ApiCustomEmojiJSON;

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -35,7 +35,10 @@ export interface EmojiAppState {
 }
 
 export type CustomEmojiData = ApiCustomEmojiJSON;
-export interface UnicodeEmojiData extends Omit<CompactEmoji, 'emoticon'> {
+export interface UnicodeEmojiData extends Omit<
+  CompactEmoji,
+  'emoticon' | 'skins' | 'tags'
+> {
   shortcodes: string[];
   tokens: string[];
   emoticons?: string[];

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -1,6 +1,6 @@
 import type { List as ImmutableList } from 'immutable';
 
-import type { FlatCompactEmoji, Locale } from 'emojibase';
+import type { CompactEmoji, Locale, SkinTone } from 'emojibase';
 
 import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
 import type { CustomEmoji } from '@/mastodon/models/custom_emoji';
@@ -35,7 +35,13 @@ export interface EmojiAppState {
 }
 
 export type CustomEmojiData = ApiCustomEmojiJSON;
-export type UnicodeEmojiData = FlatCompactEmoji;
+export interface UnicodeEmojiData extends Omit<CompactEmoji, 'emoticon'> {
+  shortcodes: string[];
+  tokens: string[];
+  emoticons?: string[];
+  skinHexcodes?: string[];
+  skinTones?: (SkinTone | SkinTone[])[];
+}
 export type AnyEmojiData = CustomEmojiData | UnicodeEmojiData;
 
 type CustomEmojiRenderFields = Pick<

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -35,7 +35,7 @@ export interface EmojiAppState {
   assetHost: string;
 }
 
-export type CustomEmojiData = ApiCustomEmojiJSON;
+export type CustomEmojiData = ApiCustomEmojiJSON & { tokens: string[] };
 export interface UnicodeEmojiData extends Omit<
   CompactEmoji,
   'emoticon' | 'skins' | 'tags'

--- a/app/javascript/mastodon/features/emoji/utils.ts
+++ b/app/javascript/mastodon/features/emoji/utils.ts
@@ -44,6 +44,23 @@ export function anyEmojiRegex() {
   );
 }
 
+export function hexStringToNumbers(hexString: string): number[] {
+  return hexString
+    .split('-')
+    .map((code) => Number.parseInt(code, 16))
+    .filter((code) => !Number.isNaN(code));
+}
+
+export function hexNumbersToString(codes: unknown[], padding = 4): string {
+  return codes
+    .filter(
+      (code): code is number =>
+        typeof code === 'number' && code > 0 && !Number.isNaN(code),
+    )
+    .map((code) => code.toString(16).padStart(padding, '0').toUpperCase())
+    .join('-');
+}
+
 function supportsRegExpSets() {
   return 'unicodeSets' in RegExp.prototype;
 }

--- a/app/javascript/mastodon/features/emoji/utils.ts
+++ b/app/javascript/mastodon/features/emoji/utils.ts
@@ -1,4 +1,5 @@
 import debug from 'debug';
+import { fromUnicodeToHexcode } from 'emojibase';
 
 import { emojiRegexPolyfill } from '@/mastodon/polyfills';
 
@@ -44,21 +45,8 @@ export function anyEmojiRegex() {
   );
 }
 
-export function hexStringToNumbers(hexString: string): number[] {
-  return hexString
-    .split('-')
-    .map((code) => Number.parseInt(code, 16))
-    .filter((code) => !Number.isNaN(code));
-}
-
-export function hexNumbersToString(codes: unknown[], padding = 4): string {
-  return codes
-    .filter(
-      (code): code is number =>
-        typeof code === 'number' && code > 0 && !Number.isNaN(code),
-    )
-    .map((code) => code.toString(16).padStart(padding, '0').toUpperCase())
-    .join('-');
+export function emojiToUnicodeHex(emoji: string): string {
+  return fromUnicodeToHexcode(emoji, false);
 }
 
 function supportsRegExpSets() {

--- a/app/javascript/testing/factories.ts
+++ b/app/javascript/testing/factories.ts
@@ -133,6 +133,7 @@ export function customEmojiFactory(
     static_url: '/custom-emoji/logo.svg',
     url: '/custom-emoji/logo.svg',
     visible_in_picker: true,
+    tokens: ['custom'],
     ...data,
   };
 }

--- a/app/javascript/testing/factories.ts
+++ b/app/javascript/testing/factories.ts
@@ -119,8 +119,9 @@ export function unicodeEmojiFactory(
     label: 'Test',
     unicode: '🧪',
     shortcodes: ['test_emoji'],
-    tokens: ['test', 'emoji'],
-    emoticons: [],
+    tokens: ['emoji', 'test'],
+    group: 1,
+    order: 1,
     ...data,
   };
 }

--- a/app/javascript/testing/factories.ts
+++ b/app/javascript/testing/factories.ts
@@ -119,7 +119,6 @@ export function unicodeEmojiFactory(
     label: 'Test',
     unicode: '🧪',
     shortcodes: ['test_emoji'],
-    tags: [],
     tokens: ['test', 'emoji'],
     emoticons: [],
     ...data,

--- a/app/javascript/testing/factories.ts
+++ b/app/javascript/testing/factories.ts
@@ -119,6 +119,9 @@ export function unicodeEmojiFactory(
     label: 'Test',
     unicode: '🧪',
     shortcodes: ['test_emoji'],
+    tags: [],
+    tokens: ['test', 'emoji'],
+    emoticons: [],
     ...data,
   };
 }


### PR DESCRIPTION
Fixes MAS-720.

The goal of this PR is finishing searching for emojis. To do that, emoji data is now tokenized on loading to a set of unique words. Search queries this new IndexedDB `tokens` field instead of trying to query multiple indices, which is much faster. Results are sorted (custom emoji first, then sort by exact matches and finally unicode order) and returned.

Performance on my Mac is about 2-5ms per query using the latest Firefox. I haven't tested in other browsers, but I expect similar performance.

Huge credit to [`emoji-picker-element`](https://github.com/nolanlawson/emoji-picker-element)'s database system for some of this inspiration!

An overview of changes:
- Changed the emoji IndexedDB schema to v3, which removes a bunch of unneeded indices and doesn't try to store all unicode data anymore- just the stuff we want.
- As part of that, I broke out the database schema creation to it's own file, as `database.ts` was getting very large.
- Emoji are now transformed on load to tokenize the data for search, along with combining skin tones into the parent emoji to reduce size.
- A search function is added to query both unicode and custom emoji data.
- Unused code in `normalize` is removed and the transformation code added.
- Some other small cleanups.

Testing:
I added this small snippet to the code in `emojis/index.ts` to test functionality:
```ts
window.query = (query: string, locale = userLocale) =>
    import('./database')
      .then(({ search }) => search({ query, locale }))
      .then((results) => {
        console.log(`Emoji search results for "${query}":`, results);
      });
```