### PR TITLE
Add default args to flatware bin

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -163,7 +163,7 @@ jobs:
             rspec-persistence-main
             rspec-persistence
 
-      - run: bin/flatware rspec -r ./spec/flatware_helper.rb
+      - run: bin/flatware
 
       - name: Upload coverage reports to Codecov
         if: matrix.ruby-version == '.ruby-version'

--- a/bin/flatware
+++ b/bin/flatware
@@ -12,5 +12,9 @@ ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "rubygems"
 require "bundler/setup"
+require "etc"
+
+# Push standard args in by default, cap parallel limit to match redis DB limit
+ARGV.unshift('rspec', '-r', './spec/flatware_helper.rb', '--workers', [Etc.nprocessors, 15].min)
 
 load Gem.bin_path("flatware", "flatware")


### PR DESCRIPTION
Despite being in shell history, its mildly annoying to spell out this full command when this `bin/` is probably *always* called with these options. The first one just does the needed rspec require to enable flatware, the second puts a cap on the number of parallel processes because of redis limit (not relevant/used on CI, but relevant locally maybe). If the redis DB default limit ever increases, or we are no longer limited that way, we could remove/increase that.

Adding more args on CLI will still work and be passed in for limited runs or whatever.