### PR TITLE
Change 'anyone can quote' label to 'quotes allowed'

### DIFF
--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -741,7 +741,7 @@
   "privacy.private.short": "Followers",
   "privacy.public.long": "Anyone on and off Mastodon",
   "privacy.public.short": "Public",
-  "privacy.quote.anyone": "{visibility}, anyone can quote",
+  "privacy.quote.anyone": "{visibility}, quotes allowed",
   "privacy.quote.disabled": "{visibility}, quotes disabled",
   "privacy.quote.limited": "{visibility}, quotes limited",
   "privacy.unlisted.additional": "This behaves exactly like public, except the post will not appear in live feeds or hashtags, explore, or Mastodon search, even if you are opted-in account-wide.",


### PR DESCRIPTION
Changes label to be consistent with the other labels when activated (quotes limited, quotes disable) and prevents the buttons from dropping to the second line with most major languages.

**Before**
<img width="604" height="494" alt="CleanShot 2026-01-08 at 16 31 52@2x" src="https://github.com/user-attachments/assets/a202e1e0-6ffd-4e22-af7d-c2ce65b35aef" />

**After**
<img width="596" height="418" alt="CleanShot 2026-01-08 at 16 32 31@2x" src="https://github.com/user-attachments/assets/1f234ed5-0b6e-400a-8ee8-a0b1d3465fda" />
