### PR TITLE
Profile redesign: Fix fields in Chromium

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
@@ -262,6 +262,11 @@ svg.badgeIcon {
       }
     }
   }
+
+  // See: https://stackoverflow.com/questions/13226296/is-scrollwidth-property-of-a-span-not-working-on-chrome
+  [data-contents] {
+    display: inline-block;
+  }
 }
 
 .fieldVerified {


### PR DESCRIPTION
This fixes a minor bug in #37976 where Chromium-based browsers do not provide `scrollWidth` for `inline` items. this converts them to `inline-block`.