### PR TITLE
Profile redesign: Fix timeline filter button color on Safari iOS

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/v2/styles.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/v2/styles.module.scss
@@ -5,6 +5,7 @@
 .filterSelectButton {
   appearance: none;
   border: none;
+  color: inherit;
   background: none;
   padding: 8px 0;
   font-size: 15px;


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes a tiny issue on Safari iOS where `appearance: none` on buttons apparently still applies the system color for buttons/links, causing the filter button on the new profile to appear blue.

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="244" height="176" alt="image" src="https://github.com/user-attachments/assets/a1d28891-048b-42ef-a6d2-f37fc9d519dc" /> | <img width="242" height="173" alt="image" src="https://github.com/user-attachments/assets/62b0fe63-eec4-4a74-b9bb-9f1872265d98" /> |