### PR TITLE
Prevent hover card from showing on touch devices

### DIFF
--- a/app/javascript/mastodon/components/hover_card_controller.tsx
+++ b/app/javascript/mastodon/components/hover_card_controller.tsx
@@ -23,6 +23,7 @@ export const HoverCardController: React.FC = () => {
   const [open, setOpen] = useState(false);
   const [accountId, setAccountId] = useState<string | undefined>();
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  const isUsingTouchRef = useRef(false);
   const cardRef = useRef<HTMLDivElement | null>(null);
   const [setLeaveTimeout, cancelLeaveTimeout] = useTimeout();
   const [setEnterTimeout, cancelEnterTimeout, delayEnterTimeout] = useTimeout();
@@ -62,12 +63,23 @@ export const HoverCardController: React.FC = () => {
       setAccountId(undefined);
     };
 
+    const handleTouchStart = () => {
+      // Keeping track of touch events to prevent the
+      // hover card from being displayed on touch devices
+      isUsingTouchRef.current = true;
+    };
+
     const handleMouseEnter = (e: MouseEvent) => {
       const { target } = e;
 
       // We've exited the window
       if (!(target instanceof HTMLElement)) {
         close();
+        return;
+      }
+
+      // Bail out if a touch is active
+      if (isUsingTouchRef.current) {
         return;
       }
 
@@ -129,8 +141,15 @@ export const HoverCardController: React.FC = () => {
     };
 
     const handleMouseMove = () => {
+      if (isUsingTouchRef.current) {
+        isUsingTouchRef.current = false;
+      }
       delayEnterTimeout(enterDelay);
     };
+
+    document.body.addEventListener('touchstart', handleTouchStart, {
+      passive: true,
+    });
 
     document.body.addEventListener('mouseenter', handleMouseEnter, {
       passive: true,
@@ -153,6 +172,7 @@ export const HoverCardController: React.FC = () => {
     });
 
     return () => {
+      document.body.removeEventListener('touchstart', handleTouchStart);
       document.body.removeEventListener('mouseenter', handleMouseEnter);
       document.body.removeEventListener('mousemove', handleMouseMove);
       document.body.removeEventListener('mouseleave', handleMouseLeave);


### PR DESCRIPTION
Fixes #32685

### Changes proposed in this PR:
- Attempts to prevent the hover card from opening when a touch event was detected. I only used the iOS Simulator on macOS to test this, and was successful at preventing the hover card from showing up after a long press, however I don't know, but hope that this translates to all other scenarios described in #32685.

### Screencaps

**Before**

https://github.com/user-attachments/assets/a335e6c2-daa0-4aa7-a9e3-5859dbaefc30

**After**

https://github.com/user-attachments/assets/06091529-fcf6-457c-b758-bbbef0f419c2

