### PR TITLE
Refactors header from Status component

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -3,14 +3,12 @@ import PropTypes from 'prop-types';
 import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
 
 import classNames from 'classnames';
-import { Link } from 'react-router-dom';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import AlternateEmailIcon from '@/material-icons/400-24px/alternate_email.svg?react';
 import RepeatIcon from '@/material-icons/400-24px/repeat.svg?react';
-import CancelFillIcon from '@/material-icons/400-24px/cancel-fill.svg?react';
 import { Hotkeys } from 'mastodon/components/hotkeys';
 import { ContentWarning } from 'mastodon/components/content_warning';
 import { FilterWarning } from 'mastodon/components/filter_warning';
@@ -26,16 +24,12 @@ import { MediaGallery, Video, Audio } from '../features/ui/util/async-components
 import { SensitiveMediaContext } from '../features/ui/util/sensitive_media_context';
 import { displayMedia } from '../initial_state';
 
-import { Avatar } from './avatar';
-import { AvatarOverlay } from './avatar_overlay';
+import { StatusHeader } from './status/header'
 import { LinkedDisplayName } from './display_name';
 import { getHashtagBarForStatus } from './hashtag_bar';
-import { RelativeTimestamp } from './relative_timestamp';
 import StatusActionBar from './status_action_bar';
 import StatusContent from './status_content';
 import { StatusThreadLabel } from './status_thread_label';
-import { VisibilityIcon } from './visibility_icon';
-import { IconButton } from './icon_button';
 
 const domParser = new DOMParser();
 
@@ -405,7 +399,7 @@ class Status extends ImmutablePureComponent {
       onTranslate: this.handleTranslate,
     };
 
-    let media, statusAvatar, prepend, rebloggedByText;
+    let media, prepend, rebloggedByText;
 
     const connectUp = previousId && previousId === status.get('in_reply_to_id');
     const connectToRoot = rootId && rootId === status.get('in_reply_to_id');
@@ -547,12 +541,6 @@ class Status extends ImmutablePureComponent {
       );
     }
 
-    if (account === undefined || account === null) {
-      statusAvatar = <Avatar account={status.get('account')} size={avatarSize} />;
-    } else {
-      statusAvatar = <AvatarOverlay account={status.get('account')} friend={account} />;
-    }
-
     const {statusContentProps, hashtagBar} = getHashtagBarForStatus(status);
     return (
       <Hotkeys handlers={handlers} focusable={!unfocusable}>
@@ -575,28 +563,14 @@ class Status extends ImmutablePureComponent {
           >
             {(connectReply || connectUp || connectToRoot) && <div className={classNames('status__line', { 'status__line--full': connectReply, 'status__line--first': !status.get('in_reply_to_id') && !connectToRoot })} />}
 
-            <div onClick={this.handleHeaderClick} onAuxClick={this.handleHeaderClick} className='status__info'>
-              <Link to={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} className='status__relative-time'>
-                <span className='status__visibility-icon'><VisibilityIcon visibility={status.get('visibility')} /></span>
-                <RelativeTimestamp timestamp={status.get('created_at')} />{status.get('edited_at') && <abbr title={intl.formatMessage(messages.edited, { date: intl.formatDate(status.get('edited_at'), { year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }) })}> *</abbr>}
-              </Link>
-
-              <LinkedDisplayName displayProps={{account: status.get('account')}} className='status__display-name'>
-                <div className='status__avatar'>
-                  {statusAvatar}
-                </div>
-              </LinkedDisplayName>
-
-              {isQuotedPost && !!this.props.onQuoteCancel &&  (
-                <IconButton
-                  onClick={this.handleQuoteCancel}
-                  className='status__quote-cancel'
-                  title={intl.formatMessage(messages.quote_cancel)}
-                  icon="cancel-fill"
-                  iconComponent={CancelFillIcon}
-                />
-              )}
-            </div>
+            <StatusHeader
+              status={status}
+              account={account}
+              avatarSize={avatarSize}
+              onQuoteCancel={this.props.onQuoteCancel}
+              wrapperProps={{ onClick: this.handleHeaderClick, onAuxClick: this.handleHeaderClick }}
+              messages={messages}
+            />
 
             {matchedFilters && <FilterWarning title={matchedFilters.join(', ')} expanded={this.state.showDespiteFilter} onClick={this.handleFilterToggle} />}
 

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -106,7 +106,6 @@ class Status extends ImmutablePureComponent {
     onToggleCollapsed: PropTypes.func,
     onTranslate: PropTypes.func,
     onInteractionModal: PropTypes.func,
-    onQuoteCancel: PropTypes.func,
     muted: PropTypes.bool,
     hidden: PropTypes.bool,
     unread: PropTypes.bool,
@@ -141,7 +140,6 @@ class Status extends ImmutablePureComponent {
     'hidden',
     'unread',
     'pictureInPicture',
-    'onQuoteCancel',
   ];
 
   state = {
@@ -358,10 +356,6 @@ class Status extends ImmutablePureComponent {
   handleFilterToggle = () => {
     this.setState(state => ({ ...state, showDespiteFilter: !state.showDespiteFilter }));
   };
-
-  handleQuoteCancel = () => {
-    this.props.onQuoteCancel?.();
-  }
 
   _properStatus () {
     const { status } = this.props;

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -123,6 +123,7 @@ class Status extends ImmutablePureComponent {
     avatarSize: PropTypes.number,
     deployPictureInPicture: PropTypes.func,
     unfocusable: PropTypes.bool,
+    headerComponent: PropTypes.element,
     pictureInPicture: ImmutablePropTypes.contains({
       inUse: PropTypes.bool,
       available: PropTypes.bool,
@@ -377,7 +378,25 @@ class Status extends ImmutablePureComponent {
   };
 
   render () {
-    const { intl, hidden, featured, unfocusable, unread, showThread, showActions = true, isQuotedPost = false, scrollKey, pictureInPicture, previousId, nextInReplyToId, rootId, skipPrepend, avatarSize = 46, children } = this.props;
+    const {
+      intl,
+      hidden,
+      featured,
+      unfocusable,
+      unread,
+      showThread,
+      showActions = true,
+      isQuotedPost = false,
+      scrollKey,
+      pictureInPicture,
+      previousId,
+      nextInReplyToId,
+      rootId,
+      skipPrepend,
+      avatarSize = 46,
+      children,
+      headerComponent: HeaderComponent = StatusHeader,
+    } = this.props;
 
     let { status, account, ...other } = this.props;
 
@@ -563,7 +582,7 @@ class Status extends ImmutablePureComponent {
           >
             {(connectReply || connectUp || connectToRoot) && <div className={classNames('status__line', { 'status__line--full': connectReply, 'status__line--first': !status.get('in_reply_to_id') && !connectToRoot })} />}
 
-            <StatusHeader
+            <HeaderComponent
               status={status}
               account={account}
               avatarSize={avatarSize}

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -9,6 +9,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import AlternateEmailIcon from '@/material-icons/400-24px/alternate_email.svg?react';
 import RepeatIcon from '@/material-icons/400-24px/repeat.svg?react';
+import CancelFillIcon from '@/material-icons/400-24px/cancel-fill.svg?react';
 import { Hotkeys } from 'mastodon/components/hotkeys';
 import { ContentWarning } from 'mastodon/components/content_warning';
 import { FilterWarning } from 'mastodon/components/filter_warning';
@@ -16,6 +17,7 @@ import { Icon }  from 'mastodon/components/icon';
 import { PictureInPicturePlaceholder } from 'mastodon/components/picture_in_picture_placeholder';
 import { withOptionalRouter, WithOptionalRouterPropTypes } from 'mastodon/utils/react_router';
 
+import { IconButton } from './icon_button';
 import Card from '../features/status/components/card';
 // We use the component (and not the container) since we do not want
 // to use the progress bar to show download progress
@@ -589,7 +591,17 @@ class Status extends ImmutablePureComponent {
               onQuoteCancel={this.props.onQuoteCancel}
               wrapperProps={{ onClick: this.handleHeaderClick, onAuxClick: this.handleHeaderClick }}
               messages={messages}
-            />
+            >
+              {isQuotedPost && this.props.onQuoteCancel && (
+                <IconButton
+                  onClick={this.props.onQuoteCancel}
+                  className='status__quote-cancel'
+                  title={intl.formatMessage(messages.quote_cancel)}
+                  icon='cancel-fill'
+                  iconComponent={CancelFillIcon}
+                />
+              )}
+            </HeaderComponent>
 
             {matchedFilters && <FilterWarning title={matchedFilters.join(', ')} expanded={this.state.showDespiteFilter} onClick={this.handleFilterToggle} />}
 

--- a/app/javascript/mastodon/components/status/header.tsx
+++ b/app/javascript/mastodon/components/status/header.tsx
@@ -1,4 +1,4 @@
-import type { FC, HTMLAttributes, MouseEventHandler } from 'react';
+import type { FC, HTMLAttributes, ReactNode } from 'react';
 
 import type { MessageDescriptor } from 'react-intl';
 import { useIntl } from 'react-intl';
@@ -8,12 +8,11 @@ import { Link } from 'react-router-dom';
 import { isStatusVisibility } from '@/mastodon/api_types/statuses';
 import type { Account } from '@/mastodon/models/account';
 import type { Status } from '@/mastodon/models/status';
-import CancelFillIcon from '@/material-icons/400-24px/cancel-fill.svg?react';
 
 import { Avatar } from '../avatar';
 import { AvatarOverlay } from '../avatar_overlay';
+import type { DisplayNameProps } from '../display_name';
 import { LinkedDisplayName } from '../display_name';
-import { IconButton } from '../icon_button';
 import { RelativeTimestamp } from '../relative_timestamp';
 import { VisibilityIcon } from '../visibility_icon';
 
@@ -21,8 +20,9 @@ export interface StatusHeaderProps {
   status: Status;
   account?: Account;
   avatarSize?: number;
-  onQuoteCancel?: MouseEventHandler;
+  children?: ReactNode;
   wrapperProps?: HTMLAttributes<HTMLDivElement>;
+  displayNameProps?: DisplayNameProps;
   messages: {
     edited: MessageDescriptor;
     quote_cancel: MessageDescriptor;
@@ -32,10 +32,11 @@ export interface StatusHeaderProps {
 export const StatusHeader: FC<StatusHeaderProps> = ({
   status,
   account,
+  children,
   avatarSize = 48,
-  onQuoteCancel,
   wrapperProps,
   messages,
+  displayNameProps,
 }) => {
   const intl = useIntl();
   const statusAccount = status.get('account') as Account | undefined;
@@ -74,7 +75,7 @@ export const StatusHeader: FC<StatusHeaderProps> = ({
       </Link>
 
       <LinkedDisplayName
-        displayProps={{ account: statusAccount }}
+        displayProps={{ ...displayNameProps, account: statusAccount }}
         className='status__display-name'
       >
         <div className='status__avatar'>
@@ -86,15 +87,7 @@ export const StatusHeader: FC<StatusHeaderProps> = ({
         </div>
       </LinkedDisplayName>
 
-      {!!onQuoteCancel && (
-        <IconButton
-          onClick={onQuoteCancel}
-          className='status__quote-cancel'
-          title={intl.formatMessage(messages.quote_cancel)}
-          icon='cancel-fill'
-          iconComponent={CancelFillIcon}
-        />
-      )}
+      {children}
     </div>
   );
 };

--- a/app/javascript/mastodon/components/status/header.tsx
+++ b/app/javascript/mastodon/components/status/header.tsx
@@ -1,0 +1,100 @@
+import type { FC, HTMLAttributes, MouseEventHandler } from 'react';
+
+import type { MessageDescriptor } from 'react-intl';
+import { useIntl } from 'react-intl';
+
+import { Link } from 'react-router-dom';
+
+import { isStatusVisibility } from '@/mastodon/api_types/statuses';
+import type { Account } from '@/mastodon/models/account';
+import type { Status } from '@/mastodon/models/status';
+import CancelFillIcon from '@/material-icons/400-24px/cancel-fill.svg?react';
+
+import { Avatar } from '../avatar';
+import { AvatarOverlay } from '../avatar_overlay';
+import { LinkedDisplayName } from '../display_name';
+import { IconButton } from '../icon_button';
+import { RelativeTimestamp } from '../relative_timestamp';
+import { VisibilityIcon } from '../visibility_icon';
+
+interface StatusHeaderProps {
+  status: Status;
+  account?: Account;
+  avatarSize?: number;
+  onQuoteCancel?: MouseEventHandler;
+  wrapperProps?: HTMLAttributes<HTMLDivElement>;
+  messages: {
+    edited: MessageDescriptor;
+    quote_cancel: MessageDescriptor;
+  };
+}
+
+export const StatusHeader: FC<StatusHeaderProps> = ({
+  status,
+  account,
+  avatarSize = 48,
+  onQuoteCancel,
+  wrapperProps,
+  messages,
+}) => {
+  const intl = useIntl();
+  const statusAccount = status.get('account') as Account | undefined;
+  const visibility = status.get('visibility') as string;
+  const editedAt = status.get('edited_at') as string;
+  const AccountComponent = account ? AvatarOverlay : Avatar;
+
+  return (
+    <div {...wrapperProps} className='status__info'>
+      <Link
+        to={`/@${statusAccount?.acct}/${status.get('id') as string}`}
+        className='status__relative-time'
+      >
+        {isStatusVisibility(visibility) && (
+          <span className='status__visibility-icon'>
+            <VisibilityIcon visibility={visibility} />
+          </span>
+        )}
+        <RelativeTimestamp timestamp={status.get('created_at') as string} />
+        {editedAt && (
+          <abbr
+            title={intl.formatMessage(messages.edited, {
+              date: intl.formatDate(editedAt, {
+                year: 'numeric',
+                month: 'short',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+              }),
+            })}
+          >
+            {' '}
+            *
+          </abbr>
+        )}
+      </Link>
+
+      <LinkedDisplayName
+        displayProps={{ account: statusAccount }}
+        className='status__display-name'
+      >
+        <div className='status__avatar'>
+          <AccountComponent
+            account={statusAccount}
+            friend={account}
+            size={avatarSize}
+          />
+        </div>
+      </LinkedDisplayName>
+
+      {!!onQuoteCancel && (
+        <IconButton
+          onClick={onQuoteCancel}
+          className='status__quote-cancel'
+          title={intl.formatMessage(messages.quote_cancel)}
+          icon='cancel-fill'
+          iconComponent={CancelFillIcon}
+        />
+      )}
+    </div>
+  );
+};

--- a/app/javascript/mastodon/components/status/header.tsx
+++ b/app/javascript/mastodon/components/status/header.tsx
@@ -17,7 +17,7 @@ import { IconButton } from '../icon_button';
 import { RelativeTimestamp } from '../relative_timestamp';
 import { VisibilityIcon } from '../visibility_icon';
 
-interface StatusHeaderProps {
+export interface StatusHeaderProps {
   status: Status;
   account?: Account;
   avatarSize?: number;

--- a/app/javascript/mastodon/components/status/header.tsx
+++ b/app/javascript/mastodon/components/status/header.tsx
@@ -36,13 +36,9 @@ export const StatusHeader: FC<StatusHeaderProps> = ({
   avatarSize = 48,
   wrapperProps,
   messages,
-  displayNameProps,
 }) => {
-  const intl = useIntl();
   const statusAccount = status.get('account') as Account | undefined;
-  const visibility = status.get('visibility') as string;
   const editedAt = status.get('edited_at') as string;
-  const AccountComponent = account ? AvatarOverlay : Avatar;
 
   return (
     <div {...wrapperProps} className='status__info'>
@@ -50,44 +46,75 @@ export const StatusHeader: FC<StatusHeaderProps> = ({
         to={`/@${statusAccount?.acct}/${status.get('id') as string}`}
         className='status__relative-time'
       >
-        {isStatusVisibility(visibility) && (
-          <span className='status__visibility-icon'>
-            <VisibilityIcon visibility={visibility} />
-          </span>
-        )}
+        <StatusVisibility visibility={status.get('visibility')} />
         <RelativeTimestamp timestamp={status.get('created_at') as string} />
-        {editedAt && (
-          <abbr
-            title={intl.formatMessage(messages.edited, {
-              date: intl.formatDate(editedAt, {
-                year: 'numeric',
-                month: 'short',
-                day: '2-digit',
-                hour: '2-digit',
-                minute: '2-digit',
-              }),
-            })}
-          >
-            {' '}
-            *
-          </abbr>
-        )}
+        {editedAt && <StatusEditedAt editedAt={editedAt} messages={messages} />}
       </Link>
 
-      <LinkedDisplayName
-        displayProps={{ ...displayNameProps, account: statusAccount }}
-        className='status__display-name'
-      >
-        <div className='status__avatar'>
-          <AccountComponent
-            account={statusAccount}
-            friend={account}
-            size={avatarSize}
-          />
-        </div>
-      </LinkedDisplayName>
+      <StatusDisplayName
+        statusAccount={statusAccount}
+        friendAccount={account}
+        avatarSize={avatarSize}
+      />
 
       {children}
     </div>
+  );
+};
+
+export const StatusVisibility: FC<{ visibility: unknown }> = ({
+  visibility,
+}) => {
+  if (typeof visibility !== 'string' || !isStatusVisibility(visibility)) {
+    return null;
+  }
+  return (
+    <span className='status__visibility-icon'>
+      <VisibilityIcon visibility={visibility} />
+    </span>
+  );
+};
+
+export const StatusEditedAt: FC<
+  { editedAt: string } & Pick<StatusHeaderProps, 'messages'>
+> = ({ editedAt, messages }) => {
+  const intl = useIntl();
+  return (
+    <abbr
+      title={intl.formatMessage(messages.edited, {
+        date: intl.formatDate(editedAt, {
+          year: 'numeric',
+          month: 'short',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+        }),
+      })}
+    >
+      {' '}
+      *
+    </abbr>
+  );
+};
+
+export const StatusDisplayName: FC<{
+  statusAccount?: Account;
+  friendAccount?: Account;
+  avatarSize: number;
+}> = ({ statusAccount, friendAccount, avatarSize }) => {
+  const AccountComponent = friendAccount ? AvatarOverlay : Avatar;
+  return (
+    <LinkedDisplayName
+      displayProps={{ account: statusAccount }}
+      className='status__display-name'
+    >
+      <div className='status__avatar'>
+        <AccountComponent
+          account={statusAccount}
+          friend={friendAccount}
+          size={avatarSize}
+        />
+      </div>
+    </LinkedDisplayName>
   );
 };

--- a/app/javascript/mastodon/components/status_quoted.tsx
+++ b/app/javascript/mastodon/components/status_quoted.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { FormattedMessage } from 'react-intl';
+import { defineMessage, FormattedMessage, useIntl } from 'react-intl';
 
 import type { Map as ImmutableMap } from 'immutable';
 
+import CancelFillIcon from '@/material-icons/400-24px/cancel-fill.svg?react';
 import { fetchRelationships } from 'mastodon/actions/accounts';
 import { revealAccount } from 'mastodon/actions/accounts_typed';
 import { fetchStatus } from 'mastodon/actions/statuses';
@@ -18,6 +19,9 @@ import type { RootState } from 'mastodon/store';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
 import { Button } from './button';
+import { IconButton } from './icon_button';
+import type { StatusHeaderRenderFn } from './status/header';
+import { StatusHeader } from './status/header';
 
 const MAX_QUOTE_POSTS_NESTING_LEVEL = 1;
 
@@ -147,6 +151,11 @@ interface QuotedStatusProps {
   onQuoteCancel?: () => void; // Used for composer.
 }
 
+const quoteCancelMessage = defineMessage({
+  id: 'status.quote.cancel',
+  defaultMessage: 'Cancel quote',
+});
+
 export const QuotedStatus: React.FC<QuotedStatusProps> = ({
   quote,
   contextType,
@@ -212,6 +221,22 @@ export const QuotedStatus: React.FC<QuotedStatusProps> = ({
   useEffect(() => {
     if (accountId && hiddenAccount) dispatch(fetchRelationships([accountId]));
   }, [accountId, hiddenAccount, dispatch]);
+
+  const intl = useIntl();
+  const headerRenderFn: StatusHeaderRenderFn = useCallback(
+    (props) => (
+      <StatusHeader {...props}>
+        <IconButton
+          onClick={onQuoteCancel}
+          className='status__quote-cancel'
+          title={intl.formatMessage(quoteCancelMessage)}
+          icon='cancel-fill'
+          iconComponent={CancelFillIcon}
+        />
+      </StatusHeader>
+    ),
+    [intl, onQuoteCancel],
+  );
 
   const isFilteredAndHidden = loadingState === 'filtered';
 
@@ -314,7 +339,7 @@ export const QuotedStatus: React.FC<QuotedStatusProps> = ({
         id={quotedStatusId}
         contextType={contextType}
         avatarSize={32}
-        onQuoteCancel={onQuoteCancel}
+        headerRenderFn={headerRenderFn}
       >
         {canRenderChildQuote && (
           <QuotedStatus


### PR DESCRIPTION
This PR refactors the Status component header into a functional component in TS, and adds a rendering function to the Status component to override it. This is used by `QuotedStatus` to insert the cancel button inside the composer, and will be used for the profile redesign as well.

