### PR TITLE
Fix extra border on accounts in settings page

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2010,7 +2010,9 @@ body > [data-popper-placement] {
 .account {
   padding: 16px;
 
-  &:not(&--without-border) {
+  // Using :where keeps specificity low, allowing for existing
+  // .account overrides to still apply
+  &:where(:not(&--without-border)) {
     border-bottom: 1px solid var(--color-border-primary);
   }
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes a small bug where accounts could show a border even if they had a CSS override not to show it

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="437" height="231" alt="image" src="https://github.com/user-attachments/assets/d2b0f451-ac78-4ff6-a32f-ce474cccde5c" /> | <img width="403" height="241" alt="image" src="https://github.com/user-attachments/assets/01216875-e35a-4c3a-9328-ca2f3f447eaa" /> |