### PR TITLE
Use `rescue_from` to handle missing status scenario in `NotificationMailer`

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -19,17 +19,15 @@ class NotificationMailer < ApplicationMailer
 
   default to: -> { email_address_with_name(@user.email, @me.username) }
 
+  rescue_from(ActiveRecord::RecordNotFound) { false }
+
   layout 'mailer'
 
   def mention
-    return if @status.blank?
-
     mail subject: default_i18n_subject(name: @status.account.acct)
   end
 
   def quote
-    return if @status.blank?
-
     mail subject: default_i18n_subject(name: @status.account.acct)
   end
 
@@ -38,14 +36,10 @@ class NotificationMailer < ApplicationMailer
   end
 
   def favourite
-    return if @status.blank?
-
     mail subject: default_i18n_subject(name: @account.acct)
   end
 
   def reblog
-    return if @status.blank?
-
     mail subject: default_i18n_subject(name: @account.acct)
   end
 
@@ -64,7 +58,7 @@ class NotificationMailer < ApplicationMailer
   end
 
   def set_status
-    @status = @notification.target_status
+    @status = @notification.target_status || raise(ActiveRecord::RecordNotFound)
   end
 
   def set_account


### PR DESCRIPTION
Follow up on https://github.com/mastodon/mastodon/pull/38140

A previous attempt at this - https://github.com/mastodon/mastodon/pull/32090/changes - yielded spec additions, but stopped short of full merge because we felt like part of the approach (setting `response_body` to any value at all to halt early) despite being documented, was only barely so, and felt like sort of a hack.

The approach here is to just rely on the behavior that rescuing a raised error stops delivery. This feels appropriate to me to handle what should be an exceptional case (missing status) with the raised exception (which halts action) and rescue (which just bails and ensures we dont deliver).

The specs in place from last time still pass, and I believe do capture this path of missing status.