### PR TITLE
Add backend support for storing remote actors profile pic and header descriptions

### DIFF
--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -67,3 +67,4 @@ The following table summarizes those limits.
 | Account `attributionDomains`                                  | 256        | List will be truncated             |
 | Account aliases (actor `alsoKnownAs`)                         | 256        | List will be truncated             |
 | Custom emoji shortcode (`Emoji` `name`)                       | 2048       | Emoji will be rejected             |
+| Media and avatar/header descriptions (`name`/`summary`)       | 1500       | Description will be truncated      |

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -9,6 +9,7 @@
 #  also_known_as                 :string           is an Array
 #  attribution_domains           :string           default([]), is an Array
 #  avatar_content_type           :string
+#  avatar_description            :string           default(""), not null
 #  avatar_file_name              :string
 #  avatar_file_size              :integer
 #  avatar_remote_url             :string

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -24,6 +24,7 @@
 #  followers_url                 :string           default(""), not null
 #  following_url                 :string           default(""), not null
 #  header_content_type           :string
+#  header_description            :string           default(""), not null
 #  header_file_name              :string
 #  header_file_size              :integer
 #  header_remote_url             :string           default(""), not null

--- a/app/models/concerns/account/avatar.rb
+++ b/app/models/concerns/account/avatar.rb
@@ -24,6 +24,8 @@ module Account::Avatar
     validates_attachment_content_type :avatar, content_type: AVATAR_IMAGE_MIME_TYPES
     validates_attachment_size :avatar, less_than: AVATAR_LIMIT
     remotable_attachment :avatar, AVATAR_LIMIT, suppress_errors: false
+
+    validates :avatar_description, length: { maximum: MediaAttachment::MAX_DESCRIPTION_LENGTH }
   end
 
   def avatar_original_url

--- a/app/models/concerns/account/header.rb
+++ b/app/models/concerns/account/header.rb
@@ -25,6 +25,8 @@ module Account::Header
     validates_attachment_content_type :header, content_type: HEADER_IMAGE_MIME_TYPES
     validates_attachment_size :header, less_than: HEADER_LIMIT
     remotable_attachment :header, HEADER_LIMIT, suppress_errors: false
+
+    validates :header_description, length: { maximum: MediaAttachment::MAX_DESCRIPTION_LENGTH }
   end
 
   def header_original_url

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -7,7 +7,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
   # Please update `app/javascript/mastodon/api_types/accounts.ts` when making changes to the attributes
 
   attributes :id, :username, :acct, :display_name, :locked, :bot, :discoverable, :indexable, :group, :created_at,
-             :note, :url, :uri, :avatar, :avatar_static, :header, :header_static,
+             :note, :url, :uri, :avatar, :avatar_static, :avatar_description, :header, :header_static, :header_description,
              :followers_count, :following_count, :statuses_count, :last_status_at, :hide_collections
 
   has_one :moved_to_account, key: :moved, serializer: REST::AccountSerializer, if: :moved_and_not_nested?

--- a/db/migrate/20260127141459_add_avatar_description_to_accounts.rb
+++ b/db/migrate/20260127141459_add_avatar_description_to_accounts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAvatarDescriptionToAccounts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :accounts, :avatar_description, :string, null: false, default: ''
+  end
+end

--- a/db/migrate/20260127141820_add_header_description_to_accounts.rb
+++ b/db/migrate/20260127141820_add_header_description_to_accounts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHeaderDescriptionToAccounts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :accounts, :header_description, :string, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_27_141459) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_27_141820) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -202,6 +202,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_27_141459) do
     t.integer "id_scheme", default: 1
     t.integer "feature_approval_policy", default: 0, null: false
     t.string "avatar_description", default: "", null: false
+    t.string "header_description", default: "", null: false
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["domain", "id"], name: "index_accounts_on_domain_and_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_19_153538) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_27_141459) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -201,6 +201,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_19_153538) do
     t.string "following_url", default: "", null: false
     t.integer "id_scheme", default: 1
     t.integer "feature_approval_policy", default: 0, null: false
+    t.string "avatar_description", default: "", null: false
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["domain", "id"], name: "index_accounts_on_domain_and_id"


### PR DESCRIPTION
This includes:
- storing `avatar_description` and `header_description` from `icon` (profile picture) and `image` (profile header) `Image` object `summary`/`name`
- returning them in the REST API

This does not include any API to set them, or any UI to display them.

Related: #32593