### PR TITLE
Fix hashtag matching by replacing negative lookbehind with positive lookbehind

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -41,7 +41,7 @@ class Tag < ApplicationRecord
   HASHTAG_LAST_SEQUENCE = '([[:word:]_]*[[:alpha:]][[:word:]_]*)'
   HASHTAG_NAME_PAT = "#{HASHTAG_FIRST_SEQUENCE}|#{HASHTAG_LAST_SEQUENCE}".freeze
 
-  HASHTAG_RE = %r{(?<![=/)\p{Alnum}])[#＃](#{HASHTAG_NAME_PAT})}
+  HASHTAG_RE = /(?<=^|\s)[#＃](#{HASHTAG_NAME_PAT})/
   HASHTAG_NAME_RE = /\A(#{HASHTAG_NAME_PAT})\z/i
   HASHTAG_INVALID_CHARS_RE = /[^[:alnum:]\u0E47-\u0E4E#{HASHTAG_SEPARATORS}]/
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -85,6 +85,10 @@ RSpec.describe Tag do
       expect(subject.match('https://en.wikipedia.org/wiki/Ghostbusters_(song)?foo=#Lawsuit')).to be_nil
     end
 
+    it 'does not match URLs with hashtag-like anchors after a dot' do
+      expect(subject.match('https://en.wikipedia.org/wiki/Google_LLC_v._Oracle_America,_Inc.#Decision')).to be_nil
+    end
+
     it 'matches ﻿#ａｅｓｔｈｅｔｉｃ' do
       expect(subject.match('﻿this is #ａｅｓｔｈｅｔｉｃ').to_s).to eq '#ａｅｓｔｈｅｔｉｃ'
     end


### PR DESCRIPTION
Fixes #37652

This seems to be ever so slightly slower than the previous regexp, but it's easier to read.

This matches all our current tests and addresses #37652 but I'm not 100% sure this is exactly the behavior we want.