### PR TITLE
Use mime type symbol to set `content_type` for custom css response

### DIFF
--- a/app/controllers/custom_css_controller.rb
+++ b/app/controllers/custom_css_controller.rb
@@ -3,7 +3,7 @@
 class CustomCssController < ActionController::Base # rubocop:disable Rails/ApplicationController
   def show
     expires_in 1.month, public: true
-    render content_type: 'text/css'
+    render content_type: :css
   end
 
   private

--- a/spec/requests/custom_css_spec.rb
+++ b/spec/requests/custom_css_spec.rb
@@ -13,11 +13,10 @@ RSpec.describe 'Custom CSS' do
         expect(response)
           .to have_http_status(200)
           .and have_cacheable_headers
-          .and have_attributes(
-            content_type: match('text/css')
-          )
-        expect(response.body.presence)
-          .to be_nil
+        expect(response.media_type)
+          .to eq('text/css')
+        expect(response.body)
+          .to be_blank
       end
     end
 
@@ -32,9 +31,8 @@ RSpec.describe 'Custom CSS' do
         expect(response)
           .to have_http_status(200)
           .and have_cacheable_headers
-          .and have_attributes(
-            content_type: match('text/css')
-          )
+        expect(response.media_type)
+          .to eq('text/css')
         expect(response.body.strip)
           .to eq(expected_css)
       end


### PR DESCRIPTION
Added in Rails 8.1.

I chose a one-off small example here as first usage. Registering an `activitystreams` mime type would probably be even more fun, if you can imagine that?!