### PR TITLE
Update devcontainer image version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # For details, see https://github.com/devcontainers/images/tree/main/src/ruby
-FROM mcr.microsoft.com/devcontainers/ruby:1-3.3-bookworm
+FROM mcr.microsoft.com/devcontainers/ruby:3.4-trixie
 
 # Install node version from .nvmrc
 WORKDIR /app


### PR DESCRIPTION
Switch to Ruby 3.4 and Debian Trixie, update image version to latest.

Fixes #37833

Note that I have only tried starting the container, not actually using it, as I don't have a working devcontainer setup.

I think the image update is correct, but the versioning scheme and apparent lack of history for the latest versions on Microsoft's repositories are confusing.