### PR TITLE
Convert `admin/accounts` controller->request specs

### DIFF
--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -279,15 +279,6 @@ RSpec.describe Admin::AccountsController do
         expect(response).to redirect_to admin_account_path(account.id)
       end
     end
-
-    context 'when user is not admin' do
-      let(:role) { UserRole.everyone }
-
-      it 'fails to remove avatar' do
-        subject
-        expect(response).to have_http_status 403
-      end
-    end
   end
 
   describe 'POST #unsensitive' do

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -258,14 +258,6 @@ RSpec.describe Admin::AccountsController do
         expect(subject).to redirect_to admin_account_path(account.id)
       end
     end
-
-    context 'when user is not admin' do
-      let(:role) { UserRole.everyone }
-
-      it 'fails to remove avatar' do
-        expect(subject).to have_http_status 403
-      end
-    end
   end
 
   describe 'POST #unblock_email' do

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -337,16 +337,6 @@ RSpec.describe Admin::AccountsController do
         expect(response).to redirect_to admin_account_path(account.id)
       end
     end
-
-    context 'when user is not admin' do
-      let(:role) { UserRole.everyone }
-
-      it 'fails to change account' do
-        subject
-
-        expect(response).to have_http_status 403
-      end
-    end
   end
 
   describe 'POST #destroy' do

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -297,16 +297,6 @@ RSpec.describe Admin::AccountsController do
         expect(response).to redirect_to admin_account_path(account.id)
       end
     end
-
-    context 'when user is not admin' do
-      let(:role) { UserRole.everyone }
-
-      it 'fails to change account' do
-        subject
-
-        expect(response).to have_http_status 403
-      end
-    end
   end
 
   describe 'POST #unsilence' do

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -363,16 +363,6 @@ RSpec.describe Admin::AccountsController do
         expect(response).to redirect_to admin_account_path(account.id)
       end
     end
-
-    context 'when user is not admin' do
-      let(:role) { UserRole.everyone }
-
-      it 'fails to change account' do
-        subject
-
-        expect(response).to have_http_status 403
-      end
-    end
   end
 
   private

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -166,15 +166,6 @@ RSpec.describe Admin::AccountsController do
         expect(user.reload).to_not be_disabled
       end
     end
-
-    context 'when user is not admin' do
-      let(:role) { UserRole.everyone }
-
-      it 'fails to enable account' do
-        expect(subject).to have_http_status 403
-        expect(user.reload).to be_disabled
-      end
-    end
   end
 
   describe 'POST #approve' do

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -243,14 +243,6 @@ RSpec.describe Admin::AccountsController do
         expect(subject).to redirect_to admin_account_path(account.id)
       end
     end
-
-    context 'when user is not admin' do
-      let(:role) { UserRole.everyone }
-
-      it 'fails to redownload' do
-        expect(subject).to have_http_status 403
-      end
-    end
   end
 
   describe 'POST #remove_avatar' do

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -223,15 +223,6 @@ RSpec.describe Admin::AccountsController do
           )
       end
     end
-
-    context 'when user is not admin' do
-      let(:role) { UserRole.everyone }
-
-      it 'fails to reject account' do
-        expect(subject).to have_http_status 403
-        expect(user.reload).to_not be_approved
-      end
-    end
   end
 
   describe 'POST #redownload' do

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -315,16 +315,6 @@ RSpec.describe Admin::AccountsController do
         expect(response).to redirect_to admin_account_path(account.id)
       end
     end
-
-    context 'when user is not admin' do
-      let(:role) { UserRole.everyone }
-
-      it 'fails to change account' do
-        subject
-
-        expect(response).to have_http_status 403
-      end
-    end
   end
 
   describe 'POST #unsuspend' do

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -195,15 +195,6 @@ RSpec.describe Admin::AccountsController do
           )
       end
     end
-
-    context 'when user is not admin' do
-      let(:role) { UserRole.everyone }
-
-      it 'fails to approve account' do
-        expect(subject).to have_http_status 403
-        expect(user.reload).to_not be_approved
-      end
-    end
   end
 
   describe 'POST #reject' do

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -109,43 +109,12 @@ RSpec.describe Admin::AccountsController do
     context 'when user is admin' do
       let(:current_role) { UserRole.find_by(name: 'Admin') }
 
-      context 'when target user is admin' do
-        let(:target_role) { UserRole.find_by(name: 'Admin') }
-
-        it 'fails to memorialize account' do
-          expect(subject).to have_http_status 403
-          expect(account.reload).to_not be_memorial
-        end
-      end
-
       context 'when target user is not admin' do
         let(:target_role) { UserRole.find_by(name: 'Moderator') }
 
         it 'succeeds in memorializing account' do
           expect(subject).to redirect_to admin_account_path(account.id)
           expect(account.reload).to be_memorial
-        end
-      end
-    end
-
-    context 'when user is not admin' do
-      let(:current_role) { UserRole.find_by(name: 'Moderator') }
-
-      context 'when target user is admin' do
-        let(:target_role) { UserRole.find_by(name: 'Admin') }
-
-        it 'fails to memorialize account' do
-          expect(subject).to have_http_status 403
-          expect(account.reload).to_not be_memorial
-        end
-      end
-
-      context 'when target user is not admin' do
-        let(:target_role) { UserRole.find_by(name: 'Moderator') }
-
-        it 'fails to memorialize account' do
-          expect(subject).to have_http_status 403
-          expect(account.reload).to_not be_memorial
         end
       end
     end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -33,4 +33,26 @@ RSpec.describe 'Admin Accounts' do
       end
     end
   end
+
+  describe 'POST /admin/accounts/:id/approve' do
+    let(:account) { user.account }
+    let(:user) { Fabricate(:user) }
+
+    before { account.user.update(approved: false) }
+
+    context 'when user is not admin' do
+      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
+
+      before { sign_in current_user }
+
+      it 'fails to approve account' do
+        post approve_admin_account_path(id: account.id)
+
+        expect(response)
+          .to have_http_status(403)
+        expect(user.reload)
+          .to_not be_approved
+      end
+    end
+  end
 end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -129,4 +129,21 @@ RSpec.describe 'Admin Accounts' do
       end
     end
   end
+
+  describe 'POST /admin/accounts/:id/unsensitive' do
+    let(:account) { Fabricate(:account, sensitized_at: 1.year.ago) }
+
+    context 'when user is not admin' do
+      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
+
+      it 'fails to unsensitive account' do
+        post unsensitive_admin_account_path(id: account.id)
+
+        expect(response)
+          .to have_http_status(403)
+        expect(account)
+          .to be_sensitized
+      end
+    end
+  end
 end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -111,4 +111,22 @@ RSpec.describe 'Admin Accounts' do
       end
     end
   end
+
+  describe 'POST /admin/accounts/:id/unblock_email' do
+    let(:account) { Fabricate(:account, suspended: true) }
+
+    before { Fabricate(:canonical_email_block, reference_account: account) }
+
+    context 'when user is not admin' do
+      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
+
+      it 'fails to unblock email' do
+        expect { post unblock_email_admin_account_path(id: account.id) }
+          .to_not change(CanonicalEmailBlock.where(reference_account: account), :count)
+
+        expect(response)
+          .to have_http_status(403)
+      end
+    end
+  end
 end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -95,4 +95,20 @@ RSpec.describe 'Admin Accounts' do
       end
     end
   end
+
+  describe 'POST /admin/accounts/:id/remove_avatar' do
+    let(:account) { Fabricate(:account) }
+
+    context 'when user is not admin' do
+      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
+
+      it 'fails to remove avatar' do
+        expect { post remove_avatar_admin_account_path(id: account.id) }
+          .to_not change(Admin::ActionLog.where(action: 'remove_avatar'), :count)
+
+        expect(response)
+          .to have_http_status(403)
+      end
+    end
+  end
 end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -163,4 +163,23 @@ RSpec.describe 'Admin Accounts' do
       end
     end
   end
+
+  describe 'POST /admin/accounts/:id/unsuspend' do
+    let(:account) { Fabricate(:account) }
+
+    before { account.suspend! }
+
+    context 'when user is not admin' do
+      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
+
+      it 'fails to unsuspend account' do
+        post unsuspend_admin_account_path(id: account.id)
+
+        expect(response)
+          .to have_http_status(403)
+        expect(account)
+          .to be_suspended
+      end
+    end
+  end
 end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -182,4 +182,23 @@ RSpec.describe 'Admin Accounts' do
       end
     end
   end
+
+  describe 'DELETE /admin/accounts/:id' do
+    let(:account) { Fabricate(:account) }
+
+    before { account.suspend! }
+
+    context 'when user is not admin' do
+      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
+
+      it 'fails to delete account' do
+        delete admin_account_path(id: account.id)
+
+        expect(response)
+          .to have_http_status(403)
+        expect { account.reload }
+          .to_not raise_error
+      end
+    end
+  end
 end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -112,6 +112,22 @@ RSpec.describe 'Admin Accounts' do
     end
   end
 
+  describe 'POST /admin/accounts/:id/remove_header' do
+    let(:account) { Fabricate(:account) }
+
+    context 'when user is not admin' do
+      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
+
+      it 'fails to remove header' do
+        expect { post remove_header_admin_account_path(id: account.id) }
+          .to_not change(Admin::ActionLog.where(action: 'remove_header'), :count)
+
+        expect(response)
+          .to have_http_status(403)
+      end
+    end
+  end
+
   describe 'POST /admin/accounts/:id/unblock_email' do
     let(:account) { Fabricate(:account, suspended: true) }
 

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -75,4 +75,24 @@ RSpec.describe 'Admin Accounts' do
       end
     end
   end
+
+  describe 'POST /admin/accounts/:id/redownload' do
+    let(:account) { Fabricate(:account, domain: 'example.com', last_webfingered_at: 10.days.ago) }
+    let(:service) { instance_double(ResolveAccountService, call: nil) }
+
+    before { allow(ResolveAccountService).to receive(:new).and_return(service) }
+
+    context 'when user is not admin' do
+      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
+
+      it 'fails to redownload' do
+        post redownload_admin_account_path(id: account.id)
+
+        expect(response)
+          .to have_http_status(403)
+        expect(account.reload.last_webfingered_at)
+          .to_not be_nil
+      end
+    end
+  end
 end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -146,4 +146,21 @@ RSpec.describe 'Admin Accounts' do
       end
     end
   end
+
+  describe 'POST /admin/accounts/:id/unsilence' do
+    let(:account) { Fabricate(:account, silenced_at: 1.year.ago) }
+
+    context 'when user is not admin' do
+      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
+
+      it 'fails to unsilence account' do
+        post unsilence_admin_account_path(id: account.id)
+
+        expect(response)
+          .to have_http_status(403)
+        expect(account)
+          .to be_silenced
+      end
+    end
+  end
 end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -13,4 +13,24 @@ RSpec.describe 'Admin Accounts' do
         .to redirect_to(admin_accounts_path)
     end
   end
+
+  describe 'POST /admin/accounts/:id/enable' do
+    let(:account) { user.account }
+    let(:user) { Fabricate(:user, disabled: true) }
+
+    context 'when user is not admin' do
+      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
+
+      before { sign_in current_user }
+
+      it 'fails to enable account' do
+        post enable_admin_account_path(id: account.id)
+
+        expect(response)
+          .to have_http_status(403)
+        expect(user.reload)
+          .to be_disabled
+      end
+    end
+  end
 end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -55,4 +55,24 @@ RSpec.describe 'Admin Accounts' do
       end
     end
   end
+
+  describe 'POST /admin/accounts/:id/reject' do
+    let(:account) { user.account }
+    let(:user) { Fabricate(:user) }
+
+    before { account.user.update(approved: false) }
+
+    context 'when user is not admin' do
+      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
+
+      it 'fails to reject account' do
+        post reject_admin_account_path(id: account.id)
+
+        expect(response)
+          .to have_http_status(403)
+        expect(user.reload)
+          .to_not be_approved
+      end
+    end
+  end
 end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -201,4 +201,56 @@ RSpec.describe 'Admin Accounts' do
       end
     end
   end
+
+  describe 'POST /admin/accounts/:id/memorialize' do
+    let(:account) { user.account }
+    let(:user) { Fabricate(:user, role: target_role) }
+
+    context 'when user is admin' do
+      let(:current_user) { Fabricate(:admin_user) }
+
+      context 'when target user is admin' do
+        let(:target_role) { UserRole.find_by(name: 'Admin') }
+
+        it 'fails to memorialize account' do
+          post memorialize_admin_account_path(id: account.id)
+
+          expect(response)
+            .to have_http_status(403)
+          expect(account.reload)
+            .to_not be_memorial
+        end
+      end
+    end
+
+    context 'when user is not admin' do
+      let(:current_user) { Fabricate(:moderator_user) }
+
+      context 'when target user is admin' do
+        let(:target_role) { UserRole.find_by(name: 'Admin') }
+
+        it 'fails to memorialize account' do
+          post memorialize_admin_account_path(id: account.id)
+
+          expect(response)
+            .to have_http_status(403)
+          expect(account.reload)
+            .to_not be_memorial
+        end
+      end
+
+      context 'when target user is not admin' do
+        let(:target_role) { UserRole.find_by(name: 'Moderator') }
+
+        it 'fails to memorialize account' do
+          post memorialize_admin_account_path(id: account.id)
+
+          expect(response)
+            .to have_http_status(403)
+          expect(account.reload)
+            .to_not be_memorial
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This one is pretty large, so I'm going to attempt to convert in multiple chunks.

This first pass moves all the non-admin failure cases from controller to request spec.

I suspect the majority of the rest of the file will move to system specs to be sure we are exercising the views. Should be able to do that in 1-2 additional PRs.