### PR TITLE
Extract `visibility_scope` method in `ReportService`

### DIFF
--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -84,24 +84,33 @@ class ReportService < BaseService
     return AccountStatusesFilter.new(@target_account, @source_account).results.with_discarded.find(Array(@status_ids)).pluck(:id) if @source_account.local?
 
     # If the account making reports is remote, it is likely anonymized so we have to relax the requirements for attaching statuses.
-    domain = @source_account.domain.to_s.downcase
-    has_followers = @target_account.followers.with_domain(domain).exists?
-    visibility = has_followers ? %i(public unlisted private) : %i(public unlisted)
     scope = @target_account.statuses.with_discarded
-    scope.merge!(scope.where(visibility: visibility).or(scope.where(domain_mentions(domain))))
+    scope.merge!(visibility_scope(scope).or(scope.where(domain_mentions)))
     # Allow missing posts to not drop reports that include e.g. a deleted post
     scope.where(id: Array(@status_ids)).pluck(:id)
   end
 
-  def domain_mentions(domain)
+  def domain_mentions
     Mention
       .joins(:account)
-      .merge(Account.with_domain(domain))
+      .merge(Account.with_domain(@source_account.domain))
       .select(1).arel.exists
   end
 
   def reported_collection_ids
     @target_account.collections.find(Array(@collection_ids)).pluck(:id)
+  end
+
+  def visibility_scope(scope)
+    if target_has_source_domain_followers?
+      scope.list_eligible_visibility
+    else
+      scope.distributable_visibility
+    end
+  end
+
+  def target_has_source_domain_followers?
+    @target_account.followers.with_domain(@source_account.domain).exists?
   end
 
   def payload


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/35718 which has the background.

Related: https://github.com/mastodon/mastodon/pull/37648

This one is _slightly_ more complex than the other one, so maybe review other one first?
