### PR TITLE
Add for searching already-known private GtS posts

### DIFF
--- a/app/services/resolve_url_service.rb
+++ b/app/services/resolve_url_service.rb
@@ -4,7 +4,7 @@ class ResolveURLService < BaseService
   include JsonLdHelper
   include Authorization
 
-  USERNAME_STATUS_RE = %r{/@(?<username>#{Account::USERNAME_RE})/(?<status_id>[0-9]+)\Z}
+  USERNAME_STATUS_RE = %r{/@(?<username>#{Account::USERNAME_RE})/(statuses/)?(?<status_id>[0-9a-zA-Z]+)\Z}
 
   def call(url, on_behalf_of: nil)
     @url          = url


### PR DESCRIPTION
This is a hack like we had for Mastodon itself. Note that this feature does not actually work anymore for new Mastodon accounts that use the numeric AP scheme, as the account ID cannot be guessed from the short account URL.