### PR TITLE
Use validation matchers for `DomainValidator` spec

### DIFF
--- a/spec/validators/domain_validator_spec.rb
+++ b/spec/validators/domain_validator_spec.rb
@@ -3,12 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe DomainValidator do
-  let(:record) { record_class.new }
+  subject { record_class.new }
 
   context 'with no options' do
     let(:record_class) do
       Class.new do
         include ActiveModel::Validations
+
+        def self.name = 'Record'
 
         attr_accessor :domain
 
@@ -16,60 +18,30 @@ RSpec.describe DomainValidator do
       end
     end
 
-    describe '#validate_each' do
-      context 'with a nil value' do
-        it 'does not add errors' do
-          record.domain = nil
+    context 'with a nil value' do
+      it { is_expected.to allow_value(nil).for(:domain) }
+    end
 
-          expect(record).to be_valid
-          expect(record.errors).to be_empty
-        end
-      end
+    context 'with a valid domain' do
+      it { is_expected.to allow_value('host.example').for(:domain) }
+    end
 
-      context 'with a valid domain' do
-        it 'does not add errors' do
-          record.domain = 'example.com'
+    context 'with a domain that is too long' do
+      before { stub_const 'DomainValidator::MAX_DOMAIN_LENGTH', 8 }
 
-          expect(record).to be_valid
-          expect(record.errors).to be_empty
-        end
-      end
+      it { is_expected.to_not allow_value('host.example').for(:domain) }
+    end
 
-      context 'with a domain that is too long' do
-        it 'adds an error' do
-          record.domain = "#{'a' * 300}.com"
+    context 'with a domain with an empty segment' do
+      it { is_expected.to_not allow_value('.example.com').for(:domain) }
+    end
 
-          expect(record).to_not be_valid
-          expect(record.errors.where(:domain)).to_not be_empty
-        end
-      end
+    context 'with a domain with an invalid character' do
+      it { is_expected.to_not allow_value('*.example.com').for(:domain) }
+    end
 
-      context 'with a domain with an empty segment' do
-        it 'adds an error' do
-          record.domain = '.example.com'
-
-          expect(record).to_not be_valid
-          expect(record.errors.where(:domain)).to_not be_empty
-        end
-      end
-
-      context 'with a domain with an invalid character' do
-        it 'adds an error' do
-          record.domain = '*.example.com'
-
-          expect(record).to_not be_valid
-          expect(record.errors.where(:domain)).to_not be_empty
-        end
-      end
-
-      context 'with a domain that would fail parsing' do
-        it 'adds an error' do
-          record.domain = '/'
-
-          expect(record).to_not be_valid
-          expect(record.errors.where(:domain)).to_not be_empty
-        end
-      end
+    context 'with a domain that would fail parsing' do
+      it { is_expected.to_not allow_value('/').for(:domain) }
     end
   end
 
@@ -78,48 +50,28 @@ RSpec.describe DomainValidator do
       Class.new do
         include ActiveModel::Validations
 
+        def self.name = 'Record'
+
         attr_accessor :acct
 
         validates :acct, domain: { acct: true }
       end
     end
 
-    describe '#validate_each' do
-      context 'with a nil value' do
-        it 'does not add errors' do
-          record.acct = nil
+    context 'with a nil value' do
+      it { is_expected.to allow_value(nil).for(:acct) }
+    end
 
-          expect(record).to be_valid
-          expect(record.errors).to be_empty
-        end
-      end
+    context 'with no domain' do
+      it { is_expected.to allow_value('hoge_123').for(:acct) }
+    end
 
-      context 'with no domain' do
-        it 'does not add errors' do
-          record.acct = 'hoge_123'
+    context 'with a valid domain' do
+      it { is_expected.to allow_value('hoge_123@example.com').for(:acct) }
+    end
 
-          expect(record).to be_valid
-          expect(record.errors).to be_empty
-        end
-      end
-
-      context 'with a valid domain' do
-        it 'does not add errors' do
-          record.acct = 'hoge_123@example.com'
-
-          expect(record).to be_valid
-          expect(record.errors).to be_empty
-        end
-      end
-
-      context 'with an invalid domain' do
-        it 'adds an error' do
-          record.acct = 'hoge_123@.example.com'
-
-          expect(record).to_not be_valid
-          expect(record.errors.where(:acct)).to_not be_empty
-        end
-      end
+    context 'with an invalid domain' do
+      it { is_expected.to_not allow_value('hoge_123@.example.com').for(:acct) }
     end
   end
 end

--- a/spec/validators/domain_validator_spec.rb
+++ b/spec/validators/domain_validator_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe DomainValidator do
     end
 
     context 'with a domain that is too long' do
-      before { stub_const 'DomainValidator::MAX_DOMAIN_LENGTH', 8 }
+      let(:long_hostname) { "#{'a' * 300}.com" }
 
-      it { is_expected.to_not allow_value('host.example').for(:domain) }
+      it { is_expected.to_not allow_value(long_hostname).for(:domain) }
     end
 
     context 'with a domain with an empty segment' do


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/37636 and linked others.

Preserved the separation of the "no options" and "with `acct` option" sections.