### PR TITLE
Migrate a few tests to use `NotificationAssertions`

### DIFF
--- a/spec/lib/request_pool_spec.rb
+++ b/spec/lib/request_pool_spec.rb
@@ -52,11 +52,17 @@ RSpec.describe RequestPool do
       end
 
       it 'closes the connections' do
-        subject.with('http://example.com') do |http_client|
-          http_client.get('/').flush
+        notifications = capture_notifications('with.request_pool') do
+          subject.with('http://example.com') do |http_client|
+            http_client.get('/').flush
+          end
         end
 
         expect { reaper_observes_idle_timeout }.to change(subject, :size).from(1).to(0)
+
+        expect(notifications.size).to eq(1)
+        expect(notifications.first.payload[:host]).to eq('http://example.com')
+        expect(notifications.first.payload[:miss]).to be(true)
       end
 
       def reaper_observes_idle_timeout

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -36,14 +36,12 @@ RSpec.describe Setting do
 
       context 'when the setting has been saved to database' do
         it 'returns the value from database' do
-          callback = double
-          allow(callback).to receive(:call)
-
-          ActiveSupport::Notifications.subscribed callback, 'sql.active_record' do
+          notifications = capture_notifications('sql.active_record') do
             expect(described_class[key]).to eq 42
           end
 
-          expect(callback).to have_received(:call)
+          expect(notifications.size).to eq(1)
+          expect(notifications.first.payload[:name]).to eq('Setting Load')
         end
       end
 
@@ -62,12 +60,11 @@ RSpec.describe Setting do
       end
 
       it 'does not query the database' do
-        callback = double
-        allow(callback).to receive(:call)
-        ActiveSupport::Notifications.subscribed callback, 'sql.active_record' do
+        notifications = capture_notifications('sql.active_record') do
           described_class[key]
         end
-        expect(callback).to_not have_received(:call)
+
+        expect(notifications).to be_empty
       end
 
       it 'returns the cached value' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,6 +82,7 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include ActionMailer::TestHelper
   config.include Paperclip::Shoulda::Matchers
+  config.include ActiveSupport::Testing::NotificationAssertions
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Chewy::Rspec::Helpers
   config.include Redisable


### PR DESCRIPTION
### Description

Proposing we migrate a few tests to use `NotificationAssertions`, a testing module that was made available as of Rails 8.1, which we can now use as we upgraded to Rails 8.1 last week in https://github.com/mastodon/mastodon/pull/36505.

References
- https://api.rubyonrails.org/classes/ActiveSupport/Testing/NotificationAssertions.html
- https://github.com/rails/rails/blob/main/activesupport/lib/active_support/testing/notification_assertions.rb

### Why?

This testing module _while primarily focused on Minitest_ still allows us to more cleanly and simply test `ActiveSupport::Notifications` behaviour and even allows us to easily make deeper expectations in said tests.

### How?

1. Add an `include ActiveSupport::Testing::NotificationAssertions` to relevant specs
2. Migrate relevant tests in said spec to use `capture_notifications` ¹ as opposed to custom subscriptions

¹ As the module is focused on Minitest we're unable to use the more expressive `assert_*` type helpers methods from the module but we can still utilize the `capture_notifications` method for clean access to notifications.