### PR TITLE
Prevent hover card from showing unintentionally

### DIFF
--- a/app/javascript/mastodon/components/hover_card_controller.tsx
+++ b/app/javascript/mastodon/components/hover_card_controller.tsx
@@ -27,7 +27,6 @@ export const HoverCardController: React.FC = () => {
   const [open, setOpen] = useState(false);
   const [accountId, setAccountId] = useState<string | undefined>();
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
-  const isUsingTouchRef = useRef(false);
   const cardRef = useRef<HTMLDivElement | null>(null);
   const [setLeaveTimeout, cancelLeaveTimeout] = useTimeout();
   const [setEnterTimeout, cancelEnterTimeout, delayEnterTimeout] = useTimeout();
@@ -50,6 +49,7 @@ export const HoverCardController: React.FC = () => {
 
   useEffect(() => {
     let isScrolling = false;
+    let isUsingTouch = false;
     let isActiveMouseMovement = false;
     let currentAnchor: HTMLElement | null = null;
     let currentTitle: string | null = null;
@@ -72,7 +72,7 @@ export const HoverCardController: React.FC = () => {
     const handleTouchStart = () => {
       // Keeping track of touch events to prevent the
       // hover card from being displayed on touch devices
-      isUsingTouchRef.current = true;
+      isUsingTouch = true;
     };
 
     const handleMouseEnter = (e: MouseEvent) => {
@@ -86,7 +86,7 @@ export const HoverCardController: React.FC = () => {
 
       // Bail out if we're scrolling, a touch is active,
       // or if there was no active mouse movement
-      if (isScrolling || !isActiveMouseMovement || isUsingTouchRef.current) {
+      if (isScrolling || !isActiveMouseMovement || isUsingTouch) {
         return;
       }
 
@@ -145,8 +145,8 @@ export const HoverCardController: React.FC = () => {
     };
 
     const handleMouseMove = () => {
-      if (isUsingTouchRef.current) {
-        isUsingTouchRef.current = false;
+      if (isUsingTouch) {
+        isUsingTouch = false;
       }
 
       delayEnterTimeout(enterDelay);

--- a/app/javascript/mastodon/components/hover_card_controller.tsx
+++ b/app/javascript/mastodon/components/hover_card_controller.tsx
@@ -14,6 +14,10 @@ import { useTimeout } from 'mastodon/hooks/useTimeout';
 const offset = [-12, 4] as OffsetValue;
 const enterDelay = 750;
 const leaveDelay = 150;
+// Only open the card if the mouse was moved within this time,
+// to avoid triggering the card without intentional mouse movement
+// (e.g. when content changed underneath the mouse cursor)
+const activeMovementThreshold = 150;
 const popperConfig = { strategy: 'fixed' } as UsePopperOptions;
 
 const isHoverCardAnchor = (element: HTMLElement) =>
@@ -27,6 +31,7 @@ export const HoverCardController: React.FC = () => {
   const cardRef = useRef<HTMLDivElement | null>(null);
   const [setLeaveTimeout, cancelLeaveTimeout] = useTimeout();
   const [setEnterTimeout, cancelEnterTimeout, delayEnterTimeout] = useTimeout();
+  const [setMoveTimeout, cancelMoveTimeout] = useTimeout();
   const [setScrollTimeout] = useTimeout();
 
   const handleClose = useCallback(() => {
@@ -45,6 +50,7 @@ export const HoverCardController: React.FC = () => {
 
   useEffect(() => {
     let isScrolling = false;
+    let isActiveMouseMovement = false;
     let currentAnchor: HTMLElement | null = null;
     let currentTitle: string | null = null;
 
@@ -78,13 +84,14 @@ export const HoverCardController: React.FC = () => {
         return;
       }
 
-      // Bail out if a touch is active
-      if (isUsingTouchRef.current) {
+      // Bail out if we're scrolling, a touch is active,
+      // or if there was no active mouse movement
+      if (isScrolling || !isActiveMouseMovement || isUsingTouchRef.current) {
         return;
       }
 
       // We've entered an anchor
-      if (!isScrolling && isHoverCardAnchor(target)) {
+      if (isHoverCardAnchor(target)) {
         cancelLeaveTimeout();
 
         currentAnchor?.removeAttribute('aria-describedby');
@@ -99,10 +106,7 @@ export const HoverCardController: React.FC = () => {
       }
 
       // We've entered the hover card
-      if (
-        !isScrolling &&
-        (target === currentAnchor || target === cardRef.current)
-      ) {
+      if (target === currentAnchor || target === cardRef.current) {
         cancelLeaveTimeout();
       }
     };
@@ -144,7 +148,14 @@ export const HoverCardController: React.FC = () => {
       if (isUsingTouchRef.current) {
         isUsingTouchRef.current = false;
       }
+
       delayEnterTimeout(enterDelay);
+
+      cancelMoveTimeout();
+      isActiveMouseMovement = true;
+      setMoveTimeout(() => {
+        isActiveMouseMovement = false;
+      }, activeMovementThreshold);
     };
 
     document.body.addEventListener('touchstart', handleTouchStart, {
@@ -188,6 +199,8 @@ export const HoverCardController: React.FC = () => {
     setOpen,
     setAccountId,
     setAnchor,
+    setMoveTimeout,
+    cancelMoveTimeout,
   ]);
 
   return (


### PR DESCRIPTION
Fixes #32685

### Changes proposed in this PR:
- Adds a new timeout to the hovercard controller that prevents the card from showing if the `mouseEnter` event wasn't preceded by a `mouseMove` event in the last 150ms
  - (It's possible that this change essentially makes the existing scroll detection obsolete and I considered removing it, but it think there's no harm having both.)
- Refactors the touch detection introduced in #38039 to use the same approach as the scroll detection (i.e. a local variable scoped to the effect rather than a component ref)

### Screen captures

**Before**

https://github.com/user-attachments/assets/a451eb5a-f642-46d9-94b4-7f33b1575875

**After** 

https://github.com/user-attachments/assets/302f32ad-5eee-42b6-ba93-0299ae2a0732


