### PR TITLE
Change media description length limit for remote media attachments from 1500 to 10000 characters

### DIFF
--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -68,6 +68,6 @@ The following table summarizes those limits.
 | Account `attributionDomains`                                  | 256        | List will be truncated             |
 | Account aliases (actor `alsoKnownAs`)                         | 256        | List will be truncated             |
 | Custom emoji shortcode (`Emoji` `name`)                       | 2048       | Emoji will be rejected             |
-| Media and avatar/header descriptions (`name`/`summary`)       | 1500       | Description will be truncated      |
+| Media and avatar/header descriptions (`name`/`summary`)       | 10000      | Description will be truncated      |
 | Collection name (`FeaturedCollection` `name`)                 | 256        | Name will be truncated             |
 | Collection description (`FeaturedCollection` `summary`)       | 2048       | Description will be truncated      |

--- a/app/lib/activitypub/parser/media_attachment_parser.rb
+++ b/app/lib/activitypub/parser/media_attachment_parser.rb
@@ -30,7 +30,7 @@ class ActivityPub::Parser::MediaAttachmentParser
 
   def description
     str = @json['summary'].presence || @json['name'].presence
-    str = str.strip[0...MediaAttachment::MAX_DESCRIPTION_LENGTH] if str.present?
+    str = str.strip[0...MediaAttachment::MAX_DESCRIPTION_HARD_LENGTH_LIMIT] if str.present?
     str
   end
 

--- a/app/models/concerns/account/avatar.rb
+++ b/app/models/concerns/account/avatar.rb
@@ -25,7 +25,7 @@ module Account::Avatar
     validates_attachment_size :avatar, less_than: AVATAR_LIMIT
     remotable_attachment :avatar, AVATAR_LIMIT, suppress_errors: false
 
-    validates :avatar_description, length: { maximum: MediaAttachment::MAX_DESCRIPTION_LENGTH }
+    validates :avatar_description, length: { maximum: MediaAttachment::MAX_DESCRIPTION_LENGTH }, if: -> { local? && will_save_change_to_avatar_description? }
   end
 
   def avatar_original_url

--- a/app/models/concerns/account/header.rb
+++ b/app/models/concerns/account/header.rb
@@ -26,7 +26,7 @@ module Account::Header
     validates_attachment_size :header, less_than: HEADER_LIMIT
     remotable_attachment :header, HEADER_LIMIT, suppress_errors: false
 
-    validates :header_description, length: { maximum: MediaAttachment::MAX_DESCRIPTION_LENGTH }
+    validates :header_description, length: { maximum: MediaAttachment::MAX_DESCRIPTION_LENGTH }, if: -> { local? && will_save_change_to_header_description? }
   end
 
   def header_original_url

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -39,6 +39,7 @@ class MediaAttachment < ApplicationRecord
   enum :processing, { queued: 0, in_progress: 1, complete: 2, failed: 3 }, prefix: true
 
   MAX_DESCRIPTION_LENGTH = 1_500
+  MAX_DESCRIPTION_HARD_LENGTH_LIMIT = 10_000
 
   IMAGE_LIMIT = 16.megabytes
   VIDEO_LIMIT = 99.megabytes

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -238,7 +238,7 @@ class ActivityPub::ProcessAccountService < BaseService
       url = first_of_value(value['url'])
       url = url['href'] if url.is_a?(Hash)
       description = value['summary'].presence || value['name'].presence
-      description = description.strip[0...MediaAttachment::MAX_DESCRIPTION_LENGTH] if description.present?
+      description = description.strip[0...MediaAttachment::MAX_DESCRIPTION_HARD_LENGTH_LIMIT] if description.present?
     else
       url = value
     end


### PR DESCRIPTION
Note that this does not change the way the descriptions are used (pop-in and `alt` attribute) nor does it increase the limit for authoring them yet.

This is preliminary work for updating the authoring limit, though the authoring limit is not decided yet and may be lower than 10000 characters. This doesn't, in itself, replace #37881.