### PR TITLE
Return empty array when requesting collections of an account that blocked you

### DIFF
--- a/app/controllers/api/v1_alpha/collections_controller.rb
+++ b/app/controllers/api/v1_alpha/collections_controller.rb
@@ -26,9 +26,11 @@ class Api::V1Alpha::CollectionsController < Api::BaseController
 
   def index
     cache_if_unauthenticated!
-    authorize Collection, :index?
+    authorize @account, :index_collections?
 
     render json: @collections, each_serializer: REST::CollectionSerializer, adapter: :json
+  rescue Mastodon::NotPermittedError
+    render json: { collections: [] }
   end
 
   def show

--- a/spec/requests/api/v1_alpha/collections_spec.rb
+++ b/spec/requests/api/v1_alpha/collections_spec.rb
@@ -81,6 +81,19 @@ RSpec.describe 'Api::V1Alpha::Collections', feature: :collections do
         end
       end
     end
+
+    context 'when the requesting user is blocked by the given account' do
+      before do
+        account.block!(user.account)
+      end
+
+      it 'returns an empty array' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body[:collections]).to eq []
+      end
+    end
   end
 
   describe 'GET /api/v1_alpha/collections/:id' do


### PR DESCRIPTION
This should be more in line with other existing APIs.