### PR TITLE
Add coverage for "too many IDs" scenario in `api/v1/statuses`

### DIFF
--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe '/api/v1/statuses' do
           hash_including(id: other_status.id.to_s)
         )
       end
+
+      context 'with too many IDs' do
+        before { stub_const 'Api::BaseController::DEFAULT_STATUSES_LIMIT', 2 }
+
+        it 'returns error response' do
+          get '/api/v1/statuses', headers: headers, params: { id: [123, 456, 789] }
+
+          expect(response)
+            .to have_http_status(422)
+          expect(response.content_type)
+            .to start_with('application/json')
+        end
+      end
     end
 
     describe 'GET /api/v1/statuses/:id' do


### PR DESCRIPTION
Pulled out of separate unrelated branch ... this check was not hit in spec.