### PR TITLE
Forbid interactions with reblogs in `/api/v1/statuses/:id` endpoints

### DIFF
--- a/app/controllers/api/v1/statuses/base_controller.rb
+++ b/app/controllers/api/v1/statuses/base_controller.rb
@@ -12,5 +12,7 @@ class Api::V1::Statuses::BaseController < Api::BaseController
     authorize @status, :show?
   rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
     not_found
+  else
+    render json: { error: 'This operation is not allowed on reblogs' }, status: 400 if @status.reblog?
   end
 end


### PR DESCRIPTION
Fixes #23095, #37999

This could potentially be considered a breaking change, as it was previously possible to bookmark, reblog or favorite a post using a reblog's ID, though the unbookmark/unreblog/unfavorite would not work correctly.