### PR TITLE
Rely on indirect dependency for playwright-ruby-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,7 +135,6 @@ group :test do
   # Browser integration testing
   gem 'capybara', '~> 3.39'
   gem 'capybara-playwright-driver'
-  gem 'playwright-ruby-client', '1.57.1', require: false # Pinning the exact version as it needs to be kept in sync with the installed npm package
 
   # Used to reset the database between system tests
   gem 'database_cleaner-active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1040,7 +1040,6 @@ DEPENDENCIES
   parslet
   pg (~> 1.5)
   pghero
-  playwright-ruby-client (= 1.57.1)
   premailer-rails
   prometheus_exporter (~> 2.2)
   propshaft


### PR DESCRIPTION
This merged a few weeks ago - https://github.com/mastodon/mastodon/pull/37809 - but we havent seen a PR yet, even though there should be one (both packages have an update).

Prior to https://github.com/mastodon/mastodon/pull/36225 we didnt actually have a direct dependency on PRC in the ruby gemfile, its an indirect dep of another package.

Looking at the history here, renovate has only ever opened a PR to bump this dep in patch versions. All the minor version bumps have come in larger (manual) bundler version bumps or standalone for playwright/PRC pairing.

This PR is testing the theory that Renovate is treating this like a pessimistic version and will not bump the minor. That said, I don't truly understand Renovate and am completely making stuff up here.