### PR TITLE
Disable `use_multi_json` for json validator / match_json_schema

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -92,3 +92,6 @@ end
 Sidekiq.strict_args!
 
 Redis.raise_deprecations = true
+
+# Silence deprecation warning from json-schema
+JSON::Validator.use_multi_json = false


### PR DESCRIPTION
Silences deprecation warning in the node info spec which shows up since the 6.2.0 update of json-schema - https://github.com/voxpupuli/json-schema/releases/tag/v6.2.0 (multi json deprecated in that release, now emits warning)

Presumably will become a default in future release and we can remove.