### PR TITLE
Move account search into hook

### DIFF
--- a/app/javascript/mastodon/features/lists/use_search_accounts.ts
+++ b/app/javascript/mastodon/features/lists/use_search_accounts.ts
@@ -1,0 +1,67 @@
+import { useRef, useState } from 'react';
+
+import { useDebouncedCallback } from 'use-debounce';
+
+import { importFetchedAccounts } from 'mastodon/actions/importer';
+import { apiRequest } from 'mastodon/api';
+import type { ApiAccountJSON } from 'mastodon/api_types/accounts';
+import { useAppDispatch } from 'mastodon/store';
+
+export function useSearchAccounts({
+  onSettled,
+}: {
+  onSettled?: (value: string) => void;
+} = {}) {
+  const dispatch = useAppDispatch();
+
+  const [accountIds, setAccountIds] = useState<string[]>();
+  const [loadingState, setLoadingState] = useState<
+    'idle' | 'loading' | 'error'
+  >('idle');
+
+  const searchRequestRef = useRef<AbortController | null>(null);
+
+  const searchAccounts = useDebouncedCallback(
+    (value: string) => {
+      if (searchRequestRef.current) {
+        searchRequestRef.current.abort();
+      }
+
+      if (value.trim().length === 0) {
+        onSettled?.('');
+        return;
+      }
+
+      setLoadingState('loading');
+
+      searchRequestRef.current = new AbortController();
+
+      void apiRequest<ApiAccountJSON[]>('GET', 'v1/accounts/search', {
+        signal: searchRequestRef.current.signal,
+        params: {
+          q: value,
+          resolve: true,
+        },
+      })
+        .then((data) => {
+          dispatch(importFetchedAccounts(data));
+          setAccountIds(data.map((a) => a.id));
+          setLoadingState('idle');
+          onSettled?.(value);
+        })
+        .catch(() => {
+          setLoadingState('error');
+          onSettled?.(value);
+        });
+    },
+    500,
+    { leading: true, trailing: true },
+  );
+
+  return {
+    searchAccounts,
+    accountIds,
+    isLoading: loadingState === 'loading',
+    isError: loadingState === 'error',
+  };
+}


### PR DESCRIPTION
Related to WEB-783

### Changes proposed in this PR:
- Refactors the account search from the list management page into a React hook (which I'll be able to re-use for Collections). There should be no functional changes.