### PR TITLE
Use implicit `class_names` in 2FA partials

### DIFF
--- a/app/views/auth/sessions/two_factor/_otp_authentication_form.html.haml
+++ b/app/views/auth/sessions/two_factor/_otp_authentication_form.html.haml
@@ -1,7 +1,7 @@
 = simple_form_for(resource,
                   as: resource_name,
                   url: session_path(resource_name),
-                  html: { method: :post, id: 'otp-authentication-form' }.merge(hidden ? { class: 'hidden' } : {})) do |f|
+                  html: { method: :post, id: 'otp-authentication-form', class: [hidden:] }) do |f|
   %p.hint.authentication-hint= t('simple_form.hints.sessions.otp')
 
   .fields-group

--- a/app/views/auth/sessions/two_factor/_webauthn_form.html.haml
+++ b/app/views/auth/sessions/two_factor/_webauthn_form.html.haml
@@ -5,7 +5,7 @@
 = simple_form_for(resource,
                   as: resource_name,
                   url: session_path(resource_name),
-                  html: { method: :post, id: 'webauthn-form' }.merge(hidden ? { class: 'hidden' } : {})) do |f|
+                  html: { method: :post, id: 'webauthn-form', class: [hidden:] }) do |f|
   %h3.title= t('simple_form.title.sessions.webauthn')
   %p.hint= t('simple_form.hints.sessions.webauthn')
 


### PR DESCRIPTION
Replace the ternary/merge which sometimes merges an empty hash into the existing class options, and replace it with the (implicit) call of `class_names` in the framework which will add the class or not based on the value of `hidden`.

Side notes here:

- I think both of these form `id` values might be pointless
- We are (unintentionally, I think) removing the generated form class (`edit_user` in this case), which probably also doesnt matter, and this update will continue to remove it.