### PR TITLE
Anchor post navigation via hotkeys to top of viewport

### DIFF
--- a/app/javascript/mastodon/features/ui/util/focusUtils.ts
+++ b/app/javascript/mastodon/features/ui/util/focusUtils.ts
@@ -47,7 +47,7 @@ function focusColumnTitle(index: number, multiColumn: boolean) {
 
 /**
  * Move focus to the column of the passed index (1-based).
- * Focus is placed on the topmost visible item, or the column title
+ * Focus is placed on the topmost visible item, or the column title.
  */
 export function focusColumn(index = 1) {
   // Skip the leftmost drawer in multi-column mode
@@ -94,8 +94,13 @@ export function focusColumn(index = 1) {
     window.innerWidth || document.documentElement.clientWidth;
   const { item, rect } = itemToFocus;
 
+  const scrollParent = isMultiColumnLayout
+    ? container
+    : document.documentElement;
+  const columnHeaderHeight = isMultiColumnLayout ? 0 : 62;
+
   if (
-    container.scrollTop > item.offsetTop ||
+    scrollParent.scrollTop > item.offsetTop - columnHeaderHeight ||
     rect.right > viewportWidth ||
     rect.left < 0
   ) {
@@ -141,11 +146,7 @@ export function focusFirstItem() {
 /**
  * Focus the item next to the one with the provided index
  */
-export function focusItemSibling(
-  index: number,
-  direction: 1 | -1,
-  scrollThreshold = 62,
-) {
+export function focusItemSibling(index: number, direction: 1 | -1) {
   const focusedElement = document.activeElement;
   const itemList = focusedElement?.closest('.item-list');
 
@@ -173,17 +174,9 @@ export function focusItemSibling(
   }
 
   if (targetElement) {
-    const elementRect = targetElement.getBoundingClientRect();
-
-    const isFullyVisible =
-      elementRect.top >= scrollThreshold &&
-      elementRect.bottom <= window.innerHeight;
-
-    if (!isFullyVisible) {
-      targetElement.scrollIntoView({
-        block: direction === 1 ? 'start' : 'center',
-      });
-    }
+    targetElement.scrollIntoView({
+      block: 'start',
+    });
 
     targetElement.focus();
   }

--- a/app/javascript/mastodon/features/ui/util/focusUtils.ts
+++ b/app/javascript/mastodon/features/ui/util/focusUtils.ts
@@ -97,7 +97,10 @@ export function focusColumn(index = 1) {
   const scrollParent = isMultiColumnLayout
     ? container
     : document.documentElement;
-  const columnHeaderHeight = isMultiColumnLayout ? 0 : 62;
+  const columnHeaderHeight =
+    parseInt(
+      getComputedStyle(scrollParent).getPropertyValue('--column-header-height'),
+    ) || 0;
 
   if (
     scrollParent.scrollTop > item.offsetTop - columnHeaderHeight ||

--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -19,6 +19,15 @@ html {
   &.rtl {
     --text-x-direction: -1;
   }
+
+  // Compensate for column header height when scrolling elements into view
+  --column-header-height: 62px;
+
+  scroll-padding-top: var(--column-header-height);
+
+  &:has(.layout-multi-column) {
+    --column-header-height: 0;
+  }
 }
 
 html.has-modal {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2983,8 +2983,6 @@ a.account__display-name {
     }
 
     &__main {
-      --column-header-height: 62px;
-
       box-sizing: border-box;
       width: 100%;
       flex: 0 1 auto;
@@ -9092,10 +9090,6 @@ noscript {
 .status__wrapper,
 .conversation {
   position: relative;
-
-  // When scrolling these elements into view, take into account
-  // the column header height
-  scroll-margin-top: var(--column-header-height, 0);
 
   &.unread {
     &::before {


### PR DESCRIPTION
Fixes #37487

### Changes proposed in this PR:
- When using the <kbd>j</kbd>/<kbd>k</kbd> hotkeys to navigate posts or other items, anchor them to the top of the viewport (except when focus wasn't previously in the list, to avoid a disorienting scroll)
- Adds a global `scroll-padding-top` declaration to the HTML element (in single-column mode), ensuring that any items that are programmatically focused/scrolled to will not be covered up by the column header bar. (The previously used `scroll-margin-top` had to be assigned per-item, and we had a few gaps.)

### Screenshots


https://github.com/user-attachments/assets/82208ba7-c403-4101-bc12-6dc07cadc3ef

