### PR TITLE
Federate `Remove` when collection is deleted

### DIFF
--- a/app/controllers/api/v1_alpha/collections_controller.rb
+++ b/app/controllers/api/v1_alpha/collections_controller.rb
@@ -59,7 +59,7 @@ class Api::V1Alpha::CollectionsController < Api::BaseController
   def destroy
     authorize @collection, :destroy?
 
-    @collection.destroy
+    DeleteCollectionService.new.call(@collection)
 
     head 200
   end

--- a/app/serializers/activitypub/remove_featured_collection_serializer.rb
+++ b/app/serializers/activitypub/remove_featured_collection_serializer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ActivityPub::RemoveFeaturedCollectionSerializer < ActivityPub::Serializer
+  include RoutingHelper
+
+  attributes :type, :actor, :target
+  has_one :object_uri, key: :object
+
+  def type
+    'Remove'
+  end
+
+  def actor
+    ActivityPub::TagManager.instance.uri_for(object.account)
+  end
+
+  def target
+    ap_account_featured_collections_url(object.account_id)
+  end
+
+  def object_uri
+    ActivityPub::TagManager.instance.uri_for(object)
+  end
+end

--- a/app/services/delete_collection_service.rb
+++ b/app/services/delete_collection_service.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class DeleteCollectionService
+  def call(collection)
+    @collection = collection
+    @collection.destroy!
+
+    distribute_remove_activity if Mastodon::Feature.collections_federation_enabled?
+  end
+
+  private
+
+  def distribute_remove_activity
+    ActivityPub::AccountRawDistributionWorker.perform_async(activity_json, @collection.account.id)
+  end
+
+  def activity_json
+    ActiveModelSerializers::SerializableResource.new(@collection, serializer: ActivityPub::RemoveFeaturedCollectionSerializer, adapter: ActivityPub::Adapter).to_json
+  end
+end

--- a/spec/serializers/activitypub/remove_featured_collection_serializer_spec.rb
+++ b/spec/serializers/activitypub/remove_featured_collection_serializer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActivityPub::RemoveFeaturedCollectionSerializer do
+  subject { serialized_record_json(object, described_class, adapter: ActivityPub::Adapter) }
+
+  let(:tag_manager) { ActivityPub::TagManager.instance }
+  let(:object) { Fabricate(:collection) }
+
+  it 'serializes to the expected json' do
+    expect(subject).to include({
+      'type' => 'Remove',
+      'actor' => tag_manager.uri_for(object.account),
+      'target' => a_string_matching(%r{/featured_collections$}),
+      'object' => tag_manager.uri_for(object),
+    })
+
+    expect(subject).to_not have_key('id')
+    expect(subject).to_not have_key('published')
+    expect(subject).to_not have_key('to')
+    expect(subject).to_not have_key('cc')
+  end
+end

--- a/spec/services/delete_collection_service_spec.rb
+++ b/spec/services/delete_collection_service_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeleteCollectionService do
+  subject { described_class.new }
+
+  let!(:collection) { Fabricate(:collection) }
+
+  describe '#call' do
+    it 'destroys the collection' do
+      expect { subject.call(collection) }.to change(Collection, :count).by(-1)
+    end
+
+    it 'federates a `Remove` activity', feature: :collections_federation do
+      subject.call(collection)
+
+      expect(ActivityPub::AccountRawDistributionWorker).to have_enqueued_sidekiq_job
+    end
+  end
+end


### PR DESCRIPTION
This is not entirely correct yet, as it only federates to the account's audience as identified by `AccountReachFinder`, when it should also federate to all the actors in the Collection.

For that purpose I will add a dedicated `CollectionReachFinder` in a follow-up PR.