### PR TITLE
Use bundler version 4.0.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,7 +352,7 @@ GEM
       azure-blob (~> 0.5.2)
       hashie (~> 5.0)
     jmespath (1.6.2)
-    json (2.18.1)
+    json (2.19.0)
     json-canonicalization (1.0.0)
     json-jwt (1.17.0)
       activesupport (>= 4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0224)
+    mime-types-data (3.2026.0303)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (6.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -792,7 +792,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
       rubocop-rspec (~> 3.5)
-    ruby-prof (2.0.2)
+    ruby-prof (2.0.3)
       base64
       ostruct
     ruby-progressbar (1.13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -792,7 +792,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
       rubocop-rspec (~> 3.5)
-    ruby-prof (2.0.3)
+    ruby-prof (2.0.4)
       base64
       ostruct
     ruby-progressbar (1.13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,9 +276,9 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    google-protobuf (4.33.5)
+    google-protobuf (4.34.0)
       bigdecimal
-      rake (>= 13)
+      rake (~> 13.3)
     googleapis-common-protos-types (1.22.0)
       google-protobuf (~> 4.26)
     haml (7.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     ast (2.4.3)
     attr_required (1.0.2)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1222.0)
+    aws-partitions (1.1223.0)
     aws-sdk-core (3.243.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,7 +352,7 @@ GEM
       azure-blob (~> 0.5.2)
       hashie (~> 5.0)
     jmespath (1.6.2)
-    json (2.19.0)
+    json (2.19.1)
     json-canonicalization (1.0.0)
     json-jwt (1.17.0)
       activesupport (>= 4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     case_transform (0.2)
       activesupport
     cbor (0.5.10.1)
-    cgi (0.4.2)
+    cgi (0.5.1)
     charlock_holmes (0.7.9)
     chewy (7.6.0)
       activesupport (>= 5.2)
@@ -507,7 +507,7 @@ GEM
       tzinfo
       validate_url
       webfinger (~> 2.0)
-    openssl (3.3.2)
+    openssl (4.0.1)
     openssl-signature_algorithm (1.3.0)
       openssl (> 2.0)
     opentelemetry-api (1.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       activerecord (>= 4.2, < 9.0)
     docile (1.4.1)
     domain_name (0.6.20240107)
-    doorkeeper (5.8.2)
+    doorkeeper (5.9.0)
       railties (>= 5)
     dotenv (3.2.0)
     drb (2.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1100,4 +1100,4 @@ RUBY VERSION
   ruby 3.4.8
 
 BUNDLED WITH
-  4.0.7
+  4.0.8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -766,7 +766,7 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.0)
+    rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-capybara (2.22.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,7 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
-    excon (1.3.2)
+    excon (1.4.0)
       logger
     fabrication (3.0.0)
     faker (3.6.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -867,7 +867,7 @@ GEM
     test-prof (1.5.2)
     thor (1.5.0)
     tilt (2.7.0)
-    timeout (0.6.0)
+    timeout (0.6.1)
     tpm-key_attestation (0.14.1)
       bindata (~> 2.4)
       openssl (> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -847,7 +847,7 @@ GEM
     stackprof (0.2.28)
     starry (0.2.0)
       base64
-    stoplight (5.7.0)
+    stoplight (5.8.0)
       concurrent-ruby
       zeitwerk
     stringio (3.2.0)


### PR DESCRIPTION
May overlap with other open PRs.

Excludes redis/sidekiq/rubocop, which have separate PRs and/or more changes needed first.