### PR TITLE
Move chewy enable for spec to search data manager

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,8 +58,6 @@ Sidekiq.default_configuration.logger = nil
 
 DatabaseCleaner.strategy = [:deletion]
 
-Chewy.settings[:enabled] = false
-
 Devise::Test::ControllerHelpers.module_eval do
   alias_method :original_sign_in, :sign_in
 

--- a/spec/support/search_data_manager.rb
+++ b/spec/support/search_data_manager.rb
@@ -45,11 +45,14 @@ end
 RSpec.configure do |config|
   config.before :suite do
     if search_examples_present?
+      Chewy.settings[:enabled] = true
       # Configure chewy to use `urgent` strategy to index documents
       Chewy.strategy(:urgent)
 
       # Create search data
       search_data_manager.prepare_test_data
+    else
+      Chewy.settings[:enabled] = false
     end
   end
 


### PR DESCRIPTION
Background in https://github.com/mastodon/mastodon/pull/38041

Prep for https://github.com/mastodon/mastodon/pull/37983

In attempting to run the search specs locally I was trying to first get a clean run by using an ES-enabled devcontainer, but couldn't get `main` to pass the search specs.

I found what I think is basically a load order issue -- the `rails_helper` disables Chewy, which means if any classes are autoloaded *before* the "search data manager" re-enables it, they will have a no-op for their `update_index` calls. This matches the failures I was seeing in the "state change removes from index" sort of specs. The change here is to move this enabled setting to the manager in an rspec config block, which seems to fix the load order issue in my local container testing. I wonder if there's some subtle load order or other config/env difference between the CI env and the devcontainer env which makes this pass on CI but fail in container?

Possible followups here:

- I may do another once-over on the existing search specs ... feels like the "model side effect" checks should just be in model specs, and I suspect some of the data setup/teardown in there is overkill and could just be normal factory setup closer to the actual examples ... it was a little weird bouncing back and forth between everything while debugging.
- We only have partial coverage of the various indexes and things that update them ... may expand a bit in advance of that chewy upgrade PR as well

Finally, if anyone regularly uses a devcontainer locally (I do not) and regularly runs the search specs (I do not) and you were NOT seeing these failures ... we could investigate that more first?
