### PR TITLE
Fix overly large avatars in report modal

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1670,7 +1670,7 @@ body > [data-popper-placement] {
   .detailed-status__display-name {
     color: var(--color-text-tertiary);
 
-    span {
+    span:not(.account__avatar) {
       display: inline;
     }
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes a regression caused by #37897 that causes avatars in the report modal to appear overly large

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="513" height="515" alt="image" src="https://github.com/user-attachments/assets/db08f5bd-21f9-4cec-8cb1-12ed29071ec9" /> | <img width="518" height="382" alt="image" src="https://github.com/user-attachments/assets/b4641265-d31c-4632-9ce0-eaa9e45569b2" /> |