### PR TITLE
Reduce `oauth/authorizations` monkey-patch size

### DIFF
--- a/app/controllers/oauth/authorizations_controller.rb
+++ b/app/controllers/oauth/authorizations_controller.rb
@@ -20,14 +20,8 @@ class OAuth::AuthorizationsController < Doorkeeper::AuthorizationsController
     store_location_for(:user, request.url)
   end
 
-  def render_success
-    if skip_authorization? || (matching_token? && !truthy_param?('force_login'))
-      redirect_or_render authorize_response
-    elsif Doorkeeper.configuration.api_only
-      render json: pre_auth
-    else
-      render :new
-    end
+  def can_authorize_response?
+    !truthy_param?('force_login') && super
   end
 
   def truthy_param?(key)


### PR DESCRIPTION
When this `force_login` param was originally added - https://github.com/mastodon/mastodon/pull/8655/changes#diff-97621384cc4d43d010f8ae4a8a0c6ae0ec3f478588b790c8dae6b2beeac61a44R17-R25 - there wasn't an obvious way to override just the portion of `render_success` relevant to that param, so the whole thing is here.

Subsequently, this `can_authorize_response?` method was added on the doorkeeper side (not just for the purposes of allowing easier override, though it does make it easier) such that the second half of the or condition now calls a method -- https://github.com/doorkeeper-gem/doorkeeper/blob/v5.8.2/app/controllers/doorkeeper/authorizations_controller.rb#L34 -- so we can just use that smaller method. There's probably some future proofing here as well from calling `super` - if doorkeeper changed more about how that method works, we'd get those changes as well.

There's a few full stack system specs for oauth flow, and one request spec for `force_login` specifically, so I think we're probably ok here, but can add more targeted edge case coverage for this param if there are specific worries.

One caveat -- there is technically a logic change here, because the extracted method does more than we were doing (and so by calling `super` we are now doing it), but I think both new things are safe (we dont set `custom_access_token_attributes` so it will be empty, and `confidential` defaults to true so it will pass, the previous matching token check is preserved) and arguably we should have added/extracted those as well sooner to stay in sync with upstream doorkeeper behavior - but it'd be good for someone with full oauth grasp to confirm my assumptions here. If there are issues, or we're just not confident, I can remove the `super` and just make this the smaller method patching.

Further improvement could be to remove the patch entirely and use a `before_action` here to bail out on force login ... but the view needs an ivar set up and it seemed easier for now to let the existing flow do that instead of duplicating it. May look at something like that as followup.