### PR TITLE
Convert attempt IP from EmailDomainBlock history tracking to string before recording

### DIFF
--- a/app/models/email_domain_block.rb
+++ b/app/models/email_domain_block.rb
@@ -59,7 +59,7 @@ class EmailDomainBlock < ApplicationRecord
 
     def blocking?(allow_with_approval: false)
       blocks = EmailDomainBlock.where(domain: domains_with_variants, allow_with_approval: allow_with_approval).by_domain_length
-      blocks.each { |block| block.history.add(@attempt_ip) } if @attempt_ip.present?
+      blocks.each { |block| block.history.add(@attempt_ip.to_s) } if @attempt_ip.present?
       blocks.any?
     end
 

--- a/app/models/trends/history.rb
+++ b/app/models/trends/history.rb
@@ -40,11 +40,11 @@ class Trends::History
       with_redis { |redis| redis.get(key_for(:uses)).to_i }
     end
 
-    def add(account_id)
+    def add(value)
       with_redis do |redis|
         redis.pipelined do |pipeline|
           pipeline.incrby(key_for(:uses), 1)
-          pipeline.pfadd(key_for(:accounts), account_id)
+          pipeline.pfadd(key_for(:accounts), value)
           pipeline.expire(key_for(:uses), EXPIRE_AFTER)
           pipeline.expire(key_for(:accounts), EXPIRE_AFTER)
         end

--- a/spec/models/email_domain_block_spec.rb
+++ b/spec/models/email_domain_block_spec.rb
@@ -56,16 +56,20 @@ RSpec.describe EmailDomainBlock do
   end
 
   describe '.requires_approval?' do
-    subject { described_class.requires_approval?(input) }
+    subject { described_class.requires_approval?(input, attempt_ip: IPAddr.new('100.100.100.100')) }
 
     let(:input) { nil }
 
     context 'with a matching block requiring approval' do
-      before { Fabricate :email_domain_block, domain: input, allow_with_approval: true }
+      let!(:email_domain_block) { Fabricate :email_domain_block, domain: input, allow_with_approval: true }
 
       let(:input) { 'host.example' }
 
-      it { is_expected.to be true }
+      it 'returns true and records attempt' do
+        expect do
+          expect(subject).to be(true)
+        end.to change { email_domain_block.history.get(Date.current).accounts }.by(1)
+      end
     end
 
     context 'with a matching block not requiring approval' do


### PR DESCRIPTION
Also prep for redis update with stricter type checking.

For this one, we are passing in an `IPAddr` instance, but the `PFADD` expects a string. I chose to put the conversion on the calling side rather than within `#add` on the assumption that there may be other callers who pass in valid non-string values in a way that might matter, but I'm not sure that's true or not, just going for smallest fixes to pass suite first.

I assume historically this at one point only received account ids (hence the var name), but then evolved to handle more? Updated the arg name to reflect that ... I was a little confused at first trying to see how/where an account ID was being sent in in this scenario.