### PR TITLE
Add `ContentPoliciesHelper#policy_list` to wrap string building in views

### DIFF
--- a/app/helpers/admin/content_policies_helper.rb
+++ b/app/helpers/admin/content_policies_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Admin::ContentPoliciesHelper
+  def policy_list(domain_block)
+    domain_block
+      .policies
+      .map { |policy| I18n.t("admin.instances.content_policies.policies.#{policy}") }
+      .join(' · ')
+  end
+end

--- a/app/views/admin/export_domain_blocks/_domain_block.html.haml
+++ b/app/views/admin/export_domain_blocks/_domain_block.html.haml
@@ -17,7 +17,7 @@
 
       %br/
 
-      = f.object.policies.map { |policy| t(policy, scope: 'admin.instances.content_policies.policies') }.join(' · ')
+      = policy_list(f.object)
       - if f.object.public_comment.present?
         ·
         = f.object.public_comment

--- a/app/views/admin/instances/_instance.html.haml
+++ b/app/views/admin/instances/_instance.html.haml
@@ -6,7 +6,7 @@
 
       %small
         - if instance.domain_block
-          = instance.domain_block.policies.map { |policy| t(policy, scope: 'admin.instances.content_policies.policies') }.join(' · ')
+          = policy_list(instance.domain_block)
           - if instance.domain_block.public_comment.present?
             %span.comment.public-comment #{t('admin.domain_blocks.public_comment')}: #{instance.domain_block.public_comment}
           - if instance.domain_block.private_comment.present?

--- a/app/views/admin/instances/show.html.haml
+++ b/app/views/admin/instances/show.html.haml
@@ -37,7 +37,7 @@
             %td= @instance.domain_block.public_comment
           %tr
             %th= t('admin.instances.content_policies.policy')
-            %td= @instance.domain_block.policies.map { |policy| t(policy, scope: 'admin.instances.content_policies.policies') }.join(' · ')
+            %td= policy_list(@instance.domain_block)
 
     = link_to t('admin.domain_blocks.edit'), edit_admin_domain_block_path(@instance.domain_block), class: 'button'
     = link_to t('admin.domain_blocks.undo'), admin_domain_block_path(@instance.domain_block), class: 'button', data: { confirm: t('admin.accounts.are_you_sure'), method: :delete }

--- a/spec/helpers/admin/content_policies_helper_spec.rb
+++ b/spec/helpers/admin/content_policies_helper_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::ContentPoliciesHelper do
+  describe '#policy_list' do
+    subject { helper.policy_list(domain_block) }
+
+    context 'when severity is suspend' do
+      let(:domain_block) { Fabricate.build :domain_block, severity: :suspend }
+
+      it { is_expected.to eq('Suspend') }
+    end
+
+    context 'when severity is silence' do
+      let(:domain_block) { Fabricate.build :domain_block, severity: :silence, reject_reports: true }
+
+      it { is_expected.to eq('Limit · Reject reports') }
+    end
+  end
+end


### PR DESCRIPTION
Seems obvious to pull out the repeated logic to a method.

I don't feel strongly about where it lives, if y'all prefer a different model, helper, presenter, whatever.