### PR TITLE
Split status batch and moderation actions

### DIFF
--- a/app/controllers/admin/reports/actions_controller.rb
+++ b/app/controllers/admin/reports/actions_controller.rb
@@ -13,7 +13,7 @@ class Admin::Reports::ActionsController < Admin::BaseController
 
     case action_from_button
     when 'delete', 'mark_as_sensitive'
-      Admin::StatusBatchAction.new(status_batch_action_params).save!
+      Admin::ModerationAction.new(moderation_action_params).save!
     when 'silence', 'suspend'
       Admin::AccountAction.new(account_action_params).save!
     else
@@ -25,9 +25,8 @@ class Admin::Reports::ActionsController < Admin::BaseController
 
   private
 
-  def status_batch_action_params
+  def moderation_action_params
     shared_params
-      .merge(status_ids: @report.status_ids)
   end
 
   def account_action_params

--- a/app/controllers/admin/statuses_controller.rb
+++ b/app/controllers/admin/statuses_controller.rb
@@ -78,8 +78,6 @@ module Admin
         'report'
       elsif params[:remove_from_report]
         'remove_from_report'
-      elsif params[:delete]
-        'delete'
       end
     end
   end

--- a/app/models/admin/moderation_action.rb
+++ b/app/models/admin/moderation_action.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+class Admin::ModerationAction < Admin::BaseAction
+  TYPES = %w(
+    delete
+    mark_as_sensitive
+  ).freeze
+
+  validates :report_id, presence: true
+
+  private
+
+  def status_ids
+    report.status_ids
+  end
+
+  def statuses
+    @statuses ||= Status.with_discarded.where(id: status_ids).reorder(nil)
+  end
+
+  def process_action!
+    case type
+    when 'delete'
+      handle_delete!
+    when 'mark_as_sensitive'
+      handle_mark_as_sensitive!
+    end
+  end
+
+  def handle_delete!
+    statuses.each { |status| authorize([:admin, status], :destroy?) }
+
+    ApplicationRecord.transaction do
+      statuses.each do |status|
+        status.discard_with_reblogs
+        log_action(:destroy, status)
+      end
+
+      report.resolve!(current_account)
+      log_action(:resolve, report)
+
+      process_strike!(:delete_statuses)
+
+      statuses.each { |status| Tombstone.find_or_create_by(uri: status.uri, account: status.account, by_moderator: true) } unless target_account.local?
+    end
+
+    process_notification!
+
+    RemovalWorker.push_bulk(status_ids) { |status_id| [status_id, { 'preserve' => target_account.local?, 'immediate' => !target_account.local? }] }
+  end
+
+  def handle_mark_as_sensitive!
+    representative_account = Account.representative
+
+    # Can't use a transaction here because UpdateStatusService queues
+    # Sidekiq jobs
+    statuses.includes(:media_attachments, preview_cards_status: :preview_card).find_each do |status|
+      next if status.discarded? || !(status.with_media? || status.with_preview_card?)
+
+      authorize([:admin, status], :update?)
+
+      if target_account.local?
+        UpdateStatusService.new.call(status, representative_account.id, sensitive: true)
+      else
+        status.update(sensitive: true)
+      end
+
+      log_action(:update, status)
+
+      report.resolve!(current_account)
+      log_action(:resolve, report)
+    end
+
+    process_strike!(:mark_statuses_as_sensitive)
+
+    process_notification!
+  end
+
+  def target_account
+    report.target_account
+  end
+
+  def text_for_warning = text
+end

--- a/spec/models/admin/moderation_action_spec.rb
+++ b/spec/models/admin/moderation_action_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::ModerationAction do
+  subject do
+    described_class.new(
+      current_account:,
+      type:,
+      report_id:,
+      text:
+    )
+  end
+
+  let(:current_account) { Fabricate(:admin_user).account }
+  let(:target_account) { Fabricate(:account) }
+  let(:statuses) { Fabricate.times(2, :status, account: target_account) }
+  let(:status_ids) { statuses.map(&:id) }
+  let(:report) { Fabricate(:report, target_account:, status_ids:) }
+  let(:report_id) { report.id }
+  let(:text) { 'test' }
+
+  describe '#save!' do
+    context 'when `type` is `delete`' do
+      let(:type) { 'delete' }
+
+      it 'discards the statuses' do
+        subject.save!
+
+        statuses.each do |status|
+          expect(status.reload).to be_discarded
+        end
+        expect(report.reload).to be_action_taken
+      end
+    end
+
+    context 'when `type` is `mark_as_sensitive`' do
+      let(:type) { 'mark_as_sensitive' }
+
+      before do
+        preview_card = Fabricate(:preview_card)
+        statuses.each do |status|
+          PreviewCardsStatus.create!(status:, preview_card:)
+        end
+      end
+
+      it 'marks the statuses as sensitive' do
+        subject.save!
+
+        statuses.each do |status|
+          expect(status.reload).to be_sensitive
+        end
+        expect(report.reload).to be_action_taken
+      end
+    end
+  end
+end

--- a/spec/models/admin/status_batch_action_spec.rb
+++ b/spec/models/admin/status_batch_action_spec.rb
@@ -22,39 +22,6 @@ RSpec.describe Admin::StatusBatchAction do
   let(:text) { 'test' }
 
   describe '#save!' do
-    context 'when `type` is `delete`' do
-      let(:type) { 'delete' }
-
-      it 'discards the statuses' do
-        subject.save!
-
-        statuses.each do |status|
-          expect(status.reload).to be_discarded
-        end
-        expect(report.reload).to be_action_taken
-      end
-    end
-
-    context 'when `type` is `mark_as_sensitive`' do
-      let(:type) { 'mark_as_sensitive' }
-
-      before do
-        preview_card = Fabricate(:preview_card)
-        statuses.each do |status|
-          PreviewCardsStatus.create!(status:, preview_card:)
-        end
-      end
-
-      it 'marks the statuses as sensitive' do
-        subject.save!
-
-        statuses.each do |status|
-          expect(status.reload).to be_sensitive
-        end
-        expect(report.reload).to be_action_taken
-      end
-    end
-
     context 'when `type` is `report`' do
       let(:report_id) { nil }
       let(:type) { 'report' }


### PR DESCRIPTION
Follow up to #37960 : This extracts a new class, `Admin::ModerationAction`, from the existing `Admin::StatusBatchAction`. The latter is now solely responsible for actions that can be performed on a number of statuses, while the new class can be extended to also handle Collections (the next step).

In the course of this, I also removed a code path that would have allowed for batch deletion of statuses without a report being present. I have not found anywhere in the UI where we would have allowed this and tests still pass. But I might well have missed something here.