### PR TITLE
Use validation matchers for `PollExpirationValidator` spec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -119,6 +119,7 @@ RSpec.configure do |config|
   config.include SignedRequestHelpers, type: :request
   config.include CommandLineHelpers, type: :cli
   config.include SystemHelpers, type: :system
+  config.include Shoulda::Matchers::ActiveModel, type: :validator
 
   # TODO: Remove when Devise fixes https://github.com/heartcombo/devise/issues/5705
   config.before do

--- a/spec/validators/poll_expiration_validator_spec.rb
+++ b/spec/validators/poll_expiration_validator_spec.rb
@@ -3,35 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe PollExpirationValidator do
-  describe '#validate' do
-    before do
-      validator.validate(poll)
-    end
+  subject { Fabricate.build :poll }
 
-    let(:validator) { described_class.new }
-    let(:poll) { instance_double(Poll, options: options, expires_at: expires_at, errors: errors) }
-    let(:errors) { instance_double(ActiveModel::Errors, add: nil) }
-    let(:options) { %w(foo bar) }
-    let(:expires_at) { 1.day.from_now }
+  context 'when poll expires in far future' do
+    let(:far_future) { 6.months.from_now }
 
-    it 'has no errors' do
-      expect(errors).to_not have_received(:add)
-    end
+    it { is_expected.to_not allow_value(far_future).for(:expires_at).with_message(I18n.t('polls.errors.duration_too_long')) }
+  end
 
-    context 'when the poll expires in 5 min from now' do
-      let(:expires_at) { 5.minutes.from_now }
+  context 'when poll expires in far past' do
+    let(:past_date) { 6.days.ago }
 
-      it 'has no errors' do
-        expect(errors).to_not have_received(:add)
-      end
-    end
+    it { is_expected.to_not allow_value(past_date).for(:expires_at).with_message(I18n.t('polls.errors.duration_too_short')) }
+  end
 
-    context 'when the poll expires in the past' do
-      let(:expires_at) { 5.minutes.ago }
+  context 'when poll expires in medium future' do
+    let(:allowed_future) { 10.minutes.from_now }
 
-      it 'has errors' do
-        expect(errors).to have_received(:add)
-      end
-    end
+    it { is_expected.to allow_value(allowed_future).for(:expires_at) }
   end
 end


### PR DESCRIPTION
Followup on https://github.com/mastodon/mastodon/pull/37597

Extracted from https://github.com/mastodon/mastodon/pull/36057

This is the smallest/simplest one from that (large) original batch. Hoping this is easier to review/merge with one small example first, and I can then work through the rest one at a time (or restore the whole larger one if desired) ... but just wanted to express the idea with smaller diff. The entire thing here is just to update the validator specs with the newer matchers we now have available that all/most of the validation-related stuff in the model specs are doing.

A side benefit is reducing the amount of subject stubbing we have in these, and also reduced factories where possible. Misc other motivations and future ideas in the original PR if curious.

As noted in that original PR, some of these validator classes really are general purpose, but some are very much single use for one model. In this case, it's very much single use, so I've just made the subject a `Poll` instance.