### PR TITLE
Allow reporting (local) Collections

### DIFF
--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -23,6 +23,10 @@ class Api::V1::ReportsController < Api::BaseController
   end
 
   def report_params
-    params.permit(:account_id, :comment, :category, :forward, forward_to_domains: [], status_ids: [], rule_ids: [])
+    if Mastodon::Feature.collections_enabled?
+      params.permit(:account_id, :comment, :category, :forward, forward_to_domains: [], status_ids: [], collection_ids: [], rule_ids: [])
+    else
+      params.permit(:account_id, :comment, :category, :forward, forward_to_domains: [], status_ids: [], rule_ids: [])
+    end
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -26,6 +26,7 @@ class Collection < ApplicationRecord
   belongs_to :tag, optional: true
 
   has_many :collection_items, dependent: :delete_all
+  has_many :collection_reports, dependent: :delete_all
 
   validates :name, presence: true
   validates :description, presence: true

--- a/app/models/collection_report.rb
+++ b/app/models/collection_report.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: collection_reports
+#
+#  id            :bigint(8)        not null, primary key
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  collection_id :bigint(8)        not null
+#  report_id     :bigint(8)        not null
+#
+class CollectionReport < ApplicationRecord
+  belongs_to :collection
+  belongs_to :report
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -40,6 +40,8 @@ class Report < ApplicationRecord
     belongs_to :assigned_account, optional: true
   end
 
+  has_many :collection_reports, dependent: :delete_all
+  has_many :collections, through: :collection_reports
   has_many :notes, class_name: 'ReportNote', inverse_of: :report, dependent: :destroy
   has_many :notifications, as: :activity, dependent: :destroy
 

--- a/app/serializers/rest/report_serializer.rb
+++ b/app/serializers/rest/report_serializer.rb
@@ -2,7 +2,8 @@
 
 class REST::ReportSerializer < ActiveModel::Serializer
   attributes :id, :action_taken, :action_taken_at, :category, :comment,
-             :forwarded, :created_at, :status_ids, :rule_ids
+             :forwarded, :created_at, :status_ids, :rule_ids,
+             :collection_ids
 
   has_one :target_account, serializer: REST::AccountSerializer
 
@@ -16,5 +17,9 @@ class REST::ReportSerializer < ActiveModel::Serializer
 
   def rule_ids
     object&.rule_ids&.map(&:to_s)
+  end
+
+  def collection_ids
+    object.collection_ids.map(&:to_s)
   end
 end

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -7,6 +7,7 @@ class ReportService < BaseService
     @source_account = source_account
     @target_account = target_account
     @status_ids     = options.delete(:status_ids).presence || []
+    @collection_ids = options.delete(:collection_ids).presence || []
     @comment        = options.delete(:comment).presence || ''
     @category       = options[:rule_ids].present? ? 'violation' : (options.delete(:category).presence || 'other')
     @rule_ids       = options.delete(:rule_ids).presence
@@ -32,6 +33,7 @@ class ReportService < BaseService
     @report = @source_account.reports.create!(
       target_account: @target_account,
       status_ids: reported_status_ids,
+      collection_ids: reported_collection_ids,
       comment: @comment,
       uri: @options[:uri],
       forwarded: forward_to_origin?,
@@ -89,6 +91,10 @@ class ReportService < BaseService
     scope.merge!(scope.where(visibility: visibility).or(scope.where('EXISTS (SELECT 1 FROM mentions m JOIN accounts a ON m.account_id = a.id WHERE lower(a.domain) = ?)', domain)))
     # Allow missing posts to not drop reports that include e.g. a deleted post
     scope.where(id: Array(@status_ids)).pluck(:id)
+  end
+
+  def reported_collection_ids
+    @target_account.collections.find(Array(@collection_ids)).pluck(:id)
   end
 
   def payload

--- a/db/migrate/20260212131934_create_collection_reports.rb
+++ b/db/migrate/20260212131934_create_collection_reports.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateCollectionReports < ActiveRecord::Migration[8.0]
+  def change
+    create_table :collection_reports do |t|
+      t.references :collection, null: false, foreign_key: { on_delete: :cascade }
+      t.references :report, null: false, foreign_key: { on_delete: :cascade }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_12_113020) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_12_131934) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -370,6 +370,15 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_113020) do
     t.index ["approval_uri"], name: "index_collection_items_on_approval_uri", unique: true, where: "(approval_uri IS NOT NULL)"
     t.index ["collection_id"], name: "index_collection_items_on_collection_id"
     t.index ["object_uri"], name: "index_collection_items_on_object_uri", unique: true, where: "(activity_uri IS NOT NULL)"
+  end
+
+  create_table "collection_reports", force: :cascade do |t|
+    t.bigint "collection_id", null: false
+    t.bigint "report_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["collection_id"], name: "index_collection_reports_on_collection_id"
+    t.index ["report_id"], name: "index_collection_reports_on_report_id"
   end
 
   create_table "collections", id: :bigint, default: -> { "timestamp_id('collections'::text)" }, force: :cascade do |t|
@@ -1431,6 +1440,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_113020) do
   add_foreign_key "canonical_email_blocks", "accounts", column: "reference_account_id", on_delete: :cascade
   add_foreign_key "collection_items", "accounts"
   add_foreign_key "collection_items", "collections", on_delete: :cascade
+  add_foreign_key "collection_reports", "collections", on_delete: :cascade
+  add_foreign_key "collection_reports", "reports", on_delete: :cascade
   add_foreign_key "collections", "accounts"
   add_foreign_key "collections", "tags"
   add_foreign_key "conversation_mutes", "accounts", name: "fk_225b4212bb", on_delete: :cascade


### PR DESCRIPTION
I *think* this should be the bare minimum to allow reporting Collections (at least local ones, no federation support for now). Having never touched this area of the code before, I am not 100% sure though.

It works by passing `collection_ids` similar to `status_ids` when creating a report.

On the DB side I diverged a bit from how `status_ids` are handled: Instead of stuffing them into an array column, I created a "real" join model. I think this is more in line with rails conventions and more versatile.

There is a small caveat though: The array column approach without a foreign key means that the information that a status was attached gets retained even if the status is deleted. In case of the join model that information would just be lost. *But* at least with a cursory search I did not find any instance in the code where we make use of this information, so functionally it should not be worse.

Part of WEB-650