### PR TITLE
Capture output in `cli/emoji` spec

### DIFF
--- a/spec/lib/mastodon/cli/emoji_spec.rb
+++ b/spec/lib/mastodon/cli/emoji_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe Mastodon::CLI::Emoji do
 
       it 'reports a successful purge' do
         expect { subject }
-          .to change { CustomEmoji.by_domain_and_subdomains(blocked_domain).count }.to(0)
+          .to output_results('OK')
+          .and change { CustomEmoji.by_domain_and_subdomains(blocked_domain).count }.to(0)
           .and change { CustomEmoji.by_domain_and_subdomains('evil.org').count }.to(0)
           .and not_change { CustomEmoji.by_domain_and_subdomains(silenced_domain).count }
           .and(not_change { CustomEmoji.local.count })


### PR DESCRIPTION
Silences some (harmless, but noisy) console output during run.