### PR TITLE
Clean up arg handling for notification worker

### DIFF
--- a/app/workers/local_notification_worker.rb
+++ b/app/workers/local_notification_worker.rb
@@ -3,14 +3,9 @@
 class LocalNotificationWorker
   include Sidekiq::Worker
 
-  def perform(receiver_account_id, activity_id = nil, activity_class_name = nil, type = nil, options = {})
-    if activity_id.nil? && activity_class_name.nil?
-      activity = Mention.find(receiver_account_id)
-      receiver = activity.account
-    else
-      receiver = Account.find(receiver_account_id)
-      activity = activity_class_name.constantize.find(activity_id)
-    end
+  def perform(receiver_account_id, activity_id, activity_class_name, type = nil, options = {})
+    receiver = Account.find(receiver_account_id)
+    activity = activity_class_name.constantize.find(activity_id)
 
     # For most notification types, only one notification should exist, and the older one is
     # preferred. For updates, such as when a status is edited, the new notification


### PR DESCRIPTION
This drops support for pre-2.7.0 jobs. Which I think is probably fine by now.