### PR TITLE
Fix `quote_approval_policy` being reset to user defaults when omitted in status update

### DIFF
--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -106,9 +106,7 @@ class Api::V1::StatusesController < Api::BaseController
     @status = Status.where(account: current_account).find(params[:id])
     authorize @status, :update?
 
-    UpdateStatusService.new.call(
-      @status,
-      current_account.id,
+    update_options = {
       text: status_params[:status],
       media_ids: status_params[:media_ids],
       media_attributes: status_params[:media_attributes],
@@ -116,8 +114,13 @@ class Api::V1::StatusesController < Api::BaseController
       language: status_params[:language],
       spoiler_text: status_params[:spoiler_text],
       poll: status_params[:poll],
-      quote_approval_policy: quote_approval_policy
-    )
+    }
+
+    if status_params[:quote_approval_policy].present?
+      update_options[:quote_approval_policy] = quote_approval_policy
+    end
+
+    UpdateStatusService.new.call(@status, current_account.id, update_options)
 
     render json: @status, serializer: REST::StatusSerializer
   end

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -116,9 +116,7 @@ class Api::V1::StatusesController < Api::BaseController
       poll: status_params[:poll],
     }
 
-    if status_params[:quote_approval_policy].present?
-      update_options[:quote_approval_policy] = quote_approval_policy
-    end
+    update_options[:quote_approval_policy] = quote_approval_policy if status_params[:quote_approval_policy].present?
 
     UpdateStatusService.new.call(@status, current_account.id, update_options)
 


### PR DESCRIPTION
I've confirmed this is an issue with the API logic and the web frontend correctly supplies the value. (No need for documentation to be updated)

Validation test

```
## CREATE WITH NOBODY QUOTE

  ~ curl -sS -X POST "https://aus.social/api/v1/statuses" \
  -H "Authorization: Bearer xxxxxx" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json" \
  -d '{"status":"Original text","quote_approval_policy":"nobody"}'

{"id":"115865366667286038","created_at":"2026-01-09T13:26:29.626Z","in_reply_to_id":null,"in_reply_to_account_id":null,"sensitive":false,"spoiler_text":"","visibility":"public","language":"en","uri":"https://aus.social/users/shlee/statuses/115865366667286038","url":"https://aus.social/@shlee/115865366667286038","replies_count":0,"reblogs_count":0,"favourites_count":0,"quotes_count":0,"edited_at":null,"favourited":false,"reblogged":false,"muted":false,"bookmarked":false,"pinned":false,"content":"\u003cp\u003eOriginal text\u003c/p\u003e","filtered":[],"reblog":null,"application":{"name":"bullshit","website":null},"account":xxxxxx"media_attachments":[],"mentions":[],"tags":[],"emojis":[],"quote":null,"card":null,"poll":null,"quote_approval":{"automatic":[],"manual":[],"current_user":"automatic"}}%

## UPDATE WITH NO POLICY CHANGE

➜  ~ curl -X PUT "https://aus.social/api/v1/statuses/115865366667286038" \
  -H "Authorization: Bearer xxxxxx" \
  -H "Content-Type: application/json" \
  -d '{
    "status": "Updated text"
  }'
{"id":"115865366667286038","created_at":"2026-01-09T13:26:29.626Z","in_reply_to_id":null,"in_reply_to_account_id":null,"sensitive":false,"spoiler_text":"","visibility":"public","language":"en","uri":"https://aus.social/users/shlee/statuses/115865366667286038","url":"https://aus.social/@shlee/115865366667286038","replies_count":0,"reblogs_count":0,"favourites_count":1,"quotes_count":0,"edited_at":"2026-01-09T13:27:10.474Z","favourited":false,"reblogged":false,"muted":false,"bookmarked":false,"pinned":false,"content":"\u003cp\u003eUpdated text\u003c/p\u003e","filtered":[],"reblog":null,"application":xxxxxxxxxx,"media_attachments":[],"mentions":[],"tags":[],"emojis":[],"quote":null,"card":null,"poll":null,"quote_approval":{"automatic":["public"],"manual":[],"current_user":"automatic"}}%

## POLICY IS CHANGED!

curl -s "https://aus.social/api/v1/statuses/115865366667286038" \
  -H "Authorization: Bearer xxxxxxxx" | jq '.quote_approval'

{
  "automatic": [
    "public"
  ],
  "manual": [],
  "current_user": "automatic"
}
```
