### PR TITLE
Fix visibility of video overlay controls in light mode

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4192,6 +4192,7 @@ a.account__display-name {
     cursor: pointer;
 
     & > div {
+      color: var(--color-text-on-media);
       background: rgb(from var(--color-bg-media) r g b / 60%);
       border-radius: 8px;
       padding: 12px 9px;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4192,7 +4192,7 @@ a.account__display-name {
     cursor: pointer;
 
     & > div {
-      background: rgb(from var(--color-shadow-primary) r g b / 60%);
+      background: rgb(from var(--color-bg-media) r g b / 60%);
       border-radius: 8px;
       padding: 12px 9px;
       backdrop-filter: $backdrop-blur-filter;
@@ -4205,7 +4205,7 @@ a.account__display-name {
     button,
     a {
       display: inline;
-      color: var(--color-text-primary);
+      color: var(--color-text-on-media);
       background: transparent;
       border: 0;
       padding: 0 8px;
@@ -4216,7 +4216,7 @@ a.account__display-name {
       &:hover,
       &:active,
       &:focus {
-        color: var(--color-text-primary);
+        color: var(--color-text-on-media);
       }
     }
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes a bug in our light color scheme whereby the play button overlaid on embedded-but-not-yet-played videos could become very hard to see.

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="576" height="435" alt="image" src="https://github.com/user-attachments/assets/53892f08-3a29-4185-9b4c-d60f48458d79" /> | <img width="576" height="435" alt="image" src="https://github.com/user-attachments/assets/60581ec2-bd0a-4fcd-9a43-56416d8e6c2a" /> |