### PR TITLE
[Early WiP] Support multiple keypair per actor

### DIFF
--- a/app/lib/activitypub/linked_data_signature.rb
+++ b/app/lib/activitypub/linked_data_signature.rb
@@ -33,18 +33,19 @@ class ActivityPub::LinkedDataSignature
   end
 
   def sign!(creator, sign_with: nil)
+    keypair = sign_with.presence || creator.keypair
+
     options = {
       'type' => 'RsaSignature2017',
-      'creator' => ActivityPub::TagManager.instance.key_uri_for(creator),
+      'creator' => keypair.uri,
       'created' => Time.now.utc.iso8601,
     }
 
     options_hash  = hash(options.without('type', 'id', 'signatureValue').merge('@context' => CONTEXT))
     document_hash = hash(@json.without('signature'))
     to_be_signed  = options_hash + document_hash
-    keypair       = sign_with.present? ? OpenSSL::PKey::RSA.new(sign_with) : creator.keypair
 
-    signature = Base64.strict_encode64(keypair.sign(OpenSSL::Digest.new('SHA256'), to_be_signed))
+    signature = Base64.strict_encode64(keypair.keypair.sign(OpenSSL::Digest.new('SHA256'), to_be_signed))
 
     # Mastodon's context is either an array or a single URL
     context_with_security = Array(@json['@context'])

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -77,6 +77,8 @@ class ActivityPub::TagManager
   end
 
   def key_uri_for(target)
+    return [uri_for(target.actor), '#', target.id].join if target.is_a?(Keypair)
+
     [uri_for(target), '#main-key'].join
   end
 

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -100,9 +100,8 @@ class Request
   def on_behalf_of(actor, sign_with: nil)
     raise ArgumentError, 'actor must not be nil' if actor.nil?
 
-    key_id = ActivityPub::TagManager.instance.key_uri_for(actor)
-    keypair = sign_with.present? ? OpenSSL::PKey::RSA.new(sign_with) : actor.keypair
-    @signing = HttpSignatureDraft.new(keypair, key_id)
+    keypair = sign_with.presence || actor.keypair
+    @signing = HttpSignatureDraft.new(keypair.keypair, keypair.uri)
 
     self
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -460,11 +460,11 @@ class Account < ApplicationRecord
   end
 
   before_validation :prepare_contents, if: :local?
-  before_create :generate_keys
+  after_create_commit :generate_keys
   before_destroy :clean_feed_manager
 
   def ensure_keys!
-    return unless local? && private_key.blank? && public_key.blank?
+    return unless local? && private_key.blank? && public_key.blank? && keypairs.empty?
 
     generate_keys
     save!
@@ -485,11 +485,10 @@ class Account < ApplicationRecord
   end
 
   def generate_keys
-    return unless local? && private_key.blank? && public_key.blank?
+    return unless local? && private_key.blank? && public_key.blank? && keypairs.empty?
 
     keypair = OpenSSL::PKey::RSA.new(2048)
-    self.private_key = keypair.to_pem
-    self.public_key  = keypair.public_key.to_pem
+    keypairs.create!(uri: ActivityPub::TagManager.instance.key_uri_for(self), type: :rsa, public_key: keypair.public_key.to_pem, private_key: keypair.to_pem)
   end
 
   def normalize_domain

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -290,7 +290,7 @@ class Account < ApplicationRecord
   end
 
   def keypair
-    @keypair ||= OpenSSL::PKey::RSA.new(private_key || public_key)
+    keypairs.usable.first || Keypair.from_legacy_account(self)
   end
 
   def tags_as_strings=(tag_names)

--- a/app/models/keypair.rb
+++ b/app/models/keypair.rb
@@ -74,4 +74,21 @@ class Keypair < ApplicationRecord
       type: :rsa
     )
   end
+
+  def self.from_worker_arg(account, private_key_pem_or_hash)
+    if private_key_pem_or_hash.is_a?(String)
+      account.keypairs.build(
+        private_key: private_key_pem_or_hash,
+        uri: ActivityPub::TagManager.instance.key_uri_for(account),
+        type: :rsa
+      )
+    else
+      account.keypairs.build(
+        private_key: private_key_pem_or_hash['private_key'],
+        public_key: private_key_pem_or_hash['public_key'],
+        uri: private_key_pem_or_hash['uri'],
+        type: private_key_pem_or_hash['type']
+      )
+    end
+  end
 end

--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -24,7 +24,7 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
   attribute :interaction_policy, if: -> { Mastodon::Feature.collections_enabled? }
   attribute :featured_collections, if: -> { Mastodon::Feature.collections_enabled? }
 
-  has_one :public_key, serializer: ActivityPub::PublicKeySerializer
+  has_one :keypair, key: :public_key, serializer: ActivityPub::PublicKeySerializer
 
   has_many :virtual_tags, key: :tag
   has_many :virtual_attachments, key: :attachment

--- a/app/serializers/activitypub/public_key_serializer.rb
+++ b/app/serializers/activitypub/public_key_serializer.rb
@@ -6,11 +6,11 @@ class ActivityPub::PublicKeySerializer < ActivityPub::Serializer
   attributes :id, :owner, :public_key_pem
 
   def id
-    ActivityPub::TagManager.instance.key_uri_for(object)
+    object.uri
   end
 
   def owner
-    ActivityPub::TagManager.instance.uri_for(object)
+    ActivityPub::TagManager.instance.uri_for(object.actor)
   end
 
   def public_key_pem

--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -48,7 +48,7 @@ class ActivityPub::DeliveryWorker
 
   def build_request(http_client)
     Request.new(:post, @inbox_url, body: @json, http_client: http_client).tap do |request|
-      request.on_behalf_of(@source_account, sign_with: @options[:sign_with])
+      request.on_behalf_of(@source_account, sign_with: sign_with)
       request.add_headers(HEADERS)
       request.add_headers({ 'Collection-Synchronization' => synchronization_header }) if ENV['DISABLE_FOLLOWERS_SYNCHRONIZATION'] != 'true' && @options[:synchronize_followers]
     end
@@ -92,5 +92,9 @@ class ActivityPub::DeliveryWorker
 
   def request_pool
     RequestPool.current
+  end
+
+  def sign_with
+    @options[:sign_with].presence && Keypair.from_worker_arg(@source_account, @options[:sign_with])
   end
 end

--- a/app/workers/activitypub/update_distribution_worker.rb
+++ b/app/workers/activitypub/update_distribution_worker.rb
@@ -23,6 +23,10 @@ class ActivityPub::UpdateDistributionWorker < ActivityPub::RawDistributionWorker
   end
 
   def payload
-    @payload ||= serialize_payload(@account, ActivityPub::UpdateActorSerializer, signer: @account, sign_with: @options[:sign_with]).to_json
+    @payload ||= serialize_payload(@account, ActivityPub::UpdateActorSerializer, signer: @account, sign_with: sign_with).to_json
+  end
+
+  def sign_with
+    @options[:sign_with].presence && Keypair.from_worker_arg(@account, @options[:sign_with])
   end
 end

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -612,10 +612,22 @@ module Mastodon::CLI
     def rotate_keys_for_account(account, delay = 0)
       fail_with_message 'No such account' if account.nil?
 
-      old_key = account.private_key
+      old_key = account.keypair
       new_key = OpenSSL::PKey::RSA.new(2048)
-      account.update(private_key: new_key.to_pem, public_key: new_key.public_key.to_pem)
-      ActivityPub::UpdateDistributionWorker.perform_in(delay, account.id, { 'sign_with' => old_key })
+
+      account.update(private_key: nil, public_key: '', keypairs: [account.keypairs.build(uri: ActivityPub::TagManager.instance.key_uri_for(account), type: :rsa, public_key: new_key.public_key.to_pem, private_key: new_key.to_pem)])
+
+      ActivityPub::UpdateDistributionWorker.perform_in(
+        delay,
+        account.id,
+        {
+          'sign_with' => {
+            'private_key' => old_key.private_key,
+            'uri' => old_key.uri,
+            'type' => old_key.type,
+          },
+        }
+      )
     end
   end
 end

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -686,6 +686,7 @@ module Mastodon::CLI
       reference_account = accounts.shift
 
       accounts.each do |other_account|
+        # TODO: this needs to get updated
         if other_account.public_key == reference_account.public_key
           # The accounts definitely point to the same resource, so
           # it's safe to re-attribute content and relationships

--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -4,18 +4,30 @@ keypair     = OpenSSL::PKey::RSA.new(2048)
 public_key  = keypair.public_key.to_pem
 private_key = keypair.to_pem
 
-Fabricator(:account) do
-  transient :suspended, :silenced
+Fabricator(:account_base, class_name: :account) do
+  transient :suspended, :silenced, :legacy_keypair
   username            { sequence(:username) { |i| "#{Faker::Internet.user_name(separators: %w(_))}#{i}" } }
   last_webfingered_at { Time.now.utc }
-  public_key          { public_key }
-  private_key         { private_key }
+  public_key          { |attrs| attrs[:legacy_keypair] ? public_key : '' }
+  private_key         { |attrs| attrs[:legacy_keypair] ? private_key : nil }
   suspended_at        { |attrs| attrs[:suspended] ? Time.now.utc : nil }
   silenced_at         { |attrs| attrs[:silenced] ? Time.now.utc : nil }
   user                { |attrs| attrs[:domain].nil? ? Fabricate.build(:user, account: nil) : nil }
   uri                 { |attrs| attrs[:domain].nil? ? '' : "https://#{attrs[:domain]}/users/#{attrs[:username]}" }
   discoverable        true
   indexable           true
+end
+
+Fabricator(:account, from: :account_base) do
+  after_create do |account|
+    account.keypairs = [Fabricate.build(:keypair, account: account)] if account.keypairs.blank? && account.public_key.blank? && account.private_key.blank?
+  end
+end
+
+Fabricator(:account_with_private_key, from: :account_base) do
+  after_create do |account|
+    account.keypairs = [Fabricate.build(:keypair, account: account, require_private_key: true)] if account.keypairs.blank? && account.public_key.blank? && account.private_key.blank?
+  end
 end
 
 Fabricator(:remote_account, from: :account) do

--- a/spec/fabricators/keypair_fabricator.rb
+++ b/spec/fabricators/keypair_fabricator.rb
@@ -5,14 +5,14 @@ public_key  = keypair.public_key.to_pem
 private_key = keypair.to_pem
 
 Fabricator(:keypair) do
-  account
+  account(fabricator: :account_base)
   type        :rsa
   public_key  public_key
   expires_at  nil
   revoked     false
 
   after_build do |keypair|
-    keypair.uri ||= ActivityPub::TagManager.instance.key_uri_for(keypair.account)
-    keypair.private_key ||= private_key if keypair.account.local?
+    keypair.uri ||= ActivityPub::TagManager.instance.key_uri_for(keypair)
+    keypair.private_key ||= private_key if keypair.account.local? || keypair.require_private_key
   end
 end

--- a/spec/lib/activitypub/linked_data_signature_spec.rb
+++ b/spec/lib/activitypub/linked_data_signature_spec.rb
@@ -159,6 +159,6 @@ RSpec.describe ActivityPub::LinkedDataSignature do
     options_hash   = Digest::SHA256.hexdigest(canonicalize(options.merge('@context' => ActivityPub::LinkedDataSignature::CONTEXT)))
     document_hash  = Digest::SHA256.hexdigest(canonicalize(document))
     to_be_verified = options_hash + document_hash
-    Base64.strict_encode64(from_actor.keypair.sign(OpenSSL::Digest.new('SHA256'), to_be_verified))
+    Base64.strict_encode64(from_actor.keypair.keypair.sign(OpenSSL::Digest.new('SHA256'), to_be_verified))
   end
 end

--- a/spec/lib/activitypub/linked_data_signature_spec.rb
+++ b/spec/lib/activitypub/linked_data_signature_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe ActivityPub::LinkedDataSignature do
 
   subject { described_class.new(json) }
 
-  let(:keyid) { 'http://example.com/alice#rsa-key' }
-  let!(:sender) { Fabricate(:account, uri: 'http://example.com/alice', domain: 'example.com') }
+  let!(:sender) { Fabricate(:account_with_private_key, uri: 'http://example.com/alice', domain: 'example.com') }
+  let!(:keyid) { sender.keypair.uri }
 
   let(:raw_json) do
     {
@@ -55,8 +55,8 @@ RSpec.describe ActivityPub::LinkedDataSignature do
         signature
 
         # Unset key
-        old_key = sender.public_key
-        sender.update!(private_key: '', public_key: '')
+        old_key = sender.keypair.public_key
+        sender.keypairs.delete_all
 
         allow(ActivityPub::FetchRemoteKeyService).to receive(:new).and_return(service_stub)
 

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -655,7 +655,7 @@ RSpec.describe Mastodon::CLI::Accounts do
 
     context 'when there are duplicate URI accounts' do
       before do
-        Fabricate.times(2, :account, domain: 'host.example', uri: uri)
+        Fabricate.times(2, :account, domain: 'host.example', legacy_keypair: true, uri: uri)
         allow(ActivityPub::FetchRemoteAccountService).to receive(:new).and_return(service_double)
       end
 

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -951,15 +951,15 @@ RSpec.describe Mastodon::CLI::Accounts do
       let(:arguments) { [account.username] }
 
       it 'correctly rotates keys for the specified account' do
-        old_private_key = account.private_key
-        old_public_key = account.public_key
+        old_private_key = account.keypair.private_key
+        old_public_key = account.keypair.public_key
 
         expect { subject }
           .to output_results('OK')
         account.reload
 
-        expect(account.private_key).to_not eq(old_private_key)
-        expect(account.public_key).to_not eq(old_public_key)
+        expect(account.keypair.private_key).to_not eq(old_private_key)
+        expect(account.keypair.public_key).to_not eq(old_public_key)
       end
 
       it 'broadcasts the new keys for the specified account' do
@@ -986,15 +986,15 @@ RSpec.describe Mastodon::CLI::Accounts do
       let(:options) { { all: true } }
 
       it 'correctly rotates keys for all local accounts' do
-        old_private_keys = accounts.map(&:private_key)
-        old_public_keys = accounts.map(&:public_key)
+        old_private_keys = accounts.map { |account| account.keypair.private_key }
+        old_public_keys = accounts.map { |account| account.keypair.public_key }
 
         expect { subject }
           .to output_results('rotated')
         accounts.each(&:reload)
 
-        expect(accounts.map(&:private_key)).to_not eq(old_private_keys)
-        expect(accounts.map(&:public_key)).to_not eq(old_public_keys)
+        expect(accounts.map { |account| account.keypair.private_key }).to_not eq(old_private_keys)
+        expect(accounts.map { |account| account.keypair.public_key }).to_not eq(old_public_keys)
       end
 
       it 'broadcasts the new keys for each account' do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -736,9 +736,8 @@ RSpec.describe Account do
     it 'generates keys' do
       account = described_class.create!(domain: nil, username: 'user_without_keys')
 
-      expect(account)
-        .to be_private_key
-        .and be_public_key
+      expect(account.private_key).to be_nil
+      expect(account.public_key).to eq ''
       expect(account.keypair.keypair)
         .to be_private
         .and be_public

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -246,9 +246,10 @@ RSpec.describe Account do
   end
 
   describe '#keypair' do
-    it 'returns an RSA key pair' do
+    it 'returns a Keypair object with a RSA key pair' do
       account = Fabricate(:account)
-      expect(account.keypair).to be_instance_of OpenSSL::PKey::RSA
+      expect(account.keypair).to be_instance_of Keypair
+      expect(account.keypair.keypair).to be_instance_of OpenSSL::PKey::RSA
     end
   end
 
@@ -738,7 +739,7 @@ RSpec.describe Account do
       expect(account)
         .to be_private_key
         .and be_public_key
-      expect(account.keypair)
+      expect(account.keypair.keypair)
         .to be_private
         .and be_public
     end
@@ -748,7 +749,7 @@ RSpec.describe Account do
     it 'does not generate keys' do
       key = OpenSSL::PKey::RSA.new(1024).public_key
       account = described_class.create!(domain: 'remote', uri: 'https://remote/actor', username: 'remote_user_with_public', public_key: key.to_pem)
-      expect(account.keypair.params).to eq key.params
+      expect(account.keypair.keypair.params).to eq key.params
     end
 
     it 'normalizes domain' do

--- a/spec/models/keypair_spec.rb
+++ b/spec/models/keypair_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe Keypair do
 
   describe 'from_keyid' do
     context 'when a key with the given key ID exists' do
-      let(:account) { Fabricate(:account, domain: 'example.com') }
-      let(:keypair) { Fabricate(:keypair, account: account) }
+      let(:keypair) { Fabricate(:keypair) }
 
       it 'returns the expected Keypair' do
         expect(described_class.from_keyid(keypair.uri))
@@ -23,7 +22,7 @@ RSpec.describe Keypair do
     end
 
     context 'when no key with the expected key ID exists but there is an account with the same ID and a key' do
-      let(:account) { Fabricate(:account, domain: 'example.com') }
+      let(:account) { Fabricate(:account, domain: 'example.com', legacy_keypair: true) }
       let(:keyid) { "#{ActivityPub::TagManager.instance.uri_for(account)}#main-rsa-key" }
 
       it 'returns the expected Keypair' do
@@ -37,7 +36,7 @@ RSpec.describe Keypair do
     end
 
     context 'when no key with the expected key ID exists but there is an account with the same ID and no key' do
-      let(:account) { Fabricate(:account, domain: 'example.com', public_key: '', private_key: nil) }
+      let(:account) { Fabricate(:account, domain: 'example.com') }
       let(:keyid) { "#{ActivityPub::TagManager.instance.uri_for(account)}#main-rsa-key" }
 
       it 'returns nil' do

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe 'Accounts show response' do
         end
 
         context 'with signature' do
-          let(:remote_account) { Fabricate(:account, domain: 'example.com') }
+          let(:remote_account) { Fabricate(:account_with_private_key, domain: 'example.com') }
 
           before do
             get short_account_path(username: account.username), headers: headers, sign_with: remote_account

--- a/spec/requests/activitypub/collections_spec.rb
+++ b/spec/requests/activitypub/collections_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'ActivityPub Collections' do
       end
 
       context 'with signature' do
-        let(:remote_account) { Fabricate(:account, domain: 'example.com') }
+        let(:remote_account) { Fabricate(:account_with_private_key, domain: 'example.com') }
 
         context 'when getting a featured resource' do
           it 'returns http success and correct media type and expected items' do

--- a/spec/requests/activitypub/featured_collections_spec.rb
+++ b/spec/requests/activitypub/featured_collections_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'Collections' do
             sign_with: remote_account
       end
 
-      let(:remote_account) { Fabricate(:account, domain: 'host.example') }
+      let(:remote_account) { Fabricate(:account_with_private_key, domain: 'host.example') }
 
       context 'when account blocks the remote account' do
         before { account.block!(remote_account) }

--- a/spec/requests/activitypub/followers_synchronizations_spec.rb
+++ b/spec/requests/activitypub/followers_synchronizations_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'ActivityPub Follower Synchronizations' do
     context 'with signature from example.com' do
       subject { get account_followers_synchronization_path(account_username: account.username), headers: nil, sign_with: remote_account }
 
-      let(:remote_account) { Fabricate(:account, domain: 'example.com', uri: 'https://example.com/instance') }
+      let(:remote_account) { Fabricate(:account_with_private_key, domain: 'example.com', uri: 'https://example.com/instance') }
 
       it 'returns http success and cache control and activity json types and correct items' do
         subject

--- a/spec/requests/activitypub/inboxes_spec.rb
+++ b/spec/requests/activitypub/inboxes_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'ActivityPub Inboxes' do
 
   describe 'POST #create' do
     context 'with signature' do
-      let(:remote_account) { Fabricate(:account, domain: 'example.com', protocol: :activitypub) }
+      let(:remote_account) { Fabricate(:account_with_private_key, domain: 'example.com', protocol: :activitypub) }
 
       context 'without a named account' do
         subject { post inbox_path, params: {}.to_json, sign_with: remote_account }
@@ -68,7 +68,7 @@ RSpec.describe 'ActivityPub Inboxes' do
     context 'with Collection-Synchronization header' do
       subject { post inbox_path, params: {}.to_json, headers: { 'Collection-Synchronization' => synchronization_header }, sign_with: remote_account }
 
-      let(:remote_account) { Fabricate(:account, followers_url: 'https://example.com/followers', domain: 'example.com', uri: 'https://example.com/actor', protocol: :activitypub) }
+      let(:remote_account) { Fabricate(:account_with_private_key, followers_url: 'https://example.com/followers', domain: 'example.com', uri: 'https://example.com/actor', protocol: :activitypub) }
       let(:synchronization_collection) { remote_account.followers_url }
       let(:synchronization_url) { 'https://example.com/followers-for-domain' }
       let(:synchronization_hash) { 'somehash' }

--- a/spec/requests/activitypub/outboxes_spec.rb
+++ b/spec/requests/activitypub/outboxes_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'ActivityPub Outboxes' do
     context 'with signature' do
       subject { get account_outbox_path(account_username: account.username, page: page), headers: nil, sign_with: remote_account }
 
-      let(:remote_account) { Fabricate(:account, domain: 'example.com') }
+      let(:remote_account) { Fabricate(:account_with_private_key, domain: 'example.com') }
       let(:page) { 'true' }
 
       context 'when signed request account does not follow account' do

--- a/spec/requests/activitypub/replies_spec.rb
+++ b/spec/requests/activitypub/replies_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe 'ActivityPub Replies' do
     context 'with signature' do
       subject { get account_status_replies_path(account_username: status.account.username, status_id: status.id, only_other_accounts: only_other_accounts), headers: nil, sign_with: remote_querier }
 
-      let(:remote_querier) { Fabricate(:account, domain: 'example.com') }
+      let(:remote_querier) { Fabricate(:account_with_private_key, domain: 'example.com') }
 
       it_behaves_like 'allowed access'
 

--- a/spec/requests/cache_spec.rb
+++ b/spec/requests/cache_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe 'Caching behavior' do
   end
 
   context 'with a Signature header' do
-    let(:remote_actor)    { Fabricate(:account, domain: 'example.org', uri: 'https://example.org/remote', protocol: :activitypub) }
+    let(:remote_actor)    { Fabricate(:account_with_private_key, domain: 'example.org', uri: 'https://example.org/remote', protocol: :activitypub) }
     let(:dummy_signature) { 'dummy-signature' }
 
     before do
@@ -442,7 +442,7 @@ RSpec.describe 'Caching behavior' do
     end
 
     context 'when providing a Signature' do
-      let(:remote_actor)    { Fabricate(:account, domain: 'example.org', uri: 'https://example.org/remote', protocol: :activitypub) }
+      let(:remote_actor)    { Fabricate(:account_with_private_key, domain: 'example.org', uri: 'https://example.org/remote', protocol: :activitypub) }
       let(:dummy_signature) { 'dummy-signature' }
 
       before do
@@ -502,7 +502,7 @@ RSpec.describe 'Caching behavior' do
     end
 
     context 'when providing a Signature from an allowed domain' do
-      let(:remote_actor)    { Fabricate(:account, domain: 'example.org', uri: 'https://example.org/remote', protocol: :activitypub) }
+      let(:remote_actor)    { Fabricate(:account_with_private_key, domain: 'example.org', uri: 'https://example.org/remote', protocol: :activitypub) }
       let(:dummy_signature) { 'dummy-signature' }
 
       before do
@@ -530,7 +530,7 @@ RSpec.describe 'Caching behavior' do
     end
 
     context 'when providing a Signature from a non-allowed domain' do
-      let(:remote_actor)    { Fabricate(:account, domain: 'example.org', uri: 'https://example.org/remote', protocol: :activitypub) }
+      let(:remote_actor)    { Fabricate(:account_with_private_key, domain: 'example.org', uri: 'https://example.org/remote', protocol: :activitypub) }
       let(:dummy_signature) { 'dummy-signature' }
 
       describe '/actor' do

--- a/spec/requests/collection_items_spec.rb
+++ b/spec/requests/collection_items_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'CollectionItems' do
             sign_with: remote_account
       end
 
-      let(:remote_account) { Fabricate(:account, domain: 'host.example') }
+      let(:remote_account) { Fabricate(:account_with_private_key, domain: 'host.example') }
 
       context 'when account blocks the remote account' do
         before { account.block!(remote_account) }

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Collections' do
             sign_with: remote_account
       end
 
-      let(:remote_account) { Fabricate(:account, domain: 'host.example') }
+      let(:remote_account) { Fabricate(:account_with_private_key, domain: 'host.example') }
 
       context 'when account blocks the remote account' do
         before { account.block!(remote_account) }

--- a/spec/requests/statuses/activity_spec.rb
+++ b/spec/requests/statuses/activity_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe 'Status Activity' do
     context 'with signature' do
       subject { get activity_account_status_path(account.username, status), headers: nil, sign_with: remote_account }
 
-      let(:remote_account) { Fabricate(:account, domain: 'example.com') }
+      let(:remote_account) { Fabricate(:account_with_private_key, domain: 'example.com') }
 
       context 'when status is public' do
         before { status.update(visibility: :public) }

--- a/spec/requests/statuses_spec.rb
+++ b/spec/requests/statuses_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe 'Statuses' do
       end
 
       let(:format) { 'html' }
-      let(:remote_account) { Fabricate(:account, domain: 'host.example') }
+      let(:remote_account) { Fabricate(:account_with_private_key, domain: 'host.example') }
 
       context 'when account blocks the remote account' do
         before { account.block!(remote_account) }

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe ActivityPub::ProcessAccountService do
     end
 
     context 'when the account was known with a legacy key' do
-      let!(:alice) { Fabricate(:account, uri: 'https://foo.test/actor', domain: 'example.com', username: 'alice') }
+      let!(:alice) { Fabricate(:account, uri: 'https://foo.test/actor', domain: 'example.com', username: 'alice', legacy_keypair: true) }
 
       it 'invalidates the legacy key and stores the new key' do
         expect { subject.call('alice', 'example.com', payload) }
@@ -132,9 +132,11 @@ RSpec.describe ActivityPub::ProcessAccountService do
     end
 
     context 'when the account was known with an old key' do
-      let!(:alice) { Fabricate(:account, uri: 'https://foo.test/actor', domain: 'example.com', username: 'alice', public_key: '') }
+      let!(:alice) { Fabricate(:account, uri: 'https://foo.test/actor', domain: 'example.com', username: 'alice') }
 
       before do
+        alice.keypairs.delete_all
+
         Fabricate(:keypair, account: alice, uri: 'https://foo.test/actor#old-key', type: :rsa)
       end
 
@@ -187,7 +189,7 @@ RSpec.describe ActivityPub::ProcessAccountService do
     end
 
     context 'when the account was known with a legacy key' do
-      let!(:alice) { Fabricate(:account, uri: 'https://foo.test/actor', domain: 'example.com', username: 'alice') }
+      let!(:alice) { Fabricate(:account, uri: 'https://foo.test/actor', domain: 'example.com', username: 'alice', legacy_keypair: true) }
 
       it 'invalidates the legacy key and stores the new keys' do
         expect { subject.call('alice', 'example.com', payload) }

--- a/spec/support/signed_request_helpers.rb
+++ b/spec/support/signed_request_helpers.rb
@@ -9,10 +9,10 @@ module SignedRequestHelpers
     headers['Host'] = Rails.configuration.x.local_domain
     signed_headers = headers.merge('(request-target)' => "get #{path}").slice('(request-target)', 'Host', 'Date')
 
-    key_id = ActivityPub::TagManager.instance.key_uri_for(sign_with)
     keypair = sign_with.keypair
+    key_id = keypair.uri
     signed_string = signed_headers.map { |key, value| "#{key.downcase}: #{value}" }.join("\n")
-    signature = Base64.strict_encode64(keypair.sign(OpenSSL::Digest.new('SHA256'), signed_string))
+    signature = Base64.strict_encode64(keypair.keypair.sign(OpenSSL::Digest.new('SHA256'), signed_string))
 
     headers['Signature'] = "keyId=\"#{key_id}\",algorithm=\"rsa-sha256\",headers=\"#{signed_headers.keys.join(' ').downcase}\",signature=\"#{signature}\""
 
@@ -29,10 +29,10 @@ module SignedRequestHelpers
 
     signed_headers = headers.merge('(request-target)' => "post #{path}").slice('(request-target)', 'Host', 'Date', 'Digest')
 
-    key_id = ActivityPub::TagManager.instance.key_uri_for(sign_with)
     keypair = sign_with.keypair
+    key_id = keypair.uri
     signed_string = signed_headers.map { |key, value| "#{key.downcase}: #{value}" }.join("\n")
-    signature = Base64.strict_encode64(keypair.sign(OpenSSL::Digest.new('SHA256'), signed_string))
+    signature = Base64.strict_encode64(keypair.keypair.sign(OpenSSL::Digest.new('SHA256'), signed_string))
 
     headers['Signature'] = "keyId=\"#{key_id}\",algorithm=\"rsa-sha256\",headers=\"#{signed_headers.keys.join(' ').downcase}\",signature=\"#{signature}\""
 


### PR DESCRIPTION
This is early work-in-progress. The idea is to support multiple keypair per actor to improve handling of key rotation and allow more modern signature algorithms.

This would supersede #31190, #36023, and #37220.

I think the biggest challenge is going to be the migration/transition, especially since we do not currently store the key ID. We can safely generate the key ID for local accounts, but not for remote ones.

I also decided to encrypt the private key at rest. This does incur an overhead, which from early measurement should be below 5% of the total time of a delivery job, excluding network.

## TODO

- [x] add `Keypair` model
- [x] find `Keypair` by URI before falling back to searching for matching accounts
- [x] add `Keypair` usability check
- [x] store remote public keys in `Keypair` objects and invalidate keypair in account record
- [x] use first usable `Keypair` from local users before falling back to account record keypair
- [ ] fix logic for keypair generation
- [ ] update logic for duplicate account merging `lib/mastodon/cli/accounts.rb` and `lib/mastodon/cli/maintenance.rb`)
- [ ] migrate and post-migrate account record keypair to `Keypair` record