### PR TITLE
fix `nan-tw` not listed in SUPPORTED_LOCALES

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -227,7 +227,7 @@ module LanguagesHelper
   # to enable the ISO-639-3 language-code with the regional variant but no
   # official name, we use a specific hash for nan-TW
   NAN_TW_CODE = {
-    'nan-TW': '臺語 (Hô-ló話)'
+    'nan-TW': ['Hokkien (Taiwan)', '臺語 (Hô-ló話)'].freeze,
   }.freeze
 
   SUPPORTED_LOCALES = {}.merge(ISO_639_1).merge(ISO_639_1_REGIONAL).merge(ISO_639_3).merge(NAN_TW_CODE).freeze
@@ -243,7 +243,7 @@ module LanguagesHelper
     'pt-BR': 'Português (Brasil)',
     'pt-PT': 'Português (Portugal)',
     'sr-Latn': 'Srpski (latinica)',
-  }.merge(NAN_TW_CODE).freeze
+  }
 
   # Helper for self.sorted_locale_keys
   private_class_method def self.locale_name_for_sorting(locale)

--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -243,7 +243,7 @@ module LanguagesHelper
     'pt-BR': 'Português (Brasil)',
     'pt-PT': 'Português (Portugal)',
     'sr-Latn': 'Srpski (latinica)',
-  }
+  }.freeze
 
   # Helper for self.sorted_locale_keys
   private_class_method def self.locale_name_for_sorting(locale)

--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -223,7 +223,16 @@ module LanguagesHelper
     'zh-YUE': ['Cantonese', '廣東話'].freeze,
   }.freeze
 
-  SUPPORTED_LOCALES = {}.merge(ISO_639_1).merge(ISO_639_1_REGIONAL).merge(ISO_639_3).freeze
+  # Since nan is not translated but nan-TW is translated,
+  # to enable the ISO-639-3 language-code with the regional variant but no
+  # official name, we use a specific hash for nan-TW 
+  NAN_TW_CODE = {'nan-TW': '臺語 (Hô-ló話)'}.freeze
+
+
+  SUPPORTED_LOCALES = {}.merge(ISO_639_1).merge(ISO_639_1_REGIONAL).merge(ISO_639_3).merge(NAN_TW_CODE).freeze
+
+
+
 
   # For ISO-639-1 and ISO-639-3 language codes, we have their official
   # names, but for some translations, we need the names of the
@@ -233,11 +242,10 @@ module LanguagesHelper
     'es-AR': 'Español (Argentina)',
     'es-MX': 'Español (México)',
     'fr-CA': 'Français (Canadien)',
-    'nan-TW': '臺語 (Hô-ló話)',
     'pt-BR': 'Português (Brasil)',
     'pt-PT': 'Português (Portugal)',
     'sr-Latn': 'Srpski (latinica)',
-  }.freeze
+  }.merge(NAN_TW_CODE).freeze
 
   # Helper for self.sorted_locale_keys
   private_class_method def self.locale_name_for_sorting(locale)

--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -225,14 +225,12 @@ module LanguagesHelper
 
   # Since nan is not translated but nan-TW is translated,
   # to enable the ISO-639-3 language-code with the regional variant but no
-  # official name, we use a specific hash for nan-TW 
-  NAN_TW_CODE = {'nan-TW': '臺語 (Hô-ló話)'}.freeze
-
+  # official name, we use a specific hash for nan-TW
+  NAN_TW_CODE = {
+    'nan-TW': '臺語 (Hô-ló話)'
+  }.freeze
 
   SUPPORTED_LOCALES = {}.merge(ISO_639_1).merge(ISO_639_1_REGIONAL).merge(ISO_639_3).merge(NAN_TW_CODE).freeze
-
-
-
 
   # For ISO-639-1 and ISO-639-3 language codes, we have their official
   # names, but for some translations, we need the names of the

--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -226,7 +226,7 @@ module LanguagesHelper
   # Since nan is not translated but nan-TW is translated,
   # to enable the ISO-639-3 language-code with the regional variant but no
   # official name, we use a specific hash for nan-TW
-  NAN_TW_CODE = {
+  ISO_639_3_REGIONAL = {
     'nan-TW': ['Hokkien (Taiwan)', '臺語 (Hô-ló話)'].freeze,
   }.freeze
 

--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -230,7 +230,7 @@ module LanguagesHelper
     'nan-TW': ['Hokkien (Taiwan)', '臺語 (Hô-ló話)'].freeze,
   }.freeze
 
-  SUPPORTED_LOCALES = {}.merge(ISO_639_1).merge(ISO_639_1_REGIONAL).merge(ISO_639_3).merge(NAN_TW_CODE).freeze
+  SUPPORTED_LOCALES = {}.merge(ISO_639_1).merge(ISO_639_1_REGIONAL).merge(ISO_639_3).merge(ISO_639_3_REGIONAL).freeze
 
   # For ISO-639-1 and ISO-639-3 language codes, we have their official
   # names, but for some translations, we need the names of the


### PR DESCRIPTION
Even though  #34923 is merged, the `nan-tw` (Taigi/Taiwanese Hokkien) is still not able to be chosen to be the interface language. I think that it's attributed to the lacking of ISO 639-3 (in the case, `nan`) is not in the `ISO_639_3` list due to the lacking translation for the language (or language set). However, the ISO 639 code (Min Nan) is not translated, and because of the language separatism of Taigi and Taiwanese Nationalism, many Taigi-speaking people are opposed  to using "Min Nan" (which means Southern Fujian Province of China) as the language they use, so I suggest to create another hash (like the dict data-structure in Python) named `NAN_TW_CODE`, and append it to variable `SUPPORTED_LOCALES` and variable `REGIONAL_LOCALE_NAMES` .

(cc @gunchleoc )