### PR TITLE
Skip tombstone creation on deleting from 404

### DIFF
--- a/app/services/activitypub/fetch_remote_status_service.rb
+++ b/app/services/activitypub/fetch_remote_status_service.rb
@@ -92,7 +92,6 @@ class ActivityPub::FetchRemoteStatusService < BaseService
       existing_status = Status.remote.find_by(uri: uri)
       if existing_status&.distributable?
         Rails.logger.debug { "FetchRemoteStatusService - Got 404 for orphaned status with URI #{uri}, deleting" }
-        Tombstone.find_or_create_by(uri: uri, account: existing_status.account)
         RemoveStatusService.new.call(existing_status, redraft: false)
       end
     end


### PR DESCRIPTION
I have witnessed a server return 404s as temporary failures. With our current logic, this would cause posts to be deleted *and unable to be re-created again*, which is very destructive. This PR changes that to still delete but skip `Tombstone` creation, allowing such deleted posts to be re-discovered and re-fetched.