### PR TITLE
Prevent account note from appearing on your own profile

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -162,11 +162,13 @@ export const AccountHeader: React.FC<{
           {!suspendedOrHidden && (
             <div className='account__header__extra'>
               <div className='account__header__bio'>
-                {me && account.id !== me && isRedesignEnabled() ? (
-                  <AccountNoteRedesign accountId={accountId} />
-                ) : (
-                  <AccountNote accountId={accountId} />
-                )}
+                {me &&
+                  account.id !== me &&
+                  (isRedesignEnabled() ? (
+                    <AccountNoteRedesign accountId={accountId} />
+                  ) : (
+                    <AccountNote accountId={accountId} />
+                  ))}
 
                 <AccountBio
                   accountId={accountId}


### PR DESCRIPTION
With #37593 a bug in the conditional crept in that causes the account notes to appear on your own profile. this PR fixes that.