### PR TITLE
Use `data-` attribute hash expansion in views

### DIFF
--- a/app/views/admin/rules/edit.html.haml
+++ b/app/views/admin/rules/edit.html.haml
@@ -24,7 +24,7 @@
       %tfoot
         %tr
           %td{ colspan: 3 }
-            = link_to_add_association form, :translations, class: 'table-action-link', partial: 'translation_fields', 'data-association-insertion-node': '.keywords-table tbody', 'data-association-insertion-method': 'append' do
+            = link_to_add_association form, :translations, class: 'table-action-link', partial: 'translation_fields', data: { association_insertion_node: '.keywords-table tbody', association_insertion_method: 'append' } do
               = safe_join([material_symbol('add'), t('admin.rules.add_translation')])
 
   .actions

--- a/app/views/filters/_filter_fields.html.haml
+++ b/app/views/filters/_filter_fields.html.haml
@@ -57,5 +57,5 @@
     %tfoot
       %tr
         %td{ colspan: 3 }
-          = link_to_add_association f, :keywords, class: 'table-action-link', partial: 'keyword_fields', 'data-association-insertion-node': '.keywords-table tbody', 'data-association-insertion-method': 'append' do
+          = link_to_add_association f, :keywords, class: 'table-action-link', partial: 'keyword_fields', data: { association_insertion_node: '.keywords-table tbody', association_insertion_method: 'append' } do
             = safe_join([material_symbol('add'), t('filters.edit.add_keyword')])

--- a/app/views/layouts/embedded.html.haml
+++ b/app/views/layouts/embedded.html.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{ lang: I18n.locale, 'data-contrast': 'auto', 'data-color-scheme': 'light' }
+%html{ lang: I18n.locale, data: { contrast: 'auto', color_scheme: 'light' } }
   %head
     %meta{ charset: 'utf-8' }/
     %meta{ name: 'robots', content: 'noindex' }/

--- a/app/views/layouts/error.html.haml
+++ b/app/views/layouts/error.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html{ lang: I18n.locale, 'data-contrast': 'auto', 'data-color-scheme': 'auto' }
+%html{ lang: I18n.locale, data: { contrast: 'auto', color_scheme: 'auto' } }
   %head
     %meta{ 'content' => 'text/html; charset=UTF-8', 'http-equiv' => 'Content-Type' }/
     %meta{ charset: 'utf-8' }/


### PR DESCRIPTION
Any `data: ...` hashes will be expanded into attributes and dasherized to generated `data-*` attributes in the html.

Basically a consistency thing to match what the rails-ujs (now native) stuff looks like with `data-method` and `data-confirm`, and also what some of the React `data-props` stuff does as well.

Side note - cocoon at this point is unmaintained, only used in these two spots (I think?) and there are multiple current approaches (in the turbo/stimulus ecosystem) to doing this dynamic field addition. Might be worth a review similar to what we did with rails-ujs stuff, and either update to those techniques, build native, etc. On the other hand, its not broken, so maybe fine to leave.