### PR TITLE
Add `PATCH /api/v1/profile`

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,11 +1,41 @@
 # frozen_string_literal: true
 
 class Api::V1::ProfilesController < Api::BaseController
-  before_action -> { doorkeeper_authorize! :profile, :read, :'read:accounts' }
+  before_action -> { doorkeeper_authorize! :profile, :read, :'read:accounts' }, except: [:update]
+  before_action -> { doorkeeper_authorize! :write, :'write:accounts' }, only: [:update]
   before_action :require_user!
 
   def show
     @account = current_account
     render json: @account, serializer: REST::ProfileSerializer
+  end
+
+  def update
+    @account = current_account
+    UpdateAccountService.new.call(@account, account_params, raise_error: true)
+    ActivityPub::UpdateDistributionWorker.perform_in(ActivityPub::UpdateDistributionWorker::DEBOUNCE_DELAY, @account.id)
+
+    render json: @account, serializer: REST::ProfileSerializer
+  rescue ActiveRecord::RecordInvalid => e
+    render json: ValidationErrorFormatter.new(e).as_json, status: 422
+  end
+
+  def account_params
+    params.permit(
+      :display_name,
+      :note,
+      :avatar,
+      :header,
+      :locked,
+      :bot,
+      :discoverable,
+      :hide_collections,
+      :indexable,
+      :show_media,
+      :show_media_replies,
+      :show_featured,
+      attribution_domains: [],
+      fields_attributes: [:name, :value]
+    )
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -327,16 +327,16 @@ class Account < ApplicationRecord
     old_fields = self[:fields] || []
     old_fields = [] if old_fields.is_a?(Hash)
 
-    if attributes.is_a?(Hash)
-      attributes.each_value do |attr|
-        next if attr[:name].blank? && attr[:value].blank?
+    attributes = attributes.values if attributes.is_a?(Hash)
 
-        previous = old_fields.find { |item| item['value'] == attr[:value] }
+    attributes.each do |attr|
+      next if attr[:name].blank? && attr[:value].blank?
 
-        attr[:verified_at] = previous['verified_at'] if previous && previous['verified_at'].present?
+      previous = old_fields.find { |item| item['value'] == attr[:value] }
 
-        fields << attr
-      end
+      attr[:verified_at] = previous['verified_at'] if previous && previous['verified_at'].present?
+
+      fields << attr
     end
 
     self[:fields] = fields

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -112,7 +112,7 @@ namespace :api, format: false do
     resources :endorsements, only: [:index]
     resources :markers, only: [:index, :create]
 
-    resource :profile, only: [:show] do
+    resource :profile, only: [:show, :update] do
       scope module: :profile do
         resource :avatar, only: :destroy
         resource :header, only: :destroy

--- a/spec/requests/api/v1/profiles_spec.rb
+++ b/spec/requests/api/v1/profiles_spec.rb
@@ -53,6 +53,66 @@ RSpec.describe 'Profile API' do
     end
   end
 
+  describe 'PATCH /api/v1/profile' do
+    subject do
+      patch '/api/v1/profile', headers: headers, params: params
+    end
+
+    let(:params) do
+      {
+        avatar: fixture_file_upload('avatar.gif', 'image/gif'),
+        discoverable: true,
+        display_name: "Alice Isn't Dead",
+        header: fixture_file_upload('attachment.jpg', 'image/jpeg'),
+        indexable: true,
+        locked: false,
+        note: 'Hello!',
+        attribution_domains: ['example.com'],
+      }
+    end
+
+    it_behaves_like 'forbidden for wrong scope', 'read read:accounts'
+
+    describe 'with invalid data' do
+      let(:params) { { note: 'a' * 2 * Account::NOTE_LENGTH_LIMIT } }
+
+      it 'returns http unprocessable entity' do
+        subject
+        expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
+        expect(response.parsed_body)
+          .to include(
+            error: /Validation failed/,
+            details: include(note: contain_exactly(include(error: 'ERR_TOO_LONG', description: /character limit/)))
+          )
+      end
+    end
+
+    it 'returns http success with updated JSON attributes' do
+      subject
+
+      expect(response)
+        .to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
+      expect(response.parsed_body)
+        .to include({
+          locked: false,
+        })
+      expect(user.account.reload)
+        .to have_attributes(
+          display_name: eq("Alice Isn't Dead"),
+          note: 'Hello!',
+          avatar: exist,
+          header: exist,
+          attribution_domains: ['example.com']
+        )
+      expect(ActivityPub::UpdateDistributionWorker)
+        .to have_enqueued_sidekiq_job(user.account_id)
+    end
+  end
+
   describe 'DELETE /api/v1/profile/avatar' do
     context 'with wrong scope' do
       before do

--- a/spec/requests/api/v1/profiles_spec.rb
+++ b/spec/requests/api/v1/profiles_spec.rb
@@ -68,6 +68,10 @@ RSpec.describe 'Profile API' do
         locked: false,
         note: 'Hello!',
         attribution_domains: ['example.com'],
+        fields_attributes: [
+          { name: 'pronouns', value: 'she/her' },
+          { name: 'foo', value: 'bar' },
+        ],
       }
     end
 
@@ -106,7 +110,17 @@ RSpec.describe 'Profile API' do
           note: 'Hello!',
           avatar: exist,
           header: exist,
-          attribution_domains: ['example.com']
+          attribution_domains: ['example.com'],
+          fields: contain_exactly(
+            have_attributes(
+              name: 'pronouns',
+              value: 'she/her'
+            ),
+            have_attributes(
+              name: 'foo',
+              value: 'bar'
+            )
+          )
         )
       expect(ActivityPub::UpdateDistributionWorker)
         .to have_enqueued_sidekiq_job(user.account_id)


### PR DESCRIPTION
Behaves like `PATCH /api/v1/accounts/update_credentials` except that it:
- does not take a `source` parameter
- returns a `Profile` entity