### PR TITLE
Update monkey patched calculate_ip with rails 8.1 practices.

### DIFF
--- a/lib/action_dispatch/remote_ip_extensions.rb
+++ b/lib/action_dispatch/remote_ip_extensions.rb
@@ -17,11 +17,11 @@ module ActionDispatch
     module GetIpExtensions
       def calculate_ip
         # Set by the Rack web server, this is a single value.
-        remote_addr = ips_from(@req.remote_addr).last
+        remote_addr = sanitize_ips(ips_from(@req.remote_addr)).last
 
         # Could be a CSV list and/or repeated headers that were concatenated.
-        client_ips    = ips_from(@req.client_ip).reverse!
-        forwarded_ips = ips_from(@req.x_forwarded_for).reverse!
+        client_ips    = sanitize_ips(ips_from(@req.client_ip)).reverse!
+        forwarded_ips = sanitize_ips(@req.forwarded_for).reverse!
 
         # `Client-Ip` and `X-Forwarded-For` should not, generally, both be set. If they
         # are both set, it means that either:


### PR DESCRIPTION
https://github.com/rails/rails/blob/d7c8ae65b7045490965218a994c300aea8dbb079/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L129

Have updated their side of the code... so the monkey patch might need to be updated? Very @ClearlyClaire PR.
```
      def calculate_ip
        # Set by the Rack web server, this is a single value.
        remote_addr = sanitize_ips(ips_from(@req.remote_addr)).last

        # Could be a CSV list and/or repeated headers that were concatenated.
        client_ips    = sanitize_ips(ips_from(@req.client_ip)).reverse!
        forwarded_ips = sanitize_ips(@req.forwarded_for || []).reverse!
```