### PR TITLE
Profile redesign: Switch to server flag

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/common.ts
+++ b/app/javascript/mastodon/features/account_timeline/common.ts
@@ -1,5 +1,5 @@
-import { isClientFeatureEnabled } from '@/mastodon/utils/environment';
+import { isServerFeatureEnabled } from '@/mastodon/utils/environment';
 
 export function isRedesignEnabled() {
-  return isClientFeatureEnabled('profile_redesign');
+  return isServerFeatureEnabled('profile_redesign');
 }

--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -22,6 +22,7 @@ import { identityContextPropShape, withIdentity } from 'mastodon/identity_contex
 import { layoutFromWindow } from 'mastodon/is_mobile';
 import { WithRouterPropTypes } from 'mastodon/utils/react_router';
 import { checkAnnualReport } from '@/mastodon/reducers/slices/annual_report';
+import { isServerFeatureEnabled } from '@/mastodon/utils/environment';
 
 import { uploadCompose, resetCompose, changeComposeSpoilerness } from '../../actions/compose';
 import { clearHeight } from '../../actions/height_cache';
@@ -89,7 +90,6 @@ import { WrappedSwitch, WrappedRoute } from './util/react_router_helpers';
 // Without this it ends up in ~8 very commonly used bundles.
 import '../../components/status';
 import { areCollectionsEnabled } from '../collections/utils';
-import { isClientFeatureEnabled } from '@/mastodon/utils/environment';
 
 const messages = defineMessages({
   beforeUnload: { id: 'ui.beforeunload', defaultMessage: 'Your draft will be lost if you leave Mastodon.' },
@@ -162,7 +162,7 @@ class SwitchingColumnsArea extends PureComponent {
       redirect = <Redirect from='/' to='/about' exact />;
     }
 
-    const profileRedesignEnabled = isClientFeatureEnabled('profile_redesign');
+    const profileRedesignEnabled = isServerFeatureEnabled('profile_redesign');
     const profileRedesignRoutes = [];
     if (profileRedesignEnabled) {
       profileRedesignRoutes.push(

--- a/app/javascript/mastodon/features/ui/util/async-components.js
+++ b/app/javascript/mastodon/features/ui/util/async-components.js
@@ -1,4 +1,4 @@
-import { isClientFeatureEnabled } from '@/mastodon/utils/environment';
+import { isServerFeatureEnabled } from '@/mastodon/utils/environment';
 
 export function EmojiPicker () {
   return import('../../emoji/emoji_picker');
@@ -73,7 +73,7 @@ export function PinnedStatuses () {
 }
 
 export function AccountTimeline () {
-  if (isClientFeatureEnabled('profile_redesign')) {
+  if (isServerFeatureEnabled('profile_redesign')) {
     return import('../../account_timeline/v2');
   }
   return import('../../account_timeline');

--- a/app/javascript/mastodon/utils/environment.ts
+++ b/app/javascript/mastodon/utils/environment.ts
@@ -12,13 +12,13 @@ export function isProduction() {
   else return import.meta.env.PROD;
 }
 
-export type ServerFeatures = 'fasp' | 'collections';
+export type ServerFeatures = 'fasp' | 'collections' | 'profile_redesign';
 
 export function isServerFeatureEnabled(feature: ServerFeatures) {
   return initialState?.features.includes(feature) ?? false;
 }
 
-type ClientFeatures = 'profile_redesign' | 'collections';
+type ClientFeatures = 'collections';
 
 export function isClientFeatureEnabled(feature: ClientFeatures) {
   try {


### PR DESCRIPTION
This swaps the profile redesign to requiring a client flag to a server flag. Details about feedback will be added in #37804.