### PR TITLE
Add option to disable infinite scroll

### DIFF
--- a/app/javascript/mastodon/components/scrollable_list/index.jsx
+++ b/app/javascript/mastodon/components/scrollable_list/index.jsx
@@ -82,10 +82,12 @@ class ScrollableList extends PureComponent {
     preventScroll: PropTypes.bool,
     footer: PropTypes.node,
     className: PropTypes.string,
+    infiniteScroll: PropTypes.bool,
   };
 
   static defaultProps = {
     trackScroll: true,
+    infiniteScroll: true,
   };
 
   state = {
@@ -102,7 +104,7 @@ class ScrollableList extends PureComponent {
       const clientHeight = this.getClientHeight();
       const offset = scrollHeight - scrollTop - clientHeight;
 
-      if (scrollTop > 0 && offset < 400 && this.props.onLoadMore && this.props.hasMore && !this.props.isLoading) {
+      if (scrollTop > 0 && offset < 400 && this.props.onLoadMore && this.props.hasMore && !this.props.isLoading && this.props.infiniteScroll) {
         this.props.onLoadMore();
       }
 

--- a/app/javascript/mastodon/components/status_list.jsx
+++ b/app/javascript/mastodon/components/status_list.jsx
@@ -14,6 +14,7 @@ import { StatusQuoteManager } from '../components/status_quoted';
 
 import { LoadGap } from './load_gap';
 import ScrollableList from './scrollable_list';
+import { disableInfiniteScroll } from 'mastodon/initial_state';
 
 
 export default class StatusList extends ImmutablePureComponent {
@@ -111,7 +112,7 @@ export default class StatusList extends ImmutablePureComponent {
     }
 
     return (
-      <ScrollableList {...other} showLoading={isLoading && statusIds.size === 0} onLoadMore={onLoadMore && this.handleLoadOlder} ref={this.setRef}>
+      <ScrollableList {...other} showLoading={isLoading && statusIds.size === 0} onLoadMore={onLoadMore && this.handleLoadOlder} ref={this.setRef} infiniteScroll={!disableInfiniteScroll} >
         {scrollableContent}
       </ScrollableList>
     );

--- a/app/javascript/mastodon/initial_state.ts
+++ b/app/javascript/mastodon/initial_state.ts
@@ -15,6 +15,7 @@ interface InitialStateMeta {
   missing_alt_text_modal?: boolean;
   disable_swiping?: boolean;
   disable_hover_cards?: boolean;
+  disable_infinite_scroll?: boolean;
   disabled_account_id?: string;
   display_media: string;
   domain: string;
@@ -103,6 +104,7 @@ export const missingAltTextModal = getMeta('missing_alt_text_modal');
 export const disableSwiping = getMeta('disable_swiping');
 export const disableHoverCards = getMeta('disable_hover_cards');
 export const disabledAccountId = getMeta('disabled_account_id');
+export const disableInfiniteScroll = getMeta('disable_infinite_scroll');
 export const displayMedia = getMeta('display_media');
 export const domain = getMeta('domain');
 export const emojiStyle = getMeta('emoji_style') ?? 'auto';

--- a/app/models/concerns/user/has_settings.rb
+++ b/app/models/concerns/user/has_settings.rb
@@ -99,6 +99,10 @@ module User::HasSettings
     settings['web.use_pending_items']
   end
 
+  def setting_disable_infinite_scroll
+    settings['web.disable_infinite_scroll']
+  end
+
   def setting_trends
     settings['web.trends']
   end

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -24,6 +24,7 @@ class UserSettings
     setting :trends, default: true
     setting :use_blurhash, default: true
     setting :use_pending_items, default: false
+    setting :disable_infinite_scroll, default: false
     setting :use_system_font, default: false
     setting :use_system_scrollbars, default: false
     setting :disable_swiping, default: false

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -27,6 +27,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:reduce_motion]     = object_account_user.setting_reduce_motion
       store[:disable_swiping]   = object_account_user.setting_disable_swiping
       store[:disable_hover_cards] = object_account_user.setting_disable_hover_cards
+      store[:disable_infinite_scroll] = object_account_user.setting_disable_infinite_scroll
       store[:advanced_layout]   = object_account_user.setting_advanced_layout
       store[:use_blurhash]      = object_account_user.setting_use_blurhash
       store[:use_pending_items] = object_account_user.setting_use_pending_items

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -78,6 +78,7 @@
                  wrapper: :with_label
 
     .fields-group
+      = ff.input :'web.disable_infinite_scroll', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_disable_infinite_scroll')
       = ff.input :'web.auto_play', wrapper: :with_label, recommended: true, label: I18n.t('simple_form.labels.defaults.setting_auto_play_gif')
       = ff.input :'web.reduce_motion', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_reduce_motion')
       = ff.input :'web.disable_swiping', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_disable_swiping')

--- a/config/locales/simple_form.en-GB.yml
+++ b/config/locales/simple_form.en-GB.yml
@@ -249,6 +249,7 @@ en-GB:
         setting_default_sensitive: Always mark media as sensitive
         setting_delete_modal: Warn me before deleting a post
         setting_disable_hover_cards: Disable profile preview on hover
+        setting_disable_infinite_scroll: Disable infinite scroll
         setting_disable_swiping: Disable swiping motions
         setting_display_media: Media display
         setting_display_media_default: Default

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -249,6 +249,7 @@ en:
         setting_default_sensitive: Always mark media as sensitive
         setting_delete_modal: Warn me before deleting a post
         setting_disable_hover_cards: Disable profile preview on hover
+        setting_disable_infinite_scroll: Disable infinite scroll
         setting_disable_swiping: Disable swiping motions
         setting_display_media: Media display
         setting_display_media_default: Default


### PR DESCRIPTION
(Partially) fixes https://github.com/mastodon/mastodon/issues/11079 .

I have made this PR in response to news reports of sites like TikTok coming under fire from regulators for implementing infinite scroll as it can be quite addictive.

Because of this, I have added a setting "Disable Infinite Scroll". Checking it will prevent the auto-load of new toots - instead the user must press the "Load More" button to do this. This creates a stopping cue and removes some of the addictiveness.

I have marked as an accessibility setting because it helps make Mastodon accessible to users with impulse control difficulties.

Screenshots:

<img width="1836" height="870" alt="image" src="https://github.com/user-attachments/assets/d756c9da-6ab8-4033-9e4f-b05c41859f4f" />

<img width="1849" height="869" alt="image" src="https://github.com/user-attachments/assets/a014a820-fc11-4995-81ae-d9e555ad4a40" />
