### PR TITLE
Fix thread-unsafe ActivityPub activity dispatch

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -21,14 +21,13 @@ class ActivityPub::Activity
 
   class << self
     def factory(json, account, **)
-      @json = json
-      klass&.new(json, account, **)
+      klass_for(json)&.new(json, account, **)
     end
 
     private
 
-    def klass
-      case @json['type']
+    def klass_for(json)
+      case json['type']
       when 'Create'
         ActivityPub::Activity::Create
       when 'Announce'


### PR DESCRIPTION
Remove shared class instance variable @json from ActivityPub::Activity.factory. Select the handler class based on the method-local json argument so concurrent calls cannot race and misroute activity processing.