### PR TITLE
Fix keyboard navigation in media modal after clicking image

### DIFF
--- a/app/javascript/mastodon/features/ui/components/media_modal.tsx
+++ b/app/javascript/mastodon/features/ui/components/media_modal.tsx
@@ -85,7 +85,7 @@ export const MediaModal: FC<MediaModalProps> = forwardRef<
         setIndex(newIndex);
         setZoomedIn(false);
         if (animate) {
-          void api.start({ x: `-${newIndex * 100}%` });
+          void api.start({ x: `calc(-${newIndex * 100}% + 0px)` });
         }
       },
       [api, media.size],


### PR DESCRIPTION
Fixes #37339

After clicking an image in the media modal to hide controls, keyboard arrow navigation stops working visually. The index state updates (background color changes) but the carousel doesn't animate.

The issue is a format mismatch in react-spring animation values. The `useDrag` callback sets the spring using `calc()` format, but `handleChangeIndex` was using a simple `-%` format. react-spring can't interpolate between these different string formats.

This change makes `handleChangeIndex` use the same `calc()` format as `useDrag`.