### PR TITLE
Use validation matchers for `LanguageValidator` spec

### DIFF
--- a/spec/validators/language_validator_spec.rb
+++ b/spec/validators/language_validator_spec.rb
@@ -3,59 +3,33 @@
 require 'rails_helper'
 
 RSpec.describe LanguageValidator do
+  subject { record_class.new }
+
   let(:record_class) do
     Class.new do
       include ActiveModel::Validations
+
+      def self.name = 'Record'
 
       attr_accessor :locale
 
       validates :locale, language: true
     end
   end
-  let(:record) { record_class.new }
 
-  describe '#validate_each' do
-    context 'with a nil value' do
-      it 'does not add errors' do
-        record.locale = nil
+  context 'with a nil value' do
+    it { is_expected.to allow_value(nil).for(:locale) }
+  end
 
-        expect(record).to be_valid
-        expect(record.errors).to be_empty
-      end
-    end
+  context 'with an array of values' do
+    it { is_expected.to allow_value(%w(en fr)).for(:locale) }
 
-    context 'with an array of values' do
-      it 'does not add errors with array of existing locales' do
-        record.locale = %w(en fr)
+    it { is_expected.to_not allow_value(%w(en fr missing)).for(:locale).with_message(:invalid) }
+  end
 
-        expect(record).to be_valid
-        expect(record.errors).to be_empty
-      end
+  context 'with a locale string' do
+    it { is_expected.to allow_value('en').for(:locale) }
 
-      it 'adds errors with array having some non-existing locales' do
-        record.locale = %w(en fr missing)
-
-        expect(record).to_not be_valid
-        expect(record.errors.first.attribute).to eq(:locale)
-        expect(record.errors.first.type).to eq(:invalid)
-      end
-    end
-
-    context 'with a locale string' do
-      it 'does not add errors when string is an existing locale' do
-        record.locale = 'en'
-
-        expect(record).to be_valid
-        expect(record.errors).to be_empty
-      end
-
-      it 'adds errors when string is non-existing locale' do
-        record.locale = 'missing'
-
-        expect(record).to_not be_valid
-        expect(record.errors.first.attribute).to eq(:locale)
-        expect(record.errors.first.type).to eq(:invalid)
-      end
-    end
+    it { is_expected.to_not allow_value('missing').for(:locale).with_message(:invalid) }
   end
 end


### PR DESCRIPTION
You may have anticipated this by now, but yes, this was pulled out of the larger multi-validator PR doing the same thing.
