### PR TITLE
Emoji text input and character counter components

### DIFF
--- a/app/javascript/mastodon/components/character_counter/character_counter.stories.tsx
+++ b/app/javascript/mastodon/components/character_counter/character_counter.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { CharacterCounter } from './index';
+
+const meta = {
+  component: CharacterCounter,
+  title: 'Components/CharacterCounter',
+} satisfies Meta<typeof CharacterCounter>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Required: Story = {
+  args: {
+    currentLength: 50,
+    maxLength: 100,
+  },
+};
+
+export const ExceedingLimit: Story = {
+  args: {
+    currentLength: 120,
+    maxLength: 100,
+  },
+};
+
+export const Recommended: Story = {
+  args: {
+    currentLength: 100,
+    maxLength: 80,
+    recommended: true,
+  },
+};

--- a/app/javascript/mastodon/components/character_counter/character_counter.stories.tsx
+++ b/app/javascript/mastodon/components/character_counter/character_counter.stories.tsx
@@ -13,22 +13,22 @@ type Story = StoryObj<typeof meta>;
 
 export const Required: Story = {
   args: {
-    currentLength: 50,
+    currentString: 'Hello, world!',
     maxLength: 100,
   },
 };
 
 export const ExceedingLimit: Story = {
   args: {
-    currentLength: 120,
-    maxLength: 100,
+    currentString: 'Hello, world!',
+    maxLength: 10,
   },
 };
 
 export const Recommended: Story = {
   args: {
-    currentLength: 100,
-    maxLength: 80,
+    currentString: 'Hello, world!',
+    maxLength: 10,
     recommended: true,
   },
 };

--- a/app/javascript/mastodon/components/character_counter/index.tsx
+++ b/app/javascript/mastodon/components/character_counter/index.tsx
@@ -21,7 +21,13 @@ export const CharacterCounter = polymorphicForwardRef<
   CharacterCounterProps
 >(
   (
-    { currentString, maxLength, as: Component = 'span', recommended = false },
+    {
+      currentString,
+      maxLength,
+      as: Component = 'span',
+      recommended = false,
+      ...props
+    },
     ref,
   ) => {
     const currentLength = useMemo(
@@ -30,6 +36,7 @@ export const CharacterCounter = polymorphicForwardRef<
     );
     return (
       <Component
+        {...props}
         ref={ref}
         className={classNames(
           classes.counter,

--- a/app/javascript/mastodon/components/character_counter/index.tsx
+++ b/app/javascript/mastodon/components/character_counter/index.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { FormattedMessage } from 'react-intl';
 
 import classNames from 'classnames';
@@ -6,35 +8,49 @@ import { polymorphicForwardRef } from '@/types/polymorphic';
 
 import classes from './styles.module.scss';
 
+interface CharacterCounterProps {
+  currentString: string;
+  maxLength: number;
+  recommended?: boolean;
+}
+
+const segmenter = new Intl.Segmenter();
+
 export const CharacterCounter = polymorphicForwardRef<
   'span',
-  { currentLength: number; maxLength: number; recommended?: boolean }
+  CharacterCounterProps
 >(
   (
-    { currentLength, maxLength, as: Component = 'span', recommended = false },
+    { currentString, maxLength, as: Component = 'span', recommended = false },
     ref,
-  ) => (
-    <Component
-      ref={ref}
-      className={classNames(
-        classes.counter,
-        currentLength > maxLength && !recommended && classes.counterError,
-      )}
-    >
-      {recommended ? (
-        <FormattedMessage
-          id='character_counter.recommended'
-          defaultMessage='{currentLength}/{maxLength} recommended characters'
-          values={{ currentLength, maxLength }}
-        />
-      ) : (
-        <FormattedMessage
-          id='character_counter.required'
-          defaultMessage='{currentLength}/{maxLength} characters'
-          values={{ currentLength, maxLength }}
-        />
-      )}
-    </Component>
-  ),
+  ) => {
+    const currentLength = useMemo(
+      () => [...segmenter.segment(currentString)].length,
+      [currentString],
+    );
+    return (
+      <Component
+        ref={ref}
+        className={classNames(
+          classes.counter,
+          currentLength > maxLength && !recommended && classes.counterError,
+        )}
+      >
+        {recommended ? (
+          <FormattedMessage
+            id='character_counter.recommended'
+            defaultMessage='{currentLength}/{maxLength} recommended characters'
+            values={{ currentLength, maxLength }}
+          />
+        ) : (
+          <FormattedMessage
+            id='character_counter.required'
+            defaultMessage='{currentLength}/{maxLength} characters'
+            values={{ currentLength, maxLength }}
+          />
+        )}
+      </Component>
+    );
+  },
 );
 CharacterCounter.displayName = 'CharCounter';

--- a/app/javascript/mastodon/components/character_counter/index.tsx
+++ b/app/javascript/mastodon/components/character_counter/index.tsx
@@ -1,0 +1,40 @@
+import { FormattedMessage } from 'react-intl';
+
+import classNames from 'classnames';
+
+import { polymorphicForwardRef } from '@/types/polymorphic';
+
+import classes from './styles.module.scss';
+
+export const CharacterCounter = polymorphicForwardRef<
+  'span',
+  { currentLength: number; maxLength: number; recommended?: boolean }
+>(
+  (
+    { currentLength, maxLength, as: Component = 'span', recommended = false },
+    ref,
+  ) => (
+    <Component
+      ref={ref}
+      className={classNames(
+        classes.counter,
+        currentLength > maxLength && !recommended && classes.counterError,
+      )}
+    >
+      {recommended ? (
+        <FormattedMessage
+          id='character_counter.recommended'
+          defaultMessage='{currentLength}/{maxLength} recommended characters'
+          values={{ currentLength, maxLength }}
+        />
+      ) : (
+        <FormattedMessage
+          id='character_counter.required'
+          defaultMessage='{currentLength}/{maxLength} characters'
+          values={{ currentLength, maxLength }}
+        />
+      )}
+    </Component>
+  ),
+);
+CharacterCounter.displayName = 'CharCounter';

--- a/app/javascript/mastodon/components/character_counter/styles.module.scss
+++ b/app/javascript/mastodon/components/character_counter/styles.module.scss
@@ -1,0 +1,8 @@
+.counter {
+  margin-top: 4px;
+  font-size: 13px;
+}
+
+.counterError {
+  color: var(--color-text-error);
+}

--- a/app/javascript/mastodon/components/emoji/picker_button.tsx
+++ b/app/javascript/mastodon/components/emoji/picker_button.tsx
@@ -1,0 +1,25 @@
+import { useCallback } from 'react';
+import type { FC } from 'react';
+
+import EmojiPickerDropdown from '@/mastodon/features/compose/containers/emoji_picker_dropdown_container';
+
+export const EmojiPickerButton: FC<{ onPick: (emoji: string) => void }> = ({
+  onPick,
+}) => {
+  const handlePick = useCallback(
+    (emoji: unknown) => {
+      if (typeof emoji === 'object' && emoji !== null) {
+        if ('native' in emoji && typeof emoji.native === 'string') {
+          onPick(emoji.native);
+        } else if (
+          'shortcode' in emoji &&
+          typeof emoji.shortcode === 'string'
+        ) {
+          onPick(`:${emoji.shortcode}:`);
+        }
+      }
+    },
+    [onPick],
+  );
+  return <EmojiPickerDropdown onPickEmoji={handlePick} />;
+};

--- a/app/javascript/mastodon/components/emoji/picker_button.tsx
+++ b/app/javascript/mastodon/components/emoji/picker_button.tsx
@@ -3,11 +3,15 @@ import type { FC } from 'react';
 
 import EmojiPickerDropdown from '@/mastodon/features/compose/containers/emoji_picker_dropdown_container';
 
-export const EmojiPickerButton: FC<{ onPick: (emoji: string) => void }> = ({
-  onPick,
-}) => {
+export const EmojiPickerButton: FC<{
+  onPick: (emoji: string) => void;
+  disabled?: boolean;
+}> = ({ onPick, disabled }) => {
   const handlePick = useCallback(
     (emoji: unknown) => {
+      if (disabled) {
+        return;
+      }
       if (typeof emoji === 'object' && emoji !== null) {
         if ('native' in emoji && typeof emoji.native === 'string') {
           onPick(emoji.native);
@@ -19,7 +23,7 @@ export const EmojiPickerButton: FC<{ onPick: (emoji: string) => void }> = ({
         }
       }
     },
-    [onPick],
+    [disabled, onPick],
   );
-  return <EmojiPickerDropdown onPickEmoji={handlePick} />;
+  return <EmojiPickerDropdown onPickEmoji={handlePick} disabled={disabled} />;
 };

--- a/app/javascript/mastodon/components/form_fields/emoji_text_field.module.scss
+++ b/app/javascript/mastodon/components/form_fields/emoji_text_field.module.scss
@@ -5,6 +5,10 @@
   > textarea {
     padding-inline-end: 36px;
   }
+
+  > textarea {
+    min-height: 40px; // Button size with 8px margin
+  }
 }
 
 .fieldWrapper :global(.emoji-picker-dropdown) {

--- a/app/javascript/mastodon/components/form_fields/emoji_text_field.module.scss
+++ b/app/javascript/mastodon/components/form_fields/emoji_text_field.module.scss
@@ -1,0 +1,20 @@
+.fieldWrapper div:has(:global(.emoji-picker-dropdown)) {
+  position: relative;
+
+  > input,
+  > textarea {
+    padding-inline-end: 36px;
+  }
+}
+
+.fieldWrapper :global(.emoji-picker-dropdown) {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  height: 24px;
+  z-index: 1;
+
+  :global(.icon-button) {
+    color: var(--color-text-secondary);
+  }
+}

--- a/app/javascript/mastodon/components/form_fields/emoji_text_field.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/emoji_text_field.stories.tsx
@@ -9,13 +9,14 @@ const meta = {
   title: 'Components/Form Fields/EmojiTextInputField',
   args: {
     label: 'Label',
+    hint: 'Hint text',
     value: 'Insert text with emoji',
   },
   render({ value: initialValue = '', ...args }) {
     const [value, setValue] = useState(initialValue);
     return <EmojiTextInputField {...args} value={value} onChange={setValue} />;
   },
-} satisfies Meta<InputProps>;
+} satisfies Meta<InputProps & { disabled?: boolean }>;
 
 export default meta;
 
@@ -33,6 +34,12 @@ export const WithRecommended: Story = {
   args: {
     maxLength: 20,
     recommended: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
   },
 };
 

--- a/app/javascript/mastodon/components/form_fields/emoji_text_field.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/emoji_text_field.stories.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import type { InputProps } from './emoji_text_field';
+import type { EmojiInputProps } from './emoji_text_field';
 import { EmojiTextAreaField, EmojiTextInputField } from './emoji_text_field';
 
 const meta = {
@@ -16,7 +16,7 @@ const meta = {
     const [value, setValue] = useState(initialValue);
     return <EmojiTextInputField {...args} value={value} onChange={setValue} />;
   },
-} satisfies Meta<InputProps & { disabled?: boolean }>;
+} satisfies Meta<EmojiInputProps & { disabled?: boolean }>;
 
 export default meta;
 

--- a/app/javascript/mastodon/components/form_fields/emoji_text_field.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/emoji_text_field.stories.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import type { InputProps } from './emoji_text_field';
+import { EmojiTextAreaField, EmojiTextInputField } from './emoji_text_field';
+
+const meta = {
+  title: 'Components/Form Fields/EmojiTextInputField',
+  args: {
+    label: 'Label',
+    value: 'Insert text with emoji',
+  },
+  render({ value: initialValue = '', ...args }) {
+    const [value, setValue] = useState(initialValue);
+    return <EmojiTextInputField {...args} value={value} onChange={setValue} />;
+  },
+} satisfies Meta<InputProps>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Simple: Story = {};
+
+export const WithMaxLength: Story = {
+  args: {
+    maxLength: 20,
+  },
+};
+
+export const WithRecommended: Story = {
+  args: {
+    maxLength: 20,
+    recommended: true,
+  },
+};
+
+export const TextArea: Story = {
+  render(args) {
+    const [value, setValue] = useState('Insert text with emoji');
+    return (
+      <EmojiTextAreaField
+        {...args}
+        value={value}
+        onChange={setValue}
+        label='Label'
+        maxLength={100}
+      />
+    );
+  },
+};

--- a/app/javascript/mastodon/components/form_fields/emoji_text_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/emoji_text_field.tsx
@@ -1,9 +1,11 @@
 import type {
   ChangeEvent,
+  ChangeEventHandler,
   ComponentPropsWithoutRef,
   Dispatch,
   FC,
   ReactNode,
+  RefObject,
   SetStateAction,
 } from 'react';
 import { useCallback, useId, useRef } from 'react';
@@ -15,21 +17,66 @@ import { CharacterCounter } from '../character_counter';
 import { EmojiPickerButton } from '../emoji/picker_button';
 
 import classes from './emoji_text_field.module.scss';
-import { TextAreaField } from './text_area_field';
+import type {
+  CommonFieldWrapperProps,
+  InputProps} from './form_field_wrapper';
+import {
+  FormFieldWrapper
+} from './form_field_wrapper';
+import { TextArea } from './text_area_field';
 import type { TextAreaProps } from './text_area_field';
-import { TextInputField } from './text_input_field';
+import { TextInput } from './text_input_field';
 
-export interface InputProps {
+export type EmojiInputProps = {
   value?: string;
   onChange?: Dispatch<SetStateAction<string>>;
-  label?: ReactNode;
-  hint?: ReactNode;
   maxLength?: number;
   recommended?: boolean;
-}
+} & Omit<CommonFieldWrapperProps, 'wrapperClassName'>;
 
 export const EmojiTextInputField: FC<
-  OmitUnion<ComponentPropsWithoutRef<'input'>, InputProps>
+  OmitUnion<ComponentPropsWithoutRef<'input'>, EmojiInputProps>
+> = ({
+  onChange,
+  value,
+  label,
+  hint,
+  hasError,
+  maxLength,
+  recommended,
+  disabled,
+  ...otherProps
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const wrapperProps = {
+    label,
+    hint,
+    hasError,
+    maxLength,
+    recommended,
+    disabled,
+    inputRef,
+    value,
+    onChange,
+  };
+
+  return (
+    <EmojiFieldWrapper {...wrapperProps}>
+      {(inputProps) => (
+        <TextInput
+          {...inputProps}
+          {...otherProps}
+          value={value}
+          ref={inputRef}
+        />
+      )}
+    </EmojiFieldWrapper>
+  );
+};
+
+export const EmojiTextAreaField: FC<
+  OmitUnion<Omit<TextAreaProps, 'style'>, EmojiInputProps>
 > = ({
   onChange,
   value,
@@ -37,17 +84,57 @@ export const EmojiTextInputField: FC<
   maxLength,
   recommended = false,
   disabled,
-  ...props
+  hint,
+  hasError,
+  ...otherProps
 }) => {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const counterId = useId();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const handleChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      onChange?.(event.target.value);
-    },
-    [onChange],
+  const wrapperProps = {
+    label,
+    hint,
+    hasError,
+    maxLength,
+    recommended,
+    disabled,
+    inputRef: textareaRef,
+    value,
+    onChange,
+  };
+
+  return (
+    <EmojiFieldWrapper {...wrapperProps}>
+      {(inputProps) => (
+        <TextArea
+          {...otherProps}
+          {...inputProps}
+          value={value}
+          ref={textareaRef}
+        />
+      )}
+    </EmojiFieldWrapper>
   );
+};
+
+const EmojiFieldWrapper: FC<
+  EmojiInputProps & {
+    disabled?: boolean;
+    children: (
+      inputProps: InputProps & { onChange: ChangeEventHandler },
+    ) => ReactNode;
+    inputRef: RefObject<HTMLTextAreaElement | HTMLInputElement>;
+  }
+> = ({
+  value,
+  onChange,
+  children,
+  disabled,
+  inputRef,
+  maxLength,
+  recommended = false,
+  ...otherProps
+}) => {
+  const counterId = useId();
 
   const handlePickEmoji = useCallback(
     (emoji: string) => {
@@ -56,79 +143,25 @@ export const EmojiTextInputField: FC<
         return insertEmojiAtPosition(prev, emoji, position);
       });
     },
-    [onChange],
+    [onChange, inputRef],
   );
-
-  return (
-    <TextInputField
-      {...props}
-      label={label}
-      value={value}
-      onChange={handleChange}
-      wrapperClassName={classes.fieldWrapper}
-      disabled={disabled}
-      ref={inputRef}
-      aria-describedby={counterId}
-      afterInput={
-        <>
-          <EmojiPickerButton onPick={handlePickEmoji} disabled={disabled} />
-          {maxLength && (
-            <CharacterCounter
-              currentString={value ?? ''}
-              maxLength={maxLength}
-              recommended={recommended}
-              id={counterId}
-            />
-          )}
-        </>
-      }
-    />
-  );
-};
-
-export const EmojiTextAreaField: FC<
-  OmitUnion<Omit<TextAreaProps, 'style'>, InputProps>
-> = ({
-  onChange,
-  value,
-  label,
-  maxLength,
-  recommended = false,
-  disabled,
-  ...props
-}) => {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const counterId = useId();
 
   const handleChange = useCallback(
-    (event: ChangeEvent<HTMLTextAreaElement>) => {
+    (event: ChangeEvent<HTMLInputElement>) => {
       onChange?.(event.target.value);
     },
     [onChange],
   );
 
-  const handlePickEmoji = useCallback(
-    (emoji: string) => {
-      onChange?.((prev) => {
-        const position = textareaRef.current?.selectionStart ?? prev.length;
-        return insertEmojiAtPosition(prev, emoji, position);
-      });
-    },
-    [onChange],
-  );
-
   return (
-    <TextAreaField
-      {...props}
-      label={label}
-      value={value}
-      onChange={handleChange}
-      wrapperClassName={classes.fieldWrapper}
-      disabled={disabled}
-      ref={textareaRef}
-      aria-describedby={counterId}
-      afterInput={
+    <FormFieldWrapper
+      className={classes.fieldWrapper}
+      describedById={counterId}
+      {...otherProps}
+    >
+      {(inputProps) => (
         <>
+          {children({ ...inputProps, onChange: handleChange })}
           <EmojiPickerButton onPick={handlePickEmoji} disabled={disabled} />
           {maxLength && (
             <CharacterCounter
@@ -139,7 +172,7 @@ export const EmojiTextAreaField: FC<
             />
           )}
         </>
-      }
-    />
+      )}
+    </FormFieldWrapper>
   );
 };

--- a/app/javascript/mastodon/components/form_fields/emoji_text_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/emoji_text_field.tsx
@@ -30,7 +30,15 @@ export interface InputProps {
 
 export const EmojiTextInputField: FC<
   OmitUnion<ComponentPropsWithoutRef<'input'>, InputProps>
-> = ({ onChange, value, label, maxLength, recommended = false, ...props }) => {
+> = ({
+  onChange,
+  value,
+  label,
+  maxLength,
+  recommended = false,
+  disabled,
+  ...props
+}) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const counterId = useId();
 
@@ -58,11 +66,12 @@ export const EmojiTextInputField: FC<
       value={value}
       onChange={handleChange}
       wrapperClassName={classes.fieldWrapper}
+      disabled={disabled}
       ref={inputRef}
       aria-describedby={counterId}
       afterInput={
         <>
-          <EmojiPickerButton onPick={handlePickEmoji} />
+          <EmojiPickerButton onPick={handlePickEmoji} disabled={disabled} />
           {maxLength && (
             <CharacterCounter
               currentString={value ?? ''}
@@ -79,7 +88,15 @@ export const EmojiTextInputField: FC<
 
 export const EmojiTextAreaField: FC<
   OmitUnion<Omit<TextAreaProps, 'style'>, InputProps>
-> = ({ onChange, value, label, maxLength, recommended = false, ...props }) => {
+> = ({
+  onChange,
+  value,
+  label,
+  maxLength,
+  recommended = false,
+  disabled,
+  ...props
+}) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const counterId = useId();
 
@@ -107,11 +124,12 @@ export const EmojiTextAreaField: FC<
       value={value}
       onChange={handleChange}
       wrapperClassName={classes.fieldWrapper}
+      disabled={disabled}
       ref={textareaRef}
       aria-describedby={counterId}
       afterInput={
         <>
-          <EmojiPickerButton onPick={handlePickEmoji} />
+          <EmojiPickerButton onPick={handlePickEmoji} disabled={disabled} />
           {maxLength && (
             <CharacterCounter
               currentString={value ?? ''}

--- a/app/javascript/mastodon/components/form_fields/emoji_text_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/emoji_text_field.tsx
@@ -1,0 +1,127 @@
+import type {
+  ChangeEvent,
+  ComponentPropsWithoutRef,
+  Dispatch,
+  FC,
+  ReactNode,
+  SetStateAction,
+} from 'react';
+import { useCallback, useId, useRef } from 'react';
+
+import { insertEmojiAtPosition } from '@/mastodon/features/emoji/utils';
+import type { OmitUnion } from '@/mastodon/utils/types';
+
+import { CharacterCounter } from '../character_counter';
+import { EmojiPickerButton } from '../emoji/picker_button';
+
+import classes from './emoji_text_field.module.scss';
+import { TextAreaField } from './text_area_field';
+import type { TextAreaProps } from './text_area_field';
+import { TextInputField } from './text_input_field';
+
+export interface InputProps {
+  value?: string;
+  onChange?: Dispatch<SetStateAction<string>>;
+  label?: ReactNode;
+  hint?: ReactNode;
+  maxLength?: number;
+  recommended?: boolean;
+}
+
+export const EmojiTextInputField: FC<
+  OmitUnion<ComponentPropsWithoutRef<'input'>, InputProps>
+> = ({ onChange, value, label, maxLength, recommended = false, ...props }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const counterId = useId();
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onChange?.(event.target.value);
+    },
+    [onChange],
+  );
+
+  const handlePickEmoji = useCallback(
+    (emoji: string) => {
+      onChange?.((prev) => {
+        const position = inputRef.current?.selectionStart ?? prev.length;
+        return insertEmojiAtPosition(prev, emoji, position);
+      });
+    },
+    [onChange],
+  );
+
+  return (
+    <TextInputField
+      {...props}
+      label={label}
+      value={value}
+      onChange={handleChange}
+      wrapperClassName={classes.fieldWrapper}
+      ref={inputRef}
+      aria-describedby={counterId}
+      afterInput={
+        <>
+          <EmojiPickerButton onPick={handlePickEmoji} />
+          {maxLength && (
+            <CharacterCounter
+              currentLength={value?.length ?? 0}
+              maxLength={maxLength}
+              recommended={recommended}
+              id={counterId}
+            />
+          )}
+        </>
+      }
+    />
+  );
+};
+
+export const EmojiTextAreaField: FC<
+  OmitUnion<Omit<TextAreaProps, 'style'>, InputProps>
+> = ({ onChange, value, label, maxLength, recommended = false, ...props }) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const counterId = useId();
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      onChange?.(event.target.value);
+    },
+    [onChange],
+  );
+
+  const handlePickEmoji = useCallback(
+    (emoji: string) => {
+      onChange?.((prev) => {
+        const position = textareaRef.current?.selectionStart ?? prev.length;
+        return insertEmojiAtPosition(prev, emoji, position);
+      });
+    },
+    [onChange],
+  );
+
+  return (
+    <TextAreaField
+      {...props}
+      label={label}
+      value={value}
+      onChange={handleChange}
+      wrapperClassName={classes.fieldWrapper}
+      ref={textareaRef}
+      aria-describedby={counterId}
+      afterInput={
+        <>
+          <EmojiPickerButton onPick={handlePickEmoji} />
+          {maxLength && (
+            <CharacterCounter
+              currentLength={value?.length ?? 0}
+              maxLength={maxLength}
+              recommended={recommended}
+              id={counterId}
+            />
+          )}
+        </>
+      }
+    />
+  );
+};

--- a/app/javascript/mastodon/components/form_fields/emoji_text_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/emoji_text_field.tsx
@@ -65,7 +65,7 @@ export const EmojiTextInputField: FC<
           <EmojiPickerButton onPick={handlePickEmoji} />
           {maxLength && (
             <CharacterCounter
-              currentLength={value?.length ?? 0}
+              currentString={value ?? ''}
               maxLength={maxLength}
               recommended={recommended}
               id={counterId}
@@ -114,7 +114,7 @@ export const EmojiTextAreaField: FC<
           <EmojiPickerButton onPick={handlePickEmoji} />
           {maxLength && (
             <CharacterCounter
-              currentLength={value?.length ?? 0}
+              currentString={value ?? ''}
               maxLength={maxLength}
               recommended={recommended}
               id={counterId}

--- a/app/javascript/mastodon/components/form_fields/emoji_text_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/emoji_text_field.tsx
@@ -17,12 +17,8 @@ import { CharacterCounter } from '../character_counter';
 import { EmojiPickerButton } from '../emoji/picker_button';
 
 import classes from './emoji_text_field.module.scss';
-import type {
-  CommonFieldWrapperProps,
-  InputProps} from './form_field_wrapper';
-import {
-  FormFieldWrapper
-} from './form_field_wrapper';
+import type { CommonFieldWrapperProps, InputProps } from './form_field_wrapper';
+import { FormFieldWrapper } from './form_field_wrapper';
 import { TextArea } from './text_area_field';
 import type { TextAreaProps } from './text_area_field';
 import { TextInput } from './text_input_field';

--- a/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
+++ b/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import { FieldsetNameContext } from './fieldset';
 import classes from './form_field_wrapper.module.scss';
 
-interface InputProps {
+export interface InputProps {
   id: string;
   required?: boolean;
   'aria-describedby'?: string;
@@ -22,6 +22,7 @@ interface FieldWrapperProps {
   required?: boolean;
   hasError?: boolean;
   inputId?: string;
+  describedById?: string;
   inputPlacement?: 'inline-start' | 'inline-end';
   children: (inputProps: InputProps) => ReactNode;
   className?: string;
@@ -45,6 +46,7 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
   inputId: inputIdProp,
   label,
   hint,
+  describedById,
   required,
   hasError,
   inputPlacement,
@@ -63,7 +65,9 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
     id: inputId,
   };
   if (hasHint) {
-    inputProps['aria-describedby'] = hintId;
+    inputProps['aria-describedby'] = describedById
+      ? `${describedById} ${hintId}`
+      : hintId;
   }
 
   const input = (

--- a/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
+++ b/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
@@ -5,6 +5,8 @@ import { useContext, useId } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
+import classNames from 'classnames';
+
 import { FieldsetNameContext } from './fieldset';
 import classes from './form_field_wrapper.module.scss';
 
@@ -22,6 +24,8 @@ interface FieldWrapperProps {
   inputId?: string;
   inputPlacement?: 'inline-start' | 'inline-end';
   children: (inputProps: InputProps) => ReactNode;
+  className?: string;
+  afterInput?: ReactNode;
 }
 
 /**
@@ -29,8 +33,8 @@ interface FieldWrapperProps {
  */
 export type CommonFieldWrapperProps = Pick<
   FieldWrapperProps,
-  'label' | 'hint' | 'hasError'
->;
+  'label' | 'hint' | 'hasError' | 'afterInput'
+> & { wrapperClassName?: string };
 
 /**
  * A simple form field wrapper for adding a label and hint to enclosed components.
@@ -46,6 +50,8 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
   hasError,
   inputPlacement,
   children,
+  className,
+  afterInput,
 }) => {
   const uniqueId = useId();
   const inputId = inputIdProp || `${uniqueId}-input`;
@@ -63,12 +69,16 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
   }
 
   const input = (
-    <div className={classes.inputWrapper}>{children(inputProps)}</div>
+    <div className={classes.inputWrapper}>
+      {children(inputProps)}
+
+      {afterInput}
+    </div>
   );
 
   return (
     <div
-      className={classes.wrapper}
+      className={classNames(classes.wrapper, className)}
       data-has-error={hasError}
       data-input-placement={inputPlacement}
     >

--- a/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
+++ b/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
@@ -25,7 +25,6 @@ interface FieldWrapperProps {
   inputPlacement?: 'inline-start' | 'inline-end';
   children: (inputProps: InputProps) => ReactNode;
   className?: string;
-  afterInput?: ReactNode;
 }
 
 /**
@@ -33,7 +32,7 @@ interface FieldWrapperProps {
  */
 export type CommonFieldWrapperProps = Pick<
   FieldWrapperProps,
-  'label' | 'hint' | 'hasError' | 'afterInput'
+  'label' | 'hint' | 'hasError'
 > & { wrapperClassName?: string };
 
 /**
@@ -51,7 +50,6 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
   inputPlacement,
   children,
   className,
-  afterInput,
 }) => {
   const uniqueId = useId();
   const inputId = inputIdProp || `${uniqueId}-input`;
@@ -69,11 +67,7 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
   }
 
   const input = (
-    <div className={classes.inputWrapper}>
-      {children(inputProps)}
-
-      {afterInput}
-    </div>
+    <div className={classes.inputWrapper}>{children(inputProps)}</div>
   );
 
   return (

--- a/app/javascript/mastodon/components/form_fields/text_area_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/text_area_field.tsx
@@ -10,7 +10,7 @@ import { FormFieldWrapper } from './form_field_wrapper';
 import type { CommonFieldWrapperProps } from './form_field_wrapper';
 import classes from './text_input.module.scss';
 
-type TextAreaProps =
+export type TextAreaProps =
   | ({ autoSize?: false } & ComponentPropsWithoutRef<'textarea'>)
   | ({ autoSize: true } & TextareaAutosizeProps);
 
@@ -24,17 +24,33 @@ type TextAreaProps =
 export const TextAreaField = forwardRef<
   HTMLTextAreaElement,
   TextAreaProps & CommonFieldWrapperProps
->(({ id, label, hint, required, hasError, ...otherProps }, ref) => (
-  <FormFieldWrapper
-    label={label}
-    hint={hint}
-    required={required}
-    hasError={hasError}
-    inputId={id}
-  >
-    {(inputProps) => <TextArea {...otherProps} {...inputProps} ref={ref} />}
-  </FormFieldWrapper>
-));
+>(
+  (
+    {
+      id,
+      label,
+      hint,
+      required,
+      hasError,
+      wrapperClassName,
+      afterInput,
+      ...otherProps
+    },
+    ref,
+  ) => (
+    <FormFieldWrapper
+      label={label}
+      hint={hint}
+      required={required}
+      hasError={hasError}
+      inputId={id}
+      className={wrapperClassName}
+      afterInput={afterInput}
+    >
+      {(inputProps) => <TextArea {...otherProps} {...inputProps} ref={ref} />}
+    </FormFieldWrapper>
+  ),
+);
 
 TextAreaField.displayName = 'TextAreaField';
 

--- a/app/javascript/mastodon/components/form_fields/text_area_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/text_area_field.tsx
@@ -26,16 +26,7 @@ export const TextAreaField = forwardRef<
   TextAreaProps & CommonFieldWrapperProps
 >(
   (
-    {
-      id,
-      label,
-      hint,
-      required,
-      hasError,
-      wrapperClassName,
-      afterInput,
-      ...otherProps
-    },
+    { id, label, hint, required, hasError, wrapperClassName, ...otherProps },
     ref,
   ) => (
     <FormFieldWrapper
@@ -45,7 +36,6 @@ export const TextAreaField = forwardRef<
       hasError={hasError}
       inputId={id}
       className={wrapperClassName}
-      afterInput={afterInput}
     >
       {(inputProps) => <TextArea {...otherProps} {...inputProps} ref={ref} />}
     </FormFieldWrapper>

--- a/app/javascript/mastodon/components/form_fields/text_input_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/text_input_field.tsx
@@ -25,16 +25,7 @@ interface Props extends TextInputProps, CommonFieldWrapperProps {}
 
 export const TextInputField = forwardRef<HTMLInputElement, Props>(
   (
-    {
-      id,
-      label,
-      hint,
-      hasError,
-      required,
-      wrapperClassName,
-      afterInput,
-      ...otherProps
-    },
+    { id, label, hint, hasError, required, wrapperClassName, ...otherProps },
     ref,
   ) => (
     <FormFieldWrapper
@@ -44,7 +35,6 @@ export const TextInputField = forwardRef<HTMLInputElement, Props>(
       hasError={hasError}
       inputId={id}
       className={wrapperClassName}
-      afterInput={afterInput}
     >
       {(inputProps) => <TextInput {...otherProps} {...inputProps} ref={ref} />}
     </FormFieldWrapper>

--- a/app/javascript/mastodon/components/form_fields/text_input_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/text_input_field.tsx
@@ -24,13 +24,27 @@ interface Props extends TextInputProps, CommonFieldWrapperProps {}
  */
 
 export const TextInputField = forwardRef<HTMLInputElement, Props>(
-  ({ id, label, hint, hasError, required, ...otherProps }, ref) => (
+  (
+    {
+      id,
+      label,
+      hint,
+      hasError,
+      required,
+      wrapperClassName,
+      afterInput,
+      ...otherProps
+    },
+    ref,
+  ) => (
     <FormFieldWrapper
       label={label}
       hint={hint}
       required={required}
       hasError={hasError}
       inputId={id}
+      className={wrapperClassName}
+      afterInput={afterInput}
     >
       {(inputProps) => <TextInput {...otherProps} {...inputProps} ref={ref} />}
     </FormFieldWrapper>

--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
@@ -396,6 +396,7 @@ class EmojiPickerDropdown extends PureComponent {
           active={active}
           iconComponent={MoodIcon}
           onClick={this.onToggle}
+          id="emoji"
           inverted
         />
 

--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
@@ -322,6 +322,7 @@ class EmojiPickerDropdown extends PureComponent {
     onPickEmoji: PropTypes.func.isRequired,
     onSkinTone: PropTypes.func.isRequired,
     skinTone: PropTypes.number.isRequired,
+    disabled: PropTypes.bool,
   };
 
   state = {
@@ -384,7 +385,7 @@ class EmojiPickerDropdown extends PureComponent {
   };
 
   render() {
-    const { intl, onPickEmoji, onSkinTone, skinTone, frequentlyUsedEmojis } = this.props;
+    const { intl, onPickEmoji, onSkinTone, skinTone, frequentlyUsedEmojis, disabled } = this.props;
     const title = intl.formatMessage(messages.emoji);
     const { active, loading, placement } = this.state;
 
@@ -396,6 +397,7 @@ class EmojiPickerDropdown extends PureComponent {
           active={active}
           iconComponent={MoodIcon}
           onClick={this.onToggle}
+          disabled={disabled}
           id="emoji"
           inverted
         />

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -276,6 +276,8 @@
   "callout.dismiss": "Dismiss",
   "carousel.current": "<sr>Slide</sr> {current, number} / {max, number}",
   "carousel.slide": "Slide {current, number} of {max, number}",
+  "character_counter.recommended": "{currentLength}/{maxLength} recommended characters",
+  "character_counter.required": "{currentLength}/{maxLength} characters",
   "closed_registrations.other_server_instructions": "Since Mastodon is decentralized, you can create an account on another server and still interact with this one.",
   "closed_registrations_modal.description": "Creating an account on {domain} is currently not possible, but please keep in mind that you do not need an account specifically on {domain} to use Mastodon.",
   "closed_registrations_modal.find_another_server": "Find another server",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ import jsxA11Y from 'eslint-plugin-jsx-a11y';
 import promisePlugin from 'eslint-plugin-promise';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
+// @ts-expect-error -- No types available for this package
 import storybook from 'eslint-plugin-storybook';
 import { globalIgnores } from 'eslint/config';
 import globals from 'globals';
@@ -368,6 +369,7 @@ export default tseslint.config([
     files: ['**/*.stories.ts', '**/*.stories.tsx', '.storybook/*'],
     rules: {
       'import/no-default-export': 'off',
+      'react-hooks/rules-of-hooks': 'off',
     },
   },
   {


### PR DESCRIPTION
This adds three new components to be used with profile editing: CharacterCounter, EmojiPickerButton, and EmojiTextInputField/EmojiTextAreaField.

Notes:
- Added way to disable emoji picker button
- Utilized `Intl.Segmenter` instead of `stringz` library like the prior character counter
- Added `wrapperClassName` and `afterInput` props to the FieldWrapper component

<img width="598" height="290" alt="Screenshot 2026-03-04 at 12 36 56" src="https://github.com/user-attachments/assets/15513f11-bec8-4ca5-9796-deb66ae4e47c" />
<img width="578" height="336" alt="Screenshot 2026-03-04 at 12 37 04" src="https://github.com/user-attachments/assets/1bbe4835-97c1-432a-9998-ebd328490ad0" />
