### PR TITLE
Add profile field limits to instance serializer

### DIFF
--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -71,6 +71,9 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       accounts: {
         max_featured_tags: FeaturedTag::LIMIT,
         max_pinned_statuses: StatusPinValidator::PIN_LIMIT,
+        max_profile_fields: Account::DEFAULT_FIELDS_SIZE,
+        profile_field_name_limit: Account::Field::MAX_CHARACTERS_LOCAL,
+        profile_field_value_limit: Account::Field::MAX_CHARACTERS_LOCAL,
       },
 
       statuses: {


### PR DESCRIPTION
Made this PR because [the docs](https://docs.joinmastodon.org/methods/accounts/#form-data-parameters-1) got me annoyed by specifying the limits are *default* while not specifying a way to check if the defaults apply.

The `configuration[accounts][max_profile_fields]` field is already used by GoToSocial.