### PR TITLE
Do not prepare returning user for unpersisted records

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -209,8 +209,10 @@ class User < ApplicationRecord
 
     increment(:sign_in_count) if new_sign_in
 
-    save(validate: false) unless new_record?
-    prepare_returning_user!
+    unless new_record?
+      save(validate: false)
+      prepare_returning_user!
+    end
   end
 
   def pending?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -208,9 +208,13 @@ RSpec.describe User do
     context 'with a new user' do
       let(:user) { Fabricate.build :user }
 
+      before { allow(ActivityTracker).to receive(:record) }
+
       it 'does not persist the user' do
         expect { user.update_sign_in! }
           .to_not change(user, :persisted?).from(false)
+        expect(ActivityTracker)
+          .to_not have_received(:record).with('activity:logins', anything)
       end
     end
   end


### PR DESCRIPTION
Prep for https://github.com/mastodon/mastodon/pull/38110

The issue in the linked PR was we were passing a nil into redis `PFADD` call. With stricter type checking this is now an error.

We already have a `new_record?` check here which is ensuring we only save existing users ... and presumably we only want to run the various "prepare returning" things for saved records as well? Added that call into the check.

As a practical matter, I strongly suspect that this is only ever actually called on saved users from production. Both the existing check and this added one are defensive but probably not regularly executed...