### PR TITLE
Fix rendering of initial state when `collections` feature is enabled

### DIFF
--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -140,7 +140,7 @@ class InitialStateSerializer < ActiveModel::Serializer
   end
 
   def serialized_account(account)
-    ActiveModelSerializers::SerializableResource.new(account, serializer: REST::AccountSerializer)
+    ActiveModelSerializers::SerializableResource.new(account, serializer: REST::AccountSerializer, scope_name: :current_user, scope: object.current_account&.user)
   end
 
   def instance_presenter


### PR DESCRIPTION
The initial state renders an account's JSON under the hood which requires access to `current_user` when the `collections` feature flag is enabled. This is injected automatically when rendered through a controller, but not in this case here.

Rendering of the initial test is not tested, and I failed spectacularly when I tried to write a helper spec for it. To get this fix out asap I opted for something a lot simpler: A request spec that just makes sure the home page can be rendered successfully.