### PR TITLE
Make use of `email_domain` in sign up approval check

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -463,18 +463,15 @@ class User < ApplicationRecord
   end
 
   def sign_up_email_requires_approval?
-    return false if email.blank?
-
-    _, domain = email.split('@', 2)
-    return false if domain.blank?
+    return false if email_domain.blank?
 
     records = []
 
     # Doing this conditionally is not very satisfying, but this is consistent
     # with the MX records validations we do and keeps the specs tractable.
-    records = DomainResource.new(domain).mx unless self.class.skip_mx_check?
+    records = DomainResource.new(email_domain).mx unless self.class.skip_mx_check?
 
-    EmailDomainBlock.requires_approval?(records + [domain], attempt_ip: sign_up_ip)
+    EmailDomainBlock.requires_approval?(records + [email_domain], attempt_ip: sign_up_ip)
   end
 
   def sign_up_username_requires_approval?


### PR DESCRIPTION
This PR https://github.com/mastodon/mastodon/pull/35838 did both a) update the blank check, like here; b) extract a method for getting the domains to check.

This one is just the blank check portion of that -- idea is just to make use of the parsing we already get from `email_domain` (added in https://github.com/mastodon/mastodon/pull/35159 ) instead of doing two checks here.