### PR TITLE
Upgrade `rubocop` from `v1.84.0` to `v1.84.2`, update config, and correct offences

### DIFF
--- a/.rubocop/layout.yml
+++ b/.rubocop/layout.yml
@@ -4,3 +4,6 @@ Layout/FirstHashElementIndentation:
 
 Layout/LineLength:
   Max: 300 # Default of 120 causes a duplicate entry in generated todo file
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -755,7 +755,7 @@ GEM
       rspec-mocks (~> 3.0)
       sidekiq (>= 5, < 9)
     rspec-support (3.13.7)
-    rubocop (1.84.0)
+    rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)

--- a/app/chewy/public_statuses_index.rb
+++ b/app/chewy/public_statuses_index.rb
@@ -53,9 +53,9 @@ class PublicStatusesIndex < Chewy::Index
   }
 
   index_scope ::Status.unscoped
-                      .kept
-                      .indexable
-                      .includes(:media_attachments, :preloadable_poll, :tags, preview_cards_status: :preview_card)
+    .kept
+    .indexable
+    .includes(:media_attachments, :preloadable_poll, :tags, preview_cards_status: :preview_card)
 
   root date_detection: false do
     field(:id, type: 'long')

--- a/app/controllers/admin/fasp/debug/callbacks_controller.rb
+++ b/app/controllers/admin/fasp/debug/callbacks_controller.rb
@@ -5,8 +5,8 @@ class Admin::Fasp::Debug::CallbacksController < Admin::BaseController
     authorize [:admin, :fasp, :provider], :update?
 
     @callbacks = Fasp::DebugCallback
-                 .includes(:fasp_provider)
-                 .order(created_at: :desc)
+      .includes(:fasp_provider)
+      .order(created_at: :desc)
   end
 
   def destroy

--- a/app/controllers/api/v1/blocks_controller.rb
+++ b/app/controllers/api/v1/blocks_controller.rb
@@ -18,14 +18,14 @@ class Api::V1::BlocksController < Api::BaseController
 
   def paginated_blocks
     @paginated_blocks ||= Block.eager_load(target_account: [:account_stat, :user])
-                               .joins(:target_account)
-                               .merge(Account.without_suspended)
-                               .where(account: current_account)
-                               .paginate_by_max_id(
-                                 limit_param(DEFAULT_ACCOUNTS_LIMIT),
-                                 params[:max_id],
-                                 params[:since_id]
-                               )
+      .joins(:target_account)
+      .merge(Account.without_suspended)
+      .where(account: current_account)
+      .paginate_by_max_id(
+        limit_param(DEFAULT_ACCOUNTS_LIMIT),
+        params[:max_id],
+        params[:since_id]
+      )
   end
 
   def next_path

--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -37,20 +37,20 @@ class Api::V1::ConversationsController < Api::BaseController
 
   def paginated_conversations
     AccountConversation.where(account: current_account)
-                       .includes(
-                         account: [:account_stat, user: :role],
-                         last_status: [
-                           :media_attachments,
-                           :status_stat,
-                           :tags,
-                           {
-                             preview_cards_status: { preview_card: { author_account: [:account_stat, user: :role] } },
-                             active_mentions: :account,
-                             account: [:account_stat, user: :role],
-                           },
-                         ]
-                       )
-                       .to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
+      .includes(
+        account: [:account_stat, user: :role],
+        last_status: [
+          :media_attachments,
+          :status_stat,
+          :tags,
+          {
+            preview_cards_status: { preview_card: { author_account: [:account_stat, user: :role] } },
+            active_mentions: :account,
+            account: [:account_stat, user: :role],
+          },
+        ]
+      )
+      .to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
   end
 
   def next_path

--- a/app/controllers/api/v1/mutes_controller.rb
+++ b/app/controllers/api/v1/mutes_controller.rb
@@ -18,14 +18,14 @@ class Api::V1::MutesController < Api::BaseController
 
   def paginated_mutes
     @paginated_mutes ||= Mute.eager_load(target_account: [:account_stat, :user])
-                             .joins(:target_account)
-                             .merge(Account.without_suspended)
-                             .where(account: current_account)
-                             .paginate_by_max_id(
-                               limit_param(DEFAULT_ACCOUNTS_LIMIT),
-                               params[:max_id],
-                               params[:since_id]
-                             )
+      .joins(:target_account)
+      .merge(Account.without_suspended)
+      .where(account: current_account)
+      .paginate_by_max_id(
+        limit_param(DEFAULT_ACCOUNTS_LIMIT),
+        params[:max_id],
+        params[:since_id]
+      )
   end
 
   def next_path

--- a/app/controllers/api/v1_alpha/collections_controller.rb
+++ b/app/controllers/api/v1_alpha/collections_controller.rb
@@ -72,10 +72,10 @@ class Api::V1Alpha::CollectionsController < Api::BaseController
 
   def set_collections
     @collections = @account.collections
-                           .with_tag
-                           .order(created_at: :desc)
-                           .offset(offset_param)
-                           .limit(limit_param(DEFAULT_COLLECTIONS_LIMIT))
+      .with_tag
+      .order(created_at: :desc)
+      .offset(offset_param)
+      .limit(limit_param(DEFAULT_COLLECTIONS_LIMIT))
     @collections = @collections.discoverable unless @account == current_account
   end
 

--- a/app/lib/fasp/request.rb
+++ b/app/lib/fasp/request.rb
@@ -27,9 +27,9 @@ class Fasp::Request
     headers = request_headers(verb, url, body)
     key = Linzer.new_ed25519_key(@provider.server_private_key_pem, @provider.remote_identifier)
     response = HTTP
-               .headers(headers)
-               .use(http_signature: { key:, covered_components: COVERED_COMPONENTS })
-               .send(verb, url, body:)
+      .headers(headers)
+      .use(http_signature: { key:, covered_components: COVERED_COMPONENTS })
+      .send(verb, url, body:)
 
     validate!(response)
     @provider.delivery_failure_tracker.track_success!

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -214,10 +214,10 @@ class FeedManager
     # This is a bit tricky because we need posts tagged with this hashtag that are not
     # also tagged with another followed hashtag or from a followed user
     scope = from_tag.statuses
-                    .where(id: timeline_status_ids)
-                    .where.not(account: into_account)
-                    .where.not(account: into_account.following)
-                    .tagged_with_none(TagFollow.where(account: into_account).pluck(:tag_id))
+      .where(id: timeline_status_ids)
+      .where.not(account: into_account)
+      .where.not(account: into_account.following)
+      .tagged_with_none(TagFollow.where(account: into_account).pluck(:tag_id))
 
     scope.select(:id, :reblog_of_id).reorder(nil).find_each do |status|
       remove_from_feed(:home, into_account.id, status, aggregate_reblogs: into_account.user&.aggregates_reblogs?)

--- a/app/lib/vacuum/statuses_vacuum.rb
+++ b/app/lib/vacuum/statuses_vacuum.rb
@@ -18,8 +18,8 @@ class Vacuum::StatusesVacuum
       # Side-effects not covered by foreign keys, such
       # as the search index, must be handled first.
       statuses.direct_visibility
-              .includes(mentions: :account)
-              .find_each(&:unlink_from_conversations!)
+        .includes(mentions: :account)
+        .find_each(&:unlink_from_conversations!)
       if Chewy.enabled?
         remove_from_index(statuses.ids, 'chewy:queue:StatusesIndex')
         remove_from_index(statuses.ids, 'chewy:queue:PublicStatusesIndex')
@@ -33,8 +33,8 @@ class Vacuum::StatusesVacuum
 
   def statuses_scope
     Status.unscoped.kept
-          .joins(:account).merge(Account.remote)
-          .where(statuses: { id: ...retention_period_as_id })
+      .joins(:account).merge(Account.remote)
+      .where(statuses: { id: ...retention_period_as_id })
   end
 
   def retention_period_as_id

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -45,7 +45,7 @@ module Account::Interactions
 
   def follow!(other_account, reblogs: nil, notify: nil, languages: nil, uri: nil, rate_limit: false, bypass_limit: false)
     rel = active_relationships.create_with(show_reblogs: reblogs.nil? || reblogs, notify: notify.nil? ? false : notify, languages: languages, uri: uri, rate_limit: rate_limit, bypass_follow_limit: bypass_limit)
-                              .find_or_create_by!(target_account: other_account)
+      .find_or_create_by!(target_account: other_account)
 
     rel.show_reblogs = reblogs   unless reblogs.nil?
     rel.notify       = notify    unless notify.nil?
@@ -58,7 +58,7 @@ module Account::Interactions
 
   def request_follow!(other_account, reblogs: nil, notify: nil, languages: nil, uri: nil, rate_limit: false, bypass_limit: false)
     rel = follow_requests.create_with(show_reblogs: reblogs.nil? || reblogs, notify: notify.nil? ? false : notify, uri: uri, languages: languages, rate_limit: rate_limit, bypass_follow_limit: bypass_limit)
-                         .find_or_create_by!(target_account: other_account)
+      .find_or_create_by!(target_account: other_account)
 
     rel.show_reblogs = reblogs   unless reblogs.nil?
     rel.notify       = notify    unless notify.nil?
@@ -71,7 +71,7 @@ module Account::Interactions
 
   def block!(other_account, uri: nil)
     block_relationships.create_with(uri: uri)
-                       .find_or_create_by!(target_account: other_account)
+      .find_or_create_by!(target_account: other_account)
   end
 
   def mute!(other_account, notifications: nil, duration: 0)
@@ -215,14 +215,14 @@ module Account::Interactions
 
   def followers_for_local_distribution
     followers.local
-             .joins(:user)
-             .merge(User.signed_in_recently)
+      .joins(:user)
+      .merge(User.signed_in_recently)
   end
 
   def lists_for_local_distribution
     scope = lists.joins(account: :user)
     scope.where.not(list_accounts: { follow_id: nil }).or(scope.where(account_id: id))
-         .merge(User.signed_in_recently)
+      .merge(User.signed_in_recently)
   end
 
   def remote_followers_hash(url)

--- a/app/models/concerns/fasp/provider/debug_concern.rb
+++ b/app/models/concerns/fasp/provider/debug_concern.rb
@@ -5,6 +5,6 @@ module Fasp::Provider::DebugConcern
 
   def perform_debug_call
     Fasp::Request.new(self)
-                 .post('/debug/v0/callback/logs', body: { hello: 'world' })
+      .post('/debug/v0/callback/logs', body: { hello: 'world' })
   end
 end

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -216,11 +216,11 @@ class MediaAttachment < ApplicationRecord
   scope :updated_before, ->(value) { where(arel_table[:updated_at].lt(value)) }
   scope :without_local_interaction, lambda {
     where.not(Favourite.joins(:account).merge(Account.local).where(Favourite.arel_table[:status_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
-         .where.not(Bookmark.where(Bookmark.arel_table[:status_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
-         .where.not(Status.local.where(Status.arel_table[:in_reply_to_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
-         .where.not(Status.local.where(Status.arel_table[:reblog_of_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
-         .where.not(Quote.joins(:status).merge(Status.local).where(Quote.arel_table[:quoted_status_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
-         .where.not(Quote.joins(:quoted_status).merge(Status.local).where(Quote.arel_table[:status_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
+      .where.not(Bookmark.where(Bookmark.arel_table[:status_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
+      .where.not(Status.local.where(Status.arel_table[:in_reply_to_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
+      .where.not(Status.local.where(Status.arel_table[:reblog_of_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
+      .where.not(Quote.joins(:status).merge(Status.local).where(Quote.arel_table[:quoted_status_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
+      .where.not(Quote.joins(:quoted_status).merge(Status.local).where(Quote.arel_table[:status_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
   }
 
   attr_accessor :skip_download

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -135,8 +135,8 @@ class Tag < ApplicationRecord
       query = query.merge(matching_name(stripped_term).or(reviewed)) if options[:exclude_unreviewed]
 
       query.order(Arel.sql('LENGTH(name)').asc, name: :asc)
-           .limit(limit)
-           .offset(offset)
+        .limit(limit)
+        .offset(offset)
     end
 
     def find_normalized(name)

--- a/app/models/trends/preview_card_filter.rb
+++ b/app/models/trends/preview_card_filter.rb
@@ -30,9 +30,9 @@ class Trends::PreviewCardFilter
 
   def initial_scope
     PreviewCard.select(PreviewCard.arel_table[Arel.star])
-               .joins(:trend)
-               .eager_load(:trend)
-               .reorder(score: :desc)
+      .joins(:trend)
+      .eager_load(:trend)
+      .reorder(score: :desc)
   end
 
   def scope_for(key, value)

--- a/app/models/trends/status_filter.rb
+++ b/app/models/trends/status_filter.rb
@@ -30,9 +30,9 @@ class Trends::StatusFilter
 
   def initial_scope
     Status.select(Status.arel_table[Arel.star])
-          .joins(:trend)
-          .eager_load(:trend)
-          .reorder(score: :desc)
+      .joins(:trend)
+      .eager_load(:trend)
+      .reorder(score: :desc)
   end
 
   def scope_for(key, value)

--- a/app/models/trends/tag_filter.rb
+++ b/app/models/trends/tag_filter.rb
@@ -30,9 +30,9 @@ class Trends::TagFilter
 
   def initial_scope
     Tag.select(Tag.arel_table[Arel.star])
-       .joins(:trend)
-       .eager_load(:trend)
-       .reorder(score: :desc)
+      .joins(:trend)
+      .eager_load(:trend)
+      .reorder(score: :desc)
   end
 
   def scope_for(key, value)

--- a/app/services/activitypub/fetch_all_replies_service.rb
+++ b/app/services/activitypub/fetch_all_replies_service.rb
@@ -33,10 +33,10 @@ class ActivityPub::FetchAllRepliesService < ActivityPub::FetchRepliesService
     parent_id = Status.where(uri: @status_uri).pick(:id)
     unless parent_id.nil?
       unsubscribed_replies = Status
-                             .where.not(uri: uris)
-                             .where(in_reply_to_id: parent_id)
-                             .unsubscribed
-                             .pluck(:uri)
+        .where.not(uri: uris)
+        .where(in_reply_to_id: parent_id)
+        .unsubscribed
+        .pluck(:uri)
       uris.concat(unsubscribed_replies)
     end
 

--- a/app/workers/activitypub/post_upgrade_worker.rb
+++ b/app/workers/activitypub/post_upgrade_worker.rb
@@ -7,9 +7,9 @@ class ActivityPub::PostUpgradeWorker
 
   def perform(domain)
     Account.where(domain: domain)
-           .where(protocol: :ostatus)
-           .where.not(last_webfingered_at: nil)
-           .in_batches
-           .update_all(last_webfingered_at: nil)
+      .where(protocol: :ostatus)
+      .where.not(last_webfingered_at: nil)
+      .in_batches
+      .update_all(last_webfingered_at: nil)
   end
 end

--- a/db/post_migrate/20190927124642_remove_invalid_web_push_subscription.rb
+++ b/db/post_migrate/20190927124642_remove_invalid_web_push_subscription.rb
@@ -5,9 +5,9 @@ class RemoveInvalidWebPushSubscription < ActiveRecord::Migration[5.2]
 
   def up
     invalid_web_push_subscriptions = Web::PushSubscription.where(endpoint: '')
-                                                          .or(Web::PushSubscription.where(key_p256dh: ''))
-                                                          .or(Web::PushSubscription.where(key_auth: ''))
-                                                          .preload(:session_activation)
+      .or(Web::PushSubscription.where(key_p256dh: ''))
+      .or(Web::PushSubscription.where(key_auth: ''))
+      .preload(:session_activation)
     invalid_web_push_subscriptions.find_each do |web_push_subscription|
       web_push_subscription.session_activation&.update!(web_push_subscription_id: nil)
       web_push_subscription.destroy!

--- a/lib/mastodon/redis_configuration.rb
+++ b/lib/mastodon/redis_configuration.rb
@@ -17,15 +17,15 @@ class Mastodon::RedisConfiguration
 
   def cache
     @cache ||= setup_config(prefix: 'CACHE_')
-               .merge({
-                 namespace: 'cache',
-                 expires_in: 10.minutes,
-                 connect_timeout: 5,
-                 pool: {
-                   size: Sidekiq.server? ? Sidekiq.default_configuration[:concurrency] : Integer(ENV['MAX_THREADS'] || 5),
-                   timeout: 5,
-                 },
-               })
+      .merge({
+        namespace: 'cache',
+        expires_in: 10.minutes,
+        connect_timeout: 5,
+        pool: {
+          size: Sidekiq.server? ? Sidekiq.default_configuration[:concurrency] : Integer(ENV['MAX_THREADS'] || 5),
+          timeout: 5,
+        },
+      })
   end
 
   private

--- a/lib/paperclip/attachment_extensions.rb
+++ b/lib/paperclip/attachment_extensions.rb
@@ -24,7 +24,7 @@ module Paperclip
 
       unadapted_file = @queued_for_write[name]
       @queued_for_write[name] = Paperclip.io_adapters
-                                         .for(@queued_for_write[name], @options[:adapter_options])
+        .for(@queued_for_write[name], @options[:adapter_options])
       unadapted_file.close if unadapted_file.respond_to?(:close)
       @queued_for_write[name]
     rescue Paperclip::Errors::NotIdentifiedByImageMagickError => e

--- a/lib/paperclip/color_extractor.rb
+++ b/lib/paperclip/color_extractor.rb
@@ -221,10 +221,10 @@ module Paperclip
       total_frequencies = frequencies.sum.to_f
 
       frequencies.map.with_index { |f, i| [f / total_frequencies, hex_values[i]] }
-                 .sort_by { |r| -r[0] }
-                 .reject { |r| r[1].size == 8 && r[1].end_with?('00') }
-                 .map { |r| ColorDiff::Color::RGB.new(*r[1][0..5].scan(/../).map { |c| c.to_i(16) }) }
-                 .slice(0, quantity)
+        .sort_by { |r| -r[0] }
+        .reject { |r| r[1].size == 8 && r[1].end_with?('00') }
+        .map { |r| ColorDiff::Color::RGB.new(*r[1][0..5].scan(/../).map { |c| c.to_i(16) }) }
+        .slice(0, quantity)
     end
 
     def rgb_to_hex(rgb)

--- a/spec/controllers/settings/two_factor_authentication/otp_authentication_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/otp_authentication_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Settings::TwoFactorAuthentication::OtpAuthenticationController do
             expect do
               post :create, session: { challenge_passed_at: Time.now.utc }
             end.to not_change { user.reload.otp_secret }
-               .and(change { session[:new_otp_secret] })
+              .and(change { session[:new_otp_secret] })
 
             expect(response).to redirect_to(new_settings_two_factor_authentication_confirmation_path)
           end
@@ -80,7 +80,7 @@ RSpec.describe Settings::TwoFactorAuthentication::OtpAuthenticationController do
             expect do
               post :create, session: { challenge_passed_at: Time.now.utc }
             end.to not_change { user.reload.otp_secret }
-               .and(change { session[:new_otp_secret] })
+              .and(change { session[:new_otp_secret] })
 
             expect(response).to redirect_to(new_settings_two_factor_authentication_confirmation_path)
           end

--- a/spec/controllers/settings/two_factor_authentication/webauthn_credentials_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/webauthn_credentials_controller_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe Settings::TwoFactorAuthentication::WebauthnCredentialsController 
             expect do
               post :create, params: { credential: new_webauthn_credential, nickname: nickname }
             end.to change { user.webauthn_credentials.count }.by(1)
-                                                             .and not_change(user, :webauthn_id)
+              .and not_change(user, :webauthn_id)
 
             expect(response).to have_http_status(200)
           end

--- a/spec/requests/activitypub/outboxes_spec.rb
+++ b/spec/requests/activitypub/outboxes_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe 'ActivityPub Outboxes' do
           expect(response.parsed_body)
             .to include(
               orderedItems: be_an(Array)
-              .and(have_attributes(size: 2))
-              .and(all(satisfy { |item| targets_public_collection?(item) }))
+                .and(have_attributes(size: 2))
+                .and(all(satisfy { |item| targets_public_collection?(item) }))
             )
         end
 
@@ -133,8 +133,8 @@ RSpec.describe 'ActivityPub Outboxes' do
           expect(response.parsed_body)
             .to include(
               orderedItems: be_an(Array)
-              .and(have_attributes(size: 2))
-              .and(all(satisfy { |item| targets_public_collection?(item) }))
+                .and(have_attributes(size: 2))
+                .and(all(satisfy { |item| targets_public_collection?(item) }))
             )
         end
       end
@@ -155,8 +155,8 @@ RSpec.describe 'ActivityPub Outboxes' do
           expect(response.parsed_body)
             .to include(
               orderedItems: be_an(Array)
-              .and(have_attributes(size: 3))
-              .and(all(satisfy { |item| targets_public_collection?(item) || targets_followers_collection?(item, account) }))
+                .and(have_attributes(size: 3))
+                .and(all(satisfy { |item| targets_public_collection?(item) || targets_followers_collection?(item, account) }))
             )
         end
       end

--- a/spec/requests/activitypub/replies_spec.rb
+++ b/spec/requests/activitypub/replies_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe 'ActivityPub Replies' do
               first: be_a(Hash).and(
                 include(
                   items: be_an(Array)
-                  .and(have_attributes(size: 1))
-                  .and(all(satisfy { |item| targets_public_collection?(item) }))
+                    .and(have_attributes(size: 1))
+                    .and(all(satisfy { |item| targets_public_collection?(item) }))
                 )
               )
             )

--- a/spec/services/bulk_import_service_spec.rb
+++ b/spec/services/bulk_import_service_spec.rb
@@ -343,10 +343,10 @@ RSpec.describe BulkImportService do
         .and_return(resolve_account_service_double)
       allow(resolve_account_service_double)
         .to receive(:call)
-        .with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
+          .with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
       allow(resolve_account_service_double)
         .to receive(:call)
-        .with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+          .with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
 
       Import::RowWorker.drain
     end

--- a/spec/system/admin/software_updates_spec.rb
+++ b/spec/system/admin/software_updates_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'finding software updates through the admin interface' do
     expect(page).to have_title(I18n.t('admin.software_updates.title'))
 
     expect(page).to have_content('99.99.99')
-                .and have_no_content('3.5.0')
+      .and have_no_content('3.5.0')
 
     click_on I18n.t('admin.software_updates.release_notes')
     expect(page).to have_current_path('https://github.com/mastodon/mastodon/releases/v99', url: true)


### PR DESCRIPTION
Upgrade `rubocop` gem from `v1.84.0` to `v1.84.2`, update `Layout` RuboCop config, and correct offences.

References
- [v1.84.1 changelog](https://github.com/rubocop/rubocop/blob/c6dd89458ca6cb12d4fb2a927f2c842f031cdfef/CHANGELOG.md#1841-2026-02-02)
- [v1.84.2 changelog](https://github.com/rubocop/rubocop/blob/e5241441f82dba17bc5ddae6c4d6fe0d58dbf38d/CHANGELOG.md#1842-2026-02-12)
- [Layout/IndentationWidth](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/IndentationWidth)
- [Layout/MultilineMethodCallIndentation cop](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineMethodCallIndentation)

Supersedes https://github.com/mastodon/mastodon/pull/37710