### PR TITLE
Emoji: Cache data by path instead of just Etag

### DIFF
--- a/app/javascript/mastodon/actions/importer/emoji.ts
+++ b/app/javascript/mastodon/actions/importer/emoji.ts
@@ -7,7 +7,7 @@ export async function importCustomEmoji(emojis: ApiCustomEmojiJSON[]) {
   }
 
   // First, check if we already have them all.
-  const { searchCustomEmojisByShortcodes, clearEtag } =
+  const { searchCustomEmojisByShortcodes, clearCache } =
     await import('@/mastodon/features/emoji/database');
 
   const existingEmojis = await searchCustomEmojisByShortcodes(
@@ -16,7 +16,7 @@ export async function importCustomEmoji(emojis: ApiCustomEmojiJSON[]) {
 
   // If there's a mismatch, re-import all custom emojis.
   if (existingEmojis.length < emojis.length) {
-    await clearEtag('custom');
+    await clearCache('custom');
     await loadCustomEmoji();
   }
 }

--- a/app/javascript/mastodon/features/emoji/database.test.ts
+++ b/app/javascript/mastodon/features/emoji/database.test.ts
@@ -3,7 +3,6 @@ import { IDBFactory } from 'fake-indexeddb';
 
 import { customEmojiFactory, unicodeEmojiFactory } from '@/testing/factories';
 
-import { EMOJI_DB_SHORTCODE_TEST } from './constants';
 import {
   putEmojiData,
   loadEmojiByHexcode,
@@ -12,8 +11,6 @@ import {
   putCustomEmojiData,
   putLegacyShortcodes,
   loadLegacyShortcodesByShortcode,
-  loadLatestEtag,
-  putLatestEtag,
 } from './database';
 
 function rawEmojiFactory(data: Partial<CompactEmoji> = {}): CompactEmoji {
@@ -118,38 +115,6 @@ describe('emoji database', () => {
       await expect(
         loadLegacyShortcodesByShortcode('shortcode2'),
       ).resolves.toEqual(data);
-    });
-  });
-
-  describe('loadLatestEtag', () => {
-    beforeEach(async () => {
-      await putLatestEtag('etag', 'en');
-      await putEmojiData([unicodeEmojiFactory()], 'en');
-      await putLatestEtag('fr-etag', 'fr');
-    });
-
-    test('retrieves the etag for loaded locale', async () => {
-      await putEmojiData(
-        [unicodeEmojiFactory({ hexcode: EMOJI_DB_SHORTCODE_TEST })],
-        'en',
-      );
-      const etag = await loadLatestEtag('en');
-      expect(etag).toBe('etag');
-    });
-
-    test('returns null if locale has no shortcodes', async () => {
-      const etag = await loadLatestEtag('en');
-      expect(etag).toBeNull();
-    });
-
-    test('returns null if locale not loaded', async () => {
-      const etag = await loadLatestEtag('de');
-      expect(etag).toBeNull();
-    });
-
-    test('returns null if locale has no data', async () => {
-      const etag = await loadLatestEtag('fr');
-      expect(etag).toBeNull();
     });
   });
 });

--- a/app/javascript/mastodon/features/emoji/db-schema.ts
+++ b/app/javascript/mastodon/features/emoji/db-schema.ts
@@ -10,7 +10,7 @@ import type {
   StoreNames,
 } from 'idb';
 
-import type { CustomEmojiData, EtagTypes, UnicodeEmojiData } from './types';
+import type { CustomEmojiData, CacheKey, UnicodeEmojiData } from './types';
 import { emojiLogger } from './utils';
 
 const log = emojiLogger('database');
@@ -35,7 +35,7 @@ interface EmojiDB extends LocaleTables, DBSchema {
     };
   };
   etags: {
-    key: EtagTypes;
+    key: CacheKey;
     value: string;
   };
 }

--- a/app/javascript/mastodon/features/emoji/locale.ts
+++ b/app/javascript/mastodon/features/emoji/locale.ts
@@ -2,7 +2,7 @@ import type { Locale } from 'emojibase';
 import { SUPPORTED_LOCALES } from 'emojibase';
 
 import { EMOJI_DB_NAME_SHORTCODES, EMOJI_TYPE_CUSTOM } from './constants';
-import type { EtagTypes, LocaleOrCustom, LocaleWithShortcodes } from './types';
+import type { CacheKey, LocaleOrCustom, LocaleWithShortcodes } from './types';
 
 export function toSupportedLocale(localeBase: string): Locale {
   const locale = localeBase.toLowerCase();
@@ -19,7 +19,7 @@ export function toSupportedLocaleOrCustom(locale: string): LocaleOrCustom {
   return toSupportedLocale(locale);
 }
 
-export function toValidEtagName(input: string): EtagTypes {
+export function toValidCacheKey(input: string): CacheKey {
   const lower = input.toLowerCase();
   if (lower === EMOJI_TYPE_CUSTOM || lower === EMOJI_DB_NAME_SHORTCODES) {
     return lower;

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -22,7 +22,7 @@ export type EmojiMode =
 
 export type LocaleOrCustom = Locale | typeof EMOJI_TYPE_CUSTOM;
 export type LocaleWithShortcodes = `${Locale}-shortcodes`;
-export type EtagTypes =
+export type CacheKey =
   | LocaleOrCustom
   | typeof EMOJI_DB_NAME_SHORTCODES
   | LocaleWithShortcodes;


### PR DESCRIPTION
Fixes WEB-829.

This converts emoji data loading (aside from custom emojis) to use the path as a cache key instead of Etag, as the emoji data files are now artifacts of the build process and have the content hash in the path. This also renames a few previous functions to be "cache" instead of "etag".