### PR TITLE
Use validation matchers for InstanceModerationNote spec

### DIFF
--- a/spec/models/instance_moderation_note_spec.rb
+++ b/spec/models/instance_moderation_note_spec.rb
@@ -14,24 +14,12 @@ RSpec.describe InstanceModerationNote do
     end
   end
 
-  describe 'validations' do
-    it 'is invalid if the content is empty' do
-      note = Fabricate.build(:instance_moderation_note, domain: 'mastodon.example', content: '')
-      expect(note.valid?).to be false
-    end
+  describe 'Validations' do
+    subject { Fabricate.build :instance_moderation_note }
 
-    it 'is invalid if content is longer than character limit' do
-      note = Fabricate.build(:instance_moderation_note, domain: 'mastodon.example', content: comment_over_limit)
-      expect(note.valid?).to be false
-    end
-
-    it 'is valid even if the instance does not exist yet' do
-      note = Fabricate.build(:instance_moderation_note, domain: 'non-existent.example', content: 'test comment')
-      expect(note.valid?).to be true
-    end
-
-    def comment_over_limit
-      Faker::Lorem.paragraph_by_chars(number: described_class::CONTENT_SIZE_LIMIT * 2)
-    end
+    it { is_expected.to allow_value('non-existent.example').for(:domain) }
+    it { is_expected.to validate_length_of(:content).is_at_most(described_class::CONTENT_SIZE_LIMIT) }
+    it { is_expected.to validate_presence_of(:content) }
+    it { is_expected.to validate_presence_of(:domain) }
   end
 end


### PR DESCRIPTION
Possibly slipped through review ... just updating this model spec to use same approach as other model specs re: validations.

Sort of related to https://github.com/mastodon/mastodon/pull/36057 which I hope to revive, possibly piece by piece, at some point.