### PR TITLE
Update devise to version 5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'bootsnap', require: false
 gem 'browser'
 gem 'charlock_holmes', '~> 0.7.7'
 gem 'chewy', '~> 7.3'
-gem 'devise', '~> 4.9'
+gem 'devise'
 gem 'devise-two-factor'
 
 group :pam_authentication, optional: true do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,10 +187,10 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     debug_inspector (1.2.0)
-    devise (4.9.4)
+    devise (5.0.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     devise-two-factor (6.4.0)
@@ -965,7 +965,7 @@ DEPENDENCIES
   csv (~> 3.2)
   database_cleaner-active_record
   debug (~> 1.8)
-  devise (~> 4.9)
+  devise
   devise-two-factor
   devise_pam_authenticatable2 (~> 9.2)
   discard (~> 1.2)

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -197,14 +197,14 @@ class Auth::SessionsController < Devise::SessionsController
     "2fa_auth_attempts:#{user.id}:#{Time.now.utc.hour}"
   end
 
-  def respond_to_on_destroy
+  def respond_to_on_destroy(**)
     respond_to do |format|
       format.json do
         render json: {
           redirect_to: after_sign_out_path_for(resource_name),
         }, status: 200
       end
-      format.all { super }
+      format.all { super(**) }
     end
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -105,11 +105,9 @@ Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
-  #
-  # Set explicitly to Rails default to avoid deprecation warnings.
-  # https://github.com/heartcombo/devise/pull/5645#issuecomment-1871849856
-  # Remove when Devise changes `SecretKeyFinder` to not emit deprecations.
-  config.secret_key = Rails.application.secret_key_base
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '<%= SecureRandom.hex(64) %>'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Auth::SessionsController do
         end
 
         it 'shows a login error and does not log the user in' do
-          expect(flash[:alert]).to match I18n.t('devise.failure.invalid', authentication_keys: I18n.t('activerecord.attributes.user.email'))
+          expect(flash[:alert]).to match(/#{failure_message_invalid_email}/i)
 
           expect(controller.current_user).to be_nil
         end
@@ -163,7 +163,7 @@ RSpec.describe Auth::SessionsController do
         end
 
         it 'shows a login error and does not log the user in' do
-          expect(flash[:alert]).to match I18n.t('devise.failure.invalid', authentication_keys: I18n.t('activerecord.attributes.user.email'))
+          expect(flash[:alert]).to match(/#{failure_message_invalid_email}/i)
 
           expect(controller.current_user).to be_nil
         end
@@ -419,6 +419,10 @@ RSpec.describe Auth::SessionsController do
           end
         end
       end
+    end
+
+    def failure_message_invalid_email
+      I18n.t('devise.failure.invalid', authentication_keys: I18n.t('activerecord.attributes.user.email'))
     end
   end
 end

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Log in' do
   it 'A invalid email and password user is not able to log in' do
     fill_in_auth_details('invalid_email', 'invalid_password')
 
-    expect(subject).to have_css('.flash-message', text: failure_message('invalid'))
+    expect(subject).to have_css('.flash-message', text: /#{failure_message_invalid}/i)
   end
 
   context 'when confirmed at is nil' do
@@ -38,8 +38,8 @@ RSpec.describe 'Log in' do
     end
   end
 
-  def failure_message(message)
+  def failure_message_invalid
     keys = User.authentication_keys.map { |key| User.human_attribute_name(key) }
-    I18n.t("devise.failure.#{message}", authentication_keys: keys.join('support.array.words_connector'))
+    I18n.t('devise.failure.invalid', authentication_keys: keys.join('support.array.words_connector'))
   end
 end


### PR DESCRIPTION
This is one of the blockers for rails 8.1 upgrade.

Includes both devise, and also devise-two-factor, which did a dep-relaxing release to allow bump.

Changes for 5.0 - https://github.com/heartcombo/devise/blob/main/CHANGELOG.md

Code changes:

- The `respond_to_on_destroy` callback now takes args, updated our override to pass them along
- Devise changed the case of some flash messages, update our specs to be case insensitive
- The default method of setting `secret_key` is now what we were doing, so remove that setting
