### PR TITLE
Fix directory showing load more button when no more profiles exist

### DIFF
--- a/app/javascript/mastodon/actions/directory.ts
+++ b/app/javascript/mastodon/actions/directory.ts
@@ -6,15 +6,17 @@ import { createDataLoadingThunk } from 'mastodon/store/typed_functions';
 import { fetchRelationships } from './accounts';
 import { importFetchedAccounts } from './importer';
 
+const DIRECTORY_FETCH_LIMIT = 20;
+
 export const fetchDirectory = createDataLoadingThunk(
   'directory/fetch',
   async (params: Parameters<typeof apiGetDirectory>[0]) =>
-    apiGetDirectory(params),
+    apiGetDirectory(params, DIRECTORY_FETCH_LIMIT),
   (data, { dispatch }) => {
     dispatch(importFetchedAccounts(data));
     dispatch(fetchRelationships(data.map((x) => x.id)));
 
-    return { accounts: data };
+    return { accounts: data, isLast: data.length < DIRECTORY_FETCH_LIMIT };
   },
 );
 
@@ -26,12 +28,15 @@ export const expandDirectory = createDataLoadingThunk(
       'items',
     ]) as ImmutableList<unknown>;
 
-    return apiGetDirectory({ ...params, offset: loadedItems.size }, 20);
+    return apiGetDirectory(
+      { ...params, offset: loadedItems.size },
+      DIRECTORY_FETCH_LIMIT,
+    );
   },
   (data, { dispatch }) => {
     dispatch(importFetchedAccounts(data));
     dispatch(fetchRelationships(data.map((x) => x.id)));
 
-    return { accounts: data };
+    return { accounts: data, isLast: data.length < DIRECTORY_FETCH_LIMIT };
   },
 );

--- a/app/javascript/mastodon/features/directory/index.tsx
+++ b/app/javascript/mastodon/features/directory/index.tsx
@@ -83,6 +83,9 @@ export const Directory: React.FC<{
     (state) =>
       state.user_lists.getIn(['directory', 'isLoading'], true) as boolean,
   );
+  const hasMore = useAppSelector(
+    (state) => !!state.user_lists.getIn(['directory', 'next']),
+  );
 
   useEffect(() => {
     void dispatch(fetchDirectory({ order, local }));
@@ -182,7 +185,7 @@ export const Directory: React.FC<{
 
       <LoadMore
         onClick={handleLoadMore}
-        visible={!initialLoad}
+        visible={!initialLoad && hasMore}
         loading={isLoading}
       />
     </div>

--- a/app/javascript/mastodon/reducers/user_lists.js
+++ b/app/javascript/mastodon/reducers/user_lists.js
@@ -204,9 +204,9 @@ export default function userLists(state = initialState, action) {
     else if (fetchFeaturedTags.rejected.match(action))
       return state.setIn(['featured_tags', action.meta.arg.accountId, 'isLoading'], false);
     else if (fetchDirectory.fulfilled.match(action))
-      return normalizeList(state, ['directory'], action.payload.accounts, undefined);
+      return normalizeList(state, ['directory'], action.payload.accounts, action.payload.isLast ? null : true);
     else if (expandDirectory.fulfilled.match(action))
-      return appendToList(state, ['directory'], action.payload.accounts, undefined);
+      return appendToList(state, ['directory'], action.payload.accounts, action.payload.isLast ? null : true);
     else if (fetchDirectory.pending.match(action) ||
      expandDirectory.pending.match(action))
       return state.setIn(['directory', 'isLoading'], true);


### PR DESCRIPTION
Fixes #37398

The directory page showed a "Load more" button even when there were no more profiles to load. This happened because the component only checked if initial loading was complete, not whether more items actually existed.

Track pagination state by returning `isLast` from directory fetch actions and storing it in the `next` field (matching the pattern used by blocks, mutes, and follow_requests). The LoadMore button now checks this state before rendering.