### PR TITLE
Fix modal closeModal ignoreFocus payload type

### DIFF
--- a/app/javascript/mastodon/features/ui/containers/modal_container.js
+++ b/app/javascript/mastodon/features/ui/containers/modal_container.js
@@ -23,7 +23,7 @@ const mapDispatchToProps = dispatch => ({
             confirm: confirmationMessage.confirm,
             onConfirm: () => dispatch(closeModal({
               modalType: undefined,
-              ignoreFocus: { ignoreFocus },
+              ignoreFocus,
             })),
           },
         }),
@@ -31,7 +31,7 @@ const mapDispatchToProps = dispatch => ({
     } else {
       dispatch(closeModal({
         modalType: undefined,
-        ignoreFocus: { ignoreFocus },
+        ignoreFocus: ignoreFocus,
       }));
     }
   },

--- a/app/javascript/mastodon/features/ui/containers/modal_container.js
+++ b/app/javascript/mastodon/features/ui/containers/modal_container.js
@@ -31,7 +31,7 @@ const mapDispatchToProps = dispatch => ({
     } else {
       dispatch(closeModal({
         modalType: undefined,
-        ignoreFocus: ignoreFocus,
+        ignoreFocus,
       }));
     }
   },


### PR DESCRIPTION
Stop wrapping ignoreFocus in an object when dispatching closeModal. The reducer and ModalRoot expect a boolean; the object wrapper made it always truthy and could suppress focus restoration after closing a modal.