### PR TITLE
Profile editing: Add singular to translated string

### DIFF
--- a/app/javascript/mastodon/features/account_edit/featured_tags.tsx
+++ b/app/javascript/mastodon/features/account_edit/featured_tags.tsx
@@ -96,7 +96,7 @@ function renderTag(tag: ApiFeaturedTagJSON) {
       {tag.statuses_count > 0 && (
         <FormattedMessage
           id='account_edit_tags.tag_status_count'
-          defaultMessage='{count} posts'
+          defaultMessage='{count, plural, one {# post} other {# posts}}'
           values={{ count: tag.statuses_count }}
           tagName='p'
         />

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -167,7 +167,7 @@
   "account_edit_tags.help_text": "Featured hashtags help users discover and interact with your profile. They appear as filters on your Profile page’s Activity view.",
   "account_edit_tags.search_placeholder": "Enter a hashtag…",
   "account_edit_tags.suggestions": "Suggestions:",
-  "account_edit_tags.tag_status_count": "{count} posts",
+  "account_edit_tags.tag_status_count": "{count, plural, one {# post} other {# posts}}",
   "account_note.placeholder": "Click to add note",
   "admin.dashboard.daily_retention": "User retention rate by day after sign-up",
   "admin.dashboard.monthly_retention": "User retention rate by month after sign-up",


### PR DESCRIPTION
In #37952 the plural was added for the string, but not singular. This fixes that.

Thanks @BzzBzzBzzBzz for pointing out the omission.