### PR TITLE
Fix filtering of mentions from filtered-on-their-origin-server accounts

### DIFF
--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -79,9 +79,11 @@ class FanOutOnWriteService < BaseService
   end
 
   def notify_mentioned_accounts!
-    @status.active_mentions.where.not(id: @options[:silenced_account_ids] || []).joins(:account).merge(Account.local).select(:id, :account_id).reorder(nil).find_in_batches do |mentions|
+    @status.active_mentions.joins(:account).merge(Account.local).select(:id, :account_id).reorder(nil).find_in_batches do |mentions|
       LocalNotificationWorker.push_bulk(mentions) do |mention|
-        [mention.account_id, mention.id, 'Mention', 'mention']
+        options = { 'silenced' => true } if @options[:silenced_account_ids]&.include?(mention.account_id)
+
+        [mention.account_id, mention.id, 'Mention', 'mention', options].compact
       end
 
       next unless update?

--- a/app/workers/local_notification_worker.rb
+++ b/app/workers/local_notification_worker.rb
@@ -3,7 +3,7 @@
 class LocalNotificationWorker
   include Sidekiq::Worker
 
-  def perform(receiver_account_id, activity_id = nil, activity_class_name = nil, type = nil)
+  def perform(receiver_account_id, activity_id = nil, activity_class_name = nil, type = nil, options = {})
     if activity_id.nil? && activity_class_name.nil?
       activity = Mention.find(receiver_account_id)
       receiver = activity.account
@@ -23,7 +23,7 @@ class LocalNotificationWorker
       return
     end
 
-    NotifyService.new.call(receiver, type || activity_class_name.underscore, activity)
+    NotifyService.new.call(receiver, type || activity_class_name.underscore, activity, **options.symbolize_keys)
   rescue ActiveRecord::RecordNotFound
     true
   end


### PR DESCRIPTION
Since the introduction of “limited(/silenced) accounts”, Mastodon has used a hack to distribute them while removing non-followers from the audience properties, and thus distinguish remotely silenced users from local ones.

This is a hack that we should honestly phase out in favor of something like a new property, but this has been Mastodon's behavior for many years.

However, at some point, the receiving logic has been rewritten, and as pointed out by #37576, it does not work as intended. The solution proposed in #37576 would restore the intended behavior meant a few years ago, but since then we have introduced notification policies, which allow the end-user to chose how to treat silenced users. Therefore, I thought it would be more suitable to use this instead of unconditionally dropping such notifications.

This is a draft as it needs additional tests.