### PR TITLE
Non-ActivityPub Link header alternate blocks HTML ActivityPub discovery in FetchResourceService

### DIFF
--- a/app/services/fetch_resource_service.rb
+++ b/app/services/fetch_resource_service.rb
@@ -60,8 +60,12 @@ class FetchResourceService < BaseService
     elsif !terminal
       link_header = response['Link'] && parse_link_header(response)
 
-      if link_header&.find_link(%w(rel alternate))
-        process_link_headers(link_header)
+      # Check for ActivityPub-specific alternate links, not just any alternate
+      ap_json = link_header&.find_link(%w(rel alternate), %w(type application/activity+json)) ||
+                link_header&.find_link(%w(rel alternate), ['type', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'])
+
+      if ap_json
+        process(ap_json.href, terminal: true)
       elsif response.mime_type == 'text/html'
         process_html(response)
       end

--- a/app/services/fetch_resource_service.rb
+++ b/app/services/fetch_resource_service.rb
@@ -67,6 +67,8 @@ class FetchResourceService < BaseService
   end
 
   def process_html(response)
+    return unless response.mime_type == 'text/html'
+
     page      = Nokogiri::HTML5(response.body_with_limit)
     json_link = page.xpath('//link[nokogiri:link_rel_include(@rel, "alternate")]', NokogiriHandler).find { |link| ACTIVITY_STREAM_LINK_TYPES.include?(link['type']) }
 
@@ -83,8 +85,6 @@ class FetchResourceService < BaseService
   end
 
   def parse_link_header(response)
-    return unless response.mime_type == 'text/html'
-
     LinkHeader.parse(response['Link'].is_a?(Array) ? response['Link'].first : response['Link'])
   end
 end


### PR DESCRIPTION
`find_link(%w(rel alternate)) which matches alternate links of ANY type`

`When a response contains both a Link header with a non-ActivityPub alternate link (e.g., RSS feed) AND an HTML body with an ActivityPub alternate link, the service fails to discover the ActivityPub resource.`

