### PR TITLE
Update `RemoteIp` patch with Rails 8.1 changes

### DIFF
--- a/lib/action_dispatch/remote_ip_extensions.rb
+++ b/lib/action_dispatch/remote_ip_extensions.rb
@@ -17,11 +17,11 @@ module ActionDispatch
     module GetIpExtensions
       def calculate_ip
         # Set by the Rack web server, this is a single value.
-        remote_addr = ips_from(@req.remote_addr).last
+        remote_addr = sanitize_ips(ips_from(@req.remote_addr)).last
 
         # Could be a CSV list and/or repeated headers that were concatenated.
-        client_ips    = ips_from(@req.client_ip).reverse!
-        forwarded_ips = ips_from(@req.x_forwarded_for).reverse!
+        client_ips    = sanitize_ips(ips_from(@req.client_ip)).reverse!
+        forwarded_ips = sanitize_ips(@req.forwarded_for || []).reverse!
 
         # `Client-Ip` and `X-Forwarded-For` should not, generally, both be set. If they
         # are both set, it means that either:


### PR DESCRIPTION
Pulls down the changes to rails base class in latest release. I believe these changes address a different aspect of behavior, and not the reason for this patch, so we still need the patch. It's not 100% clear to me from where this was originally added how to verify things are working correctly, so I am relying somewhat on specs passing and seemingly unrelatedness of the changes to assume its ok. Any pointers on how to verify, or even better, use cases and/or spec to add, would be useful.