### PR TITLE
Fix incorrect I18n string in webauthn mailers

### DIFF
--- a/app/views/user_mailer/webauthn_credential_added.text.erb
+++ b/app/views/user_mailer/webauthn_credential_added.text.erb
@@ -1,7 +1,7 @@
-<%= t 'devise.mailer.two_factor_enabled.title' %>
+<%= t 'devise.mailer.webauthn_credential.added.title' %>
 
 ===
 
-<%= t 'devise.mailer.two_factor_enabled.explanation' %>
+<%= t 'devise.mailer.webauthn_credential.added.explanation' %>
 
 => <%= edit_user_registration_url %>

--- a/app/views/user_mailer/webauthn_enabled.text.erb
+++ b/app/views/user_mailer/webauthn_enabled.text.erb
@@ -1,7 +1,7 @@
-<%= t 'devise.mailer.webauthn_credential.added.title' %>
+<%= t 'devise.mailer.webauthn_enabled.title' %>
 
 ===
 
-<%= t 'devise.mailer.webauthn_credential.added.explanation' %>
+<%= t 'devise.mailer.webauthn_enabled.explanation' %>
 
 => <%= edit_user_registration_url %>


### PR DESCRIPTION
I assume these were copy/pasted at some point - or possibly the text views were missed when the html mailers were updated a while back. These updates match the strings used in the corresponding html views for each mailer.