### PR TITLE
Add JSON and HTML responses to health controller

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
-class HealthController < ActionController::Base # rubocop:disable Rails/ApplicationController
-  def show
+class HealthController < Rails::HealthController
+  content_security_policy false
+
+  before_action :handle_default, if: -> { request.format.text? }
+
+  private
+
+  def handle_default
     render plain: 'OK'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
 
   mount LetterOpenerWeb::Engine, at: 'letter_opener' if Rails.env.development?
 
-  get 'health', to: 'health#show'
+  get 'health', to: 'health#show', defaults: { format: :text }
 
   authenticate :user, ->(user) { user.role&.can?(:view_devops) } do
     mount Sidekiq::Web, at: 'sidekiq', as: :sidekiq

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -4,13 +4,47 @@ require 'rails_helper'
 
 RSpec.describe 'Health check endpoint' do
   describe 'GET /health' do
-    it 'returns http success when server is functioning' do
-      get '/health'
+    context 'without format specified' do
+      it 'returns plain text response' do
+        get health_path
 
-      expect(response)
-        .to have_http_status(200)
-      expect(response.body)
-        .to include('OK')
+        expect(response)
+          .to have_http_status(200)
+        expect(response.headers)
+          .to_not include('content-security-policy')
+        expect(response.parsed_body)
+          .to include('OK')
+        expect(response.media_type)
+          .to eq('text/plain')
+      end
+    end
+
+    context 'with HTML format' do
+      it 'returns HTML page' do
+        get health_path(format: :html)
+
+        expect(response)
+          .to have_http_status(200)
+        expect(response.headers)
+          .to_not include('content-security-policy')
+        expect(response.media_type)
+          .to eq('text/html')
+      end
+    end
+
+    context 'with JSON format' do
+      it 'returns JSON document' do
+        get health_path(format: :json)
+
+        expect(response)
+          .to have_http_status(200)
+        expect(response.headers)
+          .to_not include('content-security-policy')
+        expect(response.parsed_body)
+          .to include(status: 'up', timestamp: be_present)
+        expect(response.media_type)
+          .to eq('application/json')
+      end
     end
   end
 end


### PR DESCRIPTION
Followup on https://github.com/mastodon/mastodon/pull/36505

Previously attempted something like this in https://github.com/mastodon/mastodon/pull/27520 but that one got hung up on part of it technically being a backwards incompatible change to the expected output. We then subsequently documented the healthcheck endpoint a bit - https://github.com/mastodon/documentation/pull/1363

Rails 8.1 preserves the previously described HTML page from that last PR, and also adds a JSON response to their default controller. So the updates here are:

- Inherit from Rails health controller which gets us "for free":
  - A handsome green html page when html requested
  - A simple JSON response when json requested, enabling clients who are into JSON processing to process even more JSON than before. This is just a hash with `status` and `timestamp` attributes.
- Update the default routing format and controller so that existing requests which do not specify a format continue to get the previous text response with an "OK" on it - I believe this should avoid the backwards breakage concerns from prior attempt, and I'm not sure why it didn't occur to us then.

I will do docs PR as followup or in conjunction with this if approved.