### PR TITLE
Remove minimum account limit on collections

### DIFF
--- a/app/javascript/mastodon/features/account_featured/index.tsx
+++ b/app/javascript/mastodon/features/account_featured/index.tsx
@@ -82,10 +82,11 @@ const AccountFeatured: React.FC<{ multiColumn: boolean }> = ({
   const { collections, status } = useAppSelector((state) =>
     selectAccountCollections(state, accountId ?? null),
   );
-  const publicCollections = collections.filter(
-    // This filter only applies when viewing your own profile, where the endpoint
-    // returns all collections, but we hide unlisted ones here to avoid confusion
-    (item) => item.discoverable,
+  const listedCollections = collections.filter(
+    // Hide unlisted and empty collections to avoid confusion
+    // (Unlisted collections will only be part of the payload
+    // when viewing your own profile.)
+    (item) => item.discoverable && !!item.item_count,
   );
 
   if (accountId === null) {
@@ -124,7 +125,7 @@ const AccountFeatured: React.FC<{ multiColumn: boolean }> = ({
         {accountId && (
           <AccountHeader accountId={accountId} hideTabs={forceEmptyState} />
         )}
-        {publicCollections.length > 0 && status === 'idle' && (
+        {listedCollections.length > 0 && status === 'idle' && (
           <>
             <h4 className='column-subheading'>
               <FormattedMessage
@@ -133,13 +134,13 @@ const AccountFeatured: React.FC<{ multiColumn: boolean }> = ({
               />
             </h4>
             <ItemList>
-              {publicCollections.map((item, index) => (
+              {listedCollections.map((item, index) => (
                 <CollectionListItem
                   key={item.id}
                   collection={item}
-                  withoutBorder={index === publicCollections.length - 1}
+                  withoutBorder={index === listedCollections.length - 1}
                   positionInList={index + 1}
-                  listSize={publicCollections.length}
+                  listSize={listedCollections.length}
                 />
               ))}
             </ItemList>

--- a/app/javascript/mastodon/features/collections/editor/accounts.tsx
+++ b/app/javascript/mastodon/features/collections/editor/accounts.tsx
@@ -15,7 +15,6 @@ import { Account } from 'mastodon/components/account';
 import { Avatar } from 'mastodon/components/avatar';
 import { Badge } from 'mastodon/components/badge';
 import { Button } from 'mastodon/components/button';
-import { Callout } from 'mastodon/components/callout';
 import { DisplayName } from 'mastodon/components/display_name';
 import { EmptyState } from 'mastodon/components/empty_state';
 import { FormStack, Combobox } from 'mastodon/components/form_fields';
@@ -40,7 +39,6 @@ import { getCollectionEditorState } from './state';
 import classes from './styles.module.scss';
 import { WizardStepHeader } from './wizard_step_header';
 
-const MIN_ACCOUNT_COUNT = 1;
 const MAX_ACCOUNT_COUNT = 25;
 
 function isOlderThanAWeek(date?: string): boolean {
@@ -164,9 +162,6 @@ export const CollectionAccounts: React.FC<{
   );
 
   const hasMaxAccounts = accountIds.length === MAX_ACCOUNT_COUNT;
-  const hasMinAccounts = accountIds.length === MIN_ACCOUNT_COUNT;
-  const hasTooFewAccounts = accountIds.length < MIN_ACCOUNT_COUNT;
-  const canSubmit = !hasTooFewAccounts;
 
   const {
     accountIds: suggestedAccountIds,
@@ -319,17 +314,13 @@ export const CollectionAccounts: React.FC<{
     (e: React.FormEvent) => {
       e.preventDefault();
 
-      if (!canSubmit) {
-        return;
-      }
-
       if (!id) {
         history.push(`/collections/new/details`, {
           account_ids: accountIds,
         });
       }
     },
-    [canSubmit, id, history, accountIds],
+    [id, history, accountIds],
   );
 
   const inputId = useId();
@@ -384,16 +375,6 @@ export const CollectionAccounts: React.FC<{
           />
         )}
 
-        {hasMinAccounts && (
-          <Callout>
-            <FormattedMessage
-              id='collections.hints.can_not_remove_more_accounts'
-              defaultMessage='Collections must contain at least {count, plural, one {# account} other {# accounts}}. Removing more accounts is not possible.'
-              values={{ count: MIN_ACCOUNT_COUNT }}
-            />
-          </Callout>
-        )}
-
         <Scrollable className={classes.scrollableWrapper}>
           <ItemList
             className={classes.scrollableInner}
@@ -425,7 +406,7 @@ export const CollectionAccounts: React.FC<{
               >
                 <AddedAccountItem
                   accountId={accountId}
-                  isRemovable={!isEditMode || !hasMinAccounts}
+                  isRemovable={!isEditMode}
                   onRemove={handleRemoveAccountItem}
                 />
               </Article>
@@ -435,39 +416,25 @@ export const CollectionAccounts: React.FC<{
       </FormStack>
       {!isEditMode && (
         <div className={classes.stickyFooter}>
-          {hasTooFewAccounts ? (
-            <Callout icon={false} className={classes.submitDisabledCallout}>
-              <FormattedMessage
-                id='collections.hints.add_more_accounts'
-                defaultMessage='Add at least {count, plural, one {# account} other {# accounts}} to continue'
-                values={{ count: MIN_ACCOUNT_COUNT }}
-              />
-            </Callout>
-          ) : (
-            <div className={classes.actionWrapper}>
-              <FormattedMessage
-                id='collections.hints.accounts_counter'
-                defaultMessage='{count} / {max} accounts'
-                values={{ count: accountIds.length, max: MAX_ACCOUNT_COUNT }}
-              >
-                {(text) => (
-                  <div className={classes.itemCountReadout}>{text}</div>
-                )}
-              </FormattedMessage>
-              {canSubmit && (
-                <Button type='submit'>
-                  {id ? (
-                    <FormattedMessage id='lists.save' defaultMessage='Save' />
-                  ) : (
-                    <FormattedMessage
-                      id='collections.continue'
-                      defaultMessage='Continue'
-                    />
-                  )}
-                </Button>
+          <div className={classes.actionWrapper}>
+            <FormattedMessage
+              id='collections.hints.accounts_counter'
+              defaultMessage='{count} / {max} accounts'
+              values={{ count: accountIds.length, max: MAX_ACCOUNT_COUNT }}
+            >
+              {(text) => <div className={classes.itemCountReadout}>{text}</div>}
+            </FormattedMessage>
+            <Button type='submit'>
+              {id ? (
+                <FormattedMessage id='lists.save' defaultMessage='Save' />
+              ) : (
+                <FormattedMessage
+                  id='collections.continue'
+                  defaultMessage='Continue'
+                />
               )}
-            </div>
-          )}
+            </Button>
+          </div>
         </div>
       )}
     </form>

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -334,8 +334,6 @@
   "collections.edit_details": "Edit details",
   "collections.error_loading_collections": "There was an error when trying to load your collections.",
   "collections.hints.accounts_counter": "{count} / {max} accounts",
-  "collections.hints.add_more_accounts": "Add at least {count, plural, one {# account} other {# accounts}} to continue",
-  "collections.hints.can_not_remove_more_accounts": "Collections must contain at least {count, plural, one {# account} other {# accounts}}. Removing more accounts is not possible.",
   "collections.last_updated_at": "Last updated: {date}",
   "collections.manage_accounts": "Manage accounts",
   "collections.mark_as_sensitive": "Mark as sensitive",


### PR DESCRIPTION
Fixes WEB-867

### Changes proposed in this PR:
- Removes minimum account limit on collections, allowing empty collections to be created & all accounts to be removed from existing collections
- Hides empty collections from user profiles (this wasn't specced, but it seems like a good idea to me to prevent user errors)