### PR TITLE
Fix target URI of featured tags collection

### DIFF
--- a/app/serializers/activitypub/add_serializer.rb
+++ b/app/serializers/activitypub/add_serializer.rb
@@ -38,6 +38,11 @@ class ActivityPub::AddSerializer < ActivityPub::Serializer
   end
 
   def target
-    ActivityPub::TagManager.instance.collection_uri_for(object.account, :featured)
+    case object
+    when Status
+      ActivityPub::TagManager.instance.collection_uri_for(object.account, :featured)
+    when FeaturedTag
+      ActivityPub::TagManager.instance.collection_uri_for(object.account, :tags)
+    end
   end
 end

--- a/spec/serializers/activitypub/add_serializer_spec.rb
+++ b/spec/serializers/activitypub/add_serializer_spec.rb
@@ -24,4 +24,20 @@ RSpec.describe ActivityPub::AddSerializer do
       it { is_expected.to eq(ActiveModel::Serializer::CollectionSerializer) }
     end
   end
+
+  describe '#target' do
+    subject { described_class.new(object).target }
+
+    context 'when object is a Status' do
+      let(:object) { Fabricate(:status) }
+
+      it { is_expected.to match(%r{/#{object.account_id}/collections/featured$}) }
+    end
+
+    context 'when object is a FeaturedTag' do
+      let(:object) { Fabricate(:featured_tag) }
+
+      it { is_expected.to match(%r{/#{object.account_id}/collections/tags$}) }
+    end
+  end
 end


### PR DESCRIPTION
`Add` activities would always target the "featured" collections, even when the `featuredTags` collections would have been correct. Caught by @ClearlyClaire while reviewing #37618