### PR TITLE
Update `haml_lint` to version 0.71.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,7 +291,7 @@ GEM
       activesupport (>= 5.1)
       haml (>= 4.0.6)
       railties (>= 5.1)
-    haml_lint (0.69.0)
+    haml_lint (0.71.0)
       haml (>= 5.0)
       parallel (~> 1.10)
       rainbow
@@ -590,7 +590,7 @@ GEM
     ox (2.14.23)
       bigdecimal (>= 3.0)
     parallel (1.27.0)
-    parser (3.3.10.1)
+    parser (3.3.10.2)
       ast (~> 2.4.1)
       racc
     parslet (2.0.0)


### PR DESCRIPTION
We originally added this problem matcher file when there was not a github reporter for haml lint. When we added the github reporter for haml lint we could have removed it, but did not.

Failing output of recent renovate PR which bumped haml-lint shows annotation data in summary - https://github.com/mastodon/mastodon/actions/runs/22117856350 - and console output in the actual job - https://github.com/mastodon/mastodon/actions/runs/22117856350/job/63930456314

Failing runs from first version of this PR has similar annotation - https://github.com/mastodon/mastodon/actions/runs/22141665598 - and same output - https://github.com/mastodon/mastodon/actions/runs/22141665598/job/64007245823 - but without needing the problem matcher.

So this PR:

- Updates haml-lint
- Removes no longer needed PM
- Fixes the one violation detected in version 0.70.0

The cop with the error here is a rubocop error bubbling up from how the haml view converts into ruby. It was sort of nonsensical at first because the line in question didn't seem to have the issue from the error. My change here is the least weird thing I could do to fix the cop and keep the generated markup the same. I guess we could also pull out a helper or something.

I've created a haml-lint issue to try to confirm if this is a false positive, or intended. Will leave as draft for now.