### PR TITLE
Update ES versions in CI/devcontainer to match primary compose

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -56,7 +56,7 @@ services:
       - internal_network
 
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.29
     restart: unless-stopped
     environment:
       ES_JAVA_OPTS: -Xms512m -Xmx512m

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -352,10 +352,10 @@ jobs:
           - '3.3'
           - '.ruby-version'
         search-image:
-          - docker.elastic.co/elasticsearch/elasticsearch:7.17.13
+          - docker.elastic.co/elasticsearch/elasticsearch:7.17.29
         include:
           - ruby-version: '.ruby-version'
-            search-image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
+            search-image: docker.elastic.co/elasticsearch/elasticsearch:8.19.2
           - ruby-version: '.ruby-version'
             search-image: opensearchproject/opensearch:2
 


### PR DESCRIPTION
Prep for https://github.com/mastodon/mastodon/pull/37983

Changes here:

- Update the 7.x ES image version for CI runs and the devcontainer to match the recommended (commented out) version from the main compose file. On a separate note, this version is EOL now, but thats out of scope for purposes here. This change is not narrowly relevant to my spec fix, but seems harmless?
- Bump the 8.x image in CI run to latest
