### PR TITLE
Fix avatar alt-text running into other elements on image load failure.

### DIFF
--- a/app/javascript/mastodon/components/__tests__/__snapshots__/avatar_overlay-test.jsx.snap
+++ b/app/javascript/mastodon/components/__tests__/__snapshots__/avatar_overlay-test.jsx.snap
@@ -26,6 +26,7 @@ exports[`<AvatarOverlay > renders a overlay avatar 1`] = `
     >
       <img
         alt="alice"
+        onError={[Function]}
         src="/static/alice.jpg"
       />
     </div>
@@ -44,6 +45,7 @@ exports[`<AvatarOverlay > renders a overlay avatar 1`] = `
     >
       <img
         alt="eve@blackhat.lair"
+        onError={[Function]}
         src="/static/eve.jpg"
       />
     </div>

--- a/app/javascript/mastodon/components/avatar_overlay.tsx
+++ b/app/javascript/mastodon/components/avatar_overlay.tsx
@@ -10,6 +10,12 @@ interface Props {
   overlaySize?: number;
 }
 
+const fallbackImage = '/avatars/original/missing.png';
+
+const handleImgError = (error: { currentTarget: { src: string } }) => {
+  error.currentTarget.src = fallbackImage;
+};
+
 export const AvatarOverlay: React.FC<Props> = ({
   account,
   friend,
@@ -38,7 +44,13 @@ export const AvatarOverlay: React.FC<Props> = ({
           className='account__avatar'
           style={{ width: `${baseSize}px`, height: `${baseSize}px` }}
         >
-          {accountSrc && <img src={accountSrc} alt={account?.get('acct')} />}
+          {accountSrc && (
+            <img
+              src={accountSrc}
+              alt={account?.get('acct')}
+              onError={handleImgError}
+            />
+          )}
         </div>
       </div>
       <div className='account__avatar-overlay-overlay'>
@@ -46,7 +58,13 @@ export const AvatarOverlay: React.FC<Props> = ({
           className='account__avatar'
           style={{ width: `${overlaySize}px`, height: `${overlaySize}px` }}
         >
-          {friendSrc && <img src={friendSrc} alt={friend?.get('acct')} />}
+          {friendSrc && (
+            <img
+              src={friendSrc}
+              alt={friend?.get('acct')}
+              onError={handleImgError}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/app/javascript/mastodon/components/avatar_overlay.tsx
+++ b/app/javascript/mastodon/components/avatar_overlay.tsx
@@ -10,10 +10,12 @@ interface Props {
   overlaySize?: number;
 }
 
-const fallbackImage = '/avatars/original/missing.png';
-
-const handleImgError = (error: { currentTarget: { src: string } }) => {
-  error.currentTarget.src = fallbackImage;
+const handleImgLoadError = (error: { currentTarget: HTMLElement }) => {
+  //
+  // When the img tag fails to load the image, set the img tag to display: none. This prevents the
+  // alt-text from overrunning the containing div.
+  //
+  error.currentTarget.style.display = 'none';
 };
 
 export const AvatarOverlay: React.FC<Props> = ({
@@ -48,7 +50,7 @@ export const AvatarOverlay: React.FC<Props> = ({
             <img
               src={accountSrc}
               alt={account?.get('acct')}
-              onError={handleImgError}
+              onError={handleImgLoadError}
             />
           )}
         </div>
@@ -62,7 +64,7 @@ export const AvatarOverlay: React.FC<Props> = ({
             <img
               src={friendSrc}
               alt={friend?.get('acct')}
-              onError={handleImgError}
+              onError={handleImgLoadError}
             />
           )}
         </div>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2236,11 +2236,6 @@ body > [data-popper-placement] {
   min-width: 0;
 }
 
-/* This visually hides the alt-text if an image fails to load preventing the alt-text from overrunning into the display name account. */
-.account__avatar img::before {
-  visibility: hidden;
-}
-
 .account__avatar {
   display: block;
   position: relative;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2236,6 +2236,11 @@ body > [data-popper-placement] {
   min-width: 0;
 }
 
+/* This visually hides the alt-text if an image fails to load preventing the alt-text from overrunning into the display name account. */
+.account__avatar img::before {
+  visibility: hidden;
+}
+
 .account__avatar {
   display: block;
   position: relative;


### PR DESCRIPTION
Avatar overlay alt text runs into other text when the img fails to load. Fix this by adding a onError handler that sets display to none for the img tag. Preventing the img from displaying also prevents the alt-text from rendering and overrunning other text. This applies to both the base avatar and the overlay avatar.

#37942 

**Overlay with valid URL**
![Overlay-with-valid-img.bmp](https://github.com/user-attachments/files/25589963/Overlay-with-valid-img.bmp)

**Overlay with invalid URL without fix.**
![Overlay-invalid-url-no-fix.bmp](https://github.com/user-attachments/files/25589996/Overlay-invalid-url-no-fix.bmp)



**Invalid URL with fix included**
![Avatar-overlay-invalid-url.bmp](https://github.com/user-attachments/files/25589943/Avatar-overlay-invalid-url.bmp)
