### PR TITLE
Profile editing: Fix bug with reordering

### DIFF
--- a/app/javascript/mastodon/features/account_edit/modals/fields_reorder_modal.tsx
+++ b/app/javascript/mastodon/features/account_edit/modals/fields_reorder_modal.tsx
@@ -212,11 +212,9 @@ export const ReorderFieldsModal: FC<DialogModalProps> = ({ onClose }) => {
         return;
       }
       newFields.push({ name: field.name, value: field.value });
-
-      void dispatch(patchProfile({ fields_attributes: newFields })).then(
-        onClose,
-      );
     }
+
+    void dispatch(patchProfile({ fields_attributes: newFields })).then(onClose);
   }, [dispatch, fieldKeys, fields, onClose]);
 
   const emojis = useAppSelector((state) => state.custom_emojis);

--- a/app/javascript/mastodon/reducers/slices/profile_edit.ts
+++ b/app/javascript/mastodon/reducers/slices/profile_edit.ts
@@ -221,7 +221,12 @@ export const patchProfile = createDataLoadingThunk(
   `${profileEditSlice.name}/patchProfile`,
   (params: Partial<ApiProfileUpdateParams>) => apiPatchProfile(params),
   transformProfile,
-  { useLoadingBar: false },
+  {
+    useLoadingBar: false,
+    condition(_, { getState }) {
+      return !getState().profileEdit.isPending;
+    },
+  },
 );
 
 export const selectFieldById = createAppSelector(


### PR DESCRIPTION
This fixes an issue with #38083 where the `patchProfile` call was _inside_ the `for` loop, causing it to submit one field three times and deleting every other field. This is now prevented by moving it outside the loop and preventing API requests if `isPending` is true.