### PR TITLE
Add `featured_tags` to `GET /api/v1/profile`

### DIFF
--- a/app/serializers/rest/profile_serializer.rb
+++ b/app/serializers/rest/profile_serializer.rb
@@ -10,6 +10,8 @@ class REST::ProfileSerializer < ActiveModel::Serializer
              :show_media, :show_media_replies, :show_featured,
              :attribution_domains
 
+  has_many :featured_tags, serializer: REST::FeaturedTagSerializer
+
   def id
     object.id.to_s
   end

--- a/spec/requests/api/v1/profiles_spec.rb
+++ b/spec/requests/api/v1/profiles_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe 'Profile API' do
           'note' => account.note,
           'show_featured' => account.show_featured,
           'show_media' => account.show_media,
-          'show_media_replies' => account.show_media_replies
+          'show_media_replies' => account.show_media_replies,
+          'featured_tags' => []
         )
     end
   end


### PR DESCRIPTION
This is already covered by `GET /api/v1/featured_tags`, but clients using `GET /api/v1/profile` are most likely to want featured tags as well, so including them would spare them one request.