### PR TITLE
Fix: Changes to pins update immediately

### DIFF
--- a/app/javascript/mastodon/actions/interactions.js
+++ b/app/javascript/mastodon/actions/interactions.js
@@ -6,6 +6,7 @@ import { fetchRelationships } from './accounts';
 import { importFetchedAccounts, importFetchedStatus } from './importer';
 import { unreblog, reblog } from './interactions_typed';
 import { openModal } from './modal';
+import { timelineExpandPinnedFromStatus } from './timelines_typed';
 
 export const REBLOGS_EXPAND_REQUEST = 'REBLOGS_EXPAND_REQUEST';
 export const REBLOGS_EXPAND_SUCCESS = 'REBLOGS_EXPAND_SUCCESS';
@@ -368,6 +369,7 @@ export function pin(status) {
     api().post(`/api/v1/statuses/${status.get('id')}/pin`).then(response => {
       dispatch(importFetchedStatus(response.data));
       dispatch(pinSuccess(status));
+      dispatch(timelineExpandPinnedFromStatus(status));
     }).catch(error => {
       dispatch(pinFail(status, error));
     });
@@ -406,6 +408,7 @@ export function unpin (status) {
     api().post(`/api/v1/statuses/${status.get('id')}/unpin`).then(response => {
       dispatch(importFetchedStatus(response.data));
       dispatch(unpinSuccess(status));
+      dispatch(timelineExpandPinnedFromStatus(status));
     }).catch(error => {
       dispatch(unpinFail(status, error));
     });

--- a/app/javascript/mastodon/actions/timelines.test.ts
+++ b/app/javascript/mastodon/actions/timelines.test.ts
@@ -57,4 +57,29 @@ describe('parseTimelineKey', () => {
       tagged: 'nature',
     });
   });
+
+  test('parses legacy account timeline key with pinned correctly', () => {
+    const params = parseTimelineKey('account:789:pinned:nature');
+    expect(params).toEqual({
+      type: 'account',
+      userId: '789',
+      replies: false,
+      boosts: false,
+      media: false,
+      pinned: true,
+      tagged: 'nature',
+    });
+  });
+
+  test('parses legacy account timeline key with media correctly', () => {
+    const params = parseTimelineKey('account:789:media');
+    expect(params).toEqual({
+      type: 'account',
+      userId: '789',
+      replies: false,
+      boosts: false,
+      media: true,
+      pinned: false,
+    });
+  });
 });

--- a/app/javascript/mastodon/actions/timelines_typed.ts
+++ b/app/javascript/mastodon/actions/timelines_typed.ts
@@ -178,9 +178,15 @@ export const timelineDelete = createAction<{
 }>('timelines/delete');
 
 export const timelineExpandPinnedFromStatus = createAppThunk(
-  (status: Status, { dispatch }) => {
+  (status: Status, { dispatch, getState }) => {
     const accountId = status.getIn(['account', 'id']) as string;
     if (!accountId) {
+      return;
+    }
+
+    // Verify that any of the relevant timelines are actually expanded before dispatching, to avoid unnecessary API calls.
+    const timelines = getState().timelines as ImmutableMap<string, unknown>;
+    if (!timelines.some((_, key) => key.startsWith(`account:${accountId}:`))) {
       return;
     }
 

--- a/app/javascript/mastodon/actions/timelines_typed.ts
+++ b/app/javascript/mastodon/actions/timelines_typed.ts
@@ -125,7 +125,24 @@ export function parseTimelineKey(key: string): TimelineParams | null {
       type: 'account',
       userId,
       tagged: segments[3],
+      pinned: false,
+      boosts: false,
+      replies: false,
+      media: false,
     };
+
+    // Handle legacy keys.
+    const flagsSegment = segments[2];
+    if (!flagsSegment || !/^[01]{4}$/.test(flagsSegment)) {
+      if (flagsSegment === 'pinned') {
+        parsed.pinned = true;
+      } else if (flagsSegment === 'with_replies') {
+        parsed.replies = true;
+      } else if (flagsSegment === 'media') {
+        parsed.media = true;
+      }
+      return parsed;
+    }
 
     const view = segments[2]?.split('') ?? [];
     for (let i = 0; i < view.length; i++) {
@@ -154,6 +171,11 @@ export function parseTimelineKey(key: string): TimelineParams | null {
   }
 
   return null;
+}
+
+export function isTimelineKeyPinned(key: string) {
+  const parsedKey = parseTimelineKey(key);
+  return parsedKey?.type === 'account' && parsedKey.pinned;
 }
 
 export function isNonStatusId(value: unknown) {

--- a/app/javascript/mastodon/actions/timelines_typed.ts
+++ b/app/javascript/mastodon/actions/timelines_typed.ts
@@ -223,8 +223,8 @@ export const timelineExpandPinnedFromStatus = createAppThunk(
 
     // Iterate over tags and clear those too.
     const tags = status.get('tags') as
-      | ImmutableList<ImmutableMap<'name', string>>
-      | undefined; // We only care about the tag name.
+      | ImmutableList<ImmutableMap<'name', string>> // We only care about the tag name.
+      | undefined;
     if (!tags) {
       return;
     }

--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -1,6 +1,5 @@
 import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrderedSet, fromJS } from 'immutable';
 
-import { timelineDelete, isNonStatusId } from 'mastodon/actions/timelines_typed';
 
 import {
   blockAccountSuccess,
@@ -21,6 +20,7 @@ import {
   TIMELINE_GAP,
   disconnectTimeline,
 } from '../actions/timelines';
+import { timelineDelete, isTimelineKeyPinned, isNonStatusId } from '../actions/timelines_typed';
 import { compareId } from '../compare_id';
 
 const initialState = ImmutableMap();
@@ -50,7 +50,7 @@ const expandNormalizedTimeline = (state, timeline, statuses, next, isPartial, is
 
     if (!next && !isLoadingRecent) mMap.set('hasMore', false);
 
-    if (timeline.includes(':pinned')) {
+    if (isTimelineKeyPinned(timeline)) {
       mMap.set('items', statuses.map(status => status.get('id')));
     } else if (!statuses.isEmpty()) {
       usePendingItems = isLoadingRecent && (usePendingItems || !mMap.get('pendingItems').isEmpty());

--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -50,7 +50,7 @@ const expandNormalizedTimeline = (state, timeline, statuses, next, isPartial, is
 
     if (!next && !isLoadingRecent) mMap.set('hasMore', false);
 
-    if (timeline.endsWith(':pinned')) {
+    if (timeline.includes(':pinned')) {
       mMap.set('items', statuses.map(status => status.get('id')));
     } else if (!statuses.isEmpty()) {
       usePendingItems = isLoadingRecent && (usePendingItems || !mMap.get('pendingItems').isEmpty());


### PR DESCRIPTION
This adds some logic to reload account timelines on pinning or unpinning a post, so they are updated immediately instead of requiring a page refresh or navigation to be updated.

Also this makes the timeline key parser handle legacy keys, so old logic can handle both new and old formats as needed.

Edit: added backport label as this is fixing a bug, but all the new timeline key logic may make that difficult.