### PR TITLE
Drop support for ruby 3.2

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -124,7 +124,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.2'
           - '3.3'
           - '.ruby-version'
     steps:
@@ -217,7 +216,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.2'
           - '3.3'
           - '.ruby-version'
 
@@ -348,7 +346,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.2'
           - '3.3'
           - '.ruby-version'
         search-image:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - lib/mastodon/migration_helpers.rb
   ExtraDetails: true
   NewCops: enable
-  TargetRubyVersion: 3.2 # Oldest supported ruby version
+  TargetRubyVersion: 3.3 # Oldest supported ruby version
 
 inherit_from:
   - .rubocop/layout.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 3.2.0', '< 3.5.0'
+ruby '>= 3.3.0', '< 3.5.0'
 
 gem 'propshaft'
 gem 'puma', '~> 7.0'

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Mastodon is a **free, open-source social network server** based on [ActivityPub]
 
 ### Requirements
 
-- **Ruby** 3.2+
+- **Ruby** 3.3+
 - **PostgreSQL** 14+
 - **Redis** 7.0+
 - **Node.js** 20+


### PR DESCRIPTION
I think that since stable debian release a few months ago and since https://github.com/mastodon/mastodon/pull/35768 merged, we might be ok to pull this now?

If not, it's EOL in a few months and can sit until then.

Related: https://github.com/mastodon/mastodon/pull/37445 / https://github.com/mastodon/mastodon/pull/37441