### PR TITLE
Fix bug with how Emojibase wasn't stripping characters

### DIFF
--- a/app/javascript/mastodon/features/emoji/utils.ts
+++ b/app/javascript/mastodon/features/emoji/utils.ts
@@ -1,7 +1,8 @@
 import debug from 'debug';
-import { fromUnicodeToHexcode } from 'emojibase';
 
 import { emojiRegexPolyfill } from '@/mastodon/polyfills';
+
+import { VARIATION_SELECTOR_CODE } from './constants';
 
 export function emojiLogger(segment: string) {
   return debug(`emojis:${segment}`);
@@ -46,7 +47,24 @@ export function anyEmojiRegex() {
 }
 
 export function emojiToUnicodeHex(emoji: string): string {
-  return fromUnicodeToHexcode(emoji, false);
+  const codes: string[] = [];
+  for (const char of emoji) {
+    const code = char.codePointAt(0);
+    if (code !== undefined) {
+      codes.push(code.toString(16).toUpperCase().padStart(4, '0'));
+    }
+  }
+
+  // Handles how Emojibase removes the variation selector for single code emojis.
+  // See: https://emojibase.dev/docs/spec/#merged-variation-selectors
+  if (
+    codes.at(1) === VARIATION_SELECTOR_CODE.toString(16).toUpperCase() &&
+    codes.length === 2
+  ) {
+    codes.pop();
+  }
+
+  return codes.join('-');
 }
 
 function supportsRegExpSets() {


### PR DESCRIPTION
Fixes a regression from #37418. Previously, the function `emojiToUnicodeHex` stripped out the emoji variation selector `FE0F` only when the codepoint was at the second position and the last in the array. the replaced Emojibase function does not do that, so I redid the old function.