### PR TITLE
fixed the bug after Tangerine-UI installed

### DIFF
--- a/app/javascript/styles/mastodon/theme/index.scss
+++ b/app/javascript/styles/mastodon/theme/index.scss
@@ -30,9 +30,7 @@ html {
 }
 
 .theme-dark,
-html:where(
-  :not([data-user-theme='mastodon-light'], [data-user-theme='system'])
-) {
+html:where([data-user-theme='default']) {
   color-scheme: dark;
 
   @include dark.tokens;
@@ -45,7 +43,9 @@ html[data-user-theme='contrast'] .theme-dark {
 }
 
 .theme-light,
-html:where([data-user-theme='mastodon-light']) {
+html:where(
+  :not([data-user-theme='default'], [data-user-theme='system'])
+) {
   color-scheme: light;
 
   @include light.tokens;


### PR DESCRIPTION
<img width="305" height="917" alt="image" src="https://github.com/user-attachments/assets/2db08a21-da94-4235-971c-4a736bd56311" />
<img width="1917" height="925" alt="无标题" src="https://github.com/user-attachments/assets/0c8bf032-dbce-4fc0-bd1f-79e2ee6764a2" />

When the Tangerine-UI is installed on the mastodon v4.6.0 by the Owner before fixed, the issue in the figures will happen. 
So I fixed it.