### PR TITLE
Experiment with adding a bundle comparison tool

### DIFF
--- a/.github/workflows/bundlesize-compare.yml
+++ b/.github/workflows/bundlesize-compare.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - 'app/javascript/**'
       - 'vite.config.mts'
+      - .github/workflows/bundlesize-compare.yml
 
 jobs:
   build-head:

--- a/.github/workflows/bundlesize-compare.yml
+++ b/.github/workflows/bundlesize-compare.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      ANALYZE_BUNDLE_SIZE: '1'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -20,19 +22,22 @@ jobs:
         uses: ./.github/actions/setup-javascript
 
       - name: Build
-        run: ANALYZE_BUNDLE_SIZE=1 yarn run build:production
+        run: yarn run build:production
 
       - name: Upload stats.json
         uses: actions/upload-artifact@v5
         with:
           name: head-stats
           path: ./stats.json
+          if-no-files-found: error
 
   build-base:
     name: 'Build base'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      ANALYZE_BUNDLE_SIZE: '1'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -42,13 +47,14 @@ jobs:
         uses: ./.github/actions/setup-javascript
 
       - name: Build
-        run: ANALYZE_BUNDLE_SIZE=1 yarn run build:production
+        run: yarn run build:production
 
       - name: Upload stats.json
         uses: actions/upload-artifact@v5
         with:
           name: base-stats
           path: ./stats.json
+          if-no-files-found: error
 
   compare:
     name: 'Compare base & head bundle sizes'
@@ -57,7 +63,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v5
 
       - uses: twk3/rollup-size-compare-action@v1.0.0
         with:

--- a/.github/workflows/bundlesize-compare.yml
+++ b/.github/workflows/bundlesize-compare.yml
@@ -1,3 +1,4 @@
+name: Compare JS bundle size
 on:
   pull_request:
     paths:
@@ -11,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         with:
           ref: ${{github.event.pull_request.head.ref}}
 
@@ -22,7 +23,7 @@ jobs:
         run: ANALYZE_BUNDLE_SIZE=1 yarn run build:production
 
       - name: Upload stats.json
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v5
         with:
           name: head-stats
           path: ./stats.json
@@ -33,7 +34,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.base_ref }}
 
@@ -44,7 +45,7 @@ jobs:
         run: ANALYZE_BUNDLE_SIZE=1 yarn run build:production
 
       - name: Upload stats.json
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v5
         with:
           name: base-stats
           path: ./stats.json

--- a/.github/workflows/bundlesize-compare.yml
+++ b/.github/workflows/bundlesize-compare.yml
@@ -1,0 +1,65 @@
+on:
+  pull_request:
+    paths:
+      - 'app/javascript/**'
+      - 'vite.config.mts'
+
+jobs:
+  build-head:
+    name: 'Build head'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+
+      - name: Set up Javascript environment
+        uses: ./.github/actions/setup-javascript
+
+      - name: Build
+        run: ANALYZE_BUNDLE_SIZE=1 yarn run build:production
+
+      - name: Upload stats.json
+        uses: actions/upload-artifact@v3
+        with:
+          name: head-stats
+          path: ./stats.json
+
+  build-base:
+    name: 'Build base'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: Set up Javascript environment
+        uses: ./.github/actions/setup-javascript
+
+      - name: Build
+        run: ANALYZE_BUNDLE_SIZE=1 yarn run build:production
+
+      - name: Upload stats.json
+        uses: actions/upload-artifact@v3
+        with:
+          name: base-stats
+          path: ./stats.json
+
+  compare:
+    name: 'Compare base & head bundle sizes'
+    runs-on: ubuntu-latest
+    needs: [build-base, build-head]
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@v3
+
+      - uses: twk3/rollup-size-compare-action@v1.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          current-stats-json-path: ./head-stats/stats.json
+          base-stats-json-path: ./base-stats/stats.json

--- a/.github/workflows/bundlesize-compare.yml
+++ b/.github/workflows/bundlesize-compare.yml
@@ -4,6 +4,8 @@ on:
     paths:
       - 'app/javascript/**'
       - 'vite.config.mts'
+      - 'package.json'
+      - 'yarn.lock'
       - .github/workflows/bundlesize-compare.yml
 
 jobs:


### PR DESCRIPTION
Adds a workflow that builds the JS and compares the head and the PR branch outputs. See below for example.

This only fires when anything in `app/javascript`, `package.json`, `yarn.lock`, Vite config, or this workflow changes. This does not block merges, and failures only happen if there's an issue generating the artifacts.