### PR TITLE
[WiP] Add support for un-deleting posts

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -90,11 +90,13 @@ class ActivityPub::Activity
   end
 
   def delete_arrived_first?(uri)
+    # TODO: existence is not enough, compare with timestamp
     redis.exists?("delete_upon_arrival:#{@account.id}:#{uri}")
   end
 
-  def delete_later!(uri)
-    redis.setex("delete_upon_arrival:#{@account.id}:#{uri}", 6.hours.seconds, true)
+  def delete_later!(uri, timestamp: nil)
+    # TODO: atomically store highest between timestamp and already-stored info
+    redis.setex("delete_upon_arrival:#{@account.id}:#{uri}", 6.hours.seconds, timestamp || 6.hours.from_now.utc.to_i)
   end
 
   def status_from_object

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -434,6 +434,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   end
 
   def tombstone_exists?
+    # TODO: take status published/updated into account to allow recovering soft-deleted posts
     Tombstone.exists?(uri: object_uri)
   end
 

--- a/app/models/tombstone.rb
+++ b/app/models/tombstone.rb
@@ -16,4 +16,6 @@ class Tombstone < ApplicationRecord
   belongs_to :account
 
   validates :uri, presence: true
+
+  scope :preventing_creation, ->(datetime) { where(by_moderator: true).or(where(created_at: datetime...)) }
 end


### PR DESCRIPTION
This is a very early exploration on adding the ability to un-delete posts.

Indeed, currently, when a post is deleted, Mastodon will prevent ever re-creating one with the same ID, which prevents re-instating posts deleted by moderation, or having remote users switch blog posts from published to draft and back again.

This would at least require protocol changes to ensure we can properly order events to avoid re-instating a really-deleted post or the other way around. Local moderation decisions to delete a post must also override remote user's ability to re-instate a deleted post.