### PR TITLE
Only suggest `discoverable` accounts in collection account editor

### DIFF
--- a/app/javascript/mastodon/api_types/accounts.ts
+++ b/app/javascript/mastodon/api_types/accounts.ts
@@ -12,6 +12,26 @@ export interface ApiAccountRoleJSON {
   name: string;
 }
 
+type ApiFeaturePolicy =
+  | 'public'
+  | 'followers'
+  | 'following'
+  | 'disabled'
+  | 'unsupported_policy';
+
+type ApiUserFeaturePolicy =
+  | 'automatic'
+  | 'manual'
+  | 'denied'
+  | 'missing'
+  | 'unknown';
+
+interface ApiFeaturePolicyJSON {
+  automatic: ApiFeaturePolicy[];
+  manual: ApiFeaturePolicy[];
+  current_user: ApiUserFeaturePolicy;
+}
+
 // See app/serializers/rest/account_serializer.rb
 export interface BaseApiAccountJSON {
   acct: string;
@@ -23,6 +43,7 @@ export interface BaseApiAccountJSON {
   indexable: boolean;
   display_name: string;
   emojis: ApiCustomEmojiJSON[];
+  feature_approval: ApiFeaturePolicyJSON;
   fields: ApiAccountFieldJSON[];
   followers_count: number;
   following_count: number;

--- a/app/javascript/mastodon/features/collections/editor/accounts.tsx
+++ b/app/javascript/mastodon/features/collections/editor/accounts.tsx
@@ -129,7 +129,11 @@ export const CollectionAccounts: React.FC<{
     accountIds: suggestedAccountIds,
     isLoading: isLoadingSuggestions,
     searchAccounts,
-  } = useSearchAccounts();
+  } = useSearchAccounts({
+    filterResults: (account) =>
+      // Only suggest accounts who allow being featured/recommended
+      account.feature_approval.current_user === 'automatic',
+  });
 
   const suggestedItems = suggestedAccountIds.map((id) => ({
     id,

--- a/app/javascript/mastodon/features/lists/use_search_accounts.ts
+++ b/app/javascript/mastodon/features/lists/use_search_accounts.ts
@@ -10,8 +10,10 @@ import { useAppDispatch } from 'mastodon/store';
 export function useSearchAccounts({
   resetOnInputClear = true,
   onSettled,
+  filterResults,
 }: {
   onSettled?: (value: string) => void;
+  filterResults?: (account: ApiAccountJSON) => boolean;
   resetOnInputClear?: boolean;
 } = {}) {
   const dispatch = useAppDispatch();
@@ -49,8 +51,9 @@ export function useSearchAccounts({
         },
       })
         .then((data) => {
-          dispatch(importFetchedAccounts(data));
-          setAccountIds(data.map((a) => a.id));
+          const accounts = filterResults ? data.filter(filterResults) : data;
+          dispatch(importFetchedAccounts(accounts));
+          setAccountIds(accounts.map((a) => a.id));
           setLoadingState('idle');
           onSettled?.(value);
         })

--- a/app/javascript/mastodon/models/account.ts
+++ b/app/javascript/mastodon/models/account.ts
@@ -69,6 +69,11 @@ export const accountDefaultValues: AccountShape = {
   display_name: '',
   display_name_html: '',
   emojis: ImmutableList<CustomEmoji>(),
+  feature_approval: {
+    automatic: [],
+    manual: [],
+    current_user: 'missing',
+  },
   fields: ImmutableList<AccountField>(),
   group: false,
   header: '',

--- a/app/javascript/testing/factories.ts
+++ b/app/javascript/testing/factories.ts
@@ -31,6 +31,11 @@ export const accountFactory: FactoryFunction<ApiAccountJSON> = ({
   created_at: '2023-01-01T00:00:00.000Z',
   discoverable: true,
   emojis: [],
+  feature_approval: {
+    automatic: [],
+    manual: [],
+    current_user: 'missing',
+  },
   fields: [],
   followers_count: 0,
   following_count: 0,


### PR DESCRIPTION
Fixes WEB-827

### Changes proposed in this PR:
- When managing accounts of a collection, don't suggest accounts whose preference is not to be discoverable (i.e., they disabled the "Feature profile and posts in discovery algorithms" option).
- Adds types for the `feature_approval` field on the account object

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="588" height="426" alt="image" src="https://github.com/user-attachments/assets/b4bc357a-0bcf-43c2-b4a3-a4252131eeb8" /> | <img width="587" height="424" alt="image" src="https://github.com/user-attachments/assets/733fd97f-c663-4810-a606-693219f43bec" /> |