### PR TITLE
Remove conditional check for timeline data

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/v2/index.tsx
+++ b/app/javascript/mastodon/features/account_timeline/v2/index.tsx
@@ -86,11 +86,9 @@ const InnerTimeline: FC<{ accountId: string; multiColumn: boolean }> = ({
   const dispatch = useAppDispatch();
   useEffect(() => {
     if (accountId) {
-      if (!timeline) {
-        dispatch(expandTimelineByKey({ key }));
-      }
+      dispatch(expandTimelineByKey({ key }));
     }
-  }, [accountId, dispatch, key, timeline]);
+  }, [accountId, dispatch, key]);
 
   const handleLoadMore = useCallback(
     (maxId: number) => {


### PR DESCRIPTION
Fixes #37917.

Ensures we always refresh the timeline on loading an account page.