### PR TITLE
Add auto `yarn dedupe` to Git staged file linting

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -9,6 +9,7 @@ const config = {
     `yarn i18n:extract`,
     'git diff --exit-code app/javascript/mastodon/locales/en.json',
   ],
+  'yarn.lock': 'yarn dedupe',
 };
 
 module.exports = config;


### PR DESCRIPTION
### Description

After working on a small eslint package bump PR (https://github.com/mastodon/mastodon/pull/37814) that needed `yarn dedupe`-ing, I had the thought that maybe we can add `yarn dedupe` to the Git staged files linting that occurs during `git commit`. Figure it should run whenever committing with changes to `yarn.lock`.

The current implementation simply runs `yarn dedupe` and updates the `yarn.lock`, changing what's committed. Alternatively we could perhaps try `yarn dedupe --check` but if we trust `yarn dedupe` the smoothest developer experience is to just dedupe behind the scenes.

### Testing screencast

Testing with arbitrary `yarn.lock` duplication.

https://github.com/user-attachments/assets/eac5d0f5-4306-43dd-9d9f-8983417ff6a6

### Testing instructions

1. Add `'yarn.lock': () => 'yarn dedupe',` to `lint-staged.config.js`.
2. Update `yarn.lock` with some duplication such as updating

https://github.com/mastodon/mastodon/blob/dfe44bcaeffe2fb908e149193fd06d4ae8946798/yarn.lock#L12462-L12469

to the following:

```
"semver@npm:^7.3.5":
  version: 7.3.5
  resolution: "semver@npm:7.3.5"
  bin:
    semver: bin/semver.js
  checksum: 10c0/dcc0a5c6cdaae0ff3d0983d1cf7ba0b82dded5d25dd9e7a3e484b43547d376c32c48e8c3c1740e29724f8ccb2c14d26dd5cdc756a3eb5515ca2089c1bf9e4ff5
  languageName: node
  linkType: hard

"semver@npm:^7.5.3, semver@npm:^7.6.2, semver@npm:^7.7.1, semver@npm:^7.7.3":
  version: 7.7.3
  resolution: "semver@npm:7.7.3"
  bin:
    semver: bin/semver.js
  checksum: 10c0/4afe5c986567db82f44c8c6faef8fe9df2a9b1d98098fc1721f57c696c4c21cebd572f297fc21002f81889492345b8470473bc6f4aff5fb032a6ea59ea2bc45e
  languageName: node
  linkType: hard
```

3. Try running `yarn dedupe --check` to confirm the duplication exists.
4. Try committing the change and confirm `yarn dedupe` cleans it up.

Note that if your only change is duplication in `yarn.lock` the dedupe will remove that leaving you with an empty staging and Git will abort the would be empty commit.