### PR TITLE
Remove unneeded `stylelint-config-prettier-scss` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,6 @@
     "react-test-renderer": "^18.2.0",
     "storybook": "^10.0.5",
     "stylelint": "^17.0.0",
-    "stylelint-config-prettier-scss": "^1.0.0",
     "stylelint-config-standard-scss": "^17.0.0",
     "typescript": "~5.9.0",
     "typescript-eslint": "^8.55.0",

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['stylelint-config-standard-scss', 'stylelint-config-prettier-scss'],
+  extends: ['stylelint-config-standard-scss'],
   ignoreFiles: [
     'app/javascript/styles/mastodon/reset.scss',
     'coverage/**/*',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2930,7 +2930,6 @@ __metadata:
     storybook: "npm:^10.0.5"
     stringz: "npm:^2.1.0"
     stylelint: "npm:^17.0.0"
-    stylelint-config-prettier-scss: "npm:^1.0.0"
     stylelint-config-standard-scss: "npm:^17.0.0"
     substring-trie: "npm:^1.0.2"
     tesseract.js: "npm:^7.0.0"
@@ -13329,18 +13328,6 @@ __metadata:
   version: 5.0.3
   resolution: "strip-json-comments@npm:5.0.3"
   checksum: 10c0/daaf20b29f69fb51112698f4a9a662490dbb78d5baf6127c75a0a83c2ac6c078a8c0f74b389ad5e0519d6fc359c4a57cb9971b1ae201aef62ce45a13247791e0
-  languageName: node
-  linkType: hard
-
-"stylelint-config-prettier-scss@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "stylelint-config-prettier-scss@npm:1.0.0"
-  peerDependencies:
-    stylelint: ">=15.0.0"
-  bin:
-    stylelint-config-prettier-scss: bin/check.js
-    stylelint-config-prettier-scss-check: bin/check.js
-  checksum: 10c0/4d5e1d1c200d4611b5b7bd2d2528cc9e301f26645802a2774aec192c4c2949cbf5a0147eba8b2e6e4ff14a071b03024f3034bb1b4fda37a8ed5a0081a9597d4d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/37962

My understanding is that this package disabled rules which are no longer enabled in stylelint (as of several versions ago), so I don't think we need it?