### PR TITLE
Add `exclude_direct` flag to `/api/v1/accounts/:id/statuses` to exclude direct messages

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -45,7 +45,7 @@ module Mastodon
 
     def api_versions
       {
-        mastodon: 7,
+        mastodon: 8,
       }
     end
 


### PR DESCRIPTION
This adds a new `exclude_direct` parameter to `GET /api/v1/accounts/:id/statuses` to filter direct messages out server-side.

The underlying SQL query actually gets simpler and generally more efficient when set to `true`, so there is no performance concern.

Bumps the API version as this is a new parameter that can't be guessed ahead of time. However, maybe that is not necessary, since the server not implementing the parameter is not that disruptive: the client application just has to perform client-side filtering on the result.