### PR TITLE
Fix Vary parsing in cache control enforcement

### DIFF
--- a/app/controllers/concerns/cache_concern.rb
+++ b/app/controllers/concerns/cache_concern.rb
@@ -19,7 +19,7 @@ module CacheConcern
   # from being used as cache keys, while allowing to `Vary` on them (to not serve
   # anonymous cached data to authenticated requests when authentication matters)
   def enforce_cache_control!
-    vary = response.headers['Vary']&.split&.map { |x| x.strip.downcase }
+    vary = response.headers['Vary'].to_s.split(',').map { |x| x.strip.downcase }.reject(&:empty?)
     return unless vary.present? && %w(cookie authorization signature).any? { |header| vary.include?(header) && request.headers[header].present? }
 
     response.cache_control.replace(private: true, no_store: true)


### PR DESCRIPTION
Parse the Vary response header as a comma-separated list instead of splitting on whitespace, so tokens like "Authorization, Accept-Language" correctly match "authorization" and trigger private/no-store when sensitive request headers are present.