### PR TITLE
Limit email domain block variant query to unique values

### DIFF
--- a/app/models/email_domain_block.rb
+++ b/app/models/email_domain_block.rb
@@ -70,7 +70,7 @@ class EmailDomainBlock < ApplicationRecord
         segments = uri.normalized_host.split('.')
 
         segments.map.with_index { |_, i| segments[i..].join('.') }
-      end
+      end.uniq
     end
 
     def extract_uris(domain_or_domains)


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/35770

Very small optimization which avoids repeating shared segments in the query.

Before:

```
EmailDomainBlock Exists? (0.3ms)  SELECT 1 AS one FROM "email_domain_blocks" WHERE "email_domain_blocks"."domain" IN ($1, $2, $3, $4, $5) AND "email_domain_blocks"."allow_with_approval" = $6 LIMIT $7  [["domain", "foo.com"], ["domain", "com"], ["domain", "mail.foo.com"], ["domain", "foo.com"], ["domain", "com"], ["allow_with_approval", false], ["LIMIT", 1]]
```

After:

```
EmailDomainBlock Exists? (0.3ms)  SELECT 1 AS one FROM "email_domain_blocks" WHERE "email_domain_blocks"."domain" IN ($1, $2, $3) AND "email_domain_blocks"."allow_with_approval" = $4 LIMIT $5  [["domain", "foo.com"], ["domain", "com"], ["domain", "mail.foo.com"], ["allow_with_approval", false], ["LIMIT", 1]]
```

Excerpts from running the "array of domains" example in model spec - note the removal of repeated values in query.