### PR TITLE
Update `connection_pool` to version 3.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
     cocoon (1.2.15)
     color_diff (0.2)
     concurrent-ruby (1.3.6)
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     cose (1.3.1)
       cbor (~> 0.5.9)
       openssl-signature_algorithm (~> 1.0)

--- a/app/lib/connection_pool/shared_connection_pool.rb
+++ b/app/lib/connection_pool/shared_connection_pool.rb
@@ -4,7 +4,7 @@ require 'connection_pool'
 require_relative 'shared_timed_stack'
 
 class ConnectionPool::SharedConnectionPool < ConnectionPool
-  def initialize(options = {}, &block)
+  def initialize(**, &block)
     super
 
     @available = ConnectionPool::SharedTimedStack.new(@size, &block)


### PR DESCRIPTION
Prerequisite for sidekiq 8.1 update.

I thought this was going to be more involved, but I think it may just be this one method signature change? The upstream change here was a move away from positional arguments and to use keyword args with 3.0+. This applies both to `initialize` method but also some of the usage methods. In most places we call things we are already using keyword args (there may have been deprecation notice about this and we already changed?).

This one spot where we subclass is the only spot I can find that needed the change, so I updated to just pass whatever we get up to super. I think this is probably correct, but would like someone with a deeper knowledge of the `SharedConnectionPool` class purpose/usage/history/etc to agree to that.

One side note ... many of the other methods in this overridden class also changed signatures to use kwargs, but this is the only one where we call `super`, so I think our usage (which is just our overriden version calling itself) is fine as-is ... but a possible follow might be to review method signatures of `with`, `checkout`, `checkin` in `SharedConnectionPool`, as well as the signatures in `SharedTimedStack`, and contemplate updating those to match the upstream classes as well, to keep it stylistically in line, preserve future upgrades, etc.

Also, Renovate continues to do stuff like https://github.com/mastodon/mastodon/pull/38094 where the title claims its a sidekiq update but the actual diff contents are not that (as of now its a json gem bump).