### PR TITLE
Federate creation of collections

### DIFF
--- a/app/serializers/activitypub/add_serializer.rb
+++ b/app/serializers/activitypub/add_serializer.rb
@@ -40,6 +40,16 @@ class ActivityPub::AddSerializer < ActivityPub::Serializer
   end
 
   def target
-    ActivityPub::TagManager.instance.collection_uri_for(object.account, :featured)
+    case object
+    when Status, FeaturedTag
+      # Technically this is not correct, as tags have their own collection.
+      # But sadly we do not store the collection URI for tags anywhere so cannot
+      # handle `Add` activities to that properly (yet). The receiving code for
+      # this currently looks at the type of the contained objects to do the
+      # right thing.
+      ActivityPub::TagManager.instance.collection_uri_for(object.account, :featured)
+    when Collection
+      ap_account_featured_collections_url(object.account_id)
+    end
   end
 end

--- a/app/serializers/activitypub/add_serializer.rb
+++ b/app/serializers/activitypub/add_serializer.rb
@@ -10,11 +10,13 @@ class ActivityPub::AddSerializer < ActivityPub::Serializer
   end
 
   def self.serializer_for(model, options)
-    case model.class.name
-    when 'Status'
+    case model
+    when Status
       UriSerializer
-    when 'FeaturedTag'
+    when FeaturedTag
       ActivityPub::HashtagSerializer
+    when Collection
+      ActivityPub::FeaturedCollectionSerializer
     else
       super
     end

--- a/spec/serializers/activitypub/add_serializer_spec.rb
+++ b/spec/serializers/activitypub/add_serializer_spec.rb
@@ -18,10 +18,38 @@ RSpec.describe ActivityPub::AddSerializer do
       it { is_expected.to eq(ActivityPub::HashtagSerializer) }
     end
 
+    context 'with a Collection model' do
+      let(:model) { Collection.new }
+
+      it { is_expected.to eq(ActivityPub::FeaturedCollectionSerializer) }
+    end
+
     context 'with an Array' do
       let(:model) { [] }
 
       it { is_expected.to eq(ActiveModel::Serializer::CollectionSerializer) }
+    end
+  end
+
+  describe '#target' do
+    subject { described_class.new(object).target }
+
+    context 'when object is a Status' do
+      let(:object) { Fabricate(:status) }
+
+      it { is_expected.to match(%r{/#{object.account_id}/collections/featured$}) }
+    end
+
+    context 'when object is a FeaturedTag' do
+      let(:object) { Fabricate(:featured_tag) }
+
+      it { is_expected.to match(%r{/#{object.account_id}/collections/featured$}) }
+    end
+
+    context 'when object is a Collection' do
+      let(:object) { Fabricate(:collection) }
+
+      it { is_expected.to match(%r{/#{object.account_id}/featured_collections$}) }
     end
   end
 end

--- a/spec/services/create_collection_service_spec.rb
+++ b/spec/services/create_collection_service_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe CreateCollectionService do
         expect(collection).to be_local
       end
 
+      it 'federates an `Add` activity', feature: :collections_federation do
+        subject.call(base_params, author)
+
+        expect(ActivityPub::AccountRawDistributionWorker).to have_enqueued_sidekiq_job
+      end
+
       context 'when given account ids' do
         let(:accounts) do
           Fabricate.times(2, :account)


### PR DESCRIPTION
Behind a new feature flag `collections_federation`, so we can enable/disable just the federation part independently.

Fixes WEB-651