### PR TITLE
Fix `isDarkMode` utility

### DIFF
--- a/app/javascript/mastodon/utils/theme.ts
+++ b/app/javascript/mastodon/utils/theme.ts
@@ -5,9 +5,7 @@ export function getUserTheme() {
 
 export function isDarkMode() {
   const { userTheme } = document.documentElement.dataset;
-  return (
-    (userTheme === 'system' &&
-      window.matchMedia('(prefers-color-scheme: dark)').matches) ||
-    userTheme !== 'mastodon-light'
-  );
+  return userTheme === 'system'
+    ? window.matchMedia('(prefers-color-scheme: dark)').matches
+    : userTheme !== 'mastodon-light';
 }


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes logic in the `isDarkMode` utility that would cause it to always return `true` when the "system" theme was active
