### PR TITLE
AuthorizeFollowWorker authorizes follows despite blocks when accounts unlock

### DIFF
--- a/app/services/update_account_service.rb
+++ b/app/services/update_account_service.rb
@@ -23,8 +23,8 @@ class UpdateAccountService < BaseService
     follow_requests = FollowRequest.where(target_account: account)
     follow_requests = follow_requests.preload(:account).reject do |req|
       req.account.silenced? ||
-      account.blocking?(req.account) ||  # target blocks requester
-      req.account.blocking?(account)     # requester blocks target
+      account.blocking?(req.account) ||  # account blocks requester
+      req.account.blocking?(account)     # requester blocks account
     end
     AuthorizeFollowWorker.push_bulk(follow_requests, limit: 1_000) do |req|
       [req.account_id, req.target_account_id]

--- a/app/services/update_account_service.rb
+++ b/app/services/update_account_service.rb
@@ -21,7 +21,11 @@ class UpdateAccountService < BaseService
 
   def authorize_all_follow_requests(account)
     follow_requests = FollowRequest.where(target_account: account)
-    follow_requests = follow_requests.preload(:account).reject { |req| req.account.silenced? }
+    follow_requests = follow_requests.preload(:account).reject do |req|
+      req.account.silenced? ||
+      account.blocking?(req.account) ||  # target blocks requester
+      req.account.blocking?(account)     # requester blocks target
+    end
     AuthorizeFollowWorker.push_bulk(follow_requests, limit: 1_000) do |req|
       [req.account_id, req.target_account_id]
     end

--- a/app/services/update_account_service.rb
+++ b/app/services/update_account_service.rb
@@ -22,9 +22,7 @@ class UpdateAccountService < BaseService
   def authorize_all_follow_requests(account)
     follow_requests = FollowRequest.where(target_account: account)
     follow_requests = follow_requests.preload(:account).reject do |req|
-      req.account.silenced? ||
-      account.blocking?(req.account) ||  # account blocks requester
-      req.account.blocking?(account)     # requester blocks account
+      req.account.silenced? || account.blocking?(req.account) || req.account.blocking?(account)
     end
     AuthorizeFollowWorker.push_bulk(follow_requests, limit: 1_000) do |req|
       [req.account_id, req.target_account_id]


### PR DESCRIPTION
`Add additional checks during bulk authorization in UpdateAccountService.authorize_all_follow_requests to skip requests where either side has blocked the other.`