### PR TITLE
MiniCard and MiniCardList components

### DIFF
--- a/app/javascript/mastodon/components/mini_card/index.tsx
+++ b/app/javascript/mastodon/components/mini_card/index.tsx
@@ -8,15 +8,24 @@ export interface MiniCardProps {
   label: ReactNode;
   value: ReactNode;
   className?: string;
+  hidden?: boolean;
 }
 
-export const MiniCard: FC<MiniCardProps> = ({ label, value, className }) => {
+export const MiniCard: FC<MiniCardProps> = ({
+  label,
+  value,
+  className,
+  hidden,
+}) => {
   if (!label) {
     return null;
   }
 
   return (
-    <div className={classNames(classes.card, className)}>
+    <div
+      className={classNames(classes.card, className)}
+      inert={hidden ? '' : undefined}
+    >
       <dt className={classes.label}>{label}</dt>
       <dd className={classes.value}>{value}</dd>
     </div>

--- a/app/javascript/mastodon/components/mini_card/index.tsx
+++ b/app/javascript/mastodon/components/mini_card/index.tsx
@@ -11,7 +11,7 @@ export interface MiniCardProps {
 }
 
 export const MiniCard: FC<MiniCardProps> = ({ label, value, className }) => {
-  if (!value || !label) {
+  if (!label) {
     return null;
   }
 

--- a/app/javascript/mastodon/components/mini_card/index.tsx
+++ b/app/javascript/mastodon/components/mini_card/index.tsx
@@ -1,0 +1,42 @@
+import type { FC, ReactNode } from 'react';
+
+import classNames from 'classnames';
+
+import classes from './styles.module.css';
+
+export interface MiniCardProps {
+  label: ReactNode;
+  value: ReactNode;
+  className?: string;
+}
+
+export const MiniCard: FC<MiniCardProps> = ({ label, value, className }) => {
+  if (!value || !label) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    const url = toUrl(value);
+    if (url) {
+      value = <a href={url.toString()}>{url.hostname}</a>;
+    }
+  }
+
+  return (
+    <div className={classNames(classes.card, className)}>
+      <dt className={classes.label}>{label}</dt>
+      <dd className={classes.value}>{value}</dd>
+    </div>
+  );
+};
+
+function toUrl(value: string) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'https:') {
+      return null;
+    }
+    return url;
+  } catch {}
+  return null;
+}

--- a/app/javascript/mastodon/components/mini_card/index.tsx
+++ b/app/javascript/mastodon/components/mini_card/index.tsx
@@ -15,13 +15,6 @@ export const MiniCard: FC<MiniCardProps> = ({ label, value, className }) => {
     return null;
   }
 
-  if (typeof value === 'string') {
-    const url = toUrl(value);
-    if (url) {
-      value = <a href={url.toString()}>{url.hostname}</a>;
-    }
-  }
-
   return (
     <div className={classNames(classes.card, className)}>
       <dt className={classes.label}>{label}</dt>
@@ -29,14 +22,3 @@ export const MiniCard: FC<MiniCardProps> = ({ label, value, className }) => {
     </div>
   );
 };
-
-function toUrl(value: string) {
-  try {
-    const url = new URL(value);
-    if (url.protocol !== 'https:') {
-      return null;
-    }
-    return url;
-  } catch {}
-  return null;
-}

--- a/app/javascript/mastodon/components/mini_card/list.tsx
+++ b/app/javascript/mastodon/components/mini_card/list.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { FC, Key, ReactNode } from 'react';
+
+import classNames from 'classnames';
+
+import { MiniCard } from '.';
+import type { MiniCardProps } from '.';
+import classes from './styles.module.css';
+
+interface MiniCardListProps {
+  cards?: (Pick<MiniCardProps, 'label' | 'value'> & { key?: Key })[];
+  children?: ReactNode;
+}
+
+export const MiniCardList: FC<MiniCardListProps> = ({
+  cards = [],
+  children,
+}) => {
+  const { wrapperRef, listRef, hidden, showOverflow } = useOverflow();
+
+  return (
+    <div className={classes.wrapper} ref={wrapperRef}>
+      <dl className={classes.list} ref={listRef}>
+        {cards.map((card, index) => (
+          <MiniCard
+            key={card.key ?? index}
+            label={card.label}
+            value={card.value}
+          />
+        ))}
+        {children}
+      </dl>
+      <button
+        type='button'
+        className={classNames(classes.more, !showOverflow && classes.hidden)}
+      >
+        + {hidden} more
+      </button>
+    </div>
+  );
+};
+
+function useOverflow() {
+  const [hidden, setHidden] = useState(0);
+
+  // This is the item container element.
+  const listRef = useRef<HTMLElement | null>(null);
+
+  // The main recalculation function.
+  const handleRecalculate = useCallback(() => {
+    const listEle = listRef.current;
+    if (!listEle) return;
+
+    // Calculate the width via the parent element, minus the more button, minus the padding.
+    const maxWidth =
+      (listEle.parentElement?.offsetWidth ?? 0) -
+      (listEle.nextElementSibling?.scrollWidth ?? 0) -
+      4;
+    if (maxWidth <= 0) {
+      listEle.style.removeProperty('max-width');
+      setHidden(0);
+      return;
+    }
+
+    // Iterate through children until we exceed max width.
+    let visible = 0;
+    let totalWidth = 0;
+    for (const child of listEle.children) {
+      if (child instanceof HTMLElement) {
+        const rightOffset = child.offsetLeft + child.offsetWidth;
+        if (rightOffset <= maxWidth) {
+          visible += 1;
+          totalWidth = rightOffset;
+        } else {
+          break;
+        }
+      }
+    }
+
+    // All are visible, so remove max-width restriction.
+    if (visible === listEle.children.length) {
+      listEle.style.removeProperty('max-width');
+      setHidden(0);
+      return;
+    }
+
+    // Set the width to avoid wrapping, and set hidden count.
+    listEle.style.setProperty('max-width', `${totalWidth}px`);
+    setHidden(listEle.children.length - visible);
+  }, []);
+
+  // Set up observers to watch for size and content changes.
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const mutationObserverRef = useRef<MutationObserver | null>(null);
+
+  // Helper to get or create the resize observer.
+  const resizeObserver = useCallback(() => {
+    const observer = (resizeObserverRef.current ??= new ResizeObserver(
+      handleRecalculate,
+    ));
+    return observer;
+  }, [handleRecalculate]);
+
+  // Iterate through children and observe them for size changes.
+  const handleChildrenChange = useCallback(() => {
+    const listEle = listRef.current;
+    const observer = resizeObserver();
+
+    if (listEle) {
+      for (const child of listEle.children) {
+        if (child instanceof HTMLElement) {
+          observer.observe(child);
+        }
+      }
+    }
+    handleRecalculate();
+  }, [handleRecalculate, resizeObserver]);
+
+  // Helper to get or create the mutation observer.
+  const mutationObserver = useCallback(() => {
+    const observer = (mutationObserverRef.current ??= new MutationObserver(
+      handleChildrenChange,
+    ));
+    return observer;
+  }, [handleChildrenChange]);
+
+  // Disconnect on unmount.
+  useEffect(() => {
+    const resizeObserverCleanup = resizeObserver();
+    const mutationObserverCleanup = mutationObserver();
+
+    return () => {
+      resizeObserverCleanup.disconnect();
+      mutationObserverCleanup.disconnect();
+    };
+  }, [mutationObserver, resizeObserver]);
+
+  // Watch the wrapper for size changes, and recalculate when it resizes.
+  const wrapperRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (node) {
+        resizeObserver().observe(node);
+      }
+    },
+    [resizeObserver],
+  );
+
+  // If there are changes to the children, recalculate which are visible.
+  const listRefCallback = useCallback(
+    (node: HTMLElement | null) => {
+      if (node) {
+        mutationObserver().observe(node, { childList: true });
+        listRef.current = node;
+        handleChildrenChange();
+      }
+    },
+    [handleChildrenChange, mutationObserver],
+  );
+
+  return {
+    hidden,
+    showOverflow: hidden > 0,
+    wrapperRef,
+    listRef: listRefCallback,
+    recalculate: handleRecalculate,
+  };
+}

--- a/app/javascript/mastodon/components/mini_card/list.tsx
+++ b/app/javascript/mastodon/components/mini_card/list.tsx
@@ -20,7 +20,7 @@ export const MiniCardList: FC<MiniCardListProps> = ({
   children,
   onOverflowClick,
 }) => {
-  const { wrapperRef, listRef, hidden, showOverflow } = useOverflow();
+  const { wrapperRef, listRef, hiddenCount, hasOverflow } = useOverflow();
 
   return (
     <div className={classes.wrapper} ref={wrapperRef}>
@@ -36,13 +36,13 @@ export const MiniCardList: FC<MiniCardListProps> = ({
       </dl>
       <button
         type='button'
-        className={classNames(classes.more, !showOverflow && classes.hidden)}
+        className={classNames(classes.more, !hasOverflow && classes.hidden)}
         onClick={onOverflowClick}
       >
         <FormattedMessage
           id='minicard.more_items'
-          defaultMessage='+ {hidden} more'
-          values={{ hidden }}
+          defaultMessage='+ {count} more'
+          values={{ count: hiddenCount }}
         />
       </button>
     </div>
@@ -50,7 +50,7 @@ export const MiniCardList: FC<MiniCardListProps> = ({
 };
 
 function useOverflow() {
-  const [hidden, setHidden] = useState(0);
+  const [hiddenCount, setHiddenCount] = useState(0);
 
   // This is the item container element.
   const listRef = useRef<HTMLElement | null>(null);
@@ -67,7 +67,7 @@ function useOverflow() {
         }
       }
       listEle.style.removeProperty('max-width');
-      setHidden(0);
+      setHiddenCount(0);
     };
 
     // Calculate the width via the parent element, minus the more button, minus the padding.
@@ -104,7 +104,7 @@ function useOverflow() {
 
     // Set the width to avoid wrapping, and set hidden count.
     listEle.style.setProperty('max-width', `${totalWidth}px`);
-    setHidden(listEle.children.length - visible);
+    setHiddenCount(listEle.children.length - visible);
   }, []);
 
   // Set up observers to watch for size and content changes.
@@ -176,8 +176,8 @@ function useOverflow() {
   );
 
   return {
-    hidden,
-    showOverflow: hidden > 0,
+    hiddenCount,
+    hasOverflow: hiddenCount > 0,
     wrapperRef,
     listRef: listRefCallback,
     recalculate: handleRecalculate,

--- a/app/javascript/mastodon/components/mini_card/list.tsx
+++ b/app/javascript/mastodon/components/mini_card/list.tsx
@@ -60,14 +60,23 @@ function useOverflow() {
     const listEle = listRef.current;
     if (!listEle) return;
 
+    const reset = () => {
+      for (const child of listEle.children) {
+        if (child instanceof HTMLElement) {
+          child.ariaHidden = 'false';
+        }
+      }
+      listEle.style.removeProperty('max-width');
+      setHidden(0);
+    };
+
     // Calculate the width via the parent element, minus the more button, minus the padding.
     const maxWidth =
       (listEle.parentElement?.offsetWidth ?? 0) -
       (listEle.nextElementSibling?.scrollWidth ?? 0) -
       4;
     if (maxWidth <= 0) {
-      listEle.style.removeProperty('max-width');
-      setHidden(0);
+      reset();
       return;
     }
 
@@ -78,18 +87,18 @@ function useOverflow() {
       if (child instanceof HTMLElement) {
         const rightOffset = child.offsetLeft + child.offsetWidth;
         if (rightOffset <= maxWidth) {
+          child.ariaHidden = 'false';
           visible += 1;
           totalWidth = rightOffset;
         } else {
-          break;
+          child.ariaHidden = 'true';
         }
       }
     }
 
     // All are visible, so remove max-width restriction.
     if (visible === listEle.children.length) {
-      listEle.style.removeProperty('max-width');
-      setHidden(0);
+      reset();
       return;
     }
 

--- a/app/javascript/mastodon/components/mini_card/list.tsx
+++ b/app/javascript/mastodon/components/mini_card/list.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FC, Key, MouseEventHandler, ReactNode } from 'react';
 
+import { FormattedMessage } from 'react-intl';
+
 import classNames from 'classnames';
 
 import { MiniCard } from '.';
@@ -37,7 +39,11 @@ export const MiniCardList: FC<MiniCardListProps> = ({
         className={classNames(classes.more, !showOverflow && classes.hidden)}
         onClick={onOverflowClick}
       >
-        + {hidden} more
+        <FormattedMessage
+          id='minicard.more_items'
+          defaultMessage='+ {hidden} more'
+          values={{ hidden }}
+        />
       </button>
     </div>
   );

--- a/app/javascript/mastodon/components/mini_card/list.tsx
+++ b/app/javascript/mastodon/components/mini_card/list.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { FC, Key, ReactNode } from 'react';
+import type { FC, Key, MouseEventHandler, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
@@ -10,11 +10,13 @@ import classes from './styles.module.css';
 interface MiniCardListProps {
   cards?: (Pick<MiniCardProps, 'label' | 'value'> & { key?: Key })[];
   children?: ReactNode;
+  onOverflowClick?: MouseEventHandler;
 }
 
 export const MiniCardList: FC<MiniCardListProps> = ({
   cards = [],
   children,
+  onOverflowClick,
 }) => {
   const { wrapperRef, listRef, hidden, showOverflow } = useOverflow();
 
@@ -33,6 +35,7 @@ export const MiniCardList: FC<MiniCardListProps> = ({
       <button
         type='button'
         className={classNames(classes.more, !showOverflow && classes.hidden)}
+        onClick={onOverflowClick}
       >
         + {hidden} more
       </button>

--- a/app/javascript/mastodon/components/mini_card/mini_card.stories.tsx
+++ b/app/javascript/mastodon/components/mini_card/mini_card.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
 
 import { MiniCardList } from './list';
 
@@ -8,10 +9,17 @@ const meta = {
   args: {
     cards: [
       { label: 'Pronouns', value: 'they/them' },
-      { label: 'Website', value: 'https://bowie-the-dj.meow' },
-      { label: 'Free playlists', value: 'https://soundcloud.com/bowie-the-dj' },
+      {
+        label: 'Website',
+        value: <a href='https://example.com'>bowie-the-db.meow</a>,
+      },
+      {
+        label: 'Free playlists',
+        value: <a href='https://soundcloud.com/bowie-the-dj'>soundcloud.com</a>,
+      },
       { label: 'Location', value: 'Purris, France' },
     ],
+    onOverflowClick: action('Overflow clicked'),
   },
   render(args) {
     return (

--- a/app/javascript/mastodon/components/mini_card/mini_card.stories.tsx
+++ b/app/javascript/mastodon/components/mini_card/mini_card.stories.tsx
@@ -44,3 +44,19 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const LongValue: Story = {
+  args: {
+    cards: [
+      {
+        label: 'Username',
+        value: 'bowie-the-dj',
+      },
+      {
+        label: 'Bio',
+        value:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+      },
+    ],
+  },
+};

--- a/app/javascript/mastodon/components/mini_card/mini_card.stories.tsx
+++ b/app/javascript/mastodon/components/mini_card/mini_card.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { MiniCardList } from './list';
+
+const meta = {
+  title: 'Components/MiniCard',
+  component: MiniCardList,
+  args: {
+    cards: [
+      { label: 'Pronouns', value: 'they/them' },
+      { label: 'Website', value: 'https://bowie-the-dj.meow' },
+      { label: 'Free playlists', value: 'https://soundcloud.com/bowie-the-dj' },
+      { label: 'Location', value: 'Purris, France' },
+    ],
+  },
+  render(args) {
+    return (
+      <div
+        style={{
+          resize: 'horizontal',
+          padding: '1rem',
+          border: '1px solid gray',
+          overflow: 'auto',
+          width: '400px',
+          minWidth: '100px',
+        }}
+      >
+        <MiniCardList {...args} />
+      </div>
+    );
+  },
+} satisfies Meta<typeof MiniCardList>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/app/javascript/mastodon/components/mini_card/styles.module.css
+++ b/app/javascript/mastodon/components/mini_card/styles.module.css
@@ -10,7 +10,6 @@
   display: flex;
   gap: 4px;
   overflow: hidden;
-  height: 54px;
   position: relative;
 }
 
@@ -20,6 +19,18 @@
   padding: 8px;
   border-radius: 8px;
   flex-shrink: 0;
+}
+
+.card {
+  max-width: 20vw;
+  overflow: hidden;
+}
+
+.more {
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  appearance: none;
+  background: none;
 }
 
 .hidden {
@@ -36,9 +47,9 @@
   font-weight: 600;
 }
 
-.more {
-  color: var(--color-text-secondary);
-  font-weight: 600;
-  appearance: none;
-  background: none;
+.label,
+.value {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }

--- a/app/javascript/mastodon/components/mini_card/styles.module.css
+++ b/app/javascript/mastodon/components/mini_card/styles.module.css
@@ -1,0 +1,43 @@
+.wrapper {
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  gap: 4px;
+}
+
+.list {
+  min-width: 0;
+  display: flex;
+  gap: 4px;
+  overflow: hidden;
+  height: 54px;
+  position: relative;
+}
+
+.card,
+.more {
+  border: 1px solid var(--color-border-primary);
+  padding: 8px;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+.hidden {
+  display: none;
+}
+
+.label {
+  color: var(--color-text-secondary);
+}
+
+.value {
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.more {
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  appearance: none;
+  background: none;
+}

--- a/app/javascript/mastodon/components/mini_card/styles.module.css
+++ b/app/javascript/mastodon/components/mini_card/styles.module.css
@@ -28,6 +28,7 @@
 
 .label {
   color: var(--color-text-secondary);
+  margin-bottom: 2px;
 }
 
 .value {

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -589,7 +589,7 @@
   "load_pending": "{count, plural, one {# new item} other {# new items}}",
   "loading_indicator.label": "Loading…",
   "media_gallery.hide": "Hide",
-  "minicard.more_items": "+ {hidden} more",
+  "minicard.more_items": "+ {count} more",
   "moved_to_account_banner.text": "Your account {disabledAccount} is currently disabled because you moved to {movedToAccount}.",
   "mute_modal.hide_from_notifications": "Hide from notifications",
   "mute_modal.hide_options": "Hide options",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -589,6 +589,7 @@
   "load_pending": "{count, plural, one {# new item} other {# new items}}",
   "loading_indicator.label": "Loading…",
   "media_gallery.hide": "Hide",
+  "minicard.more_items": "+ {hidden} more",
   "moved_to_account_banner.text": "Your account {disabledAccount} is currently disabled because you moved to {movedToAccount}.",
   "mute_modal.hide_from_notifications": "Hide from notifications",
   "mute_modal.hide_options": "Hide options",


### PR DESCRIPTION
Fixes MAS-757.

This adds new components to show label/value pairs in mini cards, with an overflow system that updates based on container width.

Known issues:
- If all items are hidden, it still shows `+X more` instead of a different label. This is fixable, but I didn't consider it a common edge case.
- Where there is subpixel widths, it's possible for the rightmost edge to crop the border. This is very small so I consider it acceptable.

![Screenshot 2026-01-13 at 20 06 36](https://github.com/user-attachments/assets/989d3098-dbc2-44f6-ac48-9c4e12c0489d)

