### PR TITLE
Fix local collection link resulting in error page

### DIFF
--- a/app/javascript/mastodon/features/collections/detail/index.tsx
+++ b/app/javascript/mastodon/features/collections/detail/index.tsx
@@ -105,8 +105,8 @@ const CollectionHeader: React.FC<{ collection: ApiCollectionJSON }> = ({
     );
   }, [collection, dispatch]);
 
-  const location = useLocation<{ newCollection?: boolean }>();
-  const wasJustCreated = location.state.newCollection;
+  const location = useLocation<{ newCollection?: boolean } | undefined>();
+  const wasJustCreated = location.state?.newCollection;
   useEffect(() => {
     if (wasJustCreated) {
       handleShare();

--- a/app/javascript/mastodon/features/collections/detail/share_modal.tsx
+++ b/app/javascript/mastodon/features/collections/detail/share_modal.tsx
@@ -40,8 +40,8 @@ export const CollectionShareModal: React.FC<{
 }> = ({ collection, onClose }) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
-  const location = useLocation<{ newCollection?: boolean }>();
-  const isNew = !!location.state.newCollection;
+  const location = useLocation<{ newCollection?: boolean } | undefined>();
+  const isNew = !!location.state?.newCollection;
   const isOwnCollection = collection.account_id === me;
 
   const collectionLink = `${window.location.origin}/collections/${collection.id}`;


### PR DESCRIPTION
### Changes proposed in this PR:
- Clicking a link of a shared local collection link will open the correct URL, but display an error caused by unsafe access to `location.state` which can be undefined. (React Router's `useLocation` really could've come with better default types here…)