### PR TITLE
Add defensive check to `AfterUnallowDomainService`

### DIFF
--- a/app/services/after_unallow_domain_service.rb
+++ b/app/services/after_unallow_domain_service.rb
@@ -2,8 +2,10 @@
 
 class AfterUnallowDomainService < BaseService
   def call(domain)
-    Account.where(domain: domain).find_each do |account|
-      DeleteAccountService.new.call(account, reserve_username: false)
+    return if domain.blank?
+
+    Account.remote.where(domain: domain).find_each do |account|
+      DeleteAccountService.new.call(account, reserve_username: false, skip_side_effects: true)
     end
   end
 end

--- a/app/services/after_unallow_domain_service.rb
+++ b/app/services/after_unallow_domain_service.rb
@@ -5,7 +5,7 @@ class AfterUnallowDomainService < BaseService
     return if domain.blank?
 
     Account.remote.where(domain: domain).find_each do |account|
-      DeleteAccountService.new.call(account, reserve_username: false, skip_side_effects: true)
+      DeleteAccountService.new.call(account, reserve_username: false)
     end
   end
 end


### PR DESCRIPTION
Compared this file to `app/services/purge_domain_service.rb`.

Pretty sure `AfterUnallowDomainService.new.call(nil)` would just nuke the entire DB... even if that should never happen -- better safe than sorry.

* return on nil domain
* only search for remote accounts (performance boost).

note: I don't know if you should append `skip_side_effects: true`.
