### PR TITLE
Use framework-native CSRF skip check

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,6 @@ class ApplicationController < ActionController::Base
   helper_method :use_seamless_external_login?
   helper_method :sso_account_settings
   helper_method :limited_federation_mode?
-  helper_method :skip_csrf_meta_tags?
 
   before_action :check_self_destruct!
 
@@ -84,10 +83,6 @@ class ApplicationController < ActionController::Base
         end
       end
     end
-  end
-
-  def skip_csrf_meta_tags?
-    false
   end
 
   def after_sign_out_path_for(_resource_or_scope)

--- a/app/controllers/concerns/web_app_controller_concern.rb
+++ b/app/controllers/concerns/web_app_controller_concern.rb
@@ -19,6 +19,11 @@ module WebAppControllerConcern
         p.form_action :none
       end
     end
+
+    with_options if: :skip_csrf_meta_tags? do
+      skip_forgery_protection
+      after_action { request.session_options[:skip] = true }
+    end
   end
 
   def skip_csrf_meta_tags?

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -35,7 +35,7 @@
     = vite_typescript_tag 'common.ts', crossorigin: 'anonymous'
 
     = vite_preload_file_tag "mastodon/locales/#{I18n.locale}.json"
-    = csrf_meta_tags unless skip_csrf_meta_tags?
+    = csrf_meta_tags
     %meta{ name: 'style-nonce', content: request.content_security_policy_nonce, property: 'csp-nonce', nonce: request.content_security_policy_nonce }
 
     = custom_stylesheet


### PR DESCRIPTION
This built-in `skip_forgery_protection` is essentially a wrapper around `protect_against_forgery`, and disables it. The CSRF meta tag method checks that setting before emitting any output.

Testing this is awkward because CSRF is disabled by default in test env. I did some verification by running in dev mode and viewing source to confirm they are skipped or present in same situations as before the change.

Unrelated to this change, the method in WebAppControllerConcern that does this check (unchanged here) would benefit from some spec coverage, and also from some `config_for` extraction, if we ever resume that.