### PR TITLE
Convert `oauth/authorized_applications` spec controller->request

### DIFF
--- a/spec/requests/oauth/authorized_applications_spec.rb
+++ b/spec/requests/oauth/authorized_applications_spec.rb
@@ -2,21 +2,16 @@
 
 require 'rails_helper'
 
-RSpec.describe OAuth::AuthorizedApplicationsController do
-  render_views
-
-  describe 'GET #index' do
-    subject do
-      get :index
-    end
+RSpec.describe 'OAuth Authorized Applications' do
+  describe 'GET /oauth/authorized_applications' do
+    subject { get oauth_authorized_applications_path }
 
     context 'when signed in' do
-      before do
-        sign_in Fabricate(:user), scope: :user
-      end
+      before { sign_in Fabricate(:user) }
 
       it 'returns http success with private cache control headers' do
         subject
+
         expect(response)
           .to have_http_status(200)
         expect(response.headers['Cache-Control'])
@@ -40,29 +35,29 @@ RSpec.describe OAuth::AuthorizedApplicationsController do
     end
   end
 
-  describe 'DELETE #destroy' do
+  describe 'DELETE /oauth/authorized_applications/:id' do
+    subject { delete oauth_authorized_application_path(application) }
+
     let!(:user) { Fabricate(:user) }
     let!(:application) { Fabricate(:application) }
     let!(:access_token) { Fabricate(:accessible_access_token, application: application, resource_owner_id: user.id) }
     let!(:web_push_subscription) { Fabricate(:web_push_subscription, user: user, access_token: access_token) }
     let(:redis_pipeline_stub) { instance_double(Redis::PipelinedConnection, publish: nil) }
 
-    before do
-      sign_in user, scope: :user
-      allow(redis).to receive(:pipelined).and_yield(redis_pipeline_stub)
-    end
+    before { allow(redis).to receive(:pipelined).and_yield(redis_pipeline_stub) }
 
-    it 'revokes access tokens for the application and removes subscriptions and sends kill payload to streaming' do
-      post :destroy, params: { id: application.id }
+    context 'when signed in' do
+      before { sign_in user }
 
-      expect(Doorkeeper::AccessToken.where(application: application).first.revoked_at)
-        .to_not be_nil
-      expect(Web::PushSubscription.where(user: user).count)
-        .to eq(0)
-      expect { web_push_subscription.reload }
-        .to raise_error(ActiveRecord::RecordNotFound)
-      expect(redis_pipeline_stub)
-        .to have_received(:publish).with("timeline:access_token:#{access_token.id}", '{"event":"kill"}')
+      it 'revokes access tokens for the application and removes subscriptions and sends kill payload to streaming' do
+        expect { subject }
+          .to change { Doorkeeper::AccessToken.where(application:).first.reload.revoked_at }.from(nil).to(be_present)
+          .and change { Web::PushSubscription.where(user:).reload.count }.to(0)
+        expect { web_push_subscription.reload }
+          .to raise_error(ActiveRecord::RecordNotFound)
+        expect(redis_pipeline_stub)
+          .to have_received(:publish).with("timeline:access_token:#{access_token.id}", '{"event":"kill"}')
+      end
     end
   end
 end


### PR DESCRIPTION
A portion of this could be further pulled out to a system spec, but just doing a straight conversion as a first pass (the `controller` usage in particular, would need updating for that conversion)