### PR TITLE
Fix instance api account merging

### DIFF
--- a/app/javascript/mastodon/actions/server.js
+++ b/app/javascript/mastodon/actions/server.js
@@ -27,7 +27,15 @@ export const fetchServer = () => (dispatch, getState) => {
 
   api()
     .get('/api/v2/instance').then(({ data }) => {
-      if (data.contact.account) dispatch(importFetchedAccount(data.contact.account));
+      // Only import the account if it doesn't already exist,
+      // because the API is cached even for logged in users.
+      const account = data.contact.account;
+      if (account) {
+        const existingAccount = getState().getIn(['accounts', account.id]);
+        if (!existingAccount) {
+          dispatch(importFetchedAccount(account));
+        }
+      }
       dispatch(fetchServerSuccess(data));
     }).catch(err => dispatch(fetchServerFail(err)));
 };


### PR DESCRIPTION
The `/v2/instance` endpoint uses [`cache_even_if_authenticated`](https://github.com/mastodon/mastodon/blob/912268295c5e833afea68783b424a389c9be14f7/app/controllers/api/v2/instances_controller.rb#L15), which means data from this endpoint can overwrite fresher data from uncached endpoints.