### PR TITLE
Normalize `current_username` on account migration

### DIFF
--- a/app/models/account_migration.rb
+++ b/app/models/account_migration.rb
@@ -25,7 +25,10 @@ class AccountMigration < ApplicationRecord
   before_validation :set_target_account
   before_validation :set_followers_count
 
+  attribute :current_username, :string
+
   normalizes :acct, with: ->(acct) { acct.strip.delete_prefix('@') }
+  normalizes :current_username, with: ->(value) { value.strip.delete_prefix('@') }
 
   validates :acct, presence: true, domain: { acct: true }
   validate :validate_migration_cooldown
@@ -33,7 +36,7 @@ class AccountMigration < ApplicationRecord
 
   scope :within_cooldown, -> { where(created_at: cooldown_duration_ago..) }
 
-  attr_accessor :current_password, :current_username
+  attr_accessor :current_password
 
   def self.cooldown_duration_ago
     Time.current - COOLDOWN_PERIOD

--- a/spec/models/account_migration_spec.rb
+++ b/spec/models/account_migration_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe AccountMigration do
     describe 'acct' do
       it { is_expected.to normalize(:acct).from('  @username@domain  ').to('username@domain') }
     end
+
+    describe 'current_username' do
+      it { is_expected.to normalize(:current_username).from('  @username  ').to('username') }
+    end
   end
 
   describe 'Validations' do

--- a/spec/system/settings/migrations_spec.rb
+++ b/spec/system/settings/migrations_spec.rb
@@ -33,20 +33,36 @@ RSpec.describe 'Settings Migrations' do
   end
 
   describe 'Creating migrations' do
-    let(:user) { Fabricate(:user, password: '12345678') }
+    let(:user) { Fabricate(:user, password:) }
+    let(:password) { '12345678' }
 
     before { sign_in(user) }
 
     context 'when migration account is changed' do
       let(:acct) { Fabricate(:account, also_known_as: [ActivityPub::TagManager.instance.uri_for(user.account)]) }
 
-      it 'updates moved to account' do
-        visit settings_migration_path
+      context 'when user has encrypted password' do
+        it 'updates moved to account' do
+          visit settings_migration_path
 
-        expect { fill_in_and_submit }
-          .to(change { user.account.reload.moved_to_account_id }.to(acct.id))
-        expect(page)
-          .to have_content(I18n.t('settings.migrate'))
+          expect { fill_in_and_submit }
+            .to(change { user.account.reload.moved_to_account_id }.to(acct.id))
+          expect(page)
+            .to have_content(I18n.t('settings.migrate'))
+        end
+      end
+
+      context 'when user has blank encrypted password value' do
+        before { user.update! encrypted_password: '' }
+
+        it 'updates moved to account using at-username value' do
+          visit settings_migration_path
+
+          expect { fill_in_and_submit_via_username("@#{user.account.username}") }
+            .to(change { user.account.reload.moved_to_account_id }.to(acct.id))
+          expect(page)
+            .to have_content(I18n.t('settings.migrate'))
+        end
       end
     end
 
@@ -92,8 +108,18 @@ RSpec.describe 'Settings Migrations' do
 
     def fill_in_and_submit
       fill_in 'account_migration_acct', with: acct.username
-      fill_in 'account_migration_current_password', with: '12345678'
+      if block_given?
+        yield
+      else
+        fill_in 'account_migration_current_password', with: password
+      end
       click_on I18n.t('migrations.proceed_with_move')
+    end
+
+    def fill_in_and_submit_via_username(username)
+      fill_in_and_submit do
+        fill_in 'account_migration_current_username', with: username
+      end
     end
   end
 end


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/discussions/36855

This improves a failure mode from that issue ... if someone entered a full `@username` (instead of just `username`), or they added something space-padded, we would currently mark it invalid. This change...

- Converts the `current_username` attr to an attribute
- Adds a normalizer to strip and remove leading at sign
- Adds example for the no-encrypted-password path which gets you to this screen in the first place, and within that scenario, submits with an `@username` style value to hit this path

Possible followups here:

- Improve the error message and/or validator copy? Its currently pretty ambiguous as to what is wrong.
- Handle the full-domain scenario better ... I'm not sure if its safe/expected to just totally drop the domain portion. If so, we could probably add to normalizer as well. If not, maybe better instructions/errors makes that better too