### PR TITLE
Add spec for quote policy update change

### DIFF
--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -508,6 +508,15 @@ RSpec.describe '/api/v1/statuses' do
             .to start_with('application/json')
         end
       end
+
+      context 'when status has non-default quote policy and param is omitted' do
+        let(:status) { Fabricate(:status, account: user.account, quote_approval_policy: 'nobody') }
+
+        it 'preserves existing quote approval policy' do
+          expect { subject }
+            .to_not(change { status.reload.quote_approval_policy })
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Followup on https://github.com/mastodon/mastodon/pull/37436

Adds spec to show the behavior change from that PR.

Also does a little tidy up of how we build the create vs update hashes - they are mostly but not entirely the same, so use some methods to highlight that. I believe this preserves the prior behavior. If this approach or portions of it are too clever, I can back that out and just do the spec addition here, and/or some variation on the hash cleanup, etc...