### PR TITLE
Change HTTP signatures to skip the `Accept` header

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -208,7 +208,7 @@ class Request
       return
     end
 
-    signature_value = @signing.sign(signed_headers.without('User-Agent', 'Accept-Encoding'), @verb, Addressable::URI.parse(request.uri))
+    signature_value = @signing.sign(signed_headers.without('User-Agent', 'Accept-Encoding', 'Accept'), @verb, Addressable::URI.parse(request.uri))
     request.headers['Signature'] = signature_value
   end
 


### PR DESCRIPTION
Fixes #38119

From a security perspective, I think the impact of not signing `Accept` would be the following:
- swapping out the return format for another in a way that would confuse the requesting server: that would require MITM, and would already be possible if you have MITM, so this is not a security concern for this change
- replay a request swapping out the `Accept` to something that would give more information: this is somewhat unlikely, and more importantly, getting a hold on such a request would require MITM in the first place as the signed headers includes the `Host`, I therefore don't think this is a security concern