### PR TITLE
Extract `visibility_scope` method in `AccountStatusesFilter`

### DIFF
--- a/app/lib/account_statuses_filter.rb
+++ b/app/lib/account_statuses_filter.rb
@@ -49,15 +49,23 @@ class AccountStatusesFilter
     scope = account.statuses
 
     if exclude_direct?
-      scope = scope.where(visibility: follower? ? %i(public unlisted private) : %i(public unlisted))
+      scope = visibility_scope(scope)
     else
       scope = account.statuses.left_outer_joins(:mentions)
-      scope.merge!(scope.where(visibility: follower? ? %i(public unlisted private) : %i(public unlisted)).or(scope.where(mentions: { account_id: current_account.id })).group(Status.arel_table[:id]))
+      scope.merge!(visibility_scope(scope).or(scope.where(mentions: { account_id: current_account.id })).group(Status.arel_table[:id]))
     end
 
     scope.merge!(filtered_reblogs_scope) if reblogs_may_occur?
 
     scope
+  end
+
+  def visibility_scope(scope)
+    if follower?
+      scope.list_eligible_visibility
+    else
+      scope.distributable_visibility
+    end
   end
 
   def filtered_reblogs_scope


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/35718 - where rationale is explained. Basically, want to rely on the defined constants/scopes instead of repeated the list of visibilities.

Possible future improvement on this one - could pull out similar method for the "mentions" stuff on same line.