### PR TITLE
Fix quote cache invalidation

### DIFF
--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -48,7 +48,7 @@ class Quote < ApplicationRecord
   def accept!
     update!(state: :accepted)
 
-    reset_parent_cache! if attribute_changed?(:state)
+    reset_parent_cache! if attribute_previously_changed?(:state)
   end
 
   def reject!


### PR DESCRIPTION
Follow-up to #37570

`attribute_changed?` is for changes that haven't been saved yet; changes that have been saved can be checked with `attribute_previously_changed?`