### PR TITLE
Fix short numbers rounding up instead of truncating (#37899)

### DIFF
--- a/app/javascript/mastodon/components/__tests__/short_number-test.tsx
+++ b/app/javascript/mastodon/components/__tests__/short_number-test.tsx
@@ -1,0 +1,80 @@
+import { IntlProvider } from 'react-intl';
+
+import { render, screen } from '@testing-library/react';
+
+import { ShortNumber } from '../short_number';
+
+function renderShortNumber(value: number) {
+  return render(
+    <IntlProvider locale='en'>
+      <ShortNumber value={value} />
+    </IntlProvider>,
+  );
+}
+
+describe('ShortNumber Component', () => {
+  it('does not abbreviate numbers under 1000', () => {
+    renderShortNumber(999);
+    expect(screen.getByText('999')).toBeDefined();
+  });
+
+  it('formats thousands correctly for 1000', () => {
+    renderShortNumber(1000);
+    expect(screen.getByText('1K')).toBeDefined();
+  });
+
+  it('truncates decimals for 1051', () => {
+    renderShortNumber(1051);
+    expect(screen.getByText('1K')).toBeDefined();
+  });
+
+  it('truncates decimals for 2999', () => {
+    renderShortNumber(2999);
+    expect(screen.getByText('2.9K')).toBeDefined();
+  });
+
+  it('truncates decimals for 9999', () => {
+    renderShortNumber(9999);
+    expect(screen.getByText('9.9K')).toBeDefined();
+  });
+
+  it('truncates decimals for 10501', () => {
+    renderShortNumber(10501);
+    expect(screen.getByText('10K')).toBeDefined();
+  });
+
+  it('truncates decimals for 11000', () => {
+    renderShortNumber(11000);
+    expect(screen.getByText('11K')).toBeDefined();
+  });
+
+  it('truncates decimals for 99999', () => {
+    renderShortNumber(99999);
+    expect(screen.getByText('99K')).toBeDefined();
+  });
+
+  it('truncates decimals for 100501', () => {
+    renderShortNumber(100501);
+    expect(screen.getByText('100K')).toBeDefined();
+  });
+
+  it('truncates decimals for 101000', () => {
+    renderShortNumber(101000);
+    expect(screen.getByText('101K')).toBeDefined();
+  });
+
+  it('truncates decimals for 999999', () => {
+    renderShortNumber(999999);
+    expect(screen.getByText('999K')).toBeDefined();
+  });
+
+  it('truncates decimals for 2999999', () => {
+    renderShortNumber(2999999);
+    expect(screen.getByText('2.9M')).toBeDefined();
+  });
+
+  it('truncates decimals for 9999999', () => {
+    renderShortNumber(9999999);
+    expect(screen.getByText('9.9M')).toBeDefined();
+  });
+});

--- a/app/javascript/mastodon/components/short_number.tsx
+++ b/app/javascript/mastodon/components/short_number.tsx
@@ -51,6 +51,7 @@ const ShortNumberCounter: React.FC<ShortNumberCounterProps> = ({ value }) => {
     <FormattedNumber
       value={rawNumber ?? 0}
       maximumFractionDigits={maxFractionDigits}
+      roundingMode='trunc'
     />
   );
 


### PR DESCRIPTION
When a count is close to the next unit (eg 2999 or 2999999), the UI incorrectly rounded the numbers up to 3K or 3M instead of showing 2.9K and 2.9M. This bug affected all abbreviated metrics (thousands, millions, and billions), causing users to see misleading statistics on profiles and posts.

This commit corrects the formatting logic across all unit scales to truncate decimals properly and adds tests to prevent future regressions.