### PR TITLE
Fixes appearing in Following list

### DIFF
--- a/app/javascript/mastodon/features/following/index.tsx
+++ b/app/javascript/mastodon/features/following/index.tsx
@@ -72,7 +72,7 @@ const Followers: FC = () => {
       footer={footer}
       list={followingList}
       loadMore={loadMore}
-      prependAccountId={currentAccountId}
+      prependAccountId={followedId}
       scrollKey='following'
     />
   );


### PR DESCRIPTION
Fixes #37852.

This is a bug from #37811 where the incorrect variable was used so all accounts showed the current account as being followed by them.