### PR TITLE
Process actor public keys when they are in a separate document without the ActivityStreams context

### DIFF
--- a/app/helpers/json_ld_helper.rb
+++ b/app/helpers/json_ld_helper.rb
@@ -70,6 +70,10 @@ module JsonLdHelper
     !json.nil? && equals_or_includes?(json['@context'], ActivityPub::TagManager::CONTEXT)
   end
 
+  def supported_security_context?(json)
+    !json.nil? && equals_or_includes?(json['@context'], 'https://w3id.org/security/v1')
+  end
+
   def unsupported_uri_scheme?(uri)
     uri.nil? || !uri.start_with?('http://', 'https://')
   end

--- a/app/services/activitypub/fetch_remote_key_service.rb
+++ b/app/services/activitypub/fetch_remote_key_service.rb
@@ -12,7 +12,7 @@ class ActivityPub::FetchRemoteKeyService < BaseService
     @json = fetch_resource(uri, false)
 
     raise Error, "Unable to fetch key JSON at #{uri}" if @json.nil?
-    raise Error, "Unsupported JSON-LD context for document #{uri}" unless supported_context?(@json)
+    raise Error, "Unsupported JSON-LD context for document #{uri}" unless supported_context?(@json) || (supported_security_context?(@json) && @json['owner'].present? && !actor_type?)
     raise Error, "Unexpected object type for key #{uri}" unless expected_type?
     return find_actor(@json['id'], @json, suppress_errors) if actor_type?
 

--- a/spec/services/activitypub/fetch_remote_key_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_key_service_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ActivityPub::FetchRemoteKeyService do
       let(:public_key_id) { 'https://example.com/alice-public-key.json' }
 
       before do
-        stub_request(:get, public_key_id).to_return(body: Oj.dump(key_json.merge({ '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'] })), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, public_key_id).to_return(body: Oj.dump(key_json.merge({ '@context': ['https://w3id.org/security/v1'] })), headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it 'returns the expected account' do


### PR DESCRIPTION
When the key is a separate document, it does not need any of the ActivityStreams vocabulary.