### PR TITLE
Fix i18n check for missing source strings

### DIFF
--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -42,8 +42,7 @@ jobs:
 
       - name: Check for missing strings in English YML
         run: |
-          bin/i18n-tasks add-missing -l en
-          git diff --exit-code
+          bin/i18n-tasks missing -t used -l en
 
       - name: Check for wrong string interpolations
         run: bin/i18n-tasks check-consistent-interpolations


### PR DESCRIPTION
The previous check also looked at keys present in other locales and absent from `en`.

This check only looks at used strings.

This allows removing strings from the source strings without touching all the translations, which will get updated at the next Crowdin merge, reducing noise and opportunity for merge conflicts.