### PR TITLE
Change cursor to make clear `summary` is clickable

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -385,6 +385,7 @@ $content-width: 840px;
     color: var(--color-text-secondary);
     padding-top: 24px;
     margin-bottom: 8px;
+    cursor: pointer;
   }
 
   @media screen and (max-width: $no-columns-breakpoint) {


### PR DESCRIPTION
Tiny, tiny thing, but I think it is not super obvious that `<summary>` is clickable and I think using the same cursor as for links makes it a little bit clearer.