### PR TITLE
Profile redesign: About tab

### DIFF
--- a/app/javascript/mastodon/components/emoji/context.tsx
+++ b/app/javascript/mastodon/components/emoji/context.tsx
@@ -92,8 +92,11 @@ export const CustomEmojiContext = createContext<ExtraCustomEmojiMap>({});
 export const CustomEmojiProvider = ({
   children,
   emojis: rawEmojis,
-}: PropsWithChildren<{ emojis?: CustomEmojiMapArg }>) => {
-  const emojis = useMemo(() => cleanExtraEmojis(rawEmojis) ?? {}, [rawEmojis]);
+}: PropsWithChildren<{ emojis?: CustomEmojiMapArg | null }>) => {
+  const emojis = useMemo(() => cleanExtraEmojis(rawEmojis), [rawEmojis]);
+  if (!emojis) {
+    return children;
+  }
   return (
     <CustomEmojiContext.Provider value={emojis}>
       {children}

--- a/app/javascript/mastodon/components/emoji/html.tsx
+++ b/app/javascript/mastodon/components/emoji/html.tsx
@@ -25,7 +25,7 @@ export const EmojiHTML = polymorphicForwardRef<'div', EmojiHTMLProps>(
       extraEmojis,
       htmlString,
       as: asProp = 'div', // Rename for syntax highlighting
-      className = '',
+      className,
       onElement,
       onAttribute,
       ...props

--- a/app/javascript/mastodon/features/account_about/index.tsx
+++ b/app/javascript/mastodon/features/account_about/index.tsx
@@ -1,28 +1,54 @@
 import type { FC } from 'react';
 
+import { FormattedMessage } from 'react-intl';
+
+import { useParams } from 'react-router';
+
 import { AccountBio } from '@/mastodon/components/account_bio';
 import { Column } from '@/mastodon/components/column';
 import { ColumnBackButton } from '@/mastodon/components/column_back_button';
 import { LoadingIndicator } from '@/mastodon/components/loading_indicator';
 import BundleColumnError from '@/mastodon/features/ui/components/bundle_column_error';
+import type { AccountId } from '@/mastodon/hooks/useAccountId';
 import { useAccountId } from '@/mastodon/hooks/useAccountId';
 import { useAccountVisibility } from '@/mastodon/hooks/useAccountVisibility';
+import { createAppSelector, useAppSelector } from '@/mastodon/store';
 
 import { AccountHeader } from '../account_timeline/components/account_header';
 import { AccountHeaderFields } from '../account_timeline/components/fields';
+import { LimitedAccountHint } from '../account_timeline/components/limited_account_hint';
 
 import classes from './styles.module.css';
+
+const selectIsProfileEmpty = createAppSelector(
+  [(state) => state.accounts, (_, accountId: AccountId) => accountId],
+  (accounts, accountId) => {
+    // Null means still loading, otherwise it's a boolean.
+    if (!accountId) {
+      return null;
+    }
+    const account = accounts.get(accountId);
+    if (!account) {
+      return null;
+    }
+    return !account.note && !account.fields.size;
+  },
+);
 
 export const AccountAbout: FC<{ multiColumn: boolean }> = ({ multiColumn }) => {
   const accountId = useAccountId();
   const { blockedBy, hidden, suspended } = useAccountVisibility(accountId);
   const forceEmptyState = blockedBy || hidden || suspended;
 
+  const isProfileEmpty = useAppSelector((state) =>
+    selectIsProfileEmpty(state, accountId),
+  );
+
   if (accountId === null) {
     return <BundleColumnError multiColumn={multiColumn} errorType='routing' />;
   }
 
-  if (!accountId) {
+  if (!accountId || isProfileEmpty === null) {
     return (
       <Column bindToDocument={!multiColumn}>
         <LoadingIndicator />
@@ -30,19 +56,70 @@ export const AccountAbout: FC<{ multiColumn: boolean }> = ({ multiColumn }) => {
     );
   }
 
+  const showEmptyMessage = forceEmptyState || isProfileEmpty;
+
   return (
     <Column bindToDocument={!multiColumn}>
       <ColumnBackButton />
       <div className='scrollable scrollable--flex'>
         <AccountHeader accountId={accountId} hideTabs={forceEmptyState} />
         <div className={classes.wrapper}>
-          <AccountBio
-            accountId={accountId}
-            className={`${classes.bio} account__header__content`}
-          />
-          <AccountHeaderFields accountId={accountId} />
+          {!showEmptyMessage ? (
+            <>
+              <AccountBio
+                accountId={accountId}
+                className={`${classes.bio} account__header__content`}
+              />
+              <AccountHeaderFields accountId={accountId} />
+            </>
+          ) : (
+            <div className='empty-column-indicator'>
+              <EmptyMessage accountId={accountId} />
+            </div>
+          )}
         </div>
       </div>
     </Column>
+  );
+};
+
+const EmptyMessage: FC<{ accountId: string }> = ({ accountId }) => {
+  const { blockedBy, hidden, suspended } = useAccountVisibility(accountId);
+  const currentUserId = useAppSelector(
+    (state) => state.meta.get('me') as string | null,
+  );
+  const { acct } = useParams<{ acct?: string }>();
+
+  if (suspended) {
+    return (
+      <FormattedMessage
+        id='empty_column.account_suspended'
+        defaultMessage='Account suspended'
+      />
+    );
+  } else if (hidden) {
+    return <LimitedAccountHint accountId={accountId} />;
+  } else if (blockedBy) {
+    return (
+      <FormattedMessage
+        id='empty_column.account_unavailable'
+        defaultMessage='Profile unavailable'
+      />
+    );
+  } else if (accountId === currentUserId) {
+    return (
+      <FormattedMessage
+        id='empty_column.account_about.me'
+        defaultMessage='You have not added any information about yourself yet.'
+      />
+    );
+  }
+
+  return (
+    <FormattedMessage
+      id='empty_column.account_about.other'
+      defaultMessage='{acct} has not added any information about themselves yet.'
+      values={{ acct }}
+    />
   );
 };

--- a/app/javascript/mastodon/features/account_about/index.tsx
+++ b/app/javascript/mastodon/features/account_about/index.tsx
@@ -1,0 +1,13 @@
+import type { FC } from 'react';
+
+import { Column } from '@/mastodon/components/column';
+import { ColumnBackButton } from '@/mastodon/components/column_back_button';
+
+export const AccountAbout: FC = () => {
+  return (
+    <Column>
+      <ColumnBackButton />
+      <div>Account About</div>
+    </Column>
+  );
+};

--- a/app/javascript/mastodon/features/account_about/index.tsx
+++ b/app/javascript/mastodon/features/account_about/index.tsx
@@ -1,13 +1,48 @@
 import type { FC } from 'react';
 
+import { AccountBio } from '@/mastodon/components/account_bio';
 import { Column } from '@/mastodon/components/column';
 import { ColumnBackButton } from '@/mastodon/components/column_back_button';
+import { LoadingIndicator } from '@/mastodon/components/loading_indicator';
+import BundleColumnError from '@/mastodon/features/ui/components/bundle_column_error';
+import { useAccountId } from '@/mastodon/hooks/useAccountId';
+import { useAccountVisibility } from '@/mastodon/hooks/useAccountVisibility';
 
-export const AccountAbout: FC = () => {
+import { AccountHeader } from '../account_timeline/components/account_header';
+import { AccountHeaderFields } from '../account_timeline/components/fields';
+
+import classes from './styles.module.css';
+
+export const AccountAbout: FC<{ multiColumn: boolean }> = ({ multiColumn }) => {
+  const accountId = useAccountId();
+  const { blockedBy, hidden, suspended } = useAccountVisibility(accountId);
+  const forceEmptyState = blockedBy || hidden || suspended;
+
+  if (accountId === null) {
+    return <BundleColumnError multiColumn={multiColumn} errorType='routing' />;
+  }
+
+  if (!accountId) {
+    return (
+      <Column bindToDocument={!multiColumn}>
+        <LoadingIndicator />
+      </Column>
+    );
+  }
+
   return (
-    <Column>
+    <Column bindToDocument={!multiColumn}>
       <ColumnBackButton />
-      <div>Account About</div>
+      <div className='scrollable scrollable--flex'>
+        <AccountHeader accountId={accountId} hideTabs={forceEmptyState} />
+        <div className={classes.wrapper}>
+          <AccountBio
+            accountId={accountId}
+            className={`${classes.bio} account__header__content`}
+          />
+          <AccountHeaderFields accountId={accountId} />
+        </div>
+      </div>
     </Column>
   );
 };

--- a/app/javascript/mastodon/features/account_about/styles.module.css
+++ b/app/javascript/mastodon/features/account_about/styles.module.css
@@ -1,0 +1,7 @@
+.wrapper {
+  padding: 16px;
+}
+
+.bio {
+  color: var(--color-text-primary);
+}

--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -86,10 +86,9 @@ export const AccountHeader: React.FC<{
   );
 
   const { layout } = useLayout();
-  const isMobile = layout === 'mobile';
   const { observedRef, isIntersecting } = useVisibility({
     observerOptions: {
-      rootMargin: isMobile ? '0px 0px -55px 0px' : '', // Height of bottom nav bar.
+      rootMargin: layout === 'mobile' ? '0px 0px -55px 0px' : '', // Height of bottom nav bar.
     },
   });
 
@@ -211,7 +210,7 @@ export const AccountHeader: React.FC<{
                     <AccountNote accountId={accountId} />
                   ))}
 
-                {(!isRedesign || !isMobile) && (
+                {(!isRedesign || layout === 'single-column') && (
                   <>
                     <AccountBio
                       accountId={accountId}

--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -86,9 +86,10 @@ export const AccountHeader: React.FC<{
   );
 
   const { layout } = useLayout();
+  const isMobile = layout === 'mobile';
   const { observedRef, isIntersecting } = useVisibility({
     observerOptions: {
-      rootMargin: layout === 'mobile' ? '0px 0px -55px 0px' : '', // Height of bottom nav bar.
+      rootMargin: isMobile ? '0px 0px -55px 0px' : '', // Height of bottom nav bar.
     },
   });
 
@@ -210,12 +211,15 @@ export const AccountHeader: React.FC<{
                     <AccountNote accountId={accountId} />
                   ))}
 
-                <AccountBio
-                  accountId={accountId}
-                  className='account__header__content'
-                />
-
-                <AccountHeaderFields accountId={accountId} />
+                {(!isRedesign || !isMobile) && (
+                  <>
+                    <AccountBio
+                      accountId={accountId}
+                      className='account__header__content'
+                    />
+                    <AccountHeaderFields accountId={accountId} />
+                  </>
+                )}
               </div>
 
               <AccountNumberFields accountId={accountId} />

--- a/app/javascript/mastodon/features/account_timeline/components/fields.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/fields.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { FC, Key } from 'react';
 
 import { FormattedMessage } from 'react-intl';
@@ -148,6 +148,11 @@ const FieldHTML: FC<
   onElement,
   ...props
 }) => {
+  const [showAll, setShowAll] = useState(false);
+  const handleClick = useCallback(() => {
+    setShowAll((prev) => !prev);
+  }, []);
+
   const handleElement: OnElementHandler = useCallback(
     (element, props, children, extra) => {
       if (element instanceof HTMLAnchorElement) {
@@ -173,7 +178,9 @@ const FieldHTML: FC<
       className={classNames(
         className,
         text && isValidUrl(text) && classes.fieldLink,
+        showAll && classes.fieldShowAll,
       )}
+      onClick={handleClick}
       onElement={handleElement}
       {...props}
     />

--- a/app/javascript/mastodon/features/account_timeline/components/fields.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/fields.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { FC, Key } from 'react';
 
-import { FormattedMessage } from 'react-intl';
+import { defineMessage, FormattedMessage, useIntl } from 'react-intl';
 
 import classNames from 'classnames';
 
@@ -58,6 +58,18 @@ export const AccountHeaderFields: FC<{ accountId: string }> = ({
   );
 };
 
+const verifyMessage = defineMessage({
+  id: 'account.link_verified_on',
+  defaultMessage: 'Ownership of this link was checked on {date}',
+});
+const dateFormatOptions: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+};
+
 const RedesignAccountHeaderFields: FC<{ account: Account }> = ({ account }) => {
   const emojis = useMemo(
     () => cleanExtraEmojis(account.emojis),
@@ -80,6 +92,7 @@ const RedesignAccountHeaderFields: FC<{ account: Account }> = ({ account }) => {
   const htmlHandlers = useElementHandledLink({
     hashtagAccountId: account.id,
   });
+  const intl = useIntl();
 
   return (
     <CustomEmojiProvider emojis={emojis}>
@@ -118,6 +131,9 @@ const RedesignAccountHeaderFields: FC<{ account: Account }> = ({ account }) => {
                   id='verified'
                   icon={IconVerified}
                   className={classes.fieldVerifiedIcon}
+                  aria-label={intl.formatMessage(verifyMessage, {
+                    date: intl.formatDate(verified_at, dateFormatOptions),
+                  })}
                   noFill
                 />
               )}

--- a/app/javascript/mastodon/features/account_timeline/components/fields.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/fields.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import classNames from 'classnames';
 
@@ -8,16 +8,11 @@ import IconVerified from '@/images/icons/icon_verified.svg?react';
 import { AccountFields } from '@/mastodon/components/account_fields';
 import { EmojiHTML } from '@/mastodon/components/emoji/html';
 import { FormattedDateWrapper } from '@/mastodon/components/formatted_date';
-import { IconButton } from '@/mastodon/components/icon_button';
-import { MiniCard } from '@/mastodon/components/mini_card';
+import { Icon } from '@/mastodon/components/icon';
 import { useElementHandledLink } from '@/mastodon/components/status/handled_link';
 import { useAccount } from '@/mastodon/hooks/useAccount';
-import { useOverflowScroll } from '@/mastodon/hooks/useOverflow';
 import type { Account } from '@/mastodon/models/account';
 import { isValidUrl } from '@/mastodon/utils/checks';
-import IconLeftArrow from '@/material-icons/400-24px/chevron_left.svg?react';
-import IconRightArrow from '@/material-icons/400-24px/chevron_right.svg?react';
-import IconLink from '@/material-icons/400-24px/link_2.svg?react';
 
 import { isRedesignEnabled } from '../common';
 
@@ -59,94 +54,60 @@ export const AccountHeaderFields: FC<{ accountId: string }> = ({
 
 const RedesignAccountHeaderFields: FC<{ account: Account }> = ({ account }) => {
   const htmlHandlers = useElementHandledLink();
-  const intl = useIntl();
-
-  const {
-    bodyRef,
-    canScrollLeft,
-    canScrollRight,
-    handleLeftNav,
-    handleRightNav,
-    handleScroll,
-  } = useOverflowScroll();
 
   return (
-    <div
-      className={classNames(
-        classes.fieldWrapper,
-        canScrollLeft && classes.fieldWrapperLeft,
-        canScrollRight && classes.fieldWrapperRight,
-      )}
-    >
-      {canScrollLeft && (
-        <IconButton
-          icon='more'
-          iconComponent={IconLeftArrow}
-          title={intl.formatMessage({
-            id: 'account.fields.scroll_prev',
-            defaultMessage: 'Show previous',
-          })}
-          className={classes.fieldArrowButton}
-          onClick={handleLeftNav}
-        />
-      )}
-      <dl ref={bodyRef} className={classes.fieldList} onScroll={handleScroll}>
-        {account.fields.map(
-          (
-            { name, name_emojified, value_emojified, value_plain, verified_at },
-            key,
-          ) => (
-            <MiniCard
-              key={key}
-              label={
-                <EmojiHTML
-                  htmlString={name_emojified}
-                  extraEmojis={account.emojis}
-                  className='translate'
-                  as='span'
-                  title={name}
-                  {...htmlHandlers}
-                />
-              }
-              value={
-                <EmojiHTML
-                  as='span'
-                  htmlString={value_emojified}
-                  extraEmojis={account.emojis}
-                  title={value_plain ?? undefined}
-                  {...htmlHandlers}
-                />
-              }
-              icon={fieldIcon(verified_at, value_plain)}
+    <dl className={classes.fieldList}>
+      {account.fields.map(
+        (
+          { name, name_emojified, value_emojified, value_plain, verified_at },
+          key,
+        ) => (
+          <div
+            key={key}
+            className={classNames(
+              classes.fieldRow,
+              verified_at && classes.fieldVerified,
+            )}
+          >
+            <EmojiHTML
+              htmlString={name_emojified}
+              extraEmojis={account.emojis}
               className={classNames(
-                classes.fieldCard,
-                verified_at && classes.fieldCardVerified,
+                'translate',
+                isValidUrl(name) && classes.fieldLink,
               )}
+              as='dt'
+              title={showTitleOnLength(name, 50)}
+              {...htmlHandlers}
             />
-          ),
-        )}
-      </dl>
-      {canScrollRight && (
-        <IconButton
-          icon='more'
-          iconComponent={IconRightArrow}
-          title={intl.formatMessage({
-            id: 'account.fields.scroll_next',
-            defaultMessage: 'Show next',
-          })}
-          className={classes.fieldArrowButton}
-          onClick={handleRightNav}
-        />
+            <EmojiHTML
+              as='dd'
+              htmlString={value_emojified}
+              extraEmojis={account.emojis}
+              title={showTitleOnLength(value_plain, 120)}
+              className={classNames(
+                value_plain && isValidUrl(value_plain) && classes.fieldLink,
+              )}
+              {...htmlHandlers}
+            />
+            {verified_at && (
+              <Icon
+                id='verified'
+                icon={IconVerified}
+                className={classes.fieldVerifiedIcon}
+                noFill
+              />
+            )}
+          </div>
+        ),
       )}
-    </div>
+    </dl>
   );
 };
 
-function fieldIcon(verified_at: string | null, value_plain: string | null) {
-  if (verified_at) {
-    return IconVerified;
-  } else if (value_plain && isValidUrl(value_plain)) {
-    return IconLink;
+function showTitleOnLength(value: string | null, maxLength: number) {
+  if (value && value.length > maxLength) {
+    return value;
   }
   return undefined;
 }

--- a/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
@@ -196,7 +196,7 @@ svg.badgeIcon {
   display: grid;
   grid-template-columns: 160px 1fr min-content;
   column-gap: 8px;
-  margin-top: 4px;
+  margin: 4px 0 16px;
 }
 
 .fieldRow {
@@ -257,6 +257,8 @@ svg.badgeIcon {
 }
 
 .fieldNumbersWrapper {
+  padding: 0;
+
   a {
     font-weight: unset;
   }

--- a/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
@@ -194,9 +194,13 @@ svg.badgeIcon {
 
 .fieldList {
   display: grid;
-  grid-template-columns: 160px 1fr min-content;
+  grid-template-columns: min(160px, 25vw) 1fr min-content;
   column-gap: 8px;
   margin: 4px 0 16px;
+
+  @container (width < 400px) {
+    display: block;
+  }
 }
 
 .fieldRow {

--- a/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
@@ -323,7 +323,11 @@ svg.badgeIcon {
   border-bottom: 1px solid var(--color-border-primary);
   display: flex;
   gap: 12px;
-  padding: 0 24px;
+  padding: 0 12px;
+
+  @container (width >= 500px) {
+    padding: 0 24px;
+  }
 
   a {
     display: block;

--- a/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
@@ -194,31 +194,33 @@ svg.badgeIcon {
 
 .fieldList {
   display: grid;
-  grid-template-columns: min(160px, 25vw) 1fr min-content;
-  column-gap: 8px;
+  grid-template-columns: 160px 1fr min-content;
+  column-gap: 12px;
   margin: 4px 0 16px;
 
-  @container (width < 400px) {
-    display: block;
+  @container (width < 420px) {
+    grid-template-columns: 100px 1fr min-content;
   }
 }
 
 .fieldRow {
   display: grid;
   grid-column: 1 / -1;
-  align-items: center;
+  align-items: start;
   grid-template-columns: subgrid;
   padding: 0 4px;
 
-  > dt,
-  > dd {
+  > :is(dt, dd) {
     margin: 8px 0;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
-    line-clamp: 2;
-    overflow: hidden;
-    text-overflow: ellipsis;
+
+    &:not(.fieldShowAll) {
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+      line-clamp: 2;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 
   > dt {
@@ -258,6 +260,7 @@ svg.badgeIcon {
 .fieldVerifiedIcon {
   width: 16px;
   height: 16px;
+  margin-top: 8px;
 }
 
 .fieldNumbersWrapper {

--- a/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
@@ -192,112 +192,68 @@ svg.badgeIcon {
   }
 }
 
-.fieldWrapper {
-  margin-top: 16px;
-  width: 100%;
-  position: relative;
-}
-
-.fieldWrapper::before,
-.fieldWrapper::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 40px;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.2s ease-in-out;
-  z-index: 1;
-}
-
-.fieldWrapper::before {
-  left: 0;
-  background: linear-gradient(
-    to left,
-    transparent 0%,
-    var(--color-bg-primary) 100%
-  );
-}
-
-.fieldWrapper::after {
-  right: 0;
-  background: linear-gradient(
-    to right,
-    transparent 0%,
-    var(--color-bg-primary) 100%
-  );
-}
-
-.fieldWrapperLeft::before {
-  opacity: 1;
-}
-
-.fieldWrapperRight::after {
-  opacity: 1;
-}
-
 .fieldList {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 4px;
-  scroll-snap-type: x mandatory;
-  scroll-padding-left: 40px;
-  scroll-padding-right: 40px;
-  scroll-behavior: smooth;
-  overflow-x: scroll;
-  scrollbar-width: none;
-  overflow-y: visible;
+  display: grid;
+  grid-template-columns: 160px 1fr min-content;
+  column-gap: 8px;
+  margin-top: 4px;
 }
 
-.fieldCard {
-  scroll-snap-align: start;
+.fieldRow {
+  display: grid;
+  grid-column: 1 / -1;
+  align-items: center;
+  grid-template-columns: subgrid;
+  padding: 0 4px;
 
-  &:focus-visible,
-  &:focus-within {
-    outline: var(--outline-focus-default);
-    outline-offset: -2px;
+  > dt,
+  > dd {
+    margin: 8px 0;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
-  :is(dt, dd) {
-    max-width: 200px;
+  > dt {
+    color: var(--color-text-secondary);
+  }
+
+  &:not(.fieldVerified) > dd {
+    grid-column: span 2;
+  }
+
+  a {
+    font-weight: 500;
+    color: var(--color-text-brand);
+    text-decoration: none;
+    transition: 0.2s ease-in-out;
+
+    &:hover,
+    &:focus {
+      color: var(--color-text-brand-soft);
+    }
   }
 }
 
-.fieldCardVerified {
+.fieldVerified {
   background-color: var(--color-bg-brand-softer);
 }
 
-.fieldArrowButton {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background-color: var(--color-bg-primary);
-  box-shadow: 0 1px 4px 0 var(--color-shadow-primary);
-  border-radius: 9999px;
-  transition:
-    color 0.2s ease-in-out,
-    background-color 0.2s ease-in-out;
-  outline-offset: 2px;
-  z-index: 2;
+.fieldLink:is(dd, dt) {
+  margin: 0;
+}
 
-  &:first-child {
-    left: 4px;
-  }
+.fieldLink > a {
+  display: block;
+  padding: 8px 0;
+}
 
-  &:last-child {
-    right: 4px;
-  }
-
-  &:hover,
-  &:focus,
-  &:focus-visible {
-    background-color: color-mix(
-      in oklab,
-      var(--color-bg-brand-base) var(--overlay-strength-brand),
-      var(--color-bg-primary)
-    );
-  }
+.fieldVerifiedIcon {
+  width: 16px;
+  height: 16px;
 }
 
 .fieldNumbersWrapper {

--- a/app/javascript/mastodon/features/account_timeline/components/tabs.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/tabs.tsx
@@ -16,7 +16,7 @@ export const AccountTabs: FC<{ acct: string }> = ({ acct }) => {
   if (isRedesignEnabled()) {
     return (
       <div className={classes.tabs}>
-        {layout === 'mobile' && (
+        {layout !== 'single-column' && (
           <NavLink exact to={`/@${acct}/about`}>
             <FormattedMessage id='account.about' defaultMessage='About' />
           </NavLink>

--- a/app/javascript/mastodon/features/account_timeline/components/tabs.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/tabs.tsx
@@ -5,14 +5,22 @@ import { FormattedMessage } from 'react-intl';
 import type { NavLinkProps } from 'react-router-dom';
 import { NavLink } from 'react-router-dom';
 
+import { useLayout } from '@/mastodon/hooks/useLayout';
+
 import { isRedesignEnabled } from '../common';
 
 import classes from './redesign.module.scss';
 
 export const AccountTabs: FC<{ acct: string }> = ({ acct }) => {
+  const { layout } = useLayout();
   if (isRedesignEnabled()) {
     return (
       <div className={classes.tabs}>
+        {layout === 'mobile' && (
+          <NavLink exact to={`/@${acct}/about`}>
+            <FormattedMessage id='account.about' defaultMessage='About' />
+          </NavLink>
+        )}
         <NavLink isActive={isActive} to={`/@${acct}`}>
           <FormattedMessage id='account.activity' defaultMessage='Activity' />
         </NavLink>

--- a/app/javascript/mastodon/features/account_timeline/components/tabs.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/tabs.tsx
@@ -21,7 +21,7 @@ export const AccountTabs: FC<{ acct: string }> = ({ acct }) => {
             <FormattedMessage id='account.about' defaultMessage='About' />
           </NavLink>
         )}
-        <NavLink isActive={isActive} to={`/@${acct}`}>
+        <NavLink isActive={isActive} to={`/@${acct}/posts`}>
           <FormattedMessage id='account.activity' defaultMessage='Activity' />
         </NavLink>
         <NavLink exact to={`/@${acct}/media`}>

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -181,7 +181,7 @@ export function emojiToInversionClassName(emoji: string): string | null {
   return null;
 }
 
-export function cleanExtraEmojis(extraEmojis?: CustomEmojiMapArg) {
+export function cleanExtraEmojis(extraEmojis?: CustomEmojiMapArg | null) {
   if (!extraEmojis) {
     return null;
   }

--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -78,6 +78,7 @@ import {
   PrivacyPolicy,
   TermsOfService,
   AccountFeatured,
+  AccountAbout,
   Quotes,
 } from './util/async-components';
 import { ColumnsContextProvider } from './util/columns_context';
@@ -207,6 +208,7 @@ class SwitchingColumnsArea extends PureComponent {
 
             <WrappedRoute path={['/@:acct', '/accounts/:id']} exact component={AccountTimeline} content={children} />
             <WrappedRoute path={['/@:acct/featured', '/accounts/:id/featured']} component={AccountFeatured} content={children} />
+            <WrappedRoute path={['/@:acct/about', '/accounts/:id/about']} component={AccountAbout} content={children} />
             <WrappedRoute path='/@:acct/tagged/:tagged?' exact component={AccountTimeline} content={children} />
             <WrappedRoute path={['/@:acct/with_replies', '/accounts/:id/with_replies']} component={AccountTimeline} content={children} componentParams={{ withReplies: true }} />
             <WrappedRoute path={['/accounts/:id/followers', '/users/:acct/followers', '/@:acct/followers']} component={Followers} content={children} />
@@ -235,7 +237,7 @@ class SwitchingColumnsArea extends PureComponent {
             }
             {areCollectionsEnabled() &&
               <WrappedRoute path='/collections' component={Collections} content={children} />
-            }    
+            }
 
             <Route component={BundleColumnError} />
           </WrappedSwitch>

--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -89,6 +89,7 @@ import { WrappedSwitch, WrappedRoute } from './util/react_router_helpers';
 // Without this it ends up in ~8 very commonly used bundles.
 import '../../components/status';
 import { areCollectionsEnabled } from '../collections/utils';
+import { isClientFeatureEnabled } from '@/mastodon/utils/environment';
 
 const messages = defineMessages({
   beforeUnload: { id: 'ui.beforeunload', defaultMessage: 'Your draft will be lost if you leave Mastodon.' },
@@ -110,6 +111,7 @@ class SwitchingColumnsArea extends PureComponent {
     children: PropTypes.node,
     location: PropTypes.object,
     singleColumn: PropTypes.bool,
+    layout: PropTypes.string.isRequired,
     forceOnboarding: PropTypes.bool,
   };
 
@@ -160,6 +162,37 @@ class SwitchingColumnsArea extends PureComponent {
       redirect = <Redirect from='/' to='/about' exact />;
     }
 
+    const profileRedesignEnabled = isClientFeatureEnabled('profile_redesign');
+    const profileRedesignRoutes = [];
+    if (profileRedesignEnabled) {
+      profileRedesignRoutes.push(
+        <WrappedRoute key="posts" path={['/@:acct/posts', '/accounts/:id/posts']} exact component={AccountTimeline} content={children} />,
+      );
+      // Check if we're in single-column mode. Confusingly, the singleColumn prop includes mobile.
+      if (this.props.layout === 'single-column') {
+        // When in single column mode (desktop w/o advanced view), redirect both the root and about to the posts tab.
+        profileRedesignRoutes.push(
+          <Redirect key="acct-redirect" from='/@:acct' to='/@:acct/posts' exact />,
+          <Redirect key="id-redirect" from='/accounts/:id' to='/accounts/:id/posts' exact />,
+          <Redirect key="about-acct-redirect" from='/@:acct/about' to='/@:acct/posts' exact />,
+          <Redirect key="about-id-redirect" from='/accounts/:id/about' to='/accounts/:id/posts' exact />,
+        );
+      } else {
+        // Otherwise, provide and redirect to the /about page.
+        profileRedesignRoutes.push(
+          <WrappedRoute key="about" path={['/@:acct/about', '/accounts/:id/about']} component={AccountAbout} content={children} />,
+          <Redirect key="acct-redirect" from='/@:acct' to='/@:acct/about' exact />,
+          <Redirect key="id-redirect" from='/accounts/:id' to='/accounts/:id/about' exact />
+        );
+      }
+    } else {
+      // If the redesign is not enabled but someone shares an /about link, redirect to the root.
+      profileRedesignRoutes.push(
+        <Redirect key="about-acct-redirect" from='/@:acct/about' to='/@:acct' exact />,
+        <Redirect key="about-id-redirect" from='/accounts/:id/about' to='/accounts/:id' exact />
+      );
+    }
+
     return (
       <ColumnsContextProvider multiColumn={!singleColumn}>
         <ColumnsAreaContainer ref={this.setRef} singleColumn={singleColumn}>
@@ -206,9 +239,9 @@ class SwitchingColumnsArea extends PureComponent {
             <WrappedRoute path='/search' component={Search} content={children} />
             <WrappedRoute path={['/publish', '/statuses/new']} component={Compose} content={children} />
 
-            <WrappedRoute path={['/@:acct', '/accounts/:id']} exact component={AccountTimeline} content={children} />
+            {!profileRedesignEnabled && <WrappedRoute path={['/@:acct', '/accounts/:id']} exact component={AccountTimeline} content={children} />}
+            {...profileRedesignRoutes}
             <WrappedRoute path={['/@:acct/featured', '/accounts/:id/featured']} component={AccountFeatured} content={children} />
-            <WrappedRoute path={['/@:acct/about', '/accounts/:id/about']} component={AccountAbout} content={children} />
             <WrappedRoute path='/@:acct/tagged/:tagged?' exact component={AccountTimeline} content={children} />
             <WrappedRoute path={['/@:acct/with_replies', '/accounts/:id/with_replies']} component={AccountTimeline} content={children} componentParams={{ withReplies: true }} />
             <WrappedRoute path={['/accounts/:id/followers', '/users/:acct/followers', '/@:acct/followers']} component={Followers} content={children} />
@@ -593,7 +626,13 @@ class UI extends PureComponent {
     return (
       <Hotkeys global handlers={handlers}>
         <div className={classNames('ui', { 'is-composing': isComposing })} ref={this.setRef}>
-          <SwitchingColumnsArea identity={this.props.identity} location={location} singleColumn={layout === 'mobile' || layout === 'single-column'} forceOnboarding={firstLaunch && newAccount}>
+          <SwitchingColumnsArea
+            identity={this.props.identity}
+            location={location}
+            singleColumn={layout === 'mobile' || layout === 'single-column'}
+            layout={layout}
+            forceOnboarding={firstLaunch && newAccount}
+          >
             {children}
           </SwitchingColumnsArea>
 

--- a/app/javascript/mastodon/features/ui/util/async-components.js
+++ b/app/javascript/mastodon/features/ui/util/async-components.js
@@ -87,6 +87,11 @@ export function AccountFeatured() {
   return import('../../account_featured');
 }
 
+export function AccountAbout() {
+  return import('../../account_about')
+    .then((module) => ({ default: module.AccountAbout }));
+}
+
 export function Followers () {
   return import('../../followers');
 }

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -451,6 +451,8 @@
   "emoji_button.search_results": "Search results",
   "emoji_button.symbols": "Symbols",
   "emoji_button.travel": "Travel & Places",
+  "empty_column.account_about.me": "You have not added any information about yourself yet.",
+  "empty_column.account_about.other": "{acct} has not added any information about themselves yet.",
   "empty_column.account_featured.me": "You have not featured anything yet. Did you know that you can feature your hashtags you use the most, and even your friend’s accounts on your profile?",
   "empty_column.account_featured.other": "{acct} has not featured anything yet. Did you know that you can feature your hashtags you use the most, and even your friend’s accounts on your profile?",
   "empty_column.account_featured_other.unknown": "This account has not featured anything yet.",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -47,8 +47,6 @@
   "account.featured.hashtags": "Hashtags",
   "account.featured_tags.last_status_at": "Last post on {date}",
   "account.featured_tags.last_status_never": "No posts",
-  "account.fields.scroll_next": "Show next",
-  "account.fields.scroll_prev": "Show previous",
   "account.filters.all": "All activity",
   "account.filters.boosts_toggle": "Show boosts",
   "account.filters.posts_boosts": "Posts and boosts",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -13,6 +13,7 @@
   "about.not_available": "This information has not been made available on this server.",
   "about.powered_by": "Decentralized social media powered by {mastodon}",
   "about.rules": "Server rules",
+  "account.about": "About",
   "account.account_note_header": "Personal note",
   "account.activity": "Activity",
   "account.add_note": "Add a personal note",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,6 +155,7 @@ Rails.application.routes.draw do
   constraints(username: %r{[^@/.]+}) do
     with_options to: 'accounts#show' do
       get '/@:username', as: :short_account
+      get '/@:username/posts'
       get '/@:username/featured'
       get '/@:username/about'
       get '/@:username/with_replies', as: :short_account_with_replies

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,7 @@ Rails.application.routes.draw do
     with_options to: 'accounts#show' do
       get '/@:username', as: :short_account
       get '/@:username/featured'
+      get '/@:username/about'
       get '/@:username/with_replies', as: :short_account_with_replies
       get '/@:username/media', as: :short_account_media
       get '/@:username/tagged/:tag', as: :short_account_tag


### PR DESCRIPTION
Fixes WEB-798 and WEB-826.

This reverts the previous changes with custom fields to a table design, and puts the bio and description into a new About tab that appears only on mobile and in the advanced view.

Main changes:
- Fields that are verified now have a background color and the verified checkmark on the right
- When a field has a custom emoji, links are removed to avoid spoofing
- Both label and values are clamped to two lines
- Hovering a field or label shows the contents if the character limits are exceeded
- Tapping the field removes the line clamp

Additionally, this fixes some types for the emoji code and has `CustomEmojiProvider` not add the context when custom emojis are blank.

| Mobile | Single Column | Advanced View |
| - | - | - |
| <img width="784" height="1156" alt="Screenshot 2026-02-12 at 16 53 29" src="https://github.com/user-attachments/assets/d528957c-7047-49ce-9fe4-0d8d6eb631c3" /> | <img width="1214" height="906" alt="Screenshot 2026-02-12 at 16 52 51" src="https://github.com/user-attachments/assets/ad863b63-ac6a-447c-8c49-4afd09c60ea2" /> | <img width="724" height="850" alt="Screenshot 2026-02-12 at 16 51 58" src="https://github.com/user-attachments/assets/cefe9a07-7a2a-480c-b57c-2a55816922fe" /> |

