### PR TITLE
Safefy: Updated Admin::AccountDeletionWorker to match AccountDeletionWorker

### DIFF
--- a/app/workers/admin/account_deletion_worker.rb
+++ b/app/workers/admin/account_deletion_worker.rb
@@ -6,7 +6,10 @@ class Admin::AccountDeletionWorker
   sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.week.to_i
 
   def perform(account_id)
-    DeleteAccountService.new.call(Account.find(account_id), reserve_username: true, reserve_email: true)
+    account = Account.find(account_id)
+    return unless account.unavailable?
+
+    DeleteAccountService.new.call(account, reserve_username: true, reserve_email: true)
   rescue ActiveRecord::RecordNotFound
     true
   end

--- a/app/workers/admin/account_deletion_worker.rb
+++ b/app/workers/admin/account_deletion_worker.rb
@@ -6,10 +6,10 @@ class Admin::AccountDeletionWorker
   sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.week.to_i
 
   def perform(account_id)
-    deleteAccount = Account.find(account_id)
-    return unless deleteAccount.unavailable?
+    delete_account = Account.find(account_id)
+    return unless delete_account.unavailable?
 
-    DeleteAccountService.new.call(deleteAccount, reserve_username: true, reserve_email: true)
+    DeleteAccountService.new.call(delete_account, reserve_username: true, reserve_email: true)
   rescue ActiveRecord::RecordNotFound
     true
   end

--- a/app/workers/admin/account_deletion_worker.rb
+++ b/app/workers/admin/account_deletion_worker.rb
@@ -6,10 +6,10 @@ class Admin::AccountDeletionWorker
   sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.week.to_i
 
   def perform(account_id)
-    account = Account.find(account_id)
-    return unless account.unavailable?
+    deleteAccount = Account.find(account_id)
+    return unless deleteAccount.unavailable?
 
-    DeleteAccountService.new.call(account, reserve_username: true, reserve_email: true)
+    DeleteAccountService.new.call(deleteAccount, reserve_username: true, reserve_email: true)
   rescue ActiveRecord::RecordNotFound
     true
   end

--- a/spec/workers/admin/account_deletion_worker_spec.rb
+++ b/spec/workers/admin/account_deletion_worker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::AccountDeletionWorker do
   let(:worker) { described_class.new }
 
   describe 'perform' do
-    let(:account) { Fabricate(:account) }
+    let(:account) { Fabricate(:account, suspended: true) }
     let(:service) { instance_double(DeleteAccountService, call: true) }
 
     it 'calls delete account service' do


### PR DESCRIPTION
The non-admin worker protects against deleting active accounts, but the admin worker does not.

Reference (app/workers/account_deletion_worker.rb):
```
  def perform(account_id, options = {})
    account = Account.find(account_id)
    return unless account.unavailable?
    ...
    DeleteAccountService.new.call(account, reserve_username: reserve_username, skip_activitypub: skip_activitypub, reserve_email: false)
```

Current (app/workers/admin/account_deletion_worker.rb):
```
  def perform(account_id)
    DeleteAccountService.new.call(Account.find(account_id), reserve_username: true, reserve_email: true)
```

Added the check to protect against accidental account deleting from admins.