### PR TITLE
Allow remote accounts in Collections

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -469,8 +469,11 @@ class Account < ApplicationRecord
     save!
   end
 
-  def featureable?
-    local? && discoverable?
+  def featureable_by?(other_account)
+    return discoverable? if local?
+    return false unless Mastodon::Feature.collections_federation_enabled?
+
+    feature_policy_for_account(other_account).in?(%i(automatic manual))
   end
 
   private

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -66,7 +66,7 @@ class AccountPolicy < ApplicationPolicy
   end
 
   def feature?
-    record.featureable? && !current_account.blocking?(record) && !current_account.blocked_by?(record)
+    record.featureable_by?(current_account) && !current_account.blocking?(record) && !current_account.blocked_by?(record)
   end
 
   def index_collections?

--- a/spec/policies/account_policy_spec.rb
+++ b/spec/policies/account_policy_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe AccountPolicy do
     end
 
     context 'when account is not featureable' do
-      before { allow(alice).to receive(:featureable?).and_return(false) }
+      before { allow(alice).to receive(:featureable_by?).and_return(false) }
 
       it 'denies' do
         expect(subject).to_not permit(john, alice)


### PR DESCRIPTION
Still hidden behind the `collections_federation` flag, because nothing will work yet. But this is a prerequisite to actually test some of the federation work in progress.