### PR TITLE
Update alt text limit for images (closed)

### DIFF
--- a/app/javascript/mastodon/features/alt_text_modal/index.tsx
+++ b/app/javascript/mastodon/features/alt_text_modal/index.tsx
@@ -54,7 +54,7 @@ const messages = defineMessages({
   },
 });
 
-const MAX_LENGTH = 1500;
+const MAX_LENGTH = 250000;
 
 type FocalPoint = [number, number];
 

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -38,7 +38,7 @@ class MediaAttachment < ApplicationRecord
   enum :type, { image: 0, gifv: 1, video: 2, unknown: 3, audio: 4 }
   enum :processing, { queued: 0, in_progress: 1, complete: 2, failed: 3 }, prefix: true
 
-  MAX_DESCRIPTION_LENGTH = 1_500
+  MAX_DESCRIPTION_LENGTH = 250_000
 
   IMAGE_LIMIT = 16.megabytes
   VIDEO_LIMIT = 99.megabytes


### PR DESCRIPTION
Fixes #22096.

Since that issue is "stalled" by the question of "how much should the limit be," here you go. (I know that the real answer is, we don't give a shit, so, we just ignored it for four years. But I'll be generous.)

Based upon the code in `app/models/concerns/attachmentable.rb`, the largest image Mastodon will accept is 7680x4320px in size. In reality, this is much larger than any image that will actually be accepted, but, you've spent over four years not giving a shit, so, you don't really get to be picky about numbers you chose.

Using Mastodon's default UI font, 15px Roboto with 20px line-height, filling an image of this size with randomly generated text results in 258,747 characters. Generously rounding this, 250,000 characters should be a reasonable alt text size.

I'm tired of being unable to fit the text contained in images of text in this field. So, since you've spent four years not architecting around this accessibility bug, I'm going to architect it with a hammer for you.

If you'd like to turn this into a server-configurable limit so you can continue to offer a shitty limit on mastodon.social, please feel free to work on that *after* you merge this change.

----

Also, in case you don't believe my test, I've attached the exact HTML page that I used to verify this myself:
[test.htm.gz](https://github.com/user-attachments/files/25310475/test.htm.gz)

----

Side note: your tests are flaky! The first commit for this failed, and an identical commit to rerun the tests passed. The original failures: https://github.com/mastodon/mastodon/actions/runs/22011480200