### PR TITLE
Do not return undiscoverable collections

### DIFF
--- a/app/controllers/api/v1_alpha/collections_controller.rb
+++ b/app/controllers/api/v1_alpha/collections_controller.rb
@@ -74,6 +74,7 @@ class Api::V1Alpha::CollectionsController < Api::BaseController
                            .order(created_at: :desc)
                            .offset(offset_param)
                            .limit(limit_param(DEFAULT_COLLECTIONS_LIMIT))
+    @collections = @collections.discoverable unless @account == current_account
   end
 
   def set_collection

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -43,6 +43,7 @@ class Collection < ApplicationRecord
 
   scope :with_items, -> { includes(:collection_items).merge(CollectionItem.with_accounts) }
   scope :with_tag, -> { includes(:tag) }
+  scope :discoverable, -> { where(discoverable: true) }
 
   def remote?
     !local?

--- a/spec/requests/api/v1_alpha/collections_spec.rb
+++ b/spec/requests/api/v1_alpha/collections_spec.rb
@@ -55,6 +55,32 @@ RSpec.describe 'Api::V1Alpha::Collections', feature: :collections do
           )
       end
     end
+
+    context 'when some collections are not discoverable' do
+      before do
+        Fabricate(:collection, account:, discoverable: false)
+      end
+
+      context 'when requesting user is a third party' do
+        it 'hides the collections that are not discoverable' do
+          subject
+
+          expect(response).to have_http_status(200)
+          expect(response.parsed_body.size).to eq 3
+        end
+      end
+
+      context 'when requesting user owns the collection' do
+        let(:account) { user.account }
+
+        it 'returns all collections, including the ones that are not discoverable' do
+          subject
+
+          expect(response).to have_http_status(200)
+          expect(response.parsed_body.size).to eq 4
+        end
+      end
+    end
   end
 
   describe 'GET /api/v1_alpha/collections/:id' do


### PR DESCRIPTION
Unless the requesting user owns the collection.

We decided to not show collections that are not `discoverable` on an account's profile. Instead of filtering them client-side, this changes the API to only return the visible collections in the first place.