### PR TITLE
Move view-use-only methods from controller to helpers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,6 @@ class ApplicationController < ActionController::Base
   helper_method :current_account
   helper_method :current_session
   helper_method :single_user_mode?
-  helper_method :use_seamless_external_login?
   helper_method :sso_account_settings
   helper_method :limited_federation_mode?
   helper_method :skip_csrf_meta_tags?
@@ -106,10 +105,6 @@ class ApplicationController < ActionController::Base
 
   def single_user_mode?
     @single_user_mode ||= Rails.configuration.x.single_user_mode && Account.without_internal.exists?
-  end
-
-  def use_seamless_external_login?
-    Devise.pam_authentication || Devise.ldap_authentication
   end
 
   def sso_account_settings

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,6 @@ class ApplicationController < ActionController::Base
   helper_method :current_account
   helper_method :current_session
   helper_method :single_user_mode?
-  helper_method :sso_account_settings
   helper_method :limited_federation_mode?
   helper_method :skip_csrf_meta_tags?
 
@@ -105,10 +104,6 @@ class ApplicationController < ActionController::Base
 
   def single_user_mode?
     @single_user_mode ||= Rails.configuration.x.single_user_mode && Account.without_internal.exists?
-  end
-
-  def sso_account_settings
-    ENV.fetch('SSO_ACCOUNT_SETTINGS', nil)
   end
 
   def current_account

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -26,4 +26,8 @@ module RegistrationHelper
       t('auth.user_privacy_agreement_html', privacy_policy_path: privacy_policy_path)
     end
   end
+
+  def use_seamless_external_login?
+    Devise.pam_authentication || Devise.ldap_authentication
+  end
 end

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -30,4 +30,8 @@ module RegistrationHelper
   def use_seamless_external_login?
     Devise.pam_authentication || Devise.ldap_authentication
   end
+
+  def sso_account_settings
+    ENV.fetch('SSO_ACCOUNT_SETTINGS', nil)
+  end
 end


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/37807

These might have historically been used in a controller somewhere, but are currently only called from views, and thus can move to helpers.