### PR TITLE
Show converted ActivityPub content body

### DIFF
--- a/app/lib/activitypub/parser/status_parser.rb
+++ b/app/lib/activitypub/parser/status_parser.rb
@@ -51,6 +51,7 @@ class ActivityPub::Parser::StatusParser
     [
       title.presence && "<h2>#{title}</h2>",
       spoiler_text.presence,
+      text.presence,
       linkify(url || uri),
     ].compact.join("\n\n")
   end


### PR DESCRIPTION
Display body content for converted ActivityPub objects

Converted ActivityPub objects (e.g. Article, Page, Event) already had their body content extracted from `content` / `contentMap`, but it was not included in `processed_text`. As a result, remote posts with headlines (such as Lemmy or Friendica posts) were rendered with only a title and link.

This change includes the extracted body text when composing `processed_text`, so remote posts display their full content as expected.

This PR addresses #36227