### PR TITLE
Redirect to short account URLs when requesting HTML for one of the AP endpoints

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -18,6 +18,8 @@ class AccountsController < ApplicationController
     respond_to do |format|
       format.html do
         expires_in(15.seconds, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.hour) unless user_signed_in?
+
+        redirect_to short_account_path(@account) if account_id_param.present? && username_param.blank?
       end
 
       format.rss do

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -26,6 +26,8 @@ class StatusesController < ApplicationController
     respond_to do |format|
       format.html do
         expires_in 10.seconds, public: true if current_account.nil?
+
+        redirect_to short_account_status_path(@account, @status) if account_id_param.present? && username_param.blank?
       end
 
       format.json do

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -6,10 +6,20 @@ RSpec.describe 'Accounts show response' do
   let(:account) { Fabricate(:account) }
 
   context 'with numeric-based identifiers' do
-    it 'returns http success' do
-      get "/ap/users/#{account.id}"
+    context 'with JSON format' do
+      it 'returns http success' do
+        get "/ap/users/#{account.id}", headers: { 'ACCEPT' => 'application/json' }
 
-      expect(response).to have_http_status(200)
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'with HTML format' do
+      it 'redirects to success' do
+        get "/ap/users/#{account.id}", as: 'html'
+
+        expect(response).to redirect_to("/@#{account.username}")
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #38045