### PR TITLE
Make “Following” correctly translatable

### DIFF
--- a/app/views/application/mailer/_account.html.haml
+++ b/app/views/application/mailer/_account.html.haml
@@ -24,7 +24,7 @@
                   %span= t('accounts.posts', count: account.statuses_count)
                 %td
                   %b= account_formatted_stat(account.following_count)
-                  %span= t('accounts.following')
+                  %span= t('accounts.following', count: account.following_count)
                 %td
                   %b= account_formatted_stat(account.followers_count)
                   %span= t('accounts.followers', count: account.followers_count)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,7 +12,9 @@ en:
     followers:
       one: Follower
       other: Followers
-    following: Following
+    following:
+      one: Following
+      other: Following
     instance_actor_flash: This account is a virtual actor used to represent the server itself and not any individual user. It is used for federation purposes and should not be suspended.
     last_active: last active
     link_verified_on: Ownership of this link was checked on %{date}


### PR DESCRIPTION
In English, *Following* doesn’t have separate singular and plural forms (unline *Follower*, *Followers*), but this is not the case in many other languages.