### PR TITLE
Add `error_code` and `action_url` to some API errors

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -64,13 +64,15 @@ class Api::BaseController < ApplicationController
 
   def require_user!
     if !current_user
-      render json: { error: 'This method requires an authenticated user' }, status: 422
+      render json: { error: 'This method requires an authenticated user', error_code: 'auth_required' }, status: 422
     elsif !current_user.confirmed?
-      render json: { error: 'Your login is missing a confirmed e-mail address' }, status: 403
+      render json: { error: 'Your login is missing a confirmed e-mail address', error_code: 'unconfirmed_email' }, status: 403
     elsif !current_user.approved?
-      render json: { error: 'Your login is currently pending approval' }, status: 403
+      render json: { error: 'Your login is currently pending approval', error_code: 'account_pending_approval' }, status: 403
+    elsif current_user.missing_2fa?
+      render json: { error: 'Your account requires two-factor authentication', error_code: 'unmet_2fa_requirement', action_url: mfa_setup_path }, status: 403
     elsif !current_user.functional?
-      render json: { error: 'Your login is currently disabled' }, status: 403
+      render json: { error: 'Your login is currently disabled', error_code: 'account_disabled' }, status: 403
     else
       update_user_sign_in
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,13 +88,13 @@ class ApplicationController < ActionController::Base
 
       format.json do
         if !current_user.confirmed?
-          render json: { error: 'Your login is missing a confirmed e-mail address' }, status: 403
+          render json: { error: 'Your login is missing a confirmed e-mail address', error_code: 'unconfirmed_email' }, status: 403
         elsif !current_user.approved?
-          render json: { error: 'Your login is currently pending approval' }, status: 403
+          render json: { error: 'Your login is currently pending approval', error_code: 'account_pending_approval' }, status: 403
         elsif current_user.missing_2fa?
-          render json: { error: 'Your account requires two-factor authentication' }, status: 403
+          render json: { error: 'Your account requires two-factor authentication', error_code: 'unmet_2fa_requirement', action_url: mfa_setup_path }, status: 403
         elsif !current_user.functional?
-          render json: { error: 'Your login is currently disabled' }, status: 403
+          render json: { error: 'Your login is currently disabled', error_code: 'account_disabled' }, status: 403
         end
       end
     end


### PR DESCRIPTION
This is to allow client developers to more easily provide localized error messages and actionable steps.

Everything in this PR is up for discussion.

`action_url` is currently only useful if the client app can make sure it will be opened with the correct user (e.g. by using a web view)