### PR TITLE
Re-use custom socket class for FASP requests

### DIFF
--- a/app/lib/fasp/request.rb
+++ b/app/lib/fasp/request.rb
@@ -29,7 +29,7 @@ class Fasp::Request
     response = HTTP
       .headers(headers)
       .use(http_signature: { key:, covered_components: COVERED_COMPONENTS })
-      .send(verb, url, body:)
+      .send(verb, url, body:, socket_class: ::Request::Socket)
 
     validate!(response)
     @provider.delivery_failure_tracker.track_success!

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -378,5 +378,5 @@ class Request
     end
   end
 
-  private_constant :ClientLimit, :Socket, :ProxySocket
+  private_constant :ClientLimit
 end


### PR DESCRIPTION
To prevent calls to local/private addresses.