### PR TITLE
Typo fix in federation document

### DIFF
--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -52,8 +52,8 @@ Mastodon requires all `POST` requests to be signed, and MAY require `GET` reques
 ## Size limits
 
 Mastodon imposes a few hard limits on federated content.
-These limits are intended to be very generous and way above what the Mastodon user experience is optimized for, so as to accomodate future changes and unusual or unforeseen usage patterns, while still providing some limits for performance reasons.
-The following table attempts to summary those limits.
+These limits are intended to be very generous and way above what the Mastodon user experience is optimized for, so as to accommodate future changes and unusual or unforeseen usage patterns, while still providing some limits for performance reasons.
+The following table summarizes those limits.
 
 | Limited property                                              | Size limit | Consequence of exceeding the limit |
 | ------------------------------------------------------------- | ---------- | ---------------------------------- |

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -564,6 +564,8 @@ RSpec.describe Account do
         it { is_expected.to_not allow_values('username', 'Username').for(:username) }
       end
 
+      it { is_expected.to validate_length_of(:username).is_at_most(described_class::USERNAME_LENGTH_HARD_LIMIT) }
+
       it { is_expected.to allow_values('the-doctor', username_over_limit).for(:username) }
       it { is_expected.to_not allow_values('the doctor').for(:username) }
 

--- a/spec/models/custom_emoji_spec.rb
+++ b/spec/models/custom_emoji_spec.rb
@@ -90,8 +90,14 @@ RSpec.describe CustomEmoji, :attachment_processing do
     subject { Fabricate.build :custom_emoji }
 
     it { is_expected.to validate_uniqueness_of(:shortcode).scoped_to(:domain) }
-    it { is_expected.to validate_length_of(:shortcode).is_at_least(described_class::MINIMUM_SHORTCODE_SIZE) }
+    it { is_expected.to validate_length_of(:shortcode).is_at_least(described_class::MINIMUM_SHORTCODE_SIZE).is_at_most(described_class::MAX_SHORTCODE_SIZE) }
     it { is_expected.to allow_values('cats').for(:shortcode) }
     it { is_expected.to_not allow_values('@#$@#$', 'X').for(:shortcode) }
+
+    context 'when remote' do
+      subject { Fabricate.build :custom_emoji, domain: 'host.example' }
+
+      it { is_expected.to validate_length_of(:shortcode).is_at_most(described_class::MAX_FEDERATED_SHORTCODE_SIZE) }
+    end
   end
 end

--- a/spec/models/custom_filter_keyword_spec.rb
+++ b/spec/models/custom_filter_keyword_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe CustomFilterKeyword do
+  describe 'Validations' do
+    it { is_expected.to validate_length_of(:keyword).is_at_most(described_class::KEYWORD_LENGTH_LIMIT) }
+    it { is_expected.to validate_presence_of(:keyword) }
+  end
+
   describe '#to_regex' do
     context 'when whole_word is true' do
       it 'builds a regex with boundaries and the keyword' do

--- a/spec/models/custom_filter_spec.rb
+++ b/spec/models/custom_filter_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe CustomFilter do
   it_behaves_like 'Expireable'
 
   describe 'Validations' do
-    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_length_of(:title).is_at_most(described_class::TITLE_LENGTH_LIMIT) }
     it { is_expected.to validate_presence_of(:context) }
+    it { is_expected.to validate_presence_of(:title) }
 
     it { is_expected.to_not allow_values([], %w(invalid)).for(:context) }
     it { is_expected.to allow_values(%w(home)).for(:context) }

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe List do
   describe 'Validations' do
     subject { Fabricate.build :list }
 
+    it { is_expected.to validate_length_of(:title).is_at_most(described_class::TITLE_LENGTH_LIMIT) }
     it { is_expected.to validate_presence_of(:title) }
 
     context 'when account has hit max list limit' do

--- a/spec/requests/activitypub/inboxes_spec.rb
+++ b/spec/requests/activitypub/inboxes_spec.rb
@@ -20,6 +20,19 @@ RSpec.describe 'ActivityPub Inboxes' do
         end
       end
 
+      context 'with an excessively large payload' do
+        subject { post inbox_path, params: { this: :that, those: :these }.to_json, sign_with: remote_account }
+
+        before { stub_const('ActivityPub::Activity::MAX_JSON_SIZE', 1.byte) }
+
+        it 'returns http content too large' do
+          subject
+
+          expect(response)
+            .to have_http_status(413)
+        end
+      end
+
       context 'with a specific account' do
         subject { post account_inbox_path(account_username: account.username), params: {}.to_json, sign_with: remote_account }
 

--- a/spec/requests/api/web/push_subscriptions_spec.rb
+++ b/spec/requests/api/web/push_subscriptions_spec.rb
@@ -190,6 +190,17 @@ RSpec.describe 'API Web Push Subscriptions' do
           .to eq(alerts_payload[:data][:alerts][type.to_sym].to_s)
       end
     end
+
+    context 'when using other user subscription' do
+      let(:subscription) { Fabricate(:web_push_subscription) }
+
+      it 'does not change settings' do
+        put api_web_push_subscription_path(subscription), params: alerts_payload
+
+        expect(response)
+          .to have_http_status(404)
+      end
+    end
   end
 
   def created_push_subscription


### PR DESCRIPTION
Misc stuff missed during review of recent block of security related commits:

- Small typo fix in federation doc
- Misc spec coverage for new validations/limits
- Spec for too large payload on inboxes
- Spec for suspended account on fan out service
- Spec for non-user-owned update of web/push/sub