### PR TITLE
Add basic ES-enabled index/service coverage

### DIFF
--- a/spec/chewy/accounts_index_spec.rb
+++ b/spec/chewy/accounts_index_spec.rb
@@ -3,6 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe AccountsIndex do
+  context 'when elasticsearch is enabled', :search do
+    describe 'indexing records' do
+      it 'indexes records from scope' do
+        expect { Fabricate :account }
+          .to change(described_class, :count).by(1)
+      end
+    end
+  end
+
   describe 'Searching the index' do
     before do
       mock_elasticsearch_response(described_class, raw_response)

--- a/spec/chewy/public_statuses_index_spec.rb
+++ b/spec/chewy/public_statuses_index_spec.rb
@@ -3,6 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe PublicStatusesIndex do
+  context 'when elasticsearch is enabled', :search do
+    describe 'indexing records' do
+      it 'indexes records from scope' do
+        expect { Fabricate :status, visibility: :public }
+          .to change(described_class, :count).by(1)
+      end
+    end
+  end
+
   describe 'Searching the index' do
     before do
       mock_elasticsearch_response(described_class, raw_response)

--- a/spec/chewy/statuses_index_spec.rb
+++ b/spec/chewy/statuses_index_spec.rb
@@ -3,6 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe StatusesIndex do
+  context 'when elasticsearch is enabled', :search do
+    describe 'indexing records' do
+      it 'indexes records from scope' do
+        expect { Fabricate :status }
+          .to change(described_class, :count).by(1)
+      end
+    end
+  end
+
   describe 'Searching the index' do
     before do
       mock_elasticsearch_response(described_class, raw_response)

--- a/spec/chewy/tags_index_spec.rb
+++ b/spec/chewy/tags_index_spec.rb
@@ -3,6 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe TagsIndex do
+  context 'when elasticsearch is enabled', :search do
+    describe 'indexing records' do
+      it 'indexes records from scope' do
+        expect { Fabricate :tag, listable: true }
+          .to change(described_class, :count).by(1)
+      end
+    end
+  end
+
   describe 'Searching the index' do
     before do
       mock_elasticsearch_response(described_class, raw_response)

--- a/spec/services/account_search_service_spec.rb
+++ b/spec/services/account_search_service_spec.rb
@@ -86,4 +86,16 @@ RSpec.describe AccountSearchService do
       expect(results).to eq []
     end
   end
+
+  context 'when elasticsearch is enabled', :search do
+    it 'returns matching accounts' do
+      account = Fabricate(:account, username: 'matchingusername')
+
+      AccountsIndex.import!
+
+      results = subject.call('match', nil, limit: 5)
+
+      expect(results).to eq [account]
+    end
+  end
 end

--- a/spec/services/statuses_search_service_spec.rb
+++ b/spec/services/statuses_search_service_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StatusesSearchService do
+  describe '#call' do
+    let!(:status) { Fabricate(:status, text: 'status number one') }
+    let(:results) { subject.call('one', status.account, limit: 5) }
+
+    before { Fabricate(:status, text: 'status number two') }
+
+    context 'when elasticsearch is enabled', :search do
+      it 'runs a search for statuses' do
+        expect(results)
+          .to have_attributes(
+            size: 1,
+            first: eq(status)
+          )
+      end
+    end
+  end
+end

--- a/spec/services/tag_search_service_spec.rb
+++ b/spec/services/tag_search_service_spec.rb
@@ -5,17 +5,28 @@ require 'rails_helper'
 RSpec.describe TagSearchService do
   describe '#call' do
     let!(:one) { Fabricate(:tag, name: 'one') }
+    let(:results) { subject.call('#one', limit: 5) }
 
     before { Fabricate(:tag, name: 'two') }
 
-    it 'runs a search for tags' do
-      results = subject.call('#one', limit: 5)
+    context 'with postgres search' do
+      it 'runs a search for tags' do
+        expect(results)
+          .to have_attributes(
+            size: 1,
+            first: eq(one)
+          )
+      end
+    end
 
-      expect(results)
-        .to have_attributes(
-          size: 1,
-          first: eq(one)
-        )
+    context 'when elasticsearch is enabled', :search do
+      it 'runs a search for tags' do
+        expect(results)
+          .to have_attributes(
+            size: 1,
+            first: eq(one)
+          )
+      end
     end
   end
 end


### PR DESCRIPTION
Combines with https://github.com/mastodon/mastodon/pull/38085 as prep for https://github.com/mastodon/mastodon/pull/37983

I think if both of these spec updates merge I can convert the chewy bump to ready for review. Basically just want to get slightly more usage of ES roundtrips in there so that if we horribly broke something we'd see it. Definitely room for more future improvement on the actual nuance of the queries.