### PR TITLE
Collection accounts editor: Show info badge on accounts that haven't posted in over a week

### DIFF
--- a/app/javascript/mastodon/components/account/index.tsx
+++ b/app/javascript/mastodon/components/account/index.tsx
@@ -73,6 +73,7 @@ interface AccountProps {
   defaultAction?: 'block' | 'mute';
   withBio?: boolean;
   withMenu?: boolean;
+  extraAccountInfo?: React.ReactNode;
   children?: React.ReactNode;
 }
 
@@ -84,6 +85,7 @@ export const Account: React.FC<AccountProps> = ({
   defaultAction,
   withBio,
   withMenu = true,
+  extraAccountInfo,
   children,
 }) => {
   const intl = useIntl();
@@ -347,6 +349,8 @@ export const Account: React.FC<AccountProps> = ({
                 />
               </div>
             ))}
+
+          {extraAccountInfo}
         </div>
 
         {!minimal && (

--- a/app/javascript/mastodon/features/collections/editor/accounts.tsx
+++ b/app/javascript/mastodon/features/collections/editor/accounts.tsx
@@ -60,17 +60,21 @@ const AddedAccountItem: React.FC<{
     onRemove(accountId);
   }, [accountId, onRemove]);
 
-  const lastPostHint = isOlderThanAWeek(account?.last_status_at) && (
-    <Badge
-      label={
-        <FormattedMessage
-          id='collections.old_last_post_note'
-          defaultMessage='Last posted over a week ago'
+  const lastPostHint = useMemo(
+    () =>
+      isOlderThanAWeek(account?.last_status_at) && (
+        <Badge
+          label={
+            <FormattedMessage
+              id='collections.old_last_post_note'
+              defaultMessage='Last posted over a week ago'
+            />
+          }
+          icon={<WarningIcon />}
+          className={classes.accountBadge}
         />
-      }
-      icon={<WarningIcon />}
-      className={classes.accountBadge}
-    />
+      ),
+    [account?.last_status_at],
   );
 
   return (

--- a/app/javascript/mastodon/features/collections/editor/accounts.tsx
+++ b/app/javascript/mastodon/features/collections/editor/accounts.tsx
@@ -6,12 +6,14 @@ import { useHistory, useLocation } from 'react-router-dom';
 
 import CancelIcon from '@/material-icons/400-24px/cancel.svg?react';
 import CheckIcon from '@/material-icons/400-24px/check.svg?react';
+import WarningIcon from '@/material-icons/400-24px/warning.svg?react';
 import { showAlertForError } from 'mastodon/actions/alerts';
 import { openModal } from 'mastodon/actions/modal';
 import { apiFollowAccount } from 'mastodon/api/accounts';
 import type { ApiCollectionJSON } from 'mastodon/api_types/collections';
 import { Account } from 'mastodon/components/account';
 import { Avatar } from 'mastodon/components/avatar';
+import { Badge } from 'mastodon/components/badge';
 import { Button } from 'mastodon/components/button';
 import { Callout } from 'mastodon/components/callout';
 import { DisplayName } from 'mastodon/components/display_name';
@@ -37,19 +39,47 @@ import { WizardStepHeader } from './wizard_step_header';
 const MIN_ACCOUNT_COUNT = 1;
 const MAX_ACCOUNT_COUNT = 25;
 
+function isOlderThanAWeek(date?: string): boolean {
+  if (!date) return false;
+
+  const targetDate = new Date(date);
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  return targetDate < sevenDaysAgo;
+}
+
 const AddedAccountItem: React.FC<{
   accountId: string;
   isRemovable: boolean;
   onRemove: (id: string) => void;
 }> = ({ accountId, isRemovable, onRemove }) => {
   const intl = useIntl();
+  const account = useAccount(accountId);
 
   const handleRemoveAccount = useCallback(() => {
     onRemove(accountId);
   }, [accountId, onRemove]);
 
+  const lastPostHint = isOlderThanAWeek(account?.last_status_at) && (
+    <Badge
+      label={
+        <FormattedMessage
+          id='collections.old_last_post_note'
+          defaultMessage='Last posted over a week ago'
+        />
+      }
+      icon={<WarningIcon />}
+      className={classes.accountBadge}
+    />
+  );
+
   return (
-    <Account minimal key={accountId} id={accountId}>
+    <Account
+      minimal
+      key={accountId}
+      id={accountId}
+      extraAccountInfo={lastPostHint}
+    >
       {isRemovable && (
         <IconButton
           title={intl.formatMessage({

--- a/app/javascript/mastodon/features/collections/editor/styles.module.scss
+++ b/app/javascript/mastodon/features/collections/editor/styles.module.scss
@@ -86,3 +86,12 @@
   margin-inline: auto;
   gap: 8px;
 }
+
+.accountBadge {
+  margin-inline-start: 56px;
+
+  @container (width < 360px) {
+    margin-top: 4px;
+    margin-inline-start: 46px;
+  }
+}

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -296,6 +296,7 @@
   "collections.name_length_hint": "40 characters limit",
   "collections.new_collection": "New collection",
   "collections.no_collections_yet": "No collections yet.",
+  "collections.old_last_post_note": "Last posted over a week ago",
   "collections.remove_account": "Remove this account",
   "collections.search_accounts_label": "Search for accounts to add…",
   "collections.search_accounts_max_reached": "You have added the maximum number of accounts",


### PR DESCRIPTION
### Changes proposed in this PR:
- In the collection accounts editor, show an info badge on accounts that haven't posted in over a week

### Screenshots

<img width="589" height="115" alt="image" src="https://github.com/user-attachments/assets/be327cbb-8499-4029-b767-6700d7e80a7f" />
