### PR TITLE
Refactor: Introduce admin base action class

### DIFF
--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -12,8 +12,6 @@ class Admin::AccountAction < Admin::BaseAction
   attr_accessor :target_account,
                 :warning_preset_id
 
-  attr_reader :warning
-
   attribute :include_statuses, :boolean, default: true
 
   alias include_statuses? include_statuses

--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::AccountAction
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-  include AccountableConcern
-  include Authorization
-
+class Admin::AccountAction < Admin::BaseAction
   TYPES = %w(
     none
     disable
@@ -15,49 +10,15 @@ class Admin::AccountAction
   ).freeze
 
   attr_accessor :target_account,
-                :current_account,
-                :type,
-                :text,
-                :report_id,
                 :warning_preset_id
 
   attr_reader :warning
 
   attribute :include_statuses, :boolean, default: true
-  attribute :send_email_notification, :boolean, default: true
 
-  alias send_email_notification? send_email_notification
   alias include_statuses? include_statuses
 
-  validates :type, :target_account, :current_account, presence: true
-  validates :type, inclusion: { in: TYPES }
-
-  def save
-    return false unless valid?
-
-    ApplicationRecord.transaction do
-      process_action!
-      process_strike!
-      process_reports!
-    end
-
-    process_notification!
-    process_queue!
-
-    true
-  end
-
-  def save!
-    raise ActiveRecord::RecordInvalid, self unless save
-  end
-
-  def report
-    @report ||= Report.find(report_id) if report_id.present?
-  end
-
-  def with_report?
-    !report.nil?
-  end
+  validates :target_account, presence: true
 
   class << self
     def types_for_account(account)
@@ -84,6 +45,17 @@ class Admin::AccountAction
   private
 
   def process_action!
+    ApplicationRecord.transaction do
+      handle_type!
+      process_strike!
+      process_reports!
+    end
+
+    process_notification!
+    process_queue!
+  end
+
+  def handle_type!
     case type
     when 'disable'
       handle_disable!

--- a/app/models/admin/base_action.rb
+++ b/app/models/admin/base_action.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Admin::BaseAction
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include AccountableConcern
+  include Authorization
+
+  attr_accessor :current_account,
+                :type,
+                :text,
+                :report_id
+
+  attr_reader :warning
+
+  attribute :send_email_notification, :boolean, default: true
+
+  alias send_email_notification? send_email_notification
+
+  validates :type, :current_account, presence: true
+  validates :type, inclusion: { in: ->(a) { a.class::TYPES } }
+
+  def save
+    return false unless valid?
+
+    process_action!
+
+    true
+  end
+
+  def save!
+    raise ActiveRecord::RecordInvalid, self unless save
+  end
+
+  def report
+    @report ||= Report.find(report_id) if report_id.present?
+  end
+
+  def with_report?
+    !report.nil?
+  end
+end

--- a/app/models/admin/status_batch_action.rb
+++ b/app/models/admin/status_batch_action.rb
@@ -1,20 +1,14 @@
 # frozen_string_literal: true
 
-class Admin::StatusBatchAction
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-  include AccountableConcern
-  include Authorization
+class Admin::StatusBatchAction < Admin::BaseAction
+  TYPES = %w(
+    delete
+    mark_as_sensitive
+    report
+    remove_from_report
+  ).freeze
 
-  attr_accessor :current_account, :type,
-                :status_ids, :report_id,
-                :text
-
-  attribute :send_email_notification, :boolean
-
-  def save!
-    process_action!
-  end
+  attr_accessor :status_ids
 
   private
 
@@ -115,14 +109,6 @@ class Admin::StatusBatchAction
 
     report.status_ids -= status_ids.map(&:to_i)
     report.save!
-  end
-
-  def report
-    @report ||= Report.find(report_id) if report_id.present?
-  end
-
-  def with_report?
-    !report.nil?
   end
 
   def process_notification!


### PR DESCRIPTION
This a small refactoring, introducing a base class for the existing `Admin::AccountAction` and `Admin::StatusBatchAction` classes. This is in preparation of adding two new such action classes for collections and moderation actions.

At first glance, the two existing classes share more commonalities, but I have refrained from extracting them here, as they are about moderation actions that I want to extract into its own class in the next step. (This will be necessary as a report could contain statuses *and* collections and we do not want two strikes recorded, two notifications being sent etc.)