### PR TITLE
Add text-autospace to status content

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1047,6 +1047,7 @@ body > [data-popper-placement] {
   font-weight: 400;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-autospace: normal;
   font-size: 15px;
   line-height: 22px;
   padding-top: 2px;


### PR DESCRIPTION
for CJK/Latin mixed-script readability. (or more precisely, non-ideographic letters adjacent to ideographic letters?)

A demo from [Webkit blog](https://webkit.org/blog/16574/webkit-features-in-safari-18-4/#css): https://codepen.io/jensimmons/pen/NPWaXxY

[caniuse](https://caniuse.com/?search=text-autospace)