### PR TITLE
Add column for html descriptions of collections

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,7 +5,8 @@
 # Table name: collections
 #
 #  id                       :bigint(8)        not null, primary key
-#  description              :text             not null
+#  description              :text
+#  description_html         :text
 #  discoverable             :boolean          not null
 #  item_count               :integer          default(0), not null
 #  language                 :string
@@ -30,7 +31,10 @@ class Collection < ApplicationRecord
   has_many :collection_reports, dependent: :delete_all
 
   validates :name, presence: true
-  validates :description, presence: true
+  validates :description, presence: true,
+                          if: :local?
+  validates :description_html, presence: true,
+                               if: :remote?
   validates :local, inclusion: [true, false]
   validates :sensitive, inclusion: [true, false]
   validates :discoverable, inclusion: [true, false]

--- a/app/serializers/rest/collection_serializer.rb
+++ b/app/serializers/rest/collection_serializer.rb
@@ -13,6 +13,10 @@ class REST::CollectionSerializer < ActiveModel::Serializer
     object.id.to_s
   end
 
+  def description
+    object.local? ? object.description : object.description_html
+  end
+
   def items
     object.items_for(current_user&.account)
   end

--- a/db/migrate/20260310095021_add_description_html_to_collections.rb
+++ b/db/migrate/20260310095021_add_description_html_to_collections.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddDescriptionHtmlToCollections < ActiveRecord::Migration[8.1]
+  def change
+    add_column :collections, :description_html, :text
+
+    reversible do |direction|
+      direction.up { change_column :collections, :description, :text, null: true }
+
+      direction.down { change_column :collections, :description, :text, null: false }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_03_144409) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_10_095021) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -387,7 +387,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_03_144409) do
   create_table "collections", id: :bigint, default: -> { "timestamp_id('collections'::text)" }, force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "created_at", null: false
-    t.text "description", null: false
+    t.text "description"
+    t.text "description_html"
     t.boolean "discoverable", null: false
     t.integer "item_count", default: 0, null: false
     t.string "language"

--- a/spec/fabricators/collection_fabricator.rb
+++ b/spec/fabricators/collection_fabricator.rb
@@ -12,6 +12,8 @@ end
 Fabricator(:remote_collection, from: :collection) do
   account { Fabricate.build(:remote_account) }
   local false
+  description nil
+  description_html '<p>People to follow</p>'
   uri { sequence(:uri) { |i| "https://example.com/collections/#{i}" } }
   original_number_of_items 0
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe Collection do
     context 'when collection is remote' do
       subject { Fabricate.build :collection, local: false }
 
+      it { is_expected.to_not validate_presence_of(:description) }
+
+      it { is_expected.to validate_presence_of(:description_html) }
+
       it { is_expected.to validate_presence_of(:uri) }
 
       it { is_expected.to validate_presence_of(:original_number_of_items) }

--- a/spec/serializers/rest/collection_serializer_spec.rb
+++ b/spec/serializers/rest/collection_serializer_spec.rb
@@ -43,4 +43,13 @@ RSpec.describe REST::CollectionSerializer do
         'items' => []
       )
   end
+
+  context 'when the collection is remote' do
+    let(:collection) { Fabricate(:remote_collection, description_html: '<p>remote</p>') }
+
+    it 'includes the html description' do
+      expect(subject)
+        .to include('description' => '<p>remote</p>')
+    end
+  end
 end


### PR DESCRIPTION
Remote collections might include HTML in their description. This adds a dedicated column for that. This deviates from statuses, where we store both in a single column. Separating the two means we can later decide to render the description of local Collections to HTML and store it in that column as well.