### PR TITLE
Add g+e keyboard shortcut for /explore (trending)

### DIFF
--- a/app/javascript/mastodon/components/hotkeys/hotkeys.stories.tsx
+++ b/app/javascript/mastodon/components/hotkeys/hotkeys.stories.tsx
@@ -50,6 +50,9 @@ const hotkeyTest: Story['play'] = async ({ canvas, userEvent }) => {
   await userEvent.keyboard('gh');
   await confirmHotkey('goToHome');
 
+  await userEvent.keyboard('ge');
+  await confirmHotkey('goToExplore');
+
   await userEvent.keyboard('gn');
   await confirmHotkey('goToNotifications');
 
@@ -105,6 +108,9 @@ export const Default = {
       },
       goToHome: () => {
         setMatchedHotkey('goToHome');
+      },
+      goToExplore: () => {
+        setMatchedHotkey('goToExplore');
       },
       goToNotifications: () => {
         setMatchedHotkey('goToNotifications');

--- a/app/javascript/mastodon/components/hotkeys/index.tsx
+++ b/app/javascript/mastodon/components/hotkeys/index.tsx
@@ -118,6 +118,7 @@ const hotkeyMatcherMap = {
   openMedia: just('e'),
   onTranslate: just('t'),
   goToHome: sequence('g', 'h'),
+  goToExplore: sequence('g', 'e'),
   goToNotifications: sequence('g', 'n'),
   goToLocal: sequence('g', 'l'),
   goToFederated: sequence('g', 't'),

--- a/app/javascript/mastodon/features/keyboard_shortcuts/index.jsx
+++ b/app/javascript/mastodon/features/keyboard_shortcuts/index.jsx
@@ -135,6 +135,10 @@ class KeyboardShortcuts extends ImmutablePureComponent {
                 <td><FormattedMessage id='keyboard_shortcuts.home' defaultMessage='to open home timeline' /></td>
               </tr>
               <tr>
+                <td><kbd>g</kbd>+<kbd>e</kbd></td>
+                <td><FormattedMessage id='keyboard_shortcuts.explore' defaultMessage='to open trending timeline' /></td>
+              </tr>
+              <tr>
                 <td><kbd>g</kbd>+<kbd>n</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.notifications' defaultMessage='to open notifications column' /></td>
               </tr>

--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -534,6 +534,10 @@ class UI extends PureComponent {
     this.props.history.push('/home');
   };
 
+  handleHotkeyGoToExplore = () => {
+    this.props.history.push('/explore');
+  };
+
   handleHotkeyGoToNotifications = () => {
     this.props.history.push('/notifications');
   };
@@ -595,6 +599,7 @@ class UI extends PureComponent {
       moveToTop: this.handleMoveToTop,
       back: this.handleHotkeyBack,
       goToHome: this.handleHotkeyGoToHome,
+      goToExplore: this.handleHotkeyGoToExplore,
       goToNotifications: this.handleHotkeyGoToNotifications,
       goToLocal: this.handleHotkeyGoToLocal,
       goToFederated: this.handleHotkeyGoToFederated,

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -673,6 +673,7 @@
   "keyboard_shortcuts.direct": "Open private mentions column",
   "keyboard_shortcuts.down": "Move down in the list",
   "keyboard_shortcuts.enter": "Open post",
+  "keyboard_shortcuts.explore": "Open trending timeline",
   "keyboard_shortcuts.favourite": "Favorite post",
   "keyboard_shortcuts.favourites": "Open favorites list",
   "keyboard_shortcuts.federated": "Open federated timeline",


### PR DESCRIPTION
Add a keyboard shortcut (g+e) for /explore

This seems to be a gap in the current keyboard shortcuts.
Given g+t was already taken for goToFederated, I went with e as that matches the route.

I have no understanding whatsoever of the mastodon code base so please do let me know if I'm getting anything wrong. I have validated locally that the change works.
