### PR TITLE
Use `file_field` support for array to `accept` attribute

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -85,6 +85,8 @@ class Form::AdminSettings
     authorized_fetch: :authorized_fetch_mode?,
   }.freeze
 
+  UPLOAD_MIME_TYPES = %w(image/jpeg image/png image/gif image/webp).freeze
+
   DESCRIPTION_LIMIT = 200
   DOMAIN_BLOCK_AUDIENCES = %w(disabled users all).freeze
   REGISTRATION_MODES = %w(open approved none).freeze

--- a/app/views/admin/custom_emojis/new.html.haml
+++ b/app/views/admin/custom_emojis/new.html.haml
@@ -12,7 +12,7 @@
   .fields-group
     = f.input :image,
               wrapper: :with_label,
-              input_html: { accept: CustomEmoji::IMAGE_MIME_TYPES.join(',') },
+              input_html: { accept: CustomEmoji::IMAGE_MIME_TYPES },
               hint: t('admin.custom_emojis.image_hint', size: number_to_human_size(CustomEmoji::LIMIT))
 
   .actions

--- a/app/views/admin/settings/branding/show.html.haml
+++ b/app/views/admin/settings/branding/show.html.haml
@@ -44,7 +44,7 @@
     .fields-row__column.fields-row__column-6.fields-group
       = f.input :favicon,
                 as: :file,
-                input_html: { accept: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].join(',') },
+                input_html: { accept: f.object.class::UPLOAD_MIME_TYPES },
                 wrapper: :with_block_label
 
     .fields-row__column.fields-row__column-6.fields-group
@@ -58,7 +58,7 @@
     .fields-row__column.fields-row__column-6.fields-group
       = f.input :app_icon,
                 as: :file,
-                input_html: { accept: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].join(',') },
+                input_html: { accept: f.object.class::UPLOAD_MIME_TYPES },
                 wrapper: :with_block_label
 
     .fields-row__column.fields-row__column-6.fields-group

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -35,7 +35,7 @@
       .fields-group
         = f.input :avatar,
                   hint: t('simple_form.hints.defaults.avatar', dimensions: Account::Avatar::AVATAR_GEOMETRY, size: number_to_human_size(Account::Avatar::AVATAR_LIMIT)),
-                  input_html: { accept: Account::Avatar::AVATAR_IMAGE_MIME_TYPES.join(',') },
+                  input_html: { accept: Account::Avatar::AVATAR_IMAGE_MIME_TYPES },
                   wrapper: :with_block_label
 
     .fields-row__column.fields-row__column-6
@@ -51,7 +51,7 @@
       .fields-group
         = f.input :header,
                   hint: t('simple_form.hints.defaults.header', dimensions: Account::Header::HEADER_GEOMETRY, size: number_to_human_size(Account::Header::HEADER_LIMIT)),
-                  input_html: { accept: Account::Header::HEADER_IMAGE_MIME_TYPES.join(',') },
+                  input_html: { accept: Account::Header::HEADER_IMAGE_MIME_TYPES },
                   wrapper: :with_block_label
 
     .fields-row__column.fields-row__column-6


### PR DESCRIPTION
Rails 8.1 adds special handling of arrays here. Previously they needed the manual string joining to get a comma list, now that just happens automatically.