### PR TITLE
Allow displaying field status (error, warning, info) under form fields

### DIFF
--- a/app/javascript/mastodon/components/a11y_live_region/a11y_live_region.stories.tsx
+++ b/app/javascript/mastodon/components/a11y_live_region/a11y_live_region.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { A11yLiveRegion } from '.';
+
+const meta = {
+  title: 'Components/A11yLiveRegion',
+  component: A11yLiveRegion,
+} satisfies Meta<typeof A11yLiveRegion>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Polite: Story = {
+  args: {
+    children: "This field can't be empty.",
+  },
+};
+
+export const Assertive: Story = {
+  args: {
+    ...Polite.args,
+    role: 'alert',
+  },
+};

--- a/app/javascript/mastodon/components/a11y_live_region/index.tsx
+++ b/app/javascript/mastodon/components/a11y_live_region/index.tsx
@@ -1,0 +1,28 @@
+import { polymorphicForwardRef } from '@/types/polymorphic';
+
+/**
+ * A live region is a content region that announces changes of its contents
+ * to users of assistive technology like screen readers.
+ *
+ * Dynamically added warnings, errors, or live status updates should be wrapped
+ * in a live region to ensure they are not missed when they appear.
+ *
+ * **Important:**
+ * Live regions must be present in the DOM _before_
+ * the to-be announced content is rendered into it.
+ */
+
+export const A11yLiveRegion = polymorphicForwardRef<'div'>(
+  ({ role = 'status', as: Component = 'div', children, ...props }, ref) => {
+    return (
+      <Component
+        role={role}
+        aria-live={role === 'alert' ? 'assertive' : 'polite'}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </Component>
+    );
+  },
+);

--- a/app/javascript/mastodon/components/callout_inline/callout_inline.stories.tsx
+++ b/app/javascript/mastodon/components/callout_inline/callout_inline.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { CalloutInline } from '.';
+
+const meta = {
+  title: 'Components/CalloutInline',
+  args: {
+    children: 'Contents here',
+  },
+  component: CalloutInline,
+} satisfies Meta<typeof CalloutInline>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Error: Story = {
+  args: {
+    variant: 'error',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    variant: 'warning',
+  },
+};
+
+export const Success: Story = {
+  args: {
+    variant: 'success',
+  },
+};
+
+export const Info: Story = {
+  args: {
+    variant: 'info',
+  },
+};

--- a/app/javascript/mastodon/components/callout_inline/index.tsx
+++ b/app/javascript/mastodon/components/callout_inline/index.tsx
@@ -25,7 +25,7 @@ const iconMap: Record<FieldStatus['variant'], React.FunctionComponent> = {
 
 export const CalloutInline: FC<
   Partial<FieldStatus> & React.ComponentPropsWithoutRef<'div'>
-> = ({ variant = 'error', className, children, ...props }) => {
+> = ({ variant = 'error', message, className, children, ...props }) => {
   return (
     <div
       {...props}
@@ -33,7 +33,7 @@ export const CalloutInline: FC<
       data-variant={variant}
     >
       <Icon id={variant} icon={iconMap[variant]} className={classes.icon} />
-      {children}
+      {message ?? children}
     </div>
   );
 };

--- a/app/javascript/mastodon/components/callout_inline/index.tsx
+++ b/app/javascript/mastodon/components/callout_inline/index.tsx
@@ -1,0 +1,39 @@
+import type { FC } from 'react';
+
+import classNames from 'classnames';
+
+import CheckIcon from '@/material-icons/400-24px/check.svg?react';
+import ErrorIcon from '@/material-icons/400-24px/error.svg?react';
+import InfoIcon from '@/material-icons/400-24px/info.svg?react';
+import WarningIcon from '@/material-icons/400-24px/warning.svg?react';
+
+import { Icon } from '../icon';
+
+import classes from './styles.module.css';
+
+export interface FieldStatus {
+  variant: 'error' | 'warning' | 'info' | 'success';
+  message?: string;
+}
+
+const iconMap: Record<FieldStatus['variant'], React.FunctionComponent> = {
+  error: ErrorIcon,
+  warning: WarningIcon,
+  info: InfoIcon,
+  success: CheckIcon,
+};
+
+export const CalloutInline: FC<
+  Partial<FieldStatus> & React.ComponentPropsWithoutRef<'div'>
+> = ({ variant = 'error', className, children, ...props }) => {
+  return (
+    <div
+      {...props}
+      className={classNames(className, classes.wrapper)}
+      data-variant={variant}
+    >
+      <Icon id={variant} icon={iconMap[variant]} className={classes.icon} />
+      {children}
+    </div>
+  );
+};

--- a/app/javascript/mastodon/components/callout_inline/styles.module.css
+++ b/app/javascript/mastodon/components/callout_inline/styles.module.css
@@ -1,0 +1,29 @@
+.wrapper {
+  display: flex;
+  align-items: start;
+  gap: 4px;
+  font-size: 13px;
+  font-weight: 500;
+
+  &[data-variant='success'] {
+    color: var(--color-text-success);
+  }
+
+  &[data-variant='warning'] {
+    color: var(--color-text-warning);
+  }
+
+  &[data-variant='error'] {
+    color: var(--color-text-error);
+  }
+
+  &[data-variant='info'] {
+    color: var(--color-text-primary);
+  }
+}
+
+.icon {
+  width: 16px;
+  height: 16px;
+  margin-top: 1px;
+}

--- a/app/javascript/mastodon/components/form_fields/checkbox_field.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/checkbox_field.stories.tsx
@@ -76,7 +76,7 @@ export const Optional: Story = {
 export const WithError: Story = {
   args: {
     required: false,
-    hasError: true,
+    status: 'error',
   },
 };
 

--- a/app/javascript/mastodon/components/form_fields/checkbox_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/checkbox_field.tsx
@@ -13,12 +13,12 @@ type Props = Omit<ComponentPropsWithoutRef<'input'>, 'type'> & {
 export const CheckboxField = forwardRef<
   HTMLInputElement,
   Props & CommonFieldWrapperProps
->(({ id, label, hint, hasError, required, ...otherProps }, ref) => (
+>(({ id, label, hint, status, required, ...otherProps }, ref) => (
   <FormFieldWrapper
     label={label}
     hint={hint}
     required={required}
-    hasError={hasError}
+    status={status}
     inputId={id}
     inputPlacement='inline-start'
   >

--- a/app/javascript/mastodon/components/form_fields/combobox_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/combobox_field.tsx
@@ -86,14 +86,14 @@ interface Props<T extends ComboboxItem>
  */
 
 export const ComboboxFieldWithRef = <T extends ComboboxItem>(
-  { id, label, hint, hasError, required, ...otherProps }: Props<T>,
+  { id, label, hint, status, required, ...otherProps }: Props<T>,
   ref: React.ForwardedRef<HTMLInputElement>,
 ) => (
   <FormFieldWrapper
     label={label}
     hint={hint}
     required={required}
-    hasError={hasError}
+    status={status}
     inputId={id}
   >
     {(inputProps) => <Combobox {...otherProps} {...inputProps} ref={ref} />}

--- a/app/javascript/mastodon/components/form_fields/copy_link_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/copy_link_field.tsx
@@ -22,7 +22,7 @@ interface CopyLinkFieldProps extends CommonFieldWrapperProps, TextInputProps {
 
 export const CopyLinkField = forwardRef<HTMLInputElement, CopyLinkFieldProps>(
   (
-    { id, label, hint, hasError, value, required, className, ...otherProps },
+    { id, label, hint, status, value, required, className, ...otherProps },
     ref,
   ) => {
     const intl = useIntl();
@@ -48,7 +48,7 @@ export const CopyLinkField = forwardRef<HTMLInputElement, CopyLinkFieldProps>(
         label={label}
         hint={hint}
         required={required}
-        hasError={hasError}
+        status={status}
         inputId={id}
       >
         {(inputProps) => (

--- a/app/javascript/mastodon/components/form_fields/emoji_text_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/emoji_text_field.tsx
@@ -37,7 +37,7 @@ export const EmojiTextInputField: FC<
   value,
   label,
   hint,
-  hasError,
+  status,
   maxLength,
   counterMax = maxLength,
   recommended,
@@ -49,7 +49,7 @@ export const EmojiTextInputField: FC<
   const wrapperProps = {
     label,
     hint,
-    hasError,
+    status,
     counterMax,
     recommended,
     disabled,
@@ -84,7 +84,7 @@ export const EmojiTextAreaField: FC<
   recommended,
   disabled,
   hint,
-  hasError,
+  status,
   ...otherProps
 }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -92,7 +92,7 @@ export const EmojiTextAreaField: FC<
   const wrapperProps = {
     label,
     hint,
-    hasError,
+    status,
     counterMax,
     recommended,
     disabled,

--- a/app/javascript/mastodon/components/form_fields/fieldset.module.scss
+++ b/app/javascript/mastodon/components/form_fields/fieldset.module.scss
@@ -1,7 +1,9 @@
 .fieldset {
+  --container-gap: 12px;
+
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--container-gap);
   color: var(--color-text-primary);
   font-size: 15px;
 }
@@ -15,5 +17,13 @@
     flex-direction: row;
     flex-wrap: wrap;
     column-gap: 24px;
+  }
+}
+
+.status {
+  // If there's no content, we need to compensate for the parent's
+  // flex gap to avoid extra spacing below the field.
+  &:empty {
+    margin-top: calc(-1 * var(--container-gap));
   }
 }

--- a/app/javascript/mastodon/components/form_fields/fieldset.tsx
+++ b/app/javascript/mastodon/components/form_fields/fieldset.tsx
@@ -3,18 +3,18 @@
 import type { ReactNode, FC } from 'react';
 import { createContext, useId } from 'react';
 
-import { A11yLiveRegion } from '../a11y_live_region';
+import { A11yLiveRegion } from 'mastodon/components/a11y_live_region';
+import type { FieldStatus } from 'mastodon/components/callout_inline';
 
 import classes from './fieldset.module.scss';
 import { getFieldStatus } from './form_field_wrapper';
-import type { FieldStatus } from './form_field_wrapper';
 import formFieldWrapperClasses from './form_field_wrapper.module.scss';
 
 interface FieldsetProps {
   legend: ReactNode;
   hint?: ReactNode;
   name?: string;
-  status?: FieldStatus | FieldStatus['type'];
+  status?: FieldStatus | FieldStatus['variant'];
   layout?: 'vertical' | 'horizontal';
   children: ReactNode;
 }

--- a/app/javascript/mastodon/components/form_fields/fieldset.tsx
+++ b/app/javascript/mastodon/components/form_fields/fieldset.tsx
@@ -3,14 +3,18 @@
 import type { ReactNode, FC } from 'react';
 import { createContext, useId } from 'react';
 
+import { A11yLiveRegion } from '../a11y_live_region';
+
 import classes from './fieldset.module.scss';
+import { getFieldStatus } from './form_field_wrapper';
+import type { FieldStatus } from './form_field_wrapper';
 import formFieldWrapperClasses from './form_field_wrapper.module.scss';
 
 interface FieldsetProps {
   legend: ReactNode;
   hint?: ReactNode;
   name?: string;
-  hasError?: boolean;
+  status?: FieldStatus | FieldStatus['type'];
   layout?: 'vertical' | 'horizontal';
   children: ReactNode;
 }
@@ -26,22 +30,29 @@ export const Fieldset: FC<FieldsetProps> = ({
   legend,
   hint,
   name,
-  hasError,
+  status,
   layout,
   children,
 }) => {
   const uniqueId = useId();
   const labelId = `${uniqueId}-label`;
   const hintId = `${uniqueId}-hint`;
+  const statusId = `${uniqueId}-status`;
   const fieldsetName = name || `${uniqueId}-fieldset-name`;
   const hasHint = !!hint;
+
+  const fieldStatus = getFieldStatus(status);
+
+  const descriptionIds = [hasHint ? hintId : '', fieldStatus ? statusId : '']
+    .filter((id) => !!id)
+    .join(' ');
 
   return (
     <fieldset
       className={classes.fieldset}
-      data-has-error={hasError}
+      data-has-error={status === 'error'}
       aria-labelledby={labelId}
-      aria-describedby={hintId}
+      aria-describedby={descriptionIds}
     >
       <div className={formFieldWrapperClasses.labelWrapper}>
         <div id={labelId} className={formFieldWrapperClasses.label}>
@@ -59,6 +70,11 @@ export const Fieldset: FC<FieldsetProps> = ({
           {children}
         </FieldsetNameContext.Provider>
       </div>
+
+      {/* Live region must be rendered even when empty */}
+      <A11yLiveRegion className={classes.status} id={statusId}>
+        {fieldStatus?.message}
+      </A11yLiveRegion>
     </fieldset>
   );
 };

--- a/app/javascript/mastodon/components/form_fields/fieldset.tsx
+++ b/app/javascript/mastodon/components/form_fields/fieldset.tsx
@@ -5,6 +5,7 @@ import { createContext, useId } from 'react';
 
 import { A11yLiveRegion } from 'mastodon/components/a11y_live_region';
 import type { FieldStatus } from 'mastodon/components/callout_inline';
+import { CalloutInline } from 'mastodon/components/callout_inline';
 
 import classes from './fieldset.module.scss';
 import { getFieldStatus } from './form_field_wrapper';
@@ -42,8 +43,12 @@ export const Fieldset: FC<FieldsetProps> = ({
   const hasHint = !!hint;
 
   const fieldStatus = getFieldStatus(status);
+  const hasStatusMessage = !!fieldStatus?.message;
 
-  const descriptionIds = [hasHint ? hintId : '', fieldStatus ? statusId : '']
+  const descriptionIds = [
+    hasHint ? hintId : '',
+    hasStatusMessage ? statusId : '',
+  ]
     .filter((id) => !!id)
     .join(' ');
 
@@ -73,7 +78,7 @@ export const Fieldset: FC<FieldsetProps> = ({
 
       {/* Live region must be rendered even when empty */}
       <A11yLiveRegion className={classes.status} id={statusId}>
-        {fieldStatus?.message}
+        {hasStatusMessage && <CalloutInline {...fieldStatus} />}
       </A11yLiveRegion>
     </fieldset>
   );

--- a/app/javascript/mastodon/components/form_fields/form_field_wrapper.module.scss
+++ b/app/javascript/mastodon/components/form_fields/form_field_wrapper.module.scss
@@ -46,6 +46,14 @@
   font-size: 13px;
 }
 
+.status {
+  // If there's no content, we need to compensate for the parent's
+  // flex gap to avoid extra spacing below the field.
+  &:empty {
+    margin-top: calc(-1 * var(--form-field-label-gap));
+  }
+}
+
 .inputWrapper {
   display: block;
 }

--- a/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
+++ b/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
@@ -7,6 +7,8 @@ import { FormattedMessage } from 'react-intl';
 
 import classNames from 'classnames';
 
+import { A11yLiveRegion } from '../a11y_live_region';
+
 import { FieldsetNameContext } from './fieldset';
 import classes from './form_field_wrapper.module.scss';
 
@@ -16,11 +18,16 @@ export interface InputProps {
   'aria-describedby'?: string;
 }
 
+interface FieldStatus {
+  type: 'error' | 'warning' | 'success';
+  message?: string;
+}
+
 interface FieldWrapperProps {
   label: ReactNode;
   hint?: ReactNode;
   required?: boolean;
-  hasError?: boolean;
+  status?: FieldStatus['type'] | FieldStatus;
   inputId?: string;
   describedById?: string;
   inputPlacement?: 'inline-start' | 'inline-end';
@@ -33,7 +40,7 @@ interface FieldWrapperProps {
  */
 export type CommonFieldWrapperProps = Pick<
   FieldWrapperProps,
-  'label' | 'hint' | 'hasError'
+  'label' | 'hint' | 'status'
 > & { wrapperClassName?: string };
 
 /**
@@ -48,15 +55,17 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
   hint,
   describedById,
   required,
-  hasError,
+  status,
   inputPlacement,
   children,
   className,
 }) => {
   const uniqueId = useId();
   const inputId = inputIdProp || `${uniqueId}-input`;
+  const statusId = `${inputIdProp || uniqueId}-status`;
   const hintId = `${inputIdProp || uniqueId}-hint`;
   const hasHint = !!hint;
+  const fieldStatus = getFieldStatus(status);
 
   const hasParentFieldset = !!useContext(FieldsetNameContext);
 
@@ -64,7 +73,7 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
     required,
     id: inputId,
   };
-  if (hasHint) {
+  if (hasHint || status || describedById) {
     inputProps['aria-describedby'] = describedById
       ? `${describedById} ${hintId}`
       : hintId;
@@ -77,7 +86,7 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
   return (
     <div
       className={classNames(classes.wrapper, className)}
-      data-has-error={hasError}
+      data-has-error={fieldStatus?.type === 'error'}
       data-input-placement={inputPlacement}
     >
       {inputPlacement === 'inline-start' && input}
@@ -100,6 +109,10 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
       </div>
 
       {inputPlacement !== 'inline-start' && input}
+
+      <A11yLiveRegion className={classes.status} id={statusId}>
+        {fieldStatus?.message}
+      </A11yLiveRegion>
     </div>
   );
 };
@@ -121,3 +134,19 @@ const RequiredMark: FC<{ required?: boolean }> = ({ required }) =>
       <FormattedMessage id='form_field.optional' defaultMessage='(optional)' />
     </>
   );
+
+function getFieldStatus(status: FieldWrapperProps['status']) {
+  if (!status) {
+    return null;
+  }
+
+  if (typeof status === 'string') {
+    const fieldStatus: FieldStatus = {
+      type: status,
+      message: '',
+    };
+    return fieldStatus;
+  }
+
+  return status;
+}

--- a/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
+++ b/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
@@ -18,7 +18,7 @@ export interface InputProps {
   'aria-describedby'?: string;
 }
 
-interface FieldStatus {
+export interface FieldStatus {
   type: 'error' | 'warning' | 'success';
   message?: string;
 }
@@ -69,15 +69,16 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
 
   const hasParentFieldset = !!useContext(FieldsetNameContext);
 
+  const descriptionIds =
+    [hasHint ? hintId : '', fieldStatus ? statusId : '', describedById]
+      .filter((id) => !!id)
+      .join(' ') || undefined;
+
   const inputProps: InputProps = {
     required,
     id: inputId,
+    'aria-describedby': descriptionIds,
   };
-  if (hasHint || status || describedById) {
-    inputProps['aria-describedby'] = describedById
-      ? `${describedById} ${hintId}`
-      : hintId;
-  }
 
   const input = (
     <div className={classes.inputWrapper}>{children(inputProps)}</div>
@@ -110,6 +111,7 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
 
       {inputPlacement !== 'inline-start' && input}
 
+      {/* Live region must be rendered even when empty */}
       <A11yLiveRegion className={classes.status} id={statusId}>
         {fieldStatus?.message}
       </A11yLiveRegion>
@@ -135,7 +137,7 @@ const RequiredMark: FC<{ required?: boolean }> = ({ required }) =>
     </>
   );
 
-function getFieldStatus(status: FieldWrapperProps['status']) {
+export function getFieldStatus(status: FieldWrapperProps['status']) {
   if (!status) {
     return null;
   }

--- a/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
+++ b/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
@@ -9,6 +9,7 @@ import classNames from 'classnames';
 
 import { A11yLiveRegion } from 'mastodon/components/a11y_live_region';
 import type { FieldStatus } from 'mastodon/components/callout_inline';
+import { CalloutInline } from 'mastodon/components/callout_inline';
 
 import { FieldsetNameContext } from './fieldset';
 import classes from './form_field_wrapper.module.scss';
@@ -62,11 +63,12 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
   const hintId = `${inputIdProp || uniqueId}-hint`;
   const hasHint = !!hint;
   const fieldStatus = getFieldStatus(status);
+  const hasStatusMessage = !!fieldStatus?.message;
 
   const hasParentFieldset = !!useContext(FieldsetNameContext);
 
   const descriptionIds =
-    [hasHint ? hintId : '', fieldStatus ? statusId : '', describedById]
+    [hasHint ? hintId : '', hasStatusMessage ? statusId : '', describedById]
       .filter((id) => !!id)
       .join(' ') || undefined;
 
@@ -109,7 +111,7 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
 
       {/* Live region must be rendered even when empty */}
       <A11yLiveRegion className={classes.status} id={statusId}>
-        {fieldStatus?.message}
+        {hasStatusMessage && <CalloutInline {...fieldStatus} />}
       </A11yLiveRegion>
     </div>
   );

--- a/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
+++ b/app/javascript/mastodon/components/form_fields/form_field_wrapper.tsx
@@ -7,7 +7,8 @@ import { FormattedMessage } from 'react-intl';
 
 import classNames from 'classnames';
 
-import { A11yLiveRegion } from '../a11y_live_region';
+import { A11yLiveRegion } from 'mastodon/components/a11y_live_region';
+import type { FieldStatus } from 'mastodon/components/callout_inline';
 
 import { FieldsetNameContext } from './fieldset';
 import classes from './form_field_wrapper.module.scss';
@@ -18,16 +19,11 @@ export interface InputProps {
   'aria-describedby'?: string;
 }
 
-export interface FieldStatus {
-  type: 'error' | 'warning' | 'success';
-  message?: string;
-}
-
 interface FieldWrapperProps {
   label: ReactNode;
   hint?: ReactNode;
   required?: boolean;
-  status?: FieldStatus['type'] | FieldStatus;
+  status?: FieldStatus['variant'] | FieldStatus;
   inputId?: string;
   describedById?: string;
   inputPlacement?: 'inline-start' | 'inline-end';
@@ -87,7 +83,7 @@ export const FormFieldWrapper: FC<FieldWrapperProps> = ({
   return (
     <div
       className={classNames(classes.wrapper, className)}
-      data-has-error={fieldStatus?.type === 'error'}
+      data-has-error={fieldStatus?.variant === 'error'}
       data-input-placement={inputPlacement}
     >
       {inputPlacement === 'inline-start' && input}
@@ -144,7 +140,7 @@ export function getFieldStatus(status: FieldWrapperProps['status']) {
 
   if (typeof status === 'string') {
     const fieldStatus: FieldStatus = {
-      type: status,
+      variant: status,
       message: '',
     };
     return fieldStatus;

--- a/app/javascript/mastodon/components/form_fields/radio_button_field.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/radio_button_field.stories.tsx
@@ -71,7 +71,7 @@ export const Optional: Story = {
 export const WithError: Story = {
   args: {
     required: false,
-    hasError: true,
+    status: 'error',
   },
 };
 

--- a/app/javascript/mastodon/components/form_fields/radio_button_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/radio_button_field.tsx
@@ -15,7 +15,7 @@ type Props = Omit<ComponentPropsWithoutRef<'input'>, 'type'> & {
 export const RadioButtonField = forwardRef<
   HTMLInputElement,
   Props & CommonFieldWrapperProps
->(({ id, label, hint, hasError, required, ...otherProps }, ref) => {
+>(({ id, label, hint, status, required, ...otherProps }, ref) => {
   const fieldsetName = useContext(FieldsetNameContext);
 
   return (
@@ -23,7 +23,7 @@ export const RadioButtonField = forwardRef<
       label={label}
       hint={hint}
       required={required}
-      hasError={hasError}
+      status={status}
       inputId={id}
       inputPlacement='inline-start'
     >

--- a/app/javascript/mastodon/components/form_fields/select_field.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/select_field.stories.tsx
@@ -51,7 +51,7 @@ export const Optional: Story = {
 export const WithError: Story = {
   args: {
     required: false,
-    hasError: true,
+    status: 'error',
   },
 };
 

--- a/app/javascript/mastodon/components/form_fields/select_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/select_field.tsx
@@ -19,12 +19,12 @@ interface Props
  */
 
 export const SelectField = forwardRef<HTMLSelectElement, Props>(
-  ({ id, label, hint, required, hasError, children, ...otherProps }, ref) => (
+  ({ id, label, hint, required, status, children, ...otherProps }, ref) => (
     <FormFieldWrapper
       label={label}
       hint={hint}
       required={required}
-      hasError={hasError}
+      status={status}
       inputId={id}
     >
       {(inputProps) => (

--- a/app/javascript/mastodon/components/form_fields/text_area_field.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/text_area_field.stories.tsx
@@ -42,6 +42,16 @@ export const WithError: Story = {
   },
 };
 
+export const WithWarning: Story = {
+  args: {
+    required: false,
+    status: {
+      variant: 'warning',
+      message: 'Special characters are not allowed',
+    },
+  },
+};
+
 export const AutoSize: Story = {
   args: {
     autoSize: true,

--- a/app/javascript/mastodon/components/form_fields/text_area_field.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/text_area_field.stories.tsx
@@ -38,7 +38,7 @@ export const Optional: Story = {
 export const WithError: Story = {
   args: {
     required: false,
-    hasError: true,
+    status: { type: 'error', message: "This field can't be empty" },
   },
 };
 

--- a/app/javascript/mastodon/components/form_fields/text_area_field.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/text_area_field.stories.tsx
@@ -38,7 +38,7 @@ export const Optional: Story = {
 export const WithError: Story = {
   args: {
     required: false,
-    status: { type: 'error', message: "This field can't be empty" },
+    status: { variant: 'error', message: "This field can't be empty" },
   },
 };
 

--- a/app/javascript/mastodon/components/form_fields/text_area_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/text_area_field.tsx
@@ -26,14 +26,14 @@ export const TextAreaField = forwardRef<
   TextAreaProps & CommonFieldWrapperProps
 >(
   (
-    { id, label, hint, required, hasError, wrapperClassName, ...otherProps },
+    { id, label, hint, required, status, wrapperClassName, ...otherProps },
     ref,
   ) => (
     <FormFieldWrapper
       label={label}
       hint={hint}
       required={required}
-      hasError={hasError}
+      status={status}
       inputId={id}
       className={wrapperClassName}
     >

--- a/app/javascript/mastodon/components/form_fields/text_input.module.scss
+++ b/app/javascript/mastodon/components/form_fields/text_input.module.scss
@@ -29,14 +29,14 @@
     color: var(--color-text-secondary);
   }
 
-  &:focus {
-    outline-color: var(--color-text-brand);
-  }
-
   &:focus:user-invalid,
   &:required:user-invalid,
   [data-has-error='true'] & {
     outline-color: var(--color-text-error);
+  }
+
+  &:focus {
+    outline-color: var(--color-text-brand);
   }
 
   &:required:user-valid {

--- a/app/javascript/mastodon/components/form_fields/text_input_field.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/text_input_field.stories.tsx
@@ -44,6 +44,16 @@ export const WithError: Story = {
   },
 };
 
+export const WithWarning: Story = {
+  args: {
+    required: false,
+    status: {
+      variant: 'warning',
+      message: 'Special characters are not allowed',
+    },
+  },
+};
+
 export const WithIcon: Story = {
   args: {
     label: 'Search',

--- a/app/javascript/mastodon/components/form_fields/text_input_field.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/text_input_field.stories.tsx
@@ -40,7 +40,7 @@ export const Optional: Story = {
 export const WithError: Story = {
   args: {
     required: false,
-    hasError: true,
+    status: 'error',
   },
 };
 

--- a/app/javascript/mastodon/components/form_fields/text_input_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/text_input_field.tsx
@@ -25,14 +25,14 @@ interface Props extends TextInputProps, CommonFieldWrapperProps {}
 
 export const TextInputField = forwardRef<HTMLInputElement, Props>(
   (
-    { id, label, hint, hasError, required, wrapperClassName, ...otherProps },
+    { id, label, hint, status, required, wrapperClassName, ...otherProps },
     ref,
   ) => (
     <FormFieldWrapper
       label={label}
       hint={hint}
       required={required}
-      hasError={hasError}
+      status={status}
       inputId={id}
       className={wrapperClassName}
     >

--- a/app/javascript/mastodon/components/form_fields/toggle_field.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/toggle_field.stories.tsx
@@ -45,7 +45,7 @@ export const Optional: Story = {
 export const WithError: Story = {
   args: {
     required: false,
-    hasError: true,
+    status: 'error',
   },
 };
 

--- a/app/javascript/mastodon/components/form_fields/toggle_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/toggle_field.tsx
@@ -14,12 +14,12 @@ type Props = Omit<ComponentPropsWithoutRef<'input'>, 'type'> & {
 export const ToggleField = forwardRef<
   HTMLInputElement,
   Props & CommonFieldWrapperProps
->(({ id, label, hint, hasError, required, ...otherProps }, ref) => (
+>(({ id, label, hint, status, required, ...otherProps }, ref) => (
   <FormFieldWrapper
     label={label}
     hint={hint}
     required={required}
-    hasError={hasError}
+    status={status}
     inputId={id}
     inputPlacement='inline-end'
   >

--- a/app/javascript/mastodon/features/account_timeline/modals/note_modal.tsx
+++ b/app/javascript/mastodon/features/account_timeline/modals/note_modal.tsx
@@ -143,7 +143,7 @@ const InnerNodeModal: FC<{
             className={classes.noteInput}
             status={
               state === 'error'
-                ? { type: 'error', message: errorText }
+                ? { variant: 'error', message: errorText }
                 : undefined
             }
             // eslint-disable-next-line jsx-a11y/no-autofocus -- We want to focus here as it's a modal.

--- a/app/javascript/mastodon/features/account_timeline/modals/note_modal.tsx
+++ b/app/javascript/mastodon/features/account_timeline/modals/note_modal.tsx
@@ -141,8 +141,11 @@ const InnerNodeModal: FC<{
             onChange={handleChange}
             label={intl.formatMessage(messages.fieldLabel)}
             className={classes.noteInput}
-            hasError={state === 'error'}
-            hint={errorText}
+            status={
+              state === 'error'
+                ? { type: 'error', message: errorText }
+                : undefined
+            }
             // eslint-disable-next-line jsx-a11y/no-autofocus -- We want to focus here as it's a modal.
             autoFocus
           />

--- a/app/javascript/mastodon/features/collections/editor/details.tsx
+++ b/app/javascript/mastodon/features/collections/editor/details.tsx
@@ -1,12 +1,15 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useHistory } from 'react-router-dom';
 
 import { isFulfilled } from '@reduxjs/toolkit';
 
-import { inputToHashtag } from '@/mastodon/utils/hashtags';
+import {
+  hasSpecialCharacters,
+  inputToHashtag,
+} from '@/mastodon/utils/hashtags';
 import type {
   ApiCreateCollectionPayload,
   ApiUpdateCollectionPayload,
@@ -31,6 +34,7 @@ import classes from './styles.module.scss';
 import { WizardStepHeader } from './wizard_step_header';
 
 export const CollectionDetails: React.FC = () => {
+  const intl = useIntl();
   const dispatch = useAppDispatch();
   const history = useHistory();
   const { id, name, description, topic, discoverable, sensitive, accountIds } =
@@ -152,6 +156,11 @@ export const CollectionDetails: React.FC = () => {
     ],
   );
 
+  const topicHasSpecialCharacters = useMemo(
+    () => hasSpecialCharacters(topic),
+    [topic],
+  );
+
   return (
     <form onSubmit={handleSubmit} className={classes.form}>
       <FormStack className={classes.formFieldStack}>
@@ -224,6 +233,18 @@ export const CollectionDetails: React.FC = () => {
           autoCorrect='off'
           spellCheck='false'
           maxLength={40}
+          status={
+            topicHasSpecialCharacters
+              ? {
+                  variant: 'warning',
+                  message: intl.formatMessage({
+                    id: 'collections.topic_special_chars_hint',
+                    defaultMessage:
+                      'Special characters will be removed when saving',
+                  }),
+                }
+              : undefined
+          }
         />
 
         <Fieldset

--- a/app/javascript/mastodon/features/onboarding/profile.tsx
+++ b/app/javascript/mastodon/features/onboarding/profile.tsx
@@ -230,7 +230,7 @@ export const Profile: React.FC<{
               }
               value={displayName}
               onChange={handleDisplayNameChange}
-              hasError={!!errors?.display_name}
+              status={errors?.display_name ? 'error' : undefined}
               id='display_name'
             />
           </div>
@@ -252,7 +252,7 @@ export const Profile: React.FC<{
               }
               value={note}
               onChange={handleNoteChange}
-              hasError={!!errors?.note}
+              status={errors?.note ? 'error' : undefined}
               id='note'
             />
           </div>

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -369,6 +369,7 @@
   "collections.search_accounts_max_reached": "You have added the maximum number of accounts",
   "collections.sensitive": "Sensitive",
   "collections.topic_hint": "Add a hashtag that helps others understand the main topic of this collection.",
+  "collections.topic_special_chars_hint": "Special characters will be removed when saving",
   "collections.view_collection": "View collection",
   "collections.view_other_collections_by_user": "View other collections by this user",
   "collections.visibility_public": "Public",

--- a/app/javascript/mastodon/reducers/slices/collections.ts
+++ b/app/javascript/mastodon/reducers/slices/collections.ts
@@ -23,6 +23,7 @@ import {
   createAppSelector,
   createDataLoadingThunk,
 } from '@/mastodon/store/typed_functions';
+import { inputToHashtag } from '@/mastodon/utils/hashtags';
 
 type QueryStatus = 'idle' | 'loading' | 'error';
 
@@ -82,7 +83,7 @@ const collectionSlice = createSlice({
         id: collection?.id ?? null,
         name: collection?.name ?? '',
         description: collection?.description ?? '',
-        topic: collection?.tag?.name ?? '',
+        topic: inputToHashtag(collection?.tag?.name ?? ''),
         language: collection?.language ?? '',
         discoverable: collection?.discoverable ?? true,
         sensitive: collection?.sensitive ?? false,

--- a/app/javascript/mastodon/utils/hashtags.ts
+++ b/app/javascript/mastodon/utils/hashtags.ts
@@ -59,3 +59,8 @@ export const inputToHashtag = (input: string): string => {
 
   return `#${words.join('')}${trailingSpace}`;
 };
+
+export const hasSpecialCharacters = (input: string) => {
+  // Regex matches any character NOT a letter/digit, except the #
+  return /[^a-zA-Z0-9# ]/.test(input);
+};


### PR DESCRIPTION
Fixes WEB-852

### Changes proposed in this PR:
- Adds new `A11yLiveRegion` component for live regions (screen reader announcements)
- Adds new `CalloutInline` component (a small callout for warnings or errors next to form fields)
- Changes the `hasError` props in `FormFieldWrapper` and `Fieldset` to `status`, using the interface of the `CalloutInline` component
- Uses this to point out special characters in the Collection Topic field
- Fixes minor issues in the assembly of ids for the `aria-describedby` attribute in `FormFieldWrapper` and `Fieldset`

### Screenshots

<img width="593" height="133" alt="image" src="https://github.com/user-attachments/assets/bdc0808f-d1c1-4af6-840b-4200b8fd97fc" />

Storybook:
<img width="255" height="170" alt="image" src="https://github.com/user-attachments/assets/fc6a720e-c720-415e-8167-6159e216c291" />
