### PR TITLE
Remove `message` argument from `NoteLengthValidator` error approach

### DIFF
--- a/app/validators/note_length_validator.rb
+++ b/app/validators/note_length_validator.rb
@@ -2,7 +2,7 @@
 
 class NoteLengthValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, :too_long, message: I18n.t('statuses.over_character_limit', max: options[:maximum]), count: options[:maximum]) if too_long?(value)
+    record.errors.add(attribute, :too_long, count: options[:maximum]) if too_long?(value)
   end
 
   private

--- a/spec/requests/api/v1/accounts/credentials_spec.rb
+++ b/spec/requests/api/v1/accounts/credentials_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'credentials API' do
         expect(response.parsed_body)
           .to include(
             error: /Validation failed/,
-            details: include(note: contain_exactly(include(error: 'ERR_TOO_LONG', description: /character limit/)))
+            details: include(note: contain_exactly(include(error: 'ERR_TOO_LONG', description: /too long/)))
           )
       end
     end

--- a/spec/requests/api/v1/profiles_spec.rb
+++ b/spec/requests/api/v1/profiles_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Profile API' do
         expect(response.parsed_body)
           .to include(
             error: /Validation failed/,
-            details: include(note: contain_exactly(include(error: 'ERR_TOO_LONG', description: /character limit/)))
+            details: include(note: contain_exactly(include(error: 'ERR_TOO_LONG', description: /too long/)))
           )
       end
     end

--- a/spec/validators/note_length_validator_spec.rb
+++ b/spec/validators/note_length_validator_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe NoteLengthValidator do
   private
 
   def too_long_message
-    I18n.t('statuses.over_character_limit', max: 100)
+    I18n.t('errors.messages.too_long', count: 100)
   end
 
   def starting_string


### PR DESCRIPTION
Typically a "length" validation would use the `too_long` i18n key for this error message, but this custom validator exists so that we can use an alternate "countable text" instead of the raw length of the `note` field, so the error message setting is also done in that validator. Here's example usage/output of this error from the credentials endpoint before this change:

```json
{"error":"Validation failed: Note character limit of 500 exceeded","details":{"note":[{"error":"ERR_TOO_LONG","description":"character limit of 500 exceeded"}]}}
```

After this change, when `count` is removed, this error JSON is unchanged, still passes spec, etc.

The history here is that the validator previously put a string directly on the `note` attribute name in the errors, but was changed - https://github.com/mastodon/mastodon/pull/15803/changes#diff-83bf489c44b5ce6d207ab731231e4d0c5008dbca67f5928c91ae2a909f76a940R5 - to also include the `too_long` type (in order to generate the `ERR_*` style errors), and in that same change the `count` argument was added (presumably to use the `too_long` i18n entry? not sure) ... however I'm not sure how/if it was ever actually needed or used, given the presence of `message: ...` there, which I believe overrides that.

Its not clear to me from the surrounding context in that PR whether the intention was to remove the message and keep the `count` and rely on the `too_long` I18n and that was forgotten ... or whether the message is desired and the `count` is unintentionally there, or maybe was needed for some linter or something? Is there some other code path which would run this validator but NOT rely on the `message`?

This PR as initially prepared removes the `count`. An alternate approach here would be to keep the `count`, and remove the entire `message` argument (just from this validator, the I18n entry in yaml is used elsewhere), which would apply the i18n from `too_long` ... which may have been the intention originally? In that case the output would look like:

```json

{"error":"Validation failed: Note is too long (maximum is 500 characters)","details":{"note":[{"error":"ERR_TOO_LONG","description":"is too long (maximum is 500 characters)"}]}}

```

Note how the `details.note.error` value of `ERR_TOO_LONG` stays the same, but the error and description texts change. The `ERR_*` are documented - https://docs.joinmastodon.org/methods/accounts/#422-unprocessable-entity - but the `description` fields are not, other than that they exist.

Alternately ... am I missing something silly/obvious here? Like, is there a requirement that when you use the `too_long` type you pass in a `count`, even if you are overriding the message ... but in a way that does not fail any specs or trip the i18n linter? Is there some use for that value outside the i18n interpolation?