### PR TITLE
Remove unneeded rescue from DOB Validator

### DIFF
--- a/app/validators/date_of_birth_validator.rb
+++ b/app/validators/date_of_birth_validator.rb
@@ -3,8 +3,6 @@
 class DateOfBirthValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     record.errors.add(attribute, :below_limit) if value.present? && value.to_date > min_age.ago
-  rescue Date::Error
-    record.errors.add(attribute, :invalid)
   end
 
   private

--- a/spec/validators/date_of_birth_validator_spec.rb
+++ b/spec/validators/date_of_birth_validator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DateOfBirthValidator do
   context 'with an invalid date' do
     let(:invalid_date) { '76.830.10' }
 
-    it { is_expected.to_not allow_values(invalid_date).for(:date_of_birth) }
+    it { is_expected.to_not allow_values(invalid_date).for(:date_of_birth).with_message(:blank) }
   end
 
   context 'with a date below the age limit' do


### PR DESCRIPTION
I did not realize this when doing https://github.com/mastodon/mastodon/pull/36039 but did during https://github.com/mastodon/mastodon/pull/37631

With this as a date attribute, this rescue will never be reached and isnt needed now ... invalid dates will get caught during assignment and blanked out, and then the presence validation in the model will handle.

Preserved/updated spec to make sure we keep the behavior.