### PR TITLE
Use `around_action` to set locale in admin/notification mailers

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -11,30 +11,26 @@ class AdminMailer < ApplicationMailer
 
   after_action :set_important_headers!, only: :new_critical_software_updates
 
+  around_action :set_locale
+
   default to: -> { @me.user_email }
 
   def new_report(report)
     @report = report
 
-    locale_for_account(@me) do
-      mail subject: default_i18n_subject(instance: @instance, id: @report.id)
-    end
+    mail subject: default_i18n_subject(instance: @instance, id: @report.id)
   end
 
   def new_appeal(appeal)
     @appeal = appeal
 
-    locale_for_account(@me) do
-      mail subject: default_i18n_subject(instance: @instance, username: @appeal.account.username)
-    end
+    mail subject: default_i18n_subject(instance: @instance, username: @appeal.account.username)
   end
 
   def new_pending_account(user)
     @account = user.account
 
-    locale_for_account(@me) do
-      mail subject: default_i18n_subject(instance: @instance, username: @account.username)
-    end
+    mail subject: default_i18n_subject(instance: @instance, username: @account.username)
   end
 
   def new_trends(links, tags, statuses)
@@ -42,31 +38,23 @@ class AdminMailer < ApplicationMailer
     @tags                   = tags
     @statuses               = statuses
 
-    locale_for_account(@me) do
-      mail subject: default_i18n_subject(instance: @instance)
-    end
+    mail subject: default_i18n_subject(instance: @instance)
   end
 
   def new_software_updates
     @software_updates = SoftwareUpdate.by_version
 
-    locale_for_account(@me) do
-      mail subject: default_i18n_subject(instance: @instance)
-    end
+    mail subject: default_i18n_subject(instance: @instance)
   end
 
   def new_critical_software_updates
     @software_updates = SoftwareUpdate.urgent.by_version
 
-    locale_for_account(@me) do
-      mail subject: default_i18n_subject(instance: @instance)
-    end
+    mail subject: default_i18n_subject(instance: @instance)
   end
 
   def auto_close_registrations
-    locale_for_account(@me) do
-      mail subject: default_i18n_subject(instance: @instance)
-    end
+    mail subject: default_i18n_subject(instance: @instance)
   end
 
   private
@@ -77,6 +65,10 @@ class AdminMailer < ApplicationMailer
 
   def set_instance
     @instance = Rails.configuration.x.local_domain
+  end
+
+  def set_locale(&block)
+    locale_for_account(@me, &block)
   end
 
   def set_important_headers!

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -15,6 +15,8 @@ class NotificationMailer < ApplicationMailer
 
   before_deliver :verify_functional_user
 
+  around_action :set_locale
+
   default to: -> { email_address_with_name(@user.email, @me.username) }
 
   layout 'mailer'
@@ -22,45 +24,33 @@ class NotificationMailer < ApplicationMailer
   def mention
     return if @status.blank?
 
-    locale_for_account(@me) do
-      mail subject: default_i18n_subject(name: @status.account.acct)
-    end
+    mail subject: default_i18n_subject(name: @status.account.acct)
   end
 
   def quote
     return if @status.blank?
 
-    locale_for_account(@me) do
-      mail subject: default_i18n_subject(name: @status.account.acct)
-    end
+    mail subject: default_i18n_subject(name: @status.account.acct)
   end
 
   def follow
-    locale_for_account(@me) do
-      mail subject: default_i18n_subject(name: @account.acct)
-    end
+    mail subject: default_i18n_subject(name: @account.acct)
   end
 
   def favourite
     return if @status.blank?
 
-    locale_for_account(@me) do
-      mail subject: default_i18n_subject(name: @account.acct)
-    end
+    mail subject: default_i18n_subject(name: @account.acct)
   end
 
   def reblog
     return if @status.blank?
 
-    locale_for_account(@me) do
-      mail subject: default_i18n_subject(name: @account.acct)
-    end
+    mail subject: default_i18n_subject(name: @account.acct)
   end
 
   def follow_request
-    locale_for_account(@me) do
-      mail subject: default_i18n_subject(name: @account.acct)
-    end
+    mail subject: default_i18n_subject(name: @account.acct)
   end
 
   private
@@ -79,6 +69,10 @@ class NotificationMailer < ApplicationMailer
 
   def set_account
     @account = @notification.from_account
+  end
+
+  def set_locale(&block)
+    locale_for_account(@me, &block)
   end
 
   def verify_functional_user


### PR DESCRIPTION
We can't also pull in the user mailer here (and put this in base class) because there's enough discrepancy between user and these ones, and within user itself (possibly breaks down along devise/non-devise lines). Further extraction/normalizing like that might be good future project.