### PR TITLE
Reduce stubbing SUT for `EmailMxValidator` spec

### DIFF
--- a/spec/validators/email_mx_validator_spec.rb
+++ b/spec/validators/email_mx_validator_spec.rb
@@ -3,89 +3,115 @@
 require 'rails_helper'
 
 RSpec.describe EmailMxValidator do
-  describe '#validate' do
-    let(:user) { instance_double(User, email: 'foo@example.com', sign_up_ip: '1.2.3.4', errors: instance_double(ActiveModel::Errors, add: nil)) }
-    let(:resolv_dns_double) { instance_double(Resolv::DNS) }
+  let(:user) { Fabricate.build :user, email: }
+  let(:email) { 'foo@example.com' }
+  let(:resolv_dns_double) { instance_double(Resolv::DNS) }
 
-    context 'with an e-mail domain that is explicitly allowed' do
-      around do |block|
-        tmp = Rails.configuration.x.email_domains_allowlist
-        Rails.configuration.x.email_domains_allowlist = 'example.com'
-        block.call
-        Rails.configuration.x.email_domains_allowlist = tmp
-      end
+  context 'with an e-mail domain that is explicitly allowed' do
+    around do |example|
+      original = Rails.configuration.x.email_domains_allowlist
+      Rails.configuration.x.email_domains_allowlist = 'example.com'
+      example.run
+      Rails.configuration.x.email_domains_allowlist = original
+    end
 
-      it 'does not add errors if there are no DNS records' do
-        configure_resolver('example.com')
+    context 'when there are not DNS records' do
+      before { configure_resolver('example.com') }
 
+      it 'does not add errors to record' do
         subject.validate(user)
-        expect(user.errors).to_not have_received(:add)
+        expect(user.errors).to be_empty
       end
-    end
-
-    it 'adds no error if there are DNS records for the e-mail domain' do
-      configure_resolver('example.com', a: resolv_double_a('192.0.2.42'))
-
-      subject.validate(user)
-      expect(user.errors).to_not have_received(:add)
-    end
-
-    it 'adds an error if the TagManager fails to normalize domain' do
-      double = instance_double(TagManager)
-      allow(TagManager).to receive(:instance).and_return(double)
-      allow(double).to receive(:normalize_domain).with('example.com').and_raise(Addressable::URI::InvalidURIError)
-
-      user = instance_double(User, email: 'foo@example.com', errors: instance_double(ActiveModel::Errors, add: nil))
-      subject.validate(user)
-      expect(user.errors).to have_received(:add)
-    end
-
-    it 'adds an error if the domain email portion is blank' do
-      user = instance_double(User, email: 'foo@', errors: instance_double(ActiveModel::Errors, add: nil))
-      subject.validate(user)
-      expect(user.errors).to have_received(:add)
-    end
-
-    it 'adds an error if the email domain name contains empty labels' do
-      configure_resolver('example..com', a: resolv_double_a('192.0.2.42'))
-
-      user = instance_double(User, email: 'foo@example..com', sign_up_ip: '1.2.3.4', errors: instance_double(ActiveModel::Errors, add: nil))
-      subject.validate(user)
-      expect(user.errors).to have_received(:add)
-    end
-
-    it 'adds an error if there are no DNS records for the e-mail domain' do
-      configure_resolver('example.com')
-
-      subject.validate(user)
-      expect(user.errors).to have_received(:add)
-    end
-
-    it 'adds an error if a MX record does not lead to an IP' do
-      configure_resolver('example.com', mx: resolv_double_mx('mail.example.com'))
-      configure_resolver('mail.example.com')
-
-      subject.validate(user)
-      expect(user.errors).to have_received(:add)
-    end
-
-    it 'adds an error if the MX record has an email domain block' do
-      EmailDomainBlock.create!(domain: 'mail.example.com')
-
-      configure_resolver(
-        'example.com',
-        mx: resolv_double_mx('mail.example.com')
-      )
-      configure_resolver(
-        'mail.example.com',
-        a: instance_double(Resolv::DNS::Resource::IN::A, address: '2.3.4.5'),
-        aaaa: instance_double(Resolv::DNS::Resource::IN::AAAA, address: 'fd00::2')
-      )
-
-      subject.validate(user)
-      expect(user.errors).to have_received(:add)
     end
   end
+
+  context 'when there are DNS records for the domain' do
+    let(:a) { resolv_double_a('192.0.2.42') }
+
+    before { configure_resolver('example.com', a:) }
+
+    it 'does not add errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_empty
+    end
+  end
+
+  context 'when the TagManager fails to normalize the domain' do
+    before do
+      allow(TagManager).to receive(:instance).and_return(tag_manage_double)
+      allow(tag_manage_double).to receive(:normalize_domain).with('example.com').and_raise(Addressable::URI::InvalidURIError)
+    end
+
+    let(:tag_manage_double) { instance_double(TagManager) }
+
+    it 'adds errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_present
+    end
+  end
+
+  context 'when the email portion is blank' do
+    let(:email) { 'foo@' }
+
+    it 'adds errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_present
+    end
+  end
+
+  context 'when the email domain contains empty labels' do
+    let(:a) { resolv_double_a('192.0.2.42') }
+    let(:email) { 'foo@example..com' }
+
+    before { configure_resolver('example..com', a:) }
+
+    it 'adds errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_present
+    end
+  end
+
+  context 'when there are no DNS records for the email domain' do
+    before { configure_resolver('example.com') }
+
+    it 'adds errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_present
+    end
+  end
+
+  context 'when MX record does not lead to an IP' do
+    let(:mx) { resolv_double_mx('mail.example.com') }
+
+    before do
+      configure_resolver('example.com', mx:)
+      configure_resolver('mail.example.com')
+    end
+
+    it 'adds errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_present
+    end
+  end
+
+  context 'when the MX record has an email domain block' do
+    let(:mx) { resolv_double_mx('mail.example.com') }
+    let(:a) { instance_double(Resolv::DNS::Resource::IN::A, address: '2.3.4.5') }
+    let(:aaaa) { instance_double(Resolv::DNS::Resource::IN::AAAA, address: 'fd00::2') }
+
+    before do
+      Fabricate :email_domain_block, domain: 'mail.example.com'
+      configure_resolver('example.com', mx:)
+      configure_resolver('mail.example.com', a:, aaaa:)
+    end
+
+    it 'adds errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_present
+    end
+  end
+
+  private
 
   def configure_resolver(domain, options = {})
     allow(resolv_dns_double)

--- a/spec/validators/email_mx_validator_spec.rb
+++ b/spec/validators/email_mx_validator_spec.rb
@@ -26,9 +26,7 @@ RSpec.describe EmailMxValidator do
   end
 
   context 'when there are DNS records for the domain' do
-    let(:a) { resolv_double_a('192.0.2.42') }
-
-    before { configure_resolver('example.com', a:) }
+    before { configure_resolver('example.com', a: resolv_double_a('192.0.2.42')) }
 
     it 'does not add errors to record' do
       subject.validate(user)
@@ -60,10 +58,9 @@ RSpec.describe EmailMxValidator do
   end
 
   context 'when the email domain contains empty labels' do
-    let(:a) { resolv_double_a('192.0.2.42') }
     let(:email) { 'foo@example..com' }
 
-    before { configure_resolver('example..com', a:) }
+    before { configure_resolver('example..com', a: resolv_double_a('192.0.2.42')) }
 
     it 'adds errors to record' do
       subject.validate(user)
@@ -81,10 +78,8 @@ RSpec.describe EmailMxValidator do
   end
 
   context 'when MX record does not lead to an IP' do
-    let(:mx) { resolv_double_mx('mail.example.com') }
-
     before do
-      configure_resolver('example.com', mx:)
+      configure_resolver('example.com', mx: resolv_double_mx('mail.example.com'))
       configure_resolver('mail.example.com')
     end
 
@@ -95,14 +90,17 @@ RSpec.describe EmailMxValidator do
   end
 
   context 'when the MX record has an email domain block' do
-    let(:mx) { resolv_double_mx('mail.example.com') }
-    let(:a) { instance_double(Resolv::DNS::Resource::IN::A, address: '2.3.4.5') }
-    let(:aaaa) { instance_double(Resolv::DNS::Resource::IN::AAAA, address: 'fd00::2') }
-
     before do
       Fabricate :email_domain_block, domain: 'mail.example.com'
-      configure_resolver('example.com', mx:)
-      configure_resolver('mail.example.com', a:, aaaa:)
+      configure_resolver(
+        'example.com',
+        mx: resolv_double_mx('mail.example.com')
+      )
+      configure_resolver(
+        'mail.example.com',
+        a: instance_double(Resolv::DNS::Resource::IN::A, address: '2.3.4.5'),
+        aaaa: instance_double(Resolv::DNS::Resource::IN::AAAA, address: 'fd00::2')
+      )
     end
 
     it 'adds errors to record' do


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/36057

This one does NOT add the validation matchers, but does a) reduce stubbing SUT in this spec, b) add in the "configure resolver" helpers previously added and used elsewhere, but not yet here.

Adding the matchers could be a followup, but is blocked somewhat on the way the skip mx check works now (always skips in test env). Something like https://github.com/mastodon/mastodon/pull/35839 or similar might be needed to enable that.