### PR TITLE
Use `CurrentAttributes` to track request details for login activity

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   include Localized
+  include CurrentRequest
   include UserTrackingConcern
   include SessionTrackingConcern
   include CacheConcern

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -41,9 +41,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @user.login_activities.create(
       success: true,
       authentication_method: :omniauth,
-      provider: @provider,
-      ip: request.remote_ip,
-      user_agent: request.user_agent
+      provider: @provider
     )
   end
 

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -141,10 +141,8 @@ class Auth::SessionsController < Devise::SessionsController
     flash.delete(:notice)
 
     user.login_activities.create(
-      request_details.merge(
-        authentication_method: security_measure,
-        success: true
-      )
+      authentication_method: security_measure,
+      success: true
     )
 
     UserMailer.suspicious_sign_in(user, request.remote_ip, request.user_agent, Time.now.utc).deliver_later! if @login_is_suspicious
@@ -156,24 +154,15 @@ class Auth::SessionsController < Devise::SessionsController
 
   def on_authentication_failure(user, security_measure, failure_reason)
     user.login_activities.create(
-      request_details.merge(
-        authentication_method: security_measure,
-        failure_reason: failure_reason,
-        success: false
-      )
+      authentication_method: security_measure,
+      failure_reason: failure_reason,
+      success: false
     )
 
     # Only send a notification email every hour at most
     return if redis.set("2fa_failure_notification:#{user.id}", '1', ex: 1.hour, get: true).present?
 
     UserMailer.failed_2fa(user, request.remote_ip, request.user_agent, Time.now.utc).deliver_later!
-  end
-
-  def request_details
-    {
-      ip: request.remote_ip,
-      user_agent: request.user_agent,
-    }
   end
 
   def second_factor_attempts_key(user)

--- a/app/controllers/concerns/current_request.rb
+++ b/app/controllers/concerns/current_request.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module CurrentRequest
+  extend ActiveSupport::Concern
+
+  included do
+    before_action do
+      Current.ip_address = request.ip
+      Current.user_agent = request.user_agent
+    end
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Current < ActiveSupport::CurrentAttributes
+  attribute :ip_address, :user_agent
+end

--- a/app/models/login_activity.rb
+++ b/app/models/login_activity.rb
@@ -23,4 +23,17 @@ class LoginActivity < ApplicationRecord
   belongs_to :user
 
   validates :authentication_method, inclusion: { in: authentication_methods.keys }
+
+  before_validation :set_ip_address
+  before_validation :set_user_agent
+
+  private
+
+  def set_ip_address
+    self.ip ||= Current.ip_address
+  end
+
+  def set_user_agent
+    self.user_agent ||= Current.user_agent
+  end
 end

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -108,7 +108,10 @@ RSpec.describe Auth::SessionsController do
           expect { subject }
             .to change(user.login_activities.where(success: true), :count).by(1)
           expect(user.login_activities.last)
-            .to have_attributes(ip: IPAddr.new(request.env['REMOTE_ADDR']), user_agent: request.env['HTTP_USER_AGENT'])
+            .to have_attributes(
+              ip: be_present.and(eq(IPAddr.new(request.env['REMOTE_ADDR']))),
+              user_agent: be_present.and(eq(request.env['HTTP_USER_AGENT']))
+            )
 
           expect(response).to redirect_to(root_path)
 

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -107,6 +107,8 @@ RSpec.describe Auth::SessionsController do
         it 'redirects to home and logs the user in' do
           expect { subject }
             .to change(user.login_activities.where(success: true), :count).by(1)
+          expect(user.login_activities.last)
+            .to have_attributes(ip: IPAddr.new(request.env['REMOTE_ADDR']), user_agent: request.env['HTTP_USER_AGENT'])
 
           expect(response).to redirect_to(root_path)
 

--- a/spec/models/login_activity_spec.rb
+++ b/spec/models/login_activity_spec.rb
@@ -14,4 +14,32 @@ RSpec.describe LoginActivity do
 
     it { is_expected.to define_enum_for(:authentication_method).backed_by_column_of_type(:string) }
   end
+
+  describe 'Callbacks' do
+    describe 'setting IP from request attributes' do
+      subject { Fabricate :login_activity, ip: nil }
+
+      before { Current.ip_address = ip }
+
+      let(:ip) { '123.123.123.123' }
+
+      it 'sets IP address from current attributes' do
+        expect(subject)
+          .to have_attributes(ip: IPAddr.new(ip))
+      end
+    end
+
+    describe 'setting user agent from request attributes' do
+      subject { Fabricate :login_activity, user_agent: nil }
+
+      before { Current.user_agent = user_agent }
+
+      let(:user_agent) { 'Browser 1.2.3' }
+
+      it 'sets user agent from current attributes' do
+        expect(subject)
+          .to have_attributes(user_agent:)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Opening as draft for feedback on the idea.

This is a first pass using this approach for the most basic example I could think of -- set the request IP/UA in a controller concern, then use `Current` in login activity to set IP and user agent. Key benefit here is not having to pass request object and attributes up/down the stack.

Obvious other areas (with just the current UA/IP) - session activations, admin action logs, suspicious sign in detector, checking registration allowed by IP, app signup service, updating access token last use, etc. These are all spots we do at least some element of passing this info around and could (I suspect, have not looked at every spot) simplify.

I suspect an even bigger benefit could be gained from putting the current `user` and/or `account` in there as well and further reducing areas where we pass those around ... though you can definitely go overboard with this pattern, hence starting with this simple example.

Anyway, just kind of want a thumbs up/down on the concept before proceeding further, but wanted to have an example as well.

If we like the general idea but want to apply more places to justify the existence of `Current`, I can either add some of the mentioned ones here (session activation and action log at least seem very similar to this one), or do more as followup PRs.