### PR TITLE
Safety: FetchRemoteActorService: raise error on malformed WebFinger subject

### DIFF
--- a/app/services/activitypub/fetch_remote_actor_service.rb
+++ b/app/services/activitypub/fetch_remote_actor_service.rb
@@ -67,8 +67,8 @@ class ActivityPub::FetchRemoteActorService < BaseService
   def split_acct(acct)
     username, domain = acct.delete_prefix('acct:').split('@', 2)
 
-    raise Error, 'Invalid acct URI: missing username' if username.blank?
-    raise Error, 'Invalid acct URI: missing domain' if domain.blank?
+    raise Error, 'acct URI: missing username' if username.blank?
+    raise Error, 'acct URI: missing domain' if domain.blank?
 
     [username, domain]
   end

--- a/app/services/activitypub/fetch_remote_actor_service.rb
+++ b/app/services/activitypub/fetch_remote_actor_service.rb
@@ -65,7 +65,12 @@ class ActivityPub::FetchRemoteActorService < BaseService
   end
 
   def split_acct(acct)
-    acct.delete_prefix('acct:').split('@')
+    username, domain = acct.delete_prefix('acct:').split('@', 2)
+  
+    raise Error, "Invalid acct URI: missing username" if username.nil? || username.empty?
+    raise Error, "Invalid acct URI: missing domain" if domain.nil? || domain.empty?
+  
+    [username, domain]
   end
 
   def supported_context?

--- a/app/services/activitypub/fetch_remote_actor_service.rb
+++ b/app/services/activitypub/fetch_remote_actor_service.rb
@@ -66,10 +66,10 @@ class ActivityPub::FetchRemoteActorService < BaseService
 
   def split_acct(acct)
     username, domain = acct.delete_prefix('acct:').split('@', 2)
-  
-    raise Error, "Invalid acct URI: missing username" if username.nil? || username.empty?
-    raise Error, "Invalid acct URI: missing domain" if domain.nil? || domain.empty?
-  
+
+    raise Error, 'Invalid acct URI: missing username' if username.blank?
+    raise Error, 'Invalid acct URI: missing domain' if domain.blank?
+
     [username, domain]
   end
 


### PR DESCRIPTION
Most servers are correctly sending this but worth checking for badly coded AP servers.

```
[RFC 7565: The 'acct' URI Scheme](https://www.rfc-editor.org/rfc/rfc7565.html)

The 'acct' URI scheme uses the format: acct:user@host

When special characters like the at-sign character (U+0040) need to be
included in the localpart, they must be percent-encoded as described
in RFC 3986.```