### PR TITLE
Update `binding_of_caller` to version 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -180,7 +180,7 @@ group :development do
 
   # Enhanced error message pages for development
   gem 'better_errors', '~> 2.9'
-  gem 'binding_of_caller', '~> 1.0'
+  gem 'binding_of_caller'
 
   # Preview mail in the browser
   gem 'letter_opener', '~> 1.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       rouge (>= 1.0.0)
     bigdecimal (3.3.1)
     bindata (2.5.1)
-    binding_of_caller (1.0.1)
+    binding_of_caller (2.0.0)
       debug_inspector (>= 1.2.0)
     blurhash (0.1.8)
     bootsnap (1.23.0)
@@ -953,7 +953,7 @@ DEPENDENCIES
   aws-sdk-core
   aws-sdk-s3 (~> 1.123)
   better_errors (~> 2.9)
-  binding_of_caller (~> 1.0)
+  binding_of_caller
   blurhash (~> 0.1)
   bootsnap
   brakeman (~> 8.0)


### PR DESCRIPTION
Adds ruby 4.0 support and drops pre-2.7 support.