### PR TITLE
Fix bad visibility of scroll buttons on follow-suggestions carousel

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10510,6 +10510,8 @@ noscript {
     position: relative;
 
     &__scroll-button {
+      --scroll-button-bg: var(--color-bg-brand-base);
+
       position: absolute;
       height: 100%;
       background: transparent;
@@ -10517,7 +10519,6 @@ noscript {
       cursor: pointer;
       top: 0;
       color: var(--color-text-primary);
-      opacity: 0.5;
 
       &.left {
         left: 0;
@@ -10530,7 +10531,7 @@ noscript {
       &__icon {
         border-radius: 50%;
         color: var(--color-text-on-brand-base);
-        background: var(--color-bg-brand-base);
+        background: var(--scroll-button-bg);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -10546,7 +10547,7 @@ noscript {
       &:hover,
       &:focus,
       &:active {
-        opacity: 1;
+        --scroll-button-bg: var(--color-bg-brand-base-hover);
       }
     }
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes bad visibility of scroll buttons on the follow-suggestions carousel. Previously they'd only turn a solid color when hovered; now they're always solid and get darker on hover, same as other buttons in our UI.

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="599" height="279" alt="image" src="https://github.com/user-attachments/assets/2d02bdd3-504b-4c21-99dd-2ff038e6a8eb" /> | <img width="599" height="278" alt="image" src="https://github.com/user-attachments/assets/4ce769ae-4da0-4b67-bb38-5685f431e991" /> |