### PR TITLE
Update doorkeeper i18n for invalid code challenge method

### DIFF
--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -84,10 +84,9 @@ en:
         credential_flow_not_configured: Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.
         invalid_client: Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.
         invalid_code_challenge_method:
-          zero: 'The authorization server does not support PKCE as there are no accepted code_challenge_method values.'
-          one: 'The code_challenge_method must be %{challenge_methods}.'
-          other: 'The code_challenge_method must be one of %{challenge_methods}.'
-
+          one: The code_challenge_method must be %{challenge_methods}.
+          other: The code_challenge_method must be one of %{challenge_methods}.
+          zero: The authorization server does not support PKCE as there are no accepted code_challenge_method values.
         invalid_grant: The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.
         invalid_redirect_uri: The redirect uri included is not valid.
         invalid_request:

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -83,7 +83,11 @@ en:
         access_denied: The resource owner or authorization server denied the request.
         credential_flow_not_configured: Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.
         invalid_client: Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.
-        invalid_code_challenge_method: The code challenge method must be S256, plain is unsupported.
+        invalid_code_challenge_method:
+          zero: 'The authorization server does not support PKCE as there are no accepted code_challenge_method values.'
+          one: 'The code_challenge_method must be %{challenge_methods}.'
+          other: 'The code_challenge_method must be one of %{challenge_methods}.'
+
         invalid_grant: The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.
         invalid_redirect_uri: The redirect uri included is not valid.
         invalid_request:

--- a/spec/system/oauth_spec.rb
+++ b/spec/system/oauth_spec.rb
@@ -98,27 +98,26 @@ RSpec.describe 'Using OAuth from an external app' do
       context 'when using plain code challenge method' do
         let(:pkce_code_challenge_method) { 'plain' }
 
-        it 'does not include the PKCE values in the response' do
+        it 'shows an error message and does not include the PKCE values or authorize button' do
           subject
 
-          expect(page).to have_no_css('.oauth-prompt input[name=code_challenge]')
-          expect(page).to have_no_css('.oauth-prompt input[name=code_challenge_method]')
-        end
-
-        it 'does not include the authorize button' do
-          subject
-
-          expect(page).to have_no_css('.oauth-prompt button[type="submit"]')
-        end
-
-        it 'includes an error message' do
-          subject
+          expect(page)
+            .to have_no_css('.oauth-prompt input[name=code_challenge]')
+            .and have_no_css('.oauth-prompt input[name=code_challenge_method]')
+            .and have_no_css('.oauth-prompt button[type="submit"]')
 
           within '.form-container .flash-message' do
-            # FIXME: Replace with doorkeeper.errors.messages.invalid_code_challenge_method.one for Doorkeeper > 5.8.0
-            # see: https://github.com/doorkeeper-gem/doorkeeper/pull/1747
-            expect(page).to have_content(I18n.t('doorkeeper.errors.messages.invalid_code_challenge_method'))
+            expect(page)
+              .to have_content(doorkeeper_invalid_code_message)
           end
+        end
+
+        def doorkeeper_invalid_code_message
+          I18n.t(
+            'doorkeeper.errors.messages.invalid_code_challenge_method',
+            challenge_methods: Doorkeeper.configuration.pkce_code_challenge_methods.join(', '),
+            count: Doorkeeper.configuration.pkce_code_challenge_methods.length
+          )
         end
       end
     end


### PR DESCRIPTION
Doorkeeper 5.8.x converts this into a pluralized i18n entry (see FIXME removed here...).

Copied the `en` translation in from doorkeeper, updated single spec to include interpolation args to mirror the lib. I think this is safe and that other languages will continue to use the previous string w/out pluralization until if/when they are updated to include the pluralized versions, ie:

```
mastodon(test)> I18n.locale
=> :en
mastodon(test)> I18n.t 'doorkeeper.errors.messages.invalid_code_challenge_method', count: 2, challenge_methods: %w(this that).join(', ')
=> "The code_challenge_method must be one of this, that."
mastodon(test)> I18n.locale = :fr
=> :fr
mastodon(test)> I18n.t 'doorkeeper.errors.messages.invalid_code_challenge_method', count: 2, challenge_methods: %w(this that).join(', ')
=> "La méthode de contrôle du code doit être S256, le mode « en clair » n'est pas pris en charge."
```

Other than in this system spec, we never call this I18n directly, its only called from underlying lib (which as of 5.8 is passing in the count/methods args...)

While in there, update spec to combine a few examples running same subject, reduces factories a bit.

On a side note - while doing this I tried to re-run the `doorkeeper:install` generator and let it replace the full config and i18n files. The i18n was a lot of formatting only changes (quoting stuff which wasnt before, etc). The config also had a lot of wording/comments changes. Because it was mostly noise I didnt include here, but it might be a worth a second look to see if there are any worthwhile non-formatting changes in either to pull in besides this one.