### PR TITLE
Fix OpenStack Swift Keystone token rate limiting

### DIFF
--- a/config/initializers/fog_connection_cache.rb
+++ b/config/initializers/fog_connection_cache.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+if ENV['SWIFT_ENABLED'] == 'true'
+  module PaperclipFogConnectionCache
+    def connection
+      @connection ||= begin
+        key = fog_credentials.hash
+        Thread.current[:paperclip_fog_connections] ||= {}
+        Thread.current[:paperclip_fog_connections][key] ||= ::Fog::Storage.new(fog_credentials)
+      end
+    end
+  end
+
+  Rails.application.config.after_initialize do
+    Paperclip::Storage::Fog.prepend(PaperclipFogConnectionCache)
+  end
+end


### PR DESCRIPTION
On large instances using OpenStack Swift, normal operations (media uploads, deletes, federation) and `tootctl` commands like `media remove` trigger a new Keystone authentication request for every attachment operation. This quickly exceeds provider rate limits on token creation (e.g. OVH limits `/v3/auth/tokens` to 90 POST requests per minute), resulting in `429 Too Many Requests` errors.

The `SWIFT_CACHE_TTL` (`openstack_cache_ttl`) only caches the token within a single connection object, so it has no effect when connections are discarded after a single use.

This adds an initializer that caches the `Fog::Storage` connection per thread instead of creating a new one per attachment, reducing authentication requests from potentially thousands per minute to a handful when `SWIFT_CACHE_TTL` expires.

Tested in production with no issues.

Fixes #21826 and #21602