### PR TITLE
A11y improvements on login & settings pages

### DIFF
--- a/app/helpers/branding_helper.rb
+++ b/app/helpers/branding_helper.rb
@@ -11,11 +11,14 @@ module BrandingHelper
   end
 
   def _logo_as_symbol_wordmark
-    content_tag(:svg, tag.use(href: '#logo-symbol-wordmark'), viewBox: '0 0 261 66', class: 'logo logo--wordmark')
+    tag.svg(viewBox: '0 0 261 66', class: 'logo logo--wordmark') do
+      tag.title('Mastodon') +
+        tag.use(href: '#logo-symbol-wordmark')
+    end
   end
 
   def _logo_as_symbol_icon
-    content_tag(:svg, tag.use(href: '#logo-symbol-icon'), viewBox: '0 0 79 79', class: 'logo logo--icon')
+    tag.svg(tag.use(href: '#logo-symbol-icon'), viewBox: '0 0 79 79', class: 'logo logo--icon')
   end
 
   def render_logo

--- a/app/javascript/styles/mastodon/containers.scss
+++ b/app/javascript/styles/mastodon/containers.scss
@@ -13,22 +13,28 @@
 .logo-container {
   margin: 50px auto;
 
-  .logo {
-    height: 42px;
-    margin-inline-end: 10px;
-  }
-
   a {
     display: flex;
     justify-content: center;
     align-items: center;
+    width: min-content;
+    margin: 0 auto;
+    padding: 12px 16px;
     color: var(--color-text-primary);
     text-decoration: none;
     outline: 0;
-    padding: 12px 16px;
     line-height: 32px;
     font-weight: 500;
     font-size: 14px;
+
+    &:focus-visible {
+      outline: var(--outline-focus-default);
+    }
+  }
+
+  .logo {
+    height: 42px;
+    margin-inline-end: 10px;
   }
 }
 

--- a/app/javascript/styles/mastodon/containers.scss
+++ b/app/javascript/styles/mastodon/containers.scss
@@ -13,28 +13,22 @@
 .logo-container {
   margin: 50px auto;
 
-  h1 {
+  .logo {
+    height: 42px;
+    margin-inline-end: 10px;
+  }
+
+  a {
     display: flex;
     justify-content: center;
     align-items: center;
-
-    .logo {
-      height: 42px;
-      margin-inline-end: 10px;
-    }
-
-    a {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: var(--color-text-primary);
-      text-decoration: none;
-      outline: 0;
-      padding: 12px 16px;
-      line-height: 32px;
-      font-weight: 500;
-      font-size: 14px;
-    }
+    color: var(--color-text-primary);
+    text-decoration: none;
+    outline: 0;
+    padding: 12px 16px;
+    line-height: 32px;
+    font-weight: 500;
+    font-size: 14px;
   }
 }
 

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -470,13 +470,19 @@ code {
     }
   }
 
-  .input.radio_buttons .radio label {
-    margin-bottom: 5px;
-    font-family: inherit;
-    font-size: 14px;
-    color: var(--color-text-primary);
-    display: block;
-    width: auto;
+  .input.radio_buttons .radio {
+    label {
+      margin-bottom: 5px;
+      font-family: inherit;
+      font-size: 14px;
+      color: var(--color-text-primary);
+      display: block;
+      width: auto;
+    }
+
+    input[type='radio'] {
+      accent-color: var(--color-text-brand);
+    }
   }
 
   .check_boxes {
@@ -499,6 +505,12 @@ code {
         top: 5px;
         margin: 0;
       }
+    }
+  }
+
+  label.checkbox {
+    input[type='checkbox'] {
+      accent-color: var(--color-text-brand);
     }
   }
 

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -77,7 +77,6 @@ code {
 
   .input {
     margin-bottom: 16px;
-    overflow: hidden;
 
     &:last-child {
       margin-bottom: 0;
@@ -523,13 +522,20 @@ code {
     color: var(--color-text-primary);
     display: block;
     width: 100%;
-    outline: 0;
     font-family: inherit;
     resize: vertical;
     background: var(--color-bg-secondary);
     border: 1px solid var(--color-border-primary);
     border-radius: 4px;
     padding: 10px 16px;
+    outline: var(--outline-focus-default);
+    outline-offset: -2px;
+    outline-color: transparent;
+    transition: outline-color 0.15s ease-out;
+
+    &:focus {
+      outline: var(--outline-focus-default);
+    }
 
     &:invalid {
       box-shadow: none;
@@ -613,6 +619,11 @@ code {
       margin-inline-end: 0;
     }
 
+    &:focus-visible {
+      outline: var(--outline-focus-default);
+      outline-offset: 2px;
+    }
+
     &:active,
     &:focus,
     &:hover {
@@ -652,6 +663,11 @@ code {
     padding-inline-start: 10px;
     padding-inline-end: 30px;
     height: 41px;
+
+    &:focus-visible {
+      outline: var(--outline-focus-default);
+      outline-offset: 2px;
+    }
 
     @media screen and (width <= 600px) {
       font-size: 16px;

--- a/app/views/auth/sessions/new.html.haml
+++ b/app/views/auth/sessions/new.html.haml
@@ -12,6 +12,7 @@
       - if use_seamless_external_login?
         = f.input :email,
                   autofocus: true,
+                  required: true,
                   hint: false,
                   input_html: { 'aria-label': t('simple_form.labels.defaults.username_or_email') },
                   label: t('simple_form.labels.defaults.username_or_email'),
@@ -19,12 +20,14 @@
       - else
         = f.input :email,
                   autofocus: true,
+                  required: true,
                   hint: false,
                   input_html: { 'aria-label': t('simple_form.labels.defaults.email') },
                   label: t('simple_form.labels.defaults.email'),
                   wrapper: :with_label
     .fields-group
       = f.input :password,
+                required: true,
                 hint: false,
                 input_html: { 'aria-label': t('simple_form.labels.defaults.password'), autocomplete: 'current-password' },
                 label: t('simple_form.labels.defaults.password'),

--- a/app/views/layouts/auth.html.haml
+++ b/app/views/layouts/auth.html.haml
@@ -4,12 +4,11 @@
 - content_for :content do
   .container-alt
     .logo-container
-      %h1
-        - if within_authorization_flow?
+      - if within_authorization_flow?
+        = logo_as_symbol(:wordmark)
+      - else
+        = link_to root_path do
           = logo_as_symbol(:wordmark)
-        - else
-          = link_to root_path do
-            = logo_as_symbol(:wordmark)
 
     .form-container
       = render 'flashes'


### PR DESCRIPTION
Related to WEB-697
Related to WEB-881
Related to #19931

### Changes proposed in this PR:
- Adds focus outlines to all focusable elements on the login page (they were previously missing from the logo link and the text inputs)
- Added focus outlines to `simple_form` inputs (those used on the admin/preferences pages)
- Removes the `<h1>` wrapper from the logo in our `auth` layout  - each page should only have one h1, and it shouldn't be the logo
- Adds alt text to the logo in the `auth` layout
- Marked login page input fields as required using the `required` attribute, rather than relying on the asterisk
- Made `simple_form` radio buttons and checkboxes fit into our design better by setting their `accent-color`

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="532" height="290" alt="image" src="https://github.com/user-attachments/assets/db860dda-bfb9-41d9-a065-c0b747379e09" /> | <img width="524" height="295" alt="image" src="https://github.com/user-attachments/assets/27e49d97-b752-4bfd-bccd-0ff1c77e0f40" /> |
| <img width="524" height="462" alt="image" src="https://github.com/user-attachments/assets/1a1de0ef-d9e0-477b-a36f-a8af5bea920f" /> | <img width="511" height="472" alt="image" src="https://github.com/user-attachments/assets/4cf2a439-79e9-4f4a-93f9-790526f0005f" /> |
| <img width="500" height="479" alt="image" src="https://github.com/user-attachments/assets/1c98bea7-14dc-4660-8ad6-4d5398f4ea6a" /> | <img width="502" height="465" alt="image" src="https://github.com/user-attachments/assets/096fd047-971c-4669-bacc-f1d3ac4d01de" /> |
| <img width="841" height="563" alt="image" src="https://github.com/user-attachments/assets/860eb181-ba94-4543-b9f3-96f2dcaa8863" /> | <img width="842" height="563" alt="image" src="https://github.com/user-attachments/assets/06b6f37c-24f9-43cf-aa50-da20e334538f" /> |
