### PR TITLE
Add a i18n check in pre-commit for JS files

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -5,6 +5,10 @@ const config = {
   '*.{css,scss}': 'stylelint --fix',
   '*.haml': 'bin/haml-lint -a',
   '**/*.ts?(x)': () => 'tsc -p tsconfig.json --noEmit',
+  'app/javascript/**/*.{js,jsx,ts,tsx}': () => [
+    `yarn i18n:extract`,
+    'git diff --exit-code app/javascript/mastodon/locales/en.json',
+  ],
 };
 
 module.exports = config;


### PR DESCRIPTION
If a JS file is changed, run `yarn i18n:extract` and check there is no diff.

If there is a change here, it means the author forgot to extract i18n strings after their code changes and avoid having to commit and push again when this is caught on CI.

On my machine, it runs faster than `eslint` or `tsc` during the pre-commit, so it does not slow things down compared to the current situation as they are all ran in parallel.

Alternatively, we could also automatically fix this and have `lint-staged` add the locales file to the commit, avoiding the need for the developer to run the command manually, but it might make it less obvious that something changed the source locale.

It looks like this:

```
❯ yarn lint-staged --continue-on-error
✔ Backed up original state in git stash (4190b1bdbf)
✔ Running tasks for staged files...
↓ Skipped because of errors from tasks.
✔ Reverting to original state because of errors...
✔ Cleaning up temporary files...

✖ git diff --exit-code app/javascript/mastodon/locales/en.json:
diff --git a/app/javascript/mastodon/locales/en.json b/app/javascript/mastodon/locales/en.json
index a646d479d7..2777610b23 100644
--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -45,7 +45,7 @@
   "account.featured": "Featured",
   "account.featured.accounts": "Profiles",
   "account.featured.hashtags": "Hashtags",
-  "account.featured_tags.last_status_at": "Last post on {date}",
+  "account.featured_tags.last_status_at2": "Last post on {date}",
   "account.featured_tags.last_status_never": "No posts",
   "account.fields.scroll_next": "Show next",
   "account.fields.scroll_prev": "Show previous",
```
