### PR TITLE
Simplify status batch removal SQL query

### DIFF
--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -31,7 +31,7 @@ class BatchedRemoveStatusService < BaseService
     # transaction lock the database, but we use the delete method instead
     # of destroy to avoid all callbacks. We rely on foreign keys to
     # cascade the delete faster without loading the associations.
-    statuses_and_reblogs.each_slice(50) { |slice| Status.where(id: slice.map(&:id)).delete_all }
+    statuses_and_reblogs.each_slice(50) { |slice| Status.unscoped.where(id: slice.pluck(:id)).delete_all }
 
     # Since we skipped all callbacks, we also need to manually
     # deindex the statuses


### PR DESCRIPTION
Fixes #37458

Since we know the status IDs and want to delete them, we don't need to use the default scope. This simplifies the query significantly.