### PR TITLE
Run `annotaterb models` after bug fix to re-order model comments

### DIFF
--- a/app/models/account_migration.rb
+++ b/app/models/account_migration.rb
@@ -5,12 +5,12 @@
 # Table name: account_migrations
 #
 #  id                :bigint(8)        not null, primary key
-#  account_id        :bigint(8)
 #  acct              :string           default(""), not null
 #  followers_count   :bigint(8)        default(0), not null
-#  target_account_id :bigint(8)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  account_id        :bigint(8)
+#  target_account_id :bigint(8)
 #
 
 class AccountMigration < ApplicationRecord

--- a/app/models/account_moderation_note.rb
+++ b/app/models/account_moderation_note.rb
@@ -6,10 +6,10 @@
 #
 #  id                :bigint(8)        not null, primary key
 #  content           :text             not null
-#  account_id        :bigint(8)        not null
-#  target_account_id :bigint(8)        not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  account_id        :bigint(8)        not null
+#  target_account_id :bigint(8)        not null
 #
 
 class AccountModerationNote < ApplicationRecord

--- a/app/models/account_relationship_severance_event.rb
+++ b/app/models/account_relationship_severance_event.rb
@@ -6,12 +6,12 @@
 # Table name: account_relationship_severance_events
 #
 #  id                              :bigint(8)        not null, primary key
-#  account_id                      :bigint(8)        not null
-#  relationship_severance_event_id :bigint(8)        not null
-#  created_at                      :datetime         not null
-#  updated_at                      :datetime         not null
 #  followers_count                 :integer          default(0), not null
 #  following_count                 :integer          default(0), not null
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  account_id                      :bigint(8)        not null
+#  relationship_severance_event_id :bigint(8)        not null
 #
 class AccountRelationshipSeveranceEvent < ApplicationRecord
   self.ignored_columns += %w(

--- a/app/models/account_stat.rb
+++ b/app/models/account_stat.rb
@@ -5,13 +5,13 @@
 # Table name: account_stats
 #
 #  id              :bigint(8)        not null, primary key
-#  account_id      :bigint(8)        not null
-#  statuses_count  :bigint(8)        default(0), not null
-#  following_count :bigint(8)        default(0), not null
 #  followers_count :bigint(8)        default(0), not null
+#  following_count :bigint(8)        default(0), not null
+#  last_status_at  :datetime
+#  statuses_count  :bigint(8)        default(0), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  last_status_at  :datetime
+#  account_id      :bigint(8)        not null
 #
 
 class AccountStat < ApplicationRecord

--- a/app/models/account_statuses_cleanup_policy.rb
+++ b/app/models/account_statuses_cleanup_policy.rb
@@ -5,19 +5,19 @@
 # Table name: account_statuses_cleanup_policies
 #
 #  id                 :bigint(8)        not null, primary key
-#  account_id         :bigint(8)        not null
 #  enabled            :boolean          default(TRUE), not null
-#  min_status_age     :integer          default(1209600), not null
 #  keep_direct        :boolean          default(TRUE), not null
+#  keep_media         :boolean          default(FALSE), not null
 #  keep_pinned        :boolean          default(TRUE), not null
 #  keep_polls         :boolean          default(FALSE), not null
-#  keep_media         :boolean          default(FALSE), not null
-#  keep_self_fav      :boolean          default(TRUE), not null
 #  keep_self_bookmark :boolean          default(TRUE), not null
+#  keep_self_fav      :boolean          default(TRUE), not null
 #  min_favs           :integer
 #  min_reblogs        :integer
+#  min_status_age     :integer          default(1209600), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  account_id         :bigint(8)        not null
 #
 class AccountStatusesCleanupPolicy < ApplicationRecord
   include Redisable

--- a/app/models/account_summary.rb
+++ b/app/models/account_summary.rb
@@ -4,9 +4,9 @@
 #
 # Table name: account_summaries
 #
-#  account_id :bigint(8)        primary key
 #  language   :string
 #  sensitive  :boolean
+#  account_id :bigint(8)        primary key
 #
 
 class AccountSummary < ApplicationRecord

--- a/app/models/account_warning.rb
+++ b/app/models/account_warning.rb
@@ -5,15 +5,15 @@
 # Table name: account_warnings
 #
 #  id                :bigint(8)        not null, primary key
-#  account_id        :bigint(8)
-#  target_account_id :bigint(8)
 #  action            :integer          default("none"), not null
+#  overruled_at      :datetime
+#  status_ids        :string           is an Array
 #  text              :text             default(""), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  account_id        :bigint(8)
 #  report_id         :bigint(8)
-#  status_ids        :string           is an Array
-#  overruled_at      :datetime
+#  target_account_id :bigint(8)
 #
 
 class AccountWarning < ApplicationRecord

--- a/app/models/account_warning_preset.rb
+++ b/app/models/account_warning_preset.rb
@@ -6,9 +6,9 @@
 #
 #  id         :bigint(8)        not null, primary key
 #  text       :text             default(""), not null
+#  title      :string           default(""), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  title      :string           default(""), not null
 #
 
 class AccountWarningPreset < ApplicationRecord

--- a/app/models/annual_report/statuses_per_account_count.rb
+++ b/app/models/annual_report/statuses_per_account_count.rb
@@ -5,9 +5,9 @@
 # Table name: annual_report_statuses_per_account_counts
 #
 #  id             :bigint(8)        not null, primary key
+#  statuses_count :bigint(8)        not null
 #  year           :integer          not null
 #  account_id     :bigint(8)        not null
-#  statuses_count :bigint(8)        not null
 #
 
 class AnnualReport::StatusesPerAccountCount < ApplicationRecord

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -5,15 +5,15 @@
 # Table name: appeals
 #
 #  id                     :bigint(8)        not null, primary key
-#  account_id             :bigint(8)        not null
-#  account_warning_id     :bigint(8)        not null
-#  text                   :text             default(""), not null
 #  approved_at            :datetime
-#  approved_by_account_id :bigint(8)
 #  rejected_at            :datetime
-#  rejected_by_account_id :bigint(8)
+#  text                   :text             default(""), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  account_id             :bigint(8)        not null
+#  account_warning_id     :bigint(8)        not null
+#  approved_by_account_id :bigint(8)
+#  rejected_by_account_id :bigint(8)
 #
 class Appeal < ApplicationRecord
   TEXT_LENGTH_LIMIT = 2_000

--- a/app/models/backup.rb
+++ b/app/models/backup.rb
@@ -5,14 +5,14 @@
 # Table name: backups
 #
 #  id                :bigint(8)        not null, primary key
-#  user_id           :bigint(8)
-#  dump_file_name    :string
 #  dump_content_type :string
+#  dump_file_name    :string
+#  dump_file_size    :bigint(8)
 #  dump_updated_at   :datetime
 #  processed         :boolean          default(FALSE), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  dump_file_size    :bigint(8)
+#  user_id           :bigint(8)
 #
 
 class Backup < ApplicationRecord

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -5,11 +5,11 @@
 # Table name: blocks
 #
 #  id                :bigint(8)        not null, primary key
+#  uri               :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  account_id        :bigint(8)        not null
 #  target_account_id :bigint(8)        not null
-#  uri               :string
 #
 
 class Block < ApplicationRecord

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -5,10 +5,10 @@
 # Table name: bookmarks
 #
 #  id         :bigint(8)        not null, primary key
-#  account_id :bigint(8)        not null
-#  status_id  :bigint(8)        not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  account_id :bigint(8)        not null
+#  status_id  :bigint(8)        not null
 #
 
 class Bookmark < ApplicationRecord

--- a/app/models/bulk_import.rb
+++ b/app/models/bulk_import.rb
@@ -5,18 +5,18 @@
 # Table name: bulk_imports
 #
 #  id                :bigint(8)        not null, primary key
-#  type              :integer          not null
-#  state             :integer          not null
-#  total_items       :integer          default(0), not null
-#  imported_items    :integer          default(0), not null
-#  processed_items   :integer          default(0), not null
 #  finished_at       :datetime
-#  overwrite         :boolean          default(FALSE), not null
+#  imported_items    :integer          default(0), not null
 #  likely_mismatched :boolean          default(FALSE), not null
 #  original_filename :string           default(""), not null
-#  account_id        :bigint(8)        not null
+#  overwrite         :boolean          default(FALSE), not null
+#  processed_items   :integer          default(0), not null
+#  state             :integer          not null
+#  total_items       :integer          default(0), not null
+#  type              :integer          not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  account_id        :bigint(8)        not null
 #
 class BulkImport < ApplicationRecord
   self.inheritance_column = false

--- a/app/models/bulk_import_row.rb
+++ b/app/models/bulk_import_row.rb
@@ -5,10 +5,10 @@
 # Table name: bulk_import_rows
 #
 #  id             :bigint(8)        not null, primary key
-#  bulk_import_id :bigint(8)        not null
 #  data           :jsonb
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  bulk_import_id :bigint(8)        not null
 #
 class BulkImportRow < ApplicationRecord
   belongs_to :bulk_import

--- a/app/models/canonical_email_block.rb
+++ b/app/models/canonical_email_block.rb
@@ -6,9 +6,9 @@
 #
 #  id                   :bigint(8)        not null, primary key
 #  canonical_email_hash :string           default(""), not null
-#  reference_account_id :bigint(8)
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  reference_account_id :bigint(8)
 #
 
 class CanonicalEmailBlock < ApplicationRecord

--- a/app/models/conversation_mute.rb
+++ b/app/models/conversation_mute.rb
@@ -5,8 +5,8 @@
 # Table name: conversation_mutes
 #
 #  id              :bigint(8)        not null, primary key
-#  conversation_id :bigint(8)        not null
 #  account_id      :bigint(8)        not null
+#  conversation_id :bigint(8)        not null
 #
 
 class ConversationMute < ApplicationRecord

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -5,20 +5,20 @@
 # Table name: custom_emojis
 #
 #  id                           :bigint(8)        not null, primary key
-#  shortcode                    :string           default(""), not null
+#  disabled                     :boolean          default(FALSE), not null
 #  domain                       :string
-#  image_file_name              :string
 #  image_content_type           :string
+#  image_file_name              :string
 #  image_file_size              :integer
+#  image_remote_url             :string
+#  image_storage_schema_version :integer
 #  image_updated_at             :datetime
+#  shortcode                    :string           default(""), not null
+#  uri                          :string
+#  visible_in_picker            :boolean          default(TRUE), not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
-#  disabled                     :boolean          default(FALSE), not null
-#  uri                          :string
-#  image_remote_url             :string
-#  visible_in_picker            :boolean          default(TRUE), not null
 #  category_id                  :bigint(8)
-#  image_storage_schema_version :integer
 #
 
 class CustomEmoji < ApplicationRecord

--- a/app/models/custom_filter_keyword.rb
+++ b/app/models/custom_filter_keyword.rb
@@ -5,11 +5,11 @@
 # Table name: custom_filter_keywords
 #
 #  id               :bigint(8)        not null, primary key
-#  custom_filter_id :bigint(8)        not null
 #  keyword          :text             default(""), not null
 #  whole_word       :boolean          default(TRUE), not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  custom_filter_id :bigint(8)        not null
 #
 
 class CustomFilterKeyword < ApplicationRecord

--- a/app/models/custom_filter_status.rb
+++ b/app/models/custom_filter_status.rb
@@ -5,10 +5,10 @@
 # Table name: custom_filter_statuses
 #
 #  id               :bigint(8)        not null, primary key
-#  custom_filter_id :bigint(8)        not null
-#  status_id        :bigint(8)        not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  custom_filter_id :bigint(8)        not null
+#  status_id        :bigint(8)        not null
 #
 
 class CustomFilterStatus < ApplicationRecord

--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -6,14 +6,14 @@
 #
 #  id              :bigint(8)        not null, primary key
 #  domain          :string           default(""), not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  severity        :integer          default("silence")
-#  reject_media    :boolean          default(FALSE), not null
-#  reject_reports  :boolean          default(FALSE), not null
+#  obfuscate       :boolean          default(FALSE), not null
 #  private_comment :text
 #  public_comment  :text
-#  obfuscate       :boolean          default(FALSE), not null
+#  reject_media    :boolean          default(FALSE), not null
+#  reject_reports  :boolean          default(FALSE), not null
+#  severity        :integer          default("silence")
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #
 
 class DomainBlock < ApplicationRecord

--- a/app/models/email_domain_block.rb
+++ b/app/models/email_domain_block.rb
@@ -5,11 +5,11 @@
 # Table name: email_domain_blocks
 #
 #  id                  :bigint(8)        not null, primary key
+#  allow_with_approval :boolean          default(FALSE), not null
 #  domain              :string           default(""), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  parent_id           :bigint(8)
-#  allow_with_approval :boolean          default(FALSE), not null
 #
 
 class EmailDomainBlock < ApplicationRecord

--- a/app/models/featured_tag.rb
+++ b/app/models/featured_tag.rb
@@ -5,13 +5,13 @@
 # Table name: featured_tags
 #
 #  id             :bigint(8)        not null, primary key
-#  account_id     :bigint(8)        not null
-#  tag_id         :bigint(8)        not null
-#  statuses_count :bigint(8)        default(0), not null
 #  last_status_at :datetime
+#  name           :string
+#  statuses_count :bigint(8)        default(0), not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  name           :string
+#  account_id     :bigint(8)        not null
+#  tag_id         :bigint(8)        not null
 #
 
 class FeaturedTag < ApplicationRecord

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -5,14 +5,14 @@
 # Table name: follows
 #
 #  id                :bigint(8)        not null, primary key
+#  languages         :string           is an Array
+#  notify            :boolean          default(FALSE), not null
+#  show_reblogs      :boolean          default(TRUE), not null
+#  uri               :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  account_id        :bigint(8)        not null
 #  target_account_id :bigint(8)        not null
-#  show_reblogs      :boolean          default(TRUE), not null
-#  uri               :string
-#  notify            :boolean          default(FALSE), not null
-#  languages         :string           is an Array
 #
 
 class Follow < ApplicationRecord

--- a/app/models/follow_recommendation.rb
+++ b/app/models/follow_recommendation.rb
@@ -4,9 +4,9 @@
 #
 # Table name: global_follow_recommendations
 #
-#  account_id :bigint(8)        primary key
 #  rank       :decimal(, )
 #  reason     :text             is an Array
+#  account_id :bigint(8)        primary key
 #
 
 class FollowRecommendation < ApplicationRecord

--- a/app/models/follow_recommendation_mute.rb
+++ b/app/models/follow_recommendation_mute.rb
@@ -5,10 +5,10 @@
 # Table name: follow_recommendation_mutes
 #
 #  id                :bigint(8)        not null, primary key
-#  account_id        :bigint(8)        not null
-#  target_account_id :bigint(8)        not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  account_id        :bigint(8)        not null
+#  target_account_id :bigint(8)        not null
 #
 class FollowRecommendationMute < ApplicationRecord
   belongs_to :account

--- a/app/models/follow_recommendation_suppression.rb
+++ b/app/models/follow_recommendation_suppression.rb
@@ -5,9 +5,9 @@
 # Table name: follow_recommendation_suppressions
 #
 #  id         :bigint(8)        not null, primary key
-#  account_id :bigint(8)        not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  account_id :bigint(8)        not null
 #
 
 class FollowRecommendationSuppression < ApplicationRecord

--- a/app/models/follow_request.rb
+++ b/app/models/follow_request.rb
@@ -5,14 +5,14 @@
 # Table name: follow_requests
 #
 #  id                :bigint(8)        not null, primary key
+#  languages         :string           is an Array
+#  notify            :boolean          default(FALSE), not null
+#  show_reblogs      :boolean          default(TRUE), not null
+#  uri               :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  account_id        :bigint(8)        not null
 #  target_account_id :bigint(8)        not null
-#  show_reblogs      :boolean          default(TRUE), not null
-#  uri               :string
-#  notify            :boolean          default(FALSE), not null
-#  languages         :string           is an Array
 #
 
 class FollowRequest < ApplicationRecord

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -4,11 +4,11 @@
 #
 # Table name: identities
 #
+#  id         :bigint(8)        not null, primary key
 #  provider   :string           default(""), not null
 #  uid        :string           default(""), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  id         :bigint(8)        not null, primary key
 #  user_id    :bigint(8)
 #
 

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -4,8 +4,8 @@
 #
 # Table name: instances
 #
-#  domain         :string           primary key
 #  accounts_count :bigint(8)
+#  domain         :string           primary key
 #
 
 class Instance < ApplicationRecord

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -5,15 +5,15 @@
 # Table name: invites
 #
 #  id         :bigint(8)        not null, primary key
-#  user_id    :bigint(8)        not null
+#  autofollow :boolean          default(FALSE), not null
 #  code       :string           default(""), not null
+#  comment    :text
 #  expires_at :datetime
 #  max_uses   :integer
 #  uses       :integer          default(0), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  autofollow :boolean          default(FALSE), not null
-#  comment    :text
+#  user_id    :bigint(8)        not null
 #
 
 class Invite < ApplicationRecord

--- a/app/models/ip_block.rb
+++ b/app/models/ip_block.rb
@@ -5,12 +5,12 @@
 # Table name: ip_blocks
 #
 #  id         :bigint(8)        not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  comment    :text             default(""), not null
 #  expires_at :datetime
 #  ip         :inet             default(#<IPAddr: IPv4:0.0.0.0/255.255.255.255>), not null
 #  severity   :integer          default(NULL), not null
-#  comment    :text             default(""), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 
 class IpBlock < ApplicationRecord

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -5,12 +5,12 @@
 # Table name: lists
 #
 #  id             :bigint(8)        not null, primary key
-#  account_id     :bigint(8)        not null
+#  exclusive      :boolean          default(FALSE), not null
+#  replies_policy :integer          default("list"), not null
 #  title          :string           default(""), not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  replies_policy :integer          default("list"), not null
-#  exclusive      :boolean          default(FALSE), not null
+#  account_id     :bigint(8)        not null
 #
 
 class List < ApplicationRecord

--- a/app/models/list_account.rb
+++ b/app/models/list_account.rb
@@ -5,10 +5,10 @@
 # Table name: list_accounts
 #
 #  id                :bigint(8)        not null, primary key
-#  list_id           :bigint(8)        not null
 #  account_id        :bigint(8)        not null
 #  follow_id         :bigint(8)
 #  follow_request_id :bigint(8)
+#  list_id           :bigint(8)        not null
 #
 
 class ListAccount < ApplicationRecord

--- a/app/models/login_activity.rb
+++ b/app/models/login_activity.rb
@@ -5,14 +5,14 @@
 # Table name: login_activities
 #
 #  id                    :bigint(8)        not null, primary key
-#  user_id               :bigint(8)        not null
 #  authentication_method :string
-#  provider              :string
-#  success               :boolean
 #  failure_reason        :string
 #  ip                    :inet
+#  provider              :string
+#  success               :boolean
 #  user_agent            :string
 #  created_at            :datetime
+#  user_id               :bigint(8)        not null
 #
 
 class LoginActivity < ApplicationRecord

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -5,11 +5,11 @@
 # Table name: mentions
 #
 #  id         :bigint(8)        not null, primary key
-#  status_id  :bigint(8)        not null
+#  silent     :boolean          default(FALSE), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  account_id :bigint(8)        not null
-#  silent     :boolean          default(FALSE), not null
+#  status_id  :bigint(8)        not null
 #
 
 class Mention < ApplicationRecord

--- a/app/models/mute.rb
+++ b/app/models/mute.rb
@@ -5,12 +5,12 @@
 # Table name: mutes
 #
 #  id                 :bigint(8)        not null, primary key
+#  expires_at         :datetime
+#  hide_notifications :boolean          default(TRUE), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  account_id         :bigint(8)        not null
 #  target_account_id  :bigint(8)        not null
-#  hide_notifications :boolean          default(TRUE), not null
-#  expires_at         :datetime
 #
 
 class Mute < ApplicationRecord

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,15 +5,15 @@
 # Table name: notifications
 #
 #  id              :bigint(8)        not null, primary key
-#  activity_id     :bigint(8)        not null
 #  activity_type   :string           not null
+#  filtered        :boolean          default(FALSE), not null
+#  group_key       :string
+#  type            :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  account_id      :bigint(8)        not null
+#  activity_id     :bigint(8)        not null
 #  from_account_id :bigint(8)        not null
-#  type            :string
-#  filtered        :boolean          default(FALSE), not null
-#  group_key       :string
 #
 
 class Notification < ApplicationRecord

--- a/app/models/notification_permission.rb
+++ b/app/models/notification_permission.rb
@@ -5,10 +5,10 @@
 # Table name: notification_permissions
 #
 #  id              :bigint(8)        not null, primary key
-#  account_id      :bigint(8)        not null
-#  from_account_id :bigint(8)        not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  account_id      :bigint(8)        not null
+#  from_account_id :bigint(8)        not null
 #
 class NotificationPermission < ApplicationRecord
   belongs_to :account

--- a/app/models/notification_policy.rb
+++ b/app/models/notification_policy.rb
@@ -5,14 +5,14 @@
 # Table name: notification_policies
 #
 #  id                   :bigint(8)        not null, primary key
-#  account_id           :bigint(8)        not null
+#  for_limited_accounts :integer          default("filter"), not null
+#  for_new_accounts     :integer          default("accept"), not null
+#  for_not_followers    :integer          default("accept"), not null
+#  for_not_following    :integer          default("accept"), not null
+#  for_private_mentions :integer          default("filter"), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
-#  for_not_following    :integer          default("accept"), not null
-#  for_not_followers    :integer          default("accept"), not null
-#  for_new_accounts     :integer          default("accept"), not null
-#  for_private_mentions :integer          default("filter"), not null
-#  for_limited_accounts :integer          default("filter"), not null
+#  account_id           :bigint(8)        not null
 #
 
 class NotificationPolicy < ApplicationRecord

--- a/app/models/notification_request.rb
+++ b/app/models/notification_request.rb
@@ -5,12 +5,12 @@
 # Table name: notification_requests
 #
 #  id                  :bigint(8)        not null, primary key
-#  account_id          :bigint(8)        not null
-#  from_account_id     :bigint(8)        not null
-#  last_status_id      :bigint(8)
 #  notifications_count :bigint(8)        default(0), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  account_id          :bigint(8)        not null
+#  from_account_id     :bigint(8)        not null
+#  last_status_id      :bigint(8)
 #
 
 class NotificationRequest < ApplicationRecord

--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -5,33 +5,33 @@
 # Table name: preview_cards
 #
 #  id                           :bigint(8)        not null, primary key
-#  url                          :string           default(""), not null
-#  title                        :string           default(""), not null
-#  description                  :string           default(""), not null
-#  image_file_name              :string
-#  image_content_type           :string
-#  image_file_size              :integer
-#  image_updated_at             :datetime
-#  type                         :integer          default("link"), not null
-#  html                         :text             default(""), not null
 #  author_name                  :string           default(""), not null
 #  author_url                   :string           default(""), not null
-#  provider_name                :string           default(""), not null
-#  provider_url                 :string           default(""), not null
-#  width                        :integer          default(0), not null
-#  height                       :integer          default(0), not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  embed_url                    :string           default(""), not null
-#  image_storage_schema_version :integer
 #  blurhash                     :string
+#  description                  :string           default(""), not null
+#  embed_url                    :string           default(""), not null
+#  height                       :integer          default(0), not null
+#  html                         :text             default(""), not null
+#  image_content_type           :string
+#  image_description            :string           default(""), not null
+#  image_file_name              :string
+#  image_file_size              :integer
+#  image_storage_schema_version :integer
+#  image_updated_at             :datetime
 #  language                     :string
+#  link_type                    :integer
 #  max_score                    :float
 #  max_score_at                 :datetime
-#  trendable                    :boolean
-#  link_type                    :integer
+#  provider_name                :string           default(""), not null
+#  provider_url                 :string           default(""), not null
 #  published_at                 :datetime
-#  image_description            :string           default(""), not null
+#  title                        :string           default(""), not null
+#  trendable                    :boolean
+#  type                         :integer          default("link"), not null
+#  url                          :string           default(""), not null
+#  width                        :integer          default(0), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #  author_account_id            :bigint(8)
 #  unverified_author_account_id :bigint(8)
 #

--- a/app/models/preview_card_provider.rb
+++ b/app/models/preview_card_provider.rb
@@ -6,13 +6,13 @@
 #
 #  id                  :bigint(8)        not null, primary key
 #  domain              :string           default(""), not null
-#  icon_file_name      :string
 #  icon_content_type   :string
+#  icon_file_name      :string
 #  icon_file_size      :bigint(8)
 #  icon_updated_at     :datetime
-#  trendable           :boolean
-#  reviewed_at         :datetime
 #  requested_review_at :datetime
+#  reviewed_at         :datetime
+#  trendable           :boolean
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #

--- a/app/models/preview_card_trend.rb
+++ b/app/models/preview_card_trend.rb
@@ -5,11 +5,11 @@
 # Table name: preview_card_trends
 #
 #  id              :bigint(8)        not null, primary key
-#  preview_card_id :bigint(8)        not null
-#  score           :float            default(0.0), not null
-#  rank            :integer          default(0), not null
 #  allowed         :boolean          default(FALSE), not null
 #  language        :string
+#  rank            :integer          default(0), not null
+#  score           :float            default(0.0), not null
+#  preview_card_id :bigint(8)        not null
 #
 class PreviewCardTrend < ApplicationRecord
   include RankedTrend

--- a/app/models/preview_cards_status.rb
+++ b/app/models/preview_cards_status.rb
@@ -4,9 +4,9 @@
 #
 # Table name: preview_cards_statuses
 #
+#  url             :string
 #  preview_card_id :bigint(8)        not null, primary key
 #  status_id       :bigint(8)        not null, primary key
-#  url             :string
 #
 class PreviewCardsStatus < ApplicationRecord
   self.primary_key = [:preview_card_id, :status_id]

--- a/app/models/relationship_severance_event.rb
+++ b/app/models/relationship_severance_event.rb
@@ -5,9 +5,9 @@
 # Table name: relationship_severance_events
 #
 #  id          :bigint(8)        not null, primary key
-#  type        :integer          not null
-#  target_name :string           not null
 #  purged      :boolean          default(FALSE), not null
+#  target_name :string           not null
+#  type        :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -6,10 +6,10 @@
 #
 #  id                 :bigint(8)        not null, primary key
 #  inbox_url          :string           default(""), not null
-#  follow_activity_id :string
+#  state              :integer          default("idle"), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  state              :integer          default("idle"), not null
+#  follow_activity_id :string
 #
 
 class Relay < ApplicationRecord

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -5,20 +5,20 @@
 # Table name: reports
 #
 #  id                         :bigint(8)        not null, primary key
-#  status_ids                 :bigint(8)        default([]), not null, is an Array
+#  action_taken_at            :datetime
+#  category                   :integer          default("other"), not null
 #  comment                    :text             default(""), not null
+#  forwarded                  :boolean
+#  rule_ids                   :bigint(8)        is an Array
+#  status_ids                 :bigint(8)        default([]), not null, is an Array
+#  uri                        :string
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  account_id                 :bigint(8)        not null
 #  action_taken_by_account_id :bigint(8)
-#  target_account_id          :bigint(8)        not null
-#  assigned_account_id        :bigint(8)
-#  uri                        :string
-#  forwarded                  :boolean
-#  category                   :integer          default("other"), not null
-#  action_taken_at            :datetime
-#  rule_ids                   :bigint(8)        is an Array
 #  application_id             :bigint(8)
+#  assigned_account_id        :bigint(8)
+#  target_account_id          :bigint(8)        not null
 #
 
 class Report < ApplicationRecord

--- a/app/models/report_note.rb
+++ b/app/models/report_note.rb
@@ -6,10 +6,10 @@
 #
 #  id         :bigint(8)        not null, primary key
 #  content    :text             not null
-#  report_id  :bigint(8)        not null
-#  account_id :bigint(8)        not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  account_id :bigint(8)        not null
+#  report_id  :bigint(8)        not null
 #
 
 class ReportNote < ApplicationRecord

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -5,12 +5,12 @@
 # Table name: rules
 #
 #  id         :bigint(8)        not null, primary key
-#  priority   :integer          default(0), not null
 #  deleted_at :datetime
+#  hint       :text             default(""), not null
+#  priority   :integer          default(0), not null
 #  text       :text             default(""), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  hint       :text             default(""), not null
 #
 class Rule < ApplicationRecord
   include Discard::Model

--- a/app/models/session_activation.rb
+++ b/app/models/session_activation.rb
@@ -5,12 +5,12 @@
 # Table name: session_activations
 #
 #  id                       :bigint(8)        not null, primary key
-#  session_id               :string           not null
+#  ip                       :inet
+#  user_agent               :string           default(""), not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
-#  user_agent               :string           default(""), not null
-#  ip                       :inet
 #  access_token_id          :bigint(8)
+#  session_id               :string           not null
 #  user_id                  :bigint(8)        not null
 #  web_push_subscription_id :bigint(8)
 #

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -5,8 +5,8 @@
 # Table name: settings
 #
 #  id         :bigint(8)        not null, primary key
-#  var        :string           not null
 #  value      :text
+#  var        :string           not null
 #  created_at :datetime
 #  updated_at :datetime
 #

--- a/app/models/severed_relationship.rb
+++ b/app/models/severed_relationship.rb
@@ -5,15 +5,15 @@
 # Table name: severed_relationships
 #
 #  id                              :bigint(8)        not null, primary key
-#  relationship_severance_event_id :bigint(8)        not null
-#  local_account_id                :bigint(8)        not null
-#  remote_account_id               :bigint(8)        not null
 #  direction                       :integer          not null
-#  show_reblogs                    :boolean
-#  notify                          :boolean
 #  languages                       :string           is an Array
+#  notify                          :boolean
+#  show_reblogs                    :boolean
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
+#  local_account_id                :bigint(8)        not null
+#  relationship_severance_event_id :bigint(8)        not null
+#  remote_account_id               :bigint(8)        not null
 #
 class SeveredRelationship < ApplicationRecord
   belongs_to :relationship_severance_event

--- a/app/models/site_upload.rb
+++ b/app/models/site_upload.rb
@@ -5,15 +5,15 @@
 # Table name: site_uploads
 #
 #  id                :bigint(8)        not null, primary key
-#  var               :string           default(""), not null
-#  file_file_name    :string
+#  blurhash          :string
 #  file_content_type :string
+#  file_file_name    :string
 #  file_file_size    :integer
 #  file_updated_at   :datetime
 #  meta              :json
+#  var               :string           default(""), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  blurhash          :string
 #
 
 class SiteUpload < ApplicationRecord

--- a/app/models/software_update.rb
+++ b/app/models/software_update.rb
@@ -5,10 +5,10 @@
 # Table name: software_updates
 #
 #  id            :bigint(8)        not null, primary key
-#  version       :string           not null
-#  urgent        :boolean          default(FALSE), not null
-#  type          :integer          default("patch"), not null
 #  release_notes :string           default(""), not null
+#  type          :integer          default("patch"), not null
+#  urgent        :boolean          default(FALSE), not null
+#  version       :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -5,30 +5,30 @@
 # Table name: statuses
 #
 #  id                           :bigint(8)        not null, primary key
-#  uri                          :string
-#  text                         :text             default(""), not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  in_reply_to_id               :bigint(8)
-#  reblog_of_id                 :bigint(8)
-#  url                          :string
-#  sensitive                    :boolean          default(FALSE), not null
-#  visibility                   :integer          default("public"), not null
-#  spoiler_text                 :text             default(""), not null
-#  reply                        :boolean          default(FALSE), not null
-#  language                     :string
-#  conversation_id              :bigint(8)
-#  local                        :boolean
-#  account_id                   :bigint(8)        not null
-#  application_id               :bigint(8)
-#  in_reply_to_account_id       :bigint(8)
-#  poll_id                      :bigint(8)
 #  deleted_at                   :datetime
 #  edited_at                    :datetime
-#  trendable                    :boolean
-#  ordered_media_attachment_ids :bigint(8)        is an Array
 #  fetched_replies_at           :datetime
+#  language                     :string
+#  local                        :boolean
+#  ordered_media_attachment_ids :bigint(8)        is an Array
 #  quote_approval_policy        :integer          default(0), not null
+#  reply                        :boolean          default(FALSE), not null
+#  sensitive                    :boolean          default(FALSE), not null
+#  spoiler_text                 :text             default(""), not null
+#  text                         :text             default(""), not null
+#  trendable                    :boolean
+#  uri                          :string
+#  url                          :string
+#  visibility                   :integer          default("public"), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  account_id                   :bigint(8)        not null
+#  application_id               :bigint(8)
+#  conversation_id              :bigint(8)
+#  in_reply_to_account_id       :bigint(8)
+#  in_reply_to_id               :bigint(8)
+#  poll_id                      :bigint(8)
+#  reblog_of_id                 :bigint(8)
 #
 
 class Status < ApplicationRecord

--- a/app/models/status_edit.rb
+++ b/app/models/status_edit.rb
@@ -5,17 +5,17 @@
 # Table name: status_edits
 #
 #  id                           :bigint(8)        not null, primary key
-#  status_id                    :bigint(8)        not null
-#  account_id                   :bigint(8)
-#  text                         :text             default(""), not null
-#  spoiler_text                 :text             default(""), not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  ordered_media_attachment_ids :bigint(8)        is an Array
 #  media_descriptions           :text             is an Array
+#  ordered_media_attachment_ids :bigint(8)        is an Array
 #  poll_options                 :string           is an Array
 #  sensitive                    :boolean
+#  spoiler_text                 :text             default(""), not null
+#  text                         :text             default(""), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  account_id                   :bigint(8)
 #  quote_id                     :bigint(8)
+#  status_id                    :bigint(8)        not null
 #
 
 class StatusEdit < ApplicationRecord

--- a/app/models/status_pin.rb
+++ b/app/models/status_pin.rb
@@ -5,10 +5,10 @@
 # Table name: status_pins
 #
 #  id         :bigint(8)        not null, primary key
-#  account_id :bigint(8)        not null
-#  status_id  :bigint(8)        not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  account_id :bigint(8)        not null
+#  status_id  :bigint(8)        not null
 #
 
 class StatusPin < ApplicationRecord

--- a/app/models/status_trend.rb
+++ b/app/models/status_trend.rb
@@ -5,12 +5,12 @@
 # Table name: status_trends
 #
 #  id         :bigint(8)        not null, primary key
-#  status_id  :bigint(8)        not null
-#  account_id :bigint(8)        not null
-#  score      :float            default(0.0), not null
-#  rank       :integer          default(0), not null
 #  allowed    :boolean          default(FALSE), not null
 #  language   :string
+#  rank       :integer          default(0), not null
+#  score      :float            default(0.0), not null
+#  account_id :bigint(8)        not null
+#  status_id  :bigint(8)        not null
 #
 
 class StatusTrend < ApplicationRecord

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -5,18 +5,18 @@
 # Table name: tags
 #
 #  id                  :bigint(8)        not null, primary key
-#  name                :string           default(""), not null
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  usable              :boolean
-#  trendable           :boolean
-#  listable            :boolean
-#  reviewed_at         :datetime
-#  requested_review_at :datetime
+#  display_name        :string
 #  last_status_at      :datetime
+#  listable            :boolean
 #  max_score           :float
 #  max_score_at        :datetime
-#  display_name        :string
+#  name                :string           default(""), not null
+#  requested_review_at :datetime
+#  reviewed_at         :datetime
+#  trendable           :boolean
+#  usable              :boolean
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #
 
 class Tag < ApplicationRecord

--- a/app/models/tag_follow.rb
+++ b/app/models/tag_follow.rb
@@ -5,10 +5,10 @@
 # Table name: tag_follows
 #
 #  id         :bigint(8)        not null, primary key
-#  tag_id     :bigint(8)        not null
-#  account_id :bigint(8)        not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  account_id :bigint(8)        not null
+#  tag_id     :bigint(8)        not null
 #
 
 class TagFollow < ApplicationRecord

--- a/app/models/user_ip.rb
+++ b/app/models/user_ip.rb
@@ -4,9 +4,9 @@
 #
 # Table name: user_ips
 #
-#  user_id :bigint(8)        primary key
 #  ip      :inet
 #  used_at :datetime
+#  user_id :bigint(8)        primary key
 #
 
 class UserIp < ApplicationRecord

--- a/app/models/webauthn_credential.rb
+++ b/app/models/webauthn_credential.rb
@@ -5,13 +5,13 @@
 # Table name: webauthn_credentials
 #
 #  id          :bigint(8)        not null, primary key
-#  external_id :string           not null
-#  public_key  :string           not null
 #  nickname    :string           not null
+#  public_key  :string           not null
 #  sign_count  :bigint(8)        default(0), not null
-#  user_id     :bigint(8)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  external_id :string           not null
+#  user_id     :bigint(8)
 #
 
 class WebauthnCredential < ApplicationRecord

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -5,13 +5,13 @@
 # Table name: webhooks
 #
 #  id         :bigint(8)        not null, primary key
-#  url        :string           not null
+#  enabled    :boolean          default(TRUE), not null
 #  events     :string           default([]), not null, is an Array
 #  secret     :string           default(""), not null
-#  enabled    :boolean          default(TRUE), not null
+#  template   :text
+#  url        :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  template   :text
 #
 
 class Webhook < ApplicationRecord


### PR DESCRIPTION
This is a followup on https://github.com/mastodon/mastodon/pull/37835 which fixed an issue in annotaterb where sort options were not applied correctly. In our case, we have `classified_sort` set to true (which puts columns into four groups: the id, all normal columns, the timestamps, the associations - and sorts by alpha within each group). So this PR as-is is just re-applying that rule, which presumably should have been applied when we switched to annotaterb from annotate?

This is still a draft - https://github.com/mastodon/mastodon/pull/38163 - but I noticed a large amount of churn in that PR which I suspect is related to running migrations after adding a table and having these rules applied.

Alternate options:

- In the aftermath of https://github.com/mastodon/mastodon/pull/38044 and the rails 8.1 upgrade, the schema rb itself should be alpha sorted, and I believe if we disable the `classified_sort` option that order will flow through to these annotations, which should also make them lower churn as well.
- My personal preference remains that we should run `annotate models --delete`, remove the schema information from the model files, and remove the gem, relying instead on looking at the schema file in those rare moments of weakness when you do not have an intimate mental map of the schema available in your active working memory.

Happy to update this PR to embrace either of those options if preferred.

Similar to that schema rebuild PR, this should be a reorder change only with no additions/removals.