### PR TITLE
Cancel quote button appearing in all statuses

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -556,7 +556,7 @@ class Status extends ImmutablePureComponent {
     const {statusContentProps, hashtagBar} = getHashtagBarForStatus(status);
 
     const header = this.props.headerRenderFn
-      ? this.props.headerRenderFn({ status, account, avatarSize, messages, onHeaderClick: this.handleHeaderClick })
+      ? this.props.headerRenderFn({ status, account, avatarSize, messages, onHeaderClick: this.handleHeaderClick, statusProps: this.props })
       : (
         <StatusHeader
           status={status}

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -140,6 +140,7 @@ class Status extends ImmutablePureComponent {
     'hidden',
     'unread',
     'pictureInPicture',
+    'headerRenderFn',
   ];
 
   state = {

--- a/app/javascript/mastodon/components/status/header.tsx
+++ b/app/javascript/mastodon/components/status/header.tsx
@@ -15,6 +15,8 @@ import { LinkedDisplayName } from '../display_name';
 import { RelativeTimestamp } from '../relative_timestamp';
 import { VisibilityIcon } from '../visibility_icon';
 
+import type { StatusProps } from './types';
+
 export interface StatusHeaderProps {
   status: Status;
   account?: Account;
@@ -25,7 +27,10 @@ export interface StatusHeaderProps {
   onHeaderClick?: MouseEventHandler<HTMLDivElement>;
 }
 
-export type StatusHeaderRenderFn = (args: StatusHeaderProps) => ReactNode;
+export type StatusHeaderRenderFn = (
+  args: StatusHeaderProps,
+  statusProps?: StatusProps,
+) => ReactNode;
 
 export const StatusHeader: FC<StatusHeaderProps> = ({
   status,

--- a/app/javascript/mastodon/components/status/types.ts
+++ b/app/javascript/mastodon/components/status/types.ts
@@ -1,0 +1,36 @@
+import type { ComponentClass, MouseEventHandler, ReactNode } from 'react';
+
+import type { Account } from '@/mastodon/models/account';
+
+import type { StatusHeaderRenderFn } from './header';
+
+// Taken from the Status component.
+export interface StatusProps {
+  account?: Account;
+  children?: ReactNode;
+  previousId?: string;
+  rootId?: string;
+  onClick?: MouseEventHandler<HTMLDivElement>;
+  muted?: boolean;
+  hidden?: boolean;
+  unread?: boolean;
+  showThread?: boolean;
+  showActions?: boolean;
+  isQuotedPost?: boolean;
+  shouldHighlightOnMount?: boolean;
+  getScrollPosition?: () => null | { height: number; top: number };
+  updateScrollBottom?: (snapshot: number) => void;
+  cacheMediaWidth?: (width: number) => void;
+  cachedMediaWidth?: number;
+  scrollKey?: string;
+  skipPrepend?: boolean;
+  avatarSize?: number;
+  unfocusable?: boolean;
+  headerRenderFn?: StatusHeaderRenderFn;
+  contextType?: string;
+}
+
+export type StatusComponent = ComponentClass<
+  StatusProps,
+  { showMedia?: boolean; showDespiteFilter?: boolean }
+>;

--- a/app/javascript/mastodon/components/status_quoted.tsx
+++ b/app/javascript/mastodon/components/status_quoted.tsx
@@ -226,13 +226,15 @@ export const QuotedStatus: React.FC<QuotedStatusProps> = ({
   const headerRenderFn: StatusHeaderRenderFn = useCallback(
     (props) => (
       <StatusHeader {...props}>
-        <IconButton
-          onClick={onQuoteCancel}
-          className='status__quote-cancel'
-          title={intl.formatMessage(quoteCancelMessage)}
-          icon='cancel-fill'
-          iconComponent={CancelFillIcon}
-        />
+        {onQuoteCancel && (
+          <IconButton
+            onClick={onQuoteCancel}
+            className='status__quote-cancel'
+            title={intl.formatMessage(quoteCancelMessage)}
+            icon='cancel-fill'
+            iconComponent={CancelFillIcon}
+          />
+        )}
       </StatusHeader>
     ),
     [intl, onQuoteCancel],


### PR DESCRIPTION
Fixes regression from #37732 where the quote cancel icon wasn't checking whether the handler was set.

This also adds a rough typing to the Status component props, and passes all those props to the status header render callback.