### PR TITLE
Update chewy to version 8.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'addressable', '~> 2.8'
 gem 'bootsnap', require: false
 gem 'browser'
 gem 'charlock_holmes', '~> 0.7.7'
-gem 'chewy', '~> 7.3'
+gem 'chewy'
 gem 'devise'
 gem 'devise-two-factor'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
     cbor (0.5.10.1)
     cgi (0.5.1)
     charlock_holmes (0.7.9)
-    chewy (8.0.0)
+    chewy (8.0.1)
       activesupport (>= 7.2)
       elasticsearch (>= 8.14, < 9.0)
       elasticsearch-dsl

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,9 +159,9 @@ GEM
     cbor (0.5.10.1)
     cgi (0.5.1)
     charlock_holmes (0.7.9)
-    chewy (7.6.0)
-      activesupport (>= 5.2)
-      elasticsearch (>= 7.14.0, < 8)
+    chewy (8.0.0)
+      activesupport (>= 7.2)
+      elasticsearch (>= 8.14, < 9.0)
       elasticsearch-dsl
     childprocess (5.1.0)
       logger (~> 1.5)
@@ -214,16 +214,16 @@ GEM
     dotenv (3.2.0)
     drb (2.2.3)
     dry-cli (1.4.1)
-    elasticsearch (7.17.11)
-      elasticsearch-api (= 7.17.11)
-      elasticsearch-transport (= 7.17.11)
-    elasticsearch-api (7.17.11)
+    elastic-transport (8.4.1)
+      faraday (< 3)
+      multi_json
+    elasticsearch (8.19.3)
+      elastic-transport (~> 8.3)
+      elasticsearch-api (= 8.19.3)
+      ostruct
+    elasticsearch-api (8.19.3)
       multi_json
     elasticsearch-dsl (0.1.10)
-    elasticsearch-transport (7.17.11)
-      base64
-      faraday (>= 1, < 3)
-      multi_json
     email_validator (2.2.4)
       activemodel
     erb (6.0.2)
@@ -958,7 +958,7 @@ DEPENDENCIES
   capybara (~> 3.39)
   capybara-playwright-driver
   charlock_holmes (~> 0.7.7)
-  chewy (~> 7.3)
+  chewy
   climate_control
   cocoon (~> 1.2)
   color_diff (~> 0.1)

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -65,7 +65,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
       value: version,
       human_value: version,
     }
-  rescue Faraday::ConnectionFailed, Elasticsearch::Transport::Transport::Error
+  rescue Faraday::ConnectionFailed, Elastic::Transport::Transport::Error
     nil
   end
 

--- a/app/lib/admin/metrics/dimension/space_usage_dimension.rb
+++ b/app/lib/admin/metrics/dimension/space_usage_dimension.rb
@@ -69,7 +69,7 @@ class Admin::Metrics::Dimension::SpaceUsageDimension < Admin::Metrics::Dimension
       unit: 'bytes',
       human_value: number_to_human_size(value),
     }
-  rescue Faraday::ConnectionFailed, Elasticsearch::Transport::Transport::Error
+  rescue Faraday::ConnectionFailed, Elastic::Transport::Transport::Error
     nil
   end
 end

--- a/app/lib/admin/system_check/elasticsearch_check.rb
+++ b/app/lib/admin/system_check/elasticsearch_check.rb
@@ -17,7 +17,7 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
     return true unless Chewy.enabled?
 
     running_version.present? && compatible_version? && cluster_health['status'] == 'green' && indexes_match? && specifications_match? && preset_matches?
-  rescue Faraday::ConnectionFailed, Elasticsearch::Transport::Transport::Error, HTTPClient::KeepAliveDisconnected
+  rescue Faraday::ConnectionFailed, Elastic::Transport::Transport::Error, HTTPClient::KeepAliveDisconnected
     false
   end
 
@@ -54,7 +54,7 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
     else
       Admin::SystemCheck::Message.new(:elasticsearch_preset, nil, 'https://docs.joinmastodon.org/admin/elasticsearch/#scaling')
     end
-  rescue Faraday::ConnectionFailed, Elasticsearch::Transport::Transport::Error, HTTPClient::KeepAliveDisconnected
+  rescue Faraday::ConnectionFailed, Elastic::Transport::Transport::Error, HTTPClient::KeepAliveDisconnected
     Admin::SystemCheck::Message.new(:elasticsearch_running_check)
   end
 
@@ -67,7 +67,7 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
   def running_version
     @running_version ||= begin
       Chewy.client.info['version']['number']
-    rescue Faraday::ConnectionFailed, Elasticsearch::Transport::Transport::Error
+    rescue Faraday::ConnectionFailed, Elastic::Transport::Transport::Error
       nil
     end
   end

--- a/lib/elasticsearch/client_extensions.rb
+++ b/lib/elasticsearch/client_extensions.rb
@@ -2,10 +2,10 @@
 
 module Elasticsearch
   module ClientExtensions
-    def verify_elasticsearch(*args, &block)
-      @transport.perform_request(*args, &block).tap do
-        @verified = true
-      end
+    def initialize(arguments = {}, &block)
+      super
+
+      @verified = true
     end
   end
 end

--- a/lib/elasticsearch/client_extensions.rb
+++ b/lib/elasticsearch/client_extensions.rb
@@ -2,7 +2,7 @@
 
 module Elasticsearch
   module ClientExtensions
-    def verify_elasticsearch
+    def verify_elasticsearch(*)
       @verified = true
     end
   end

--- a/lib/elasticsearch/client_extensions.rb
+++ b/lib/elasticsearch/client_extensions.rb
@@ -2,8 +2,10 @@
 
 module Elasticsearch
   module ClientExtensions
-    def verify_elasticsearch(*)
-      @verified = true
+    def verify_elasticsearch(*args, &block)
+      @transport.perform_request(*args, &block).tap do
+        @verified = true
+      end
     end
   end
 end

--- a/lib/mastodon/cli/search.rb
+++ b/lib/mastodon/cli/search.rb
@@ -115,7 +115,7 @@ module Mastodon::CLI
       progress.finish
 
       say("Indexed #{added} records, de-indexed #{removed}", :green, true)
-    rescue Elasticsearch::Transport::Transport::ServerError => e
+    rescue Elastic::Transport::Transport::ServerError => e
       fail_with_message <<~ERROR
         There was an issue connecting to the search server. Make sure the
         server is configured and running correctly, and that the environment

--- a/spec/lib/admin/system_check/elasticsearch_check_spec.rb
+++ b/spec/lib/admin/system_check/elasticsearch_check_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Admin::SystemCheck::ElasticsearchCheck do
 
   def stub_elasticsearch_error
     client = instance_double(Elasticsearch::Client)
-    allow(client).to receive(:info).and_raise(Elasticsearch::Transport::Transport::Error)
+    allow(client).to receive(:info).and_raise(Elastic::Transport::Transport::Error)
     allow(Chewy).to receive(:client).and_return(client)
   end
 end

--- a/spec/lib/elasticsearch/client_extensions_spec.rb
+++ b/spec/lib/elasticsearch/client_extensions_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Elasticsearch::ClientExtensions do
+  describe '#initialize' do
+    it 'marks the connection as verified on initialization' do
+      client = Elasticsearch::Client.new
+
+      expect(client.instance_variable_get(:@verified))
+        .to be(true)
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/search_spec.rb
+++ b/spec/lib/mastodon/cli/search_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Mastodon::CLI::Search do
     context 'when server communication raises an error' do
       let(:options) { { reset_chewy: true } }
 
-      before { allow(Chewy::Stash::Specification).to receive(:reset!).and_raise(Elasticsearch::Transport::Transport::Errors::InternalServerError) }
+      before { allow(Chewy::Stash::Specification).to receive(:reset!).and_raise(Elastic::Transport::Transport::Errors::InternalServerError) }
 
       it 'Exits with error message' do
         expect { subject }


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/37982

Somewhat of a re-attempt of https://github.com/mastodon/mastodon/pull/26399

Related to https://github.com/mastodon/mastodon/issues/34401 - and possibly other issues/PRs generally in the chewy/ES/versions realm.

I did not run full ES suite locally, will watch CI and update if needed.