### PR TITLE
Add `--suspended-only` option to `tootctl emoji purge`

### DIFF
--- a/lib/mastodon/cli/emoji.rb
+++ b/lib/mastodon/cli/emoji.rb
@@ -109,15 +109,27 @@ module Mastodon::CLI
     end
 
     option :remote_only, type: :boolean
+    option :suspended_only, type: :boolean
     desc 'purge', 'Remove all custom emoji'
     long_desc <<-LONG_DESC
       Removes all custom emoji.
 
       With the --remote-only option, only remote emoji will be deleted.
+
+      With the --suspended-only option, only emoji from suspended servers will be deleted.
     LONG_DESC
     def purge
-      scope = options[:remote_only] ? CustomEmoji.remote : CustomEmoji
-      scope.in_batches.destroy_all
+      if options[:suspended_only]
+        DomainBlock.where(severity: :suspend).find_each do |domain_block|
+          next unless CustomEmoji.by_domain_and_subdomains(domain_block.domain).exists?
+
+          PurgeCustomEmojiWorker.perform_async(domain_block.domain)
+        end
+      else
+        scope = options[:remote_only] ? CustomEmoji.remote : CustomEmoji
+        scope.in_batches.destroy_all
+      end
+
       say('OK', :green)
     end
 

--- a/spec/lib/mastodon/cli/emoji_spec.rb
+++ b/spec/lib/mastodon/cli/emoji_spec.rb
@@ -46,9 +46,10 @@ RSpec.describe Mastodon::CLI::Emoji do
 
       it 'reports a successful purge' do
         expect { subject }
-          .to enqueue_sidekiq_job(PurgeCustomEmojiWorker).with(blocked_domain)
-          .and enqueue_sidekiq_job(PurgeCustomEmojiWorker).with('evil.org')
-          .and output_results('OK')
+          .to change { CustomEmoji.by_domain_and_subdomains(blocked_domain).count }.to(0)
+          .and change { CustomEmoji.by_domain_and_subdomains('evil.org').count }.to(0)
+          .and not_change { CustomEmoji.by_domain_and_subdomains(silenced_domain).count }
+          .and(not_change { CustomEmoji.local.count })
       end
     end
   end


### PR DESCRIPTION
Since #37808, custom emojis are immediately deleted on server suspension, but this is not retroactive.

Add `--suspended-only` to `tootctl emoji purge` to remove custom emoji from already-suspended servers.