### PR TITLE
Typo in PrepareFollowersSynchronizationService

### DIFF
--- a/app/services/activitypub/prepare_followers_synchronization_service.rb
+++ b/app/services/activitypub/prepare_followers_synchronization_service.rb
@@ -6,7 +6,7 @@ class ActivityPub::PrepareFollowersSynchronizationService < BaseService
   def call(account, params)
     @account = account
 
-    return if params['collectionId'] != @account.followers_url || non_matching_uri_hosts?(@account.uri, params['url']) || @account.local_followers_hash == params['digest']
+    return if params['digest'].blank? || params['collectionId'] != @account.followers_url || non_matching_uri_hosts?(@account.uri, params['url']) || @account.local_followers_hash == params['digest']
 
     ActivityPub::FollowersSynchronizationWorker.perform_async(@account.id, params['url'], params['digest'])
   end

--- a/app/services/activitypub/synchronize_followers_service.rb
+++ b/app/services/activitypub/synchronize_followers_service.rb
@@ -14,7 +14,7 @@ class ActivityPub::SynchronizeFollowersService < BaseService
     return unless process_collection!(partial_collection_url)
 
     # Only remove followers if the digests match, as it is a destructive operation
-    remove_unexpected_local_followers! if expected_digest.blank? || @digest == "\x00" * 32
+    remove_unexpected_local_followers! if expected_digest.present? && @digest == "\x00" * 32
   end
 
   private


### PR DESCRIPTION
```
    # Only remove followers if the digests match, as it is a destructive operation
    remove_unexpected_local_followers! if expected_digest.blank? || @digest == "\x00" * 32
```

Comment is "if the digests match", but the check is blank?.