### PR TITLE
Remove extra splat args from user mailer

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -18,7 +18,7 @@ class UserMailer < Devise::Mailer
 
   default to: -> { @resource.email }
 
-  def confirmation_instructions(user, token, *, **)
+  def confirmation_instructions(user, token, **)
     @resource = user
     @token    = token
 
@@ -31,7 +31,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def reset_password_instructions(user, token, *, **)
+  def reset_password_instructions(user, token, **)
     @resource = user
     @token    = token
 
@@ -42,7 +42,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def password_change(user, *, **)
+  def password_change(user, **)
     @resource = user
 
     return unless @resource.active_for_authentication?
@@ -52,7 +52,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def email_changed(user, *, **)
+  def email_changed(user, **)
     @resource = user
 
     return unless @resource.active_for_authentication?
@@ -62,7 +62,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def two_factor_enabled(user, *, **)
+  def two_factor_enabled(user)
     @resource = user
 
     return unless @resource.active_for_authentication?
@@ -72,7 +72,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def two_factor_disabled(user, *, **)
+  def two_factor_disabled(user)
     @resource = user
 
     return unless @resource.active_for_authentication?
@@ -82,7 +82,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def two_factor_recovery_codes_changed(user, *, **)
+  def two_factor_recovery_codes_changed(user)
     @resource = user
 
     return unless @resource.active_for_authentication?
@@ -92,7 +92,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def webauthn_enabled(user, *, **)
+  def webauthn_enabled(user)
     @resource = user
 
     return unless @resource.active_for_authentication?
@@ -102,7 +102,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def webauthn_disabled(user, *, **)
+  def webauthn_disabled(user)
     @resource = user
 
     return unless @resource.active_for_authentication?


### PR DESCRIPTION
Two related changes:

- The first four changes are in methods which inherit from devise and use the initial named args and discard the rest. A [previous change for ruby 3.1 support](https://github.com/mastodon/mastodon/pull/22246) added the `*, **` style to work around a bug, but that bug has been fixed since 3.2, so we can revert to just using `**`.
- The latter four changes do not inherit from devise, and all usage within the app supplies just the exact named args. I'm not sure what the the splats were initially for (they were added like this, but dont call super or inherit from anything ... probably copy/paste or something?), but I don't think they are needed now?

I think these should both be queue-safe even though we are changing the signature - as far as I can tell the actual inbound arguments sent from anywhere have not changed in a long time, or ever, and the changes should still accept what is being sent in from queueud jobs. It'd be great to contemplate that during review, though, I know its been a blocker on previous mailer improvement attempts.