### PR TITLE
Add `InstancesIndex` coverage

### DIFF
--- a/spec/chewy/instances_index_spec.rb
+++ b/spec/chewy/instances_index_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InstancesIndex do
+  context 'when elasticsearch is enabled', :search do
+    describe 'indexing records' do
+      before do
+        Fabricate :account, domain: 'host.example'
+        Instance.refresh
+      end
+
+      it 'indexes records from scope' do
+        expect { described_class.import }
+          .to change(described_class, :count).by(1)
+      end
+    end
+  end
+
+  describe 'Searching the index' do
+    before do
+      mock_elasticsearch_response(described_class, raw_response)
+    end
+
+    it 'returns results from a query' do
+      results = described_class.query(match: { name: 'account' })
+
+      expect(results).to eq []
+    end
+  end
+
+  def raw_response
+    {
+      took: 3,
+      hits: {
+        hits: [
+          {
+            _id: '0',
+            _score: 1.6375021,
+          },
+        ],
+      },
+    }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -138,12 +138,6 @@ RSpec.configure do |config|
     example.run
   end
 
-  config.around(:each, type: :search) do |example|
-    Chewy.settings[:enabled] = true
-    example.run
-    Chewy.settings[:enabled] = false
-  end
-
   config.before :each, type: :cli do
     stub_reset_connection_pools
   end

--- a/spec/support/search.rb
+++ b/spec/support/search.rb
@@ -20,6 +20,7 @@ RSpec.configure do |config|
   def search_indices
     [
       AccountsIndex,
+      InstancesIndex,
       PublicStatusesIndex,
       StatusesIndex,
       TagsIndex,

--- a/spec/workers/scheduler/instance_refresh_scheduler_spec.rb
+++ b/spec/workers/scheduler/instance_refresh_scheduler_spec.rb
@@ -7,7 +7,17 @@ RSpec.describe Scheduler::InstanceRefreshScheduler do
 
   describe 'perform' do
     it 'runs without error' do
-      expect { worker.perform }.to_not raise_error
+      expect { worker.perform }
+        .to_not raise_error
+    end
+  end
+
+  context 'with elasticsearch enabled', :search do
+    before { Fabricate :remote_account }
+
+    it 'updates search indexes' do
+      expect { worker.perform }
+        .to change(InstancesIndex, :count).by(1)
     end
   end
 end


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/37983

The initial change here was just to add `InstancesIndex` to the existing list, and basic coverage for it (basically copy/paste the others, with the exception that instance is a view and needs slight different treatment).

In working on that I was running into order-dependent failures, and what I realized is that we had a little breakage between specs marked with the "search" TAG (see the added spec/workers example here) -vs- specs of the "search" TYPE (anything under `spec/search/`.

There is a `before(:suite)` in search.rb in support which enables chewy whenever there are search specs present. Separately, this block (removed in this PR) was enabling chewy before any search TYPE examples, and disabling after. This was leading to a scenario where, if a search-tagged-but-not-search-type example ran after search-type example, chewy would have been disabled after the type, but not re-enabled for the tag.

I think that just removing this type one should work ... we are disabling the tag by default, so any time we enable it in CI or locally we are only going to be running chewy/ES/search specs, and it seems safe to have it enabled once at start. I'm actually surprised I didn't see this on the previous PR adding the spec/chewy/* specs ... but I guess there are so few overall and I didn't run it many many times maybe it just didn't come up.