### PR TITLE
Typo: Fix fan_out_on_write_service.rb notify_mentioned_accounts argument.

### DIFF
--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -79,7 +79,7 @@ class FanOutOnWriteService < BaseService
   end
 
   def notify_mentioned_accounts!
-    @status.active_mentions.where.not(id: @options[:silenced_account_ids] || []).joins(:account).merge(Account.local).select(:id, :account_id).reorder(nil).find_in_batches do |mentions|
+    @status.active_mentions.where.not(account_id: @options[:silenced_account_ids] || []).joins(:account).merge(Account.local).select(:id, :account_id).reorder(nil).find_in_batches do |mentions|
       LocalNotificationWorker.push_bulk(mentions) do |mention|
         [mention.account_id, mention.id, 'Mention', 'mention']
       end


### PR DESCRIPTION
I've tried to understand the code and I think `silenced_account_ids` is not expecting the primary key of the mentions record? So this will never match anything?

I think this means the mentions are getting sent for suspended remote accounts? but I have no idea if this is blocked further up the logic...