### PR TITLE
Adds experiments doc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ charset = utf-8
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
+
+[*.md]
+# Markdown uses trailing whitespace for line breaks.
+trim_trailing_whitespace = false

--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -27,7 +27,7 @@ Status: Active development
 
 ## Client Flags
 
-Client flags are for incomplete features in the web UI, and are enabled via inputting `localStorage.experiments = 'xyz'`. Multiple flags are separated by a comma.
+Client flags are for incomplete features in the web UI, and are enabled by entering `localStorage.experiments = 'xyz'` in the browser developer console. Multiple flags are separated by a comma.
 
 ### Collections
 

--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -1,0 +1,42 @@
+# Experiments
+
+Here are some of the current features under development or otherwise not quite ready for release.
+
+**Important:** All features here are considered incomplete and are not supported for production servers, and may cause bugs or corruption of data. **Enable these at your own risk!**
+
+As these are incomplete features, all bug reports around these flags will be closed without comment unless we specifically note otherwise below.
+
+## Server Flags
+
+Server-side flags are enabled via the `EXPERIMENTAL_FEATURES` environment variable. Multiple flags are separated by a comma.
+
+### FASP
+
+Name: `fasp`  
+Status: Beta testing
+
+### Collections
+
+Name: `collections`  
+Status: Active development
+
+### Collections Federation
+
+Name: `collections_federation`  
+Status: Active development
+
+## Client Flags
+
+Client flags are for incomplete features in the web UI, and are enabled via inputting `localStorage.experiments = 'xyz'`. Multiple flags are separated by a comma.
+
+### Collections
+
+Name: `collections`  
+Status: Active development
+
+### Profile Redesign
+
+Name: `profile_redesign`  
+Status: Active development
+
+This is a redesign of the web UI for viewing accounts.


### PR DESCRIPTION
Starts a document to track experimental flags so server administrators know the effects and what sort of feedback we're looking for.