### PR TITLE
Use separate rules with same `groupName` for playwright updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -154,9 +154,15 @@
       groupName: 'opentelemetry-ruby (non-major)',
     },
     {
-      // Group Playwright Ruby & JS deps in the same PR, as they need to be in sync
-      matchManagers: ['bundler', 'npm'],
-      matchPackageNames: ['playwright-ruby-client', 'playwright'],
+      // The ruby portion of the Playwright group
+      matchManagers: ['bundler'],
+      matchPackageNames: ['playwright-ruby-client'],
+      groupName: 'Playwright',
+    },
+    {
+      // The node portion of the Playwright group
+      matchManagers: ['npm'],
+      matchPackageNames: ['playwright'],
       groupName: 'Playwright',
     },
     // Add labels depending on package manager


### PR DESCRIPTION
Background - https://github.com/mastodon/mastodon/pull/36608

This is sort of a guess as to what might be needed (create per-ecosystem manager<>package groups, unite them with same group name), based on reading the renovate docs. Specifically, the Multiple Conditions section - https://docs.mend.io/wsk/renovate-package-rules-guide#RenovatePackageRulesGuide-MultipleConditions - which claims:

> When multiple matching criteria are present in the same rule, they are combined with AND logic

If that means "these packages must all exist in every manager and at least one needs an update" ... I could see that being the thing that blocks this from updating? (ie, there is not an npm package named `playwright-ruby-client`)

On the other hand, we did have one PR succeed with this same exact rule. Could be renovate flakiness? Could be change in how renovate works? Really not sure, sort of a stab here.

We could merge this and see if it triggers update (both packages have new version now). Or we can keep periodically bumping by hand and see if/when renovate does it again? Open to other ideas