### PR TITLE
Add `GET /api/v1/profile`

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Api::V1::ProfilesController < Api::BaseController
+  before_action -> { doorkeeper_authorize! :profile, :read, :'read:accounts' }
+  before_action :require_user!
+
+  def show
+    @account = current_account
+    render json: @account, serializer: REST::ProfileSerializer
+  end
+end

--- a/app/serializers/rest/profile_serializer.rb
+++ b/app/serializers/rest/profile_serializer.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class REST::ProfileSerializer < ActiveModel::Serializer
+  include RoutingHelper
+
+  attributes :id, :display_name, :note, :fields,
+             :avatar, :avatar_static, :avatar_description, :header, :header_static, :header_description,
+             :locked, :bot,
+             :hide_collections, :discoverable, :indexable,
+             :show_media, :show_media_replies, :show_featured,
+             :attribution_domains
+
+  def id
+    object.id.to_s
+  end
+
+  def fields
+    object.fields.map(&:to_h)
+  end
+
+  def avatar
+    object.avatar_file_name.present? ? full_asset_url(object.avatar_original_url) : nil
+  end
+
+  def avatar_static
+    object.avatar_file_name.present? ? full_asset_url(object.avatar_static_url) : nil
+  end
+
+  def header
+    object.header_file_name.present? ? full_asset_url(object.header_original_url) : nil
+  end
+
+  def header_static
+    object.header_file_name.present? ? full_asset_url(object.header_static_url) : nil
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -112,9 +112,11 @@ namespace :api, format: false do
     resources :endorsements, only: [:index]
     resources :markers, only: [:index, :create]
 
-    namespace :profile do
-      resource :avatar, only: :destroy
-      resource :header, only: :destroy
+    resource :profile, only: [:show] do
+      scope module: :profile do
+        resource :avatar, only: :destroy
+        resource :header, only: :destroy
+      end
     end
 
     namespace :apps do

--- a/spec/requests/api/v1/profiles_spec.rb
+++ b/spec/requests/api/v1/profiles_spec.rb
@@ -2,8 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Deleting profile images' do
-  include_context 'with API authentication', oauth_scopes: 'write:accounts'
+RSpec.describe 'Profile API' do
+  include_context 'with API authentication'
+
+  let(:scopes) { 'write:accounts' }
 
   let(:account) do
     Fabricate(
@@ -14,53 +16,88 @@ RSpec.describe 'Deleting profile images' do
   end
   let(:user) { account.user }
 
-  describe 'DELETE /api/v1/profile' do
-    context 'when deleting an avatar' do
-      context 'with wrong scope' do
-        before do
-          delete '/api/v1/profile/avatar', headers: headers
-        end
+  describe 'GET /api/v1/profile' do
+    let(:scopes) { 'read:accounts' }
 
-        it_behaves_like 'forbidden for wrong scope', 'read'
-      end
+    it 'returns HTTP success with the appropriate profile' do
+      get '/api/v1/profile', headers: headers
 
-      it 'returns http success and deletes the avatar, preserves the header, queues up distribution' do
+      expect(response)
+        .to have_http_status(200)
+
+      expect(response.content_type)
+        .to start_with('application/json')
+
+      expect(response.parsed_body)
+        .to match(
+          'id' => account.id.to_s,
+          'avatar' => %r{https://.*},
+          'avatar_static' => %r{https://.*},
+          'avatar_description' => '',
+          'header' => %r{https://.*},
+          'header_static' => %r{https://.*},
+          'header_description' => '',
+          'hide_collections' => anything,
+          'bot' => account.bot,
+          'locked' => account.locked,
+          'discoverable' => account.discoverable,
+          'indexable' => account.indexable,
+          'display_name' => account.display_name,
+          'fields' => [],
+          'attribution_domains' => [],
+          'note' => account.note,
+          'show_featured' => account.show_featured,
+          'show_media' => account.show_media,
+          'show_media_replies' => account.show_media_replies
+        )
+    end
+  end
+
+  describe 'DELETE /api/v1/profile/avatar' do
+    context 'with wrong scope' do
+      before do
         delete '/api/v1/profile/avatar', headers: headers
-
-        expect(response).to have_http_status(200)
-        expect(response.content_type)
-          .to start_with('application/json')
-
-        account.reload
-        expect(account.avatar).to_not exist
-        expect(account.header).to exist
-        expect(ActivityPub::UpdateDistributionWorker)
-          .to have_enqueued_sidekiq_job(account.id)
       end
+
+      it_behaves_like 'forbidden for wrong scope', 'read'
     end
 
-    context 'when deleting a header' do
-      context 'with wrong scope' do
-        before do
-          delete '/api/v1/profile/header', headers: headers
-        end
+    it 'returns http success and deletes the avatar, preserves the header, queues up distribution' do
+      delete '/api/v1/profile/avatar', headers: headers
 
-        it_behaves_like 'forbidden for wrong scope', 'read'
-      end
+      expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
-      it 'returns http success, preserves the avatar, deletes the header, queues up distribution' do
+      account.reload
+      expect(account.avatar).to_not exist
+      expect(account.header).to exist
+      expect(ActivityPub::UpdateDistributionWorker)
+        .to have_enqueued_sidekiq_job(account.id)
+    end
+  end
+
+  describe 'DELETE /api/v1/profile/header' do
+    context 'with wrong scope' do
+      before do
         delete '/api/v1/profile/header', headers: headers
-
-        expect(response).to have_http_status(200)
-        expect(response.content_type)
-          .to start_with('application/json')
-
-        account.reload
-        expect(account.avatar).to exist
-        expect(account.header).to_not exist
-        expect(ActivityPub::UpdateDistributionWorker)
-          .to have_enqueued_sidekiq_job(account.id)
       end
+
+      it_behaves_like 'forbidden for wrong scope', 'read'
+    end
+
+    it 'returns http success, preserves the avatar, deletes the header, queues up distribution' do
+      delete '/api/v1/profile/header', headers: headers
+
+      expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
+
+      account.reload
+      expect(account.avatar).to exist
+      expect(account.header).to_not exist
+      expect(ActivityPub::UpdateDistributionWorker)
+        .to have_enqueued_sidekiq_job(account.id)
     end
   end
 end


### PR DESCRIPTION
The aim is to eventually replace `GET /api/v1/accounts/verify_credentials` and `PATCH /api/v1/accounts/update_credentials` for profile editing.