### PR TITLE
Rename deprecated ffmpeg `vsync` arg to `fps_mode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Mastodon is a **free, open-source social network server** based on [ActivityPub]
 - **PostgreSQL** 14+
 - **Redis** 7.0+
 - **Node.js** 20+
+- **FFmpeg** 5.1+
 
 This repository includes deployment configurations for **Docker and docker-compose**, as well as for other environments like Heroku and Scalingo. For Helm charts, reference the [mastodon/chart repository](https://github.com/mastodon/chart). A [**standalone** installation guide](https://docs.joinmastodon.org/admin/install/) is available in the main documentation.
 

--- a/lib/paperclip/transcoder.rb
+++ b/lib/paperclip/transcoder.rb
@@ -51,10 +51,7 @@ module Paperclip
           @output_options['maxrate'] = bitrate + 192_000
           @output_options['bufsize'] = bitrate * 5
 
-          if high_vfr?(metadata)
-            # TODO: change to `fps_mode` in the future, as `vsync` is being deprecated
-            @output_options['vsync'] = 'vfr'
-          end
+          @output_options['fps_mode'] = 'vfr' if high_vfr?(metadata)
         end
       end
 


### PR DESCRIPTION
Looks like this was added in 5.1, released ~4 years ago. Not sure what the version policy here is ... we provide a custom 8.x build in Dockerfile. We show version info in metrics, but not sure there's a documented min version?