### PR TITLE
Remove unused `@markdown` from user mailer terms action

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -216,7 +216,6 @@ class UserMailer < Devise::Mailer
   def terms_of_service_changed(user, terms_of_service)
     @resource = user
     @terms_of_service = terms_of_service
-    @markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, escape_html: true, no_images: true)
 
     I18n.with_locale(locale) do
       mail subject: default_i18n_subject


### PR DESCRIPTION
This view uses the `markdown` helper method, pulled in from `FormattingHelper` (which uses same options as this unused i-var). I suspect this is unused since addition.