### PR TITLE
Fix collections not shown on profile when there are no featured tags or accounts

### DIFF
--- a/app/javascript/mastodon/features/account_featured/index.tsx
+++ b/app/javascript/mastodon/features/account_featured/index.tsx
@@ -103,7 +103,11 @@ const AccountFeatured: React.FC<{ multiColumn: boolean }> = ({
     );
   }
 
-  if (featuredTags.isEmpty() && featuredAccountIds.isEmpty()) {
+  if (
+    featuredTags.isEmpty() &&
+    featuredAccountIds.isEmpty() &&
+    listedCollections.length === 0
+  ) {
     return (
       <AccountFeaturedWrapper accountId={accountId}>
         <EmptyMessage


### PR DESCRIPTION
Fixes an issue reported by @imani-the-maker [on staging](https://staging.mastodon.social/@therealimani/116199385945379603)

### Changes proposed in this PR:
- Fixes empty state from being shown on the profile/featured tab when there are featured collections