### PR TITLE
Add `GET /api/v1/admin/warning_presets` and `GET /api/v1/admin/warning_presets/:id`

### DIFF
--- a/app/controllers/api/v1/admin/warning_presets_controller.rb
+++ b/app/controllers/api/v1/admin/warning_presets_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Api::V1::Admin::WarningPresetsController < Api::BaseController
+  include Authorization
+  include AccountableConcern
+
+  before_action -> { authorize_if_got_token! :'admin:read', :'admin:read:reports' }, only: [:index, :show]
+  before_action :set_presets, only: :index
+  before_action :set_preset, except: :index
+
+  after_action :verify_authorized
+
+  def index
+    authorize :account_warning_preset, :show?
+    render json: @warning_presets, each_serializer: REST::Admin::AccountWarningPresetSerializer
+  end
+
+  def show
+    authorize @warning_preset, :show?
+    render json: @warning_preset, serializer: REST::Admin::AccountWarningPresetSerializer
+  end
+
+  private
+
+  def set_presets
+    @warning_presets = AccountWarningPreset.all
+  end
+
+  def set_preset
+    @warning_preset = AccountWarningPreset.find(params[:id])
+  end
+end

--- a/app/policies/account_warning_preset_policy.rb
+++ b/app/policies/account_warning_preset_policy.rb
@@ -5,6 +5,10 @@ class AccountWarningPresetPolicy < ApplicationPolicy
     role.can?(:manage_settings)
   end
 
+  def show?
+    role.can?(:manage_settings, :manage_reports, :manage_users)
+  end
+
   def create?
     role.can?(:manage_settings)
   end

--- a/app/serializers/rest/admin/account_warning_preset_serializer.rb
+++ b/app/serializers/rest/admin/account_warning_preset_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class REST::Admin::AccountWarningPresetSerializer < ActiveModel::Serializer
+  attributes :id, :text, :title, :created_at, :updated_at
+
+  def id
+    object.id.to_s
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -298,6 +298,7 @@ namespace :api, format: false do
       resources :domain_blocks, only: [:index, :show, :update, :create, :destroy]
       resources :email_domain_blocks, only: [:index, :show, :create, :destroy]
       resources :ip_blocks, only: [:index, :show, :update, :create, :destroy]
+      resources :warning_presets, only: [:index, :show]
 
       namespace :trends do
         resources :tags, only: [:index] do

--- a/spec/requests/api/v1/admin/warning_presets_spec.rb
+++ b/spec/requests/api/v1/admin/warning_presets_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Warning presets' do
+  include_context 'with API authentication', user_fabricator: :admin_user, oauth_scopes: 'admin:read:reports'
+
+  describe 'GET /api/v1/admin/warning_presets' do
+    subject do
+      get '/api/v1/admin/warning_presets', headers: headers, params: params
+    end
+
+    let(:params) { {} }
+
+    it_behaves_like 'forbidden for wrong scope', 'write:statuses'
+    it_behaves_like 'forbidden for wrong role', ''
+
+    context 'when there are no presets' do
+      it 'returns an empty list' do
+        subject
+
+        expect(response)
+          .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
+        expect(response.parsed_body)
+          .to be_empty
+      end
+    end
+
+    context 'when there are presets' do
+      let!(:preset) { Fabricate(:account_warning_preset, title: 'Simple moderation warning', text: 'Boilerplate here') }
+
+      it 'returns all available presets' do
+        subject
+
+        expect(response)
+          .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
+        expect(response.parsed_body)
+          .to match_array(a_hash_including({
+            'id' => preset.id.to_s,
+            'text' => preset.text,
+            'title' => preset.title,
+          }))
+      end
+    end
+  end
+
+  describe 'GET /api/v1/admin/reports/:id' do
+    subject do
+      get "/api/v1/admin/reports/#{report.id}", headers: headers
+    end
+
+    let(:report) { Fabricate(:report) }
+
+    it_behaves_like 'forbidden for wrong scope', 'write:statuses'
+    it_behaves_like 'forbidden for wrong role', ''
+
+    it 'returns the requested report content', :aggregate_failures do
+      subject
+
+      expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
+      expect(response.parsed_body).to include(
+        {
+          id: report.id.to_s,
+          action_taken: report.action_taken?,
+          category: report.category,
+          comment: report.comment,
+          account: a_hash_including(id: report.account.id.to_s),
+          target_account: a_hash_including(id: report.target_account.id.to_s),
+          statuses: report.statuses,
+          rules: report.rules,
+          forwarded: report.forwarded,
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
The admin API already allowed to use presets through `POST /api/v1/admin/accounts/:id/action`, but did not provide any way of listing or checking them.

This PR adds `GET /api/v1/admin/warning_presets` to list them and `GET /api/v1/admin/warning_presets/:id` to check a particular one.

The permission checks are a bit awkward because we don't have permissions or OAuth scopes dedicated to this.

So I decided that to access this, the roles should allow either of:
- `manage_settings`: currently used to show the interface to manage warning presets in the admin interface
- `manage_users`: currently used to allow moderators to perform actions on a user, including selecting a preset
- `manage_reports`: this one is actually new, but I think it makes sense to be able to select a preset for resolution of a report

As for OAuth scopes: `admin:read` or `admin:read:reports`