### PR TITLE
Update haml_lint to version 0.72.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,7 +294,7 @@ GEM
       activesupport (>= 5.1)
       haml (>= 4.0.6)
       railties (>= 5.1)
-    haml_lint (0.71.0)
+    haml_lint (0.72.0)
       haml (>= 5.0)
       parallel (~> 1.10)
       rainbow


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/37981 - which contains a rubocop bump we cant do yet, see: https://github.com/mastodon/mastodon/pull/37988#issuecomment-3967212426

The 0.70.0 release had a regression / https://github.com/mastodon/mastodon/pull/37902 / rolled back in 0.71.0.

The 0.72.0 once again contains the improvement from 0.70.0, but without the regression?!