### PR TITLE
Update model-concern-related spec locations for consistency

### DIFF
--- a/spec/models/account/avatar_spec.rb
+++ b/spec/models/account/avatar_spec.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'AccountAvatar' do |fabricator|
+RSpec.describe Account::Avatar do
   describe 'static avatars', :attachment_processing do
     describe 'with a square GIF' do
       it 'creates a png static style' do
-        account = Fabricate(fabricator, avatar: attachment_fixture('avatar.gif'))
+        account = Fabricate(:account, avatar: attachment_fixture('avatar.gif'))
         expect(account.avatar_static_url).to_not eq account.avatar_original_url
       end
     end
 
     describe 'with a higher-than-wide GIF' do
       it 'creates a png static style' do
-        account = Fabricate(fabricator, avatar: attachment_fixture('avatar-high.gif'))
+        account = Fabricate(:account, avatar: attachment_fixture('avatar-high.gif'))
         expect(account.avatar_static_url).to_not eq account.avatar_original_url
       end
     end
 
     describe 'when non-GIF' do
       it 'does not create extra static style' do
-        account = Fabricate(fabricator, avatar: attachment_fixture('attachment.jpg'))
+        account = Fabricate(:account, avatar: attachment_fixture('attachment.jpg'))
         expect(account.avatar_static_url).to eq account.avatar_original_url
       end
     end
@@ -26,7 +26,7 @@ RSpec.shared_examples 'AccountAvatar' do |fabricator|
 
   describe 'base64-encoded files', :attachment_processing do
     let(:base64_attachment) { "data:image/jpeg;base64,#{Base64.encode64(attachment_fixture('attachment.jpg').read)}" }
-    let(:account) { Fabricate(fabricator, avatar: base64_attachment) }
+    let(:account) { Fabricate(:account, avatar: base64_attachment) }
 
     it 'saves avatar' do
       expect(account.persisted?).to be true

--- a/spec/models/account/header_spec.rb
+++ b/spec/models/account/header_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'AccountHeader' do |fabricator|
+RSpec.describe Account::Header do
   describe 'base64-encoded files', :attachment_processing do
     let(:base64_attachment) { "data:image/jpeg;base64,#{Base64.encode64(attachment_fixture('attachment.jpg').read)}" }
-    let(:account) { Fabricate(fabricator, header: base64_attachment) }
+    let(:account) { Fabricate(:account, header: base64_attachment) }
 
     it 'saves header' do
       expect(account.persisted?).to be true

--- a/spec/models/account/search_spec.rb
+++ b/spec/models/account/search_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'Account::Search' do
+RSpec.describe Account::Search do
   describe '.search_for' do
     before do
       _missing = Fabricate(
@@ -20,7 +20,7 @@ RSpec.shared_examples 'Account::Search' do
         suspended: true
       )
 
-      results = described_class.search_for('username')
+      results = Account.search_for('username')
       expect(results).to eq []
     end
 
@@ -33,7 +33,7 @@ RSpec.shared_examples 'Account::Search' do
 
       match.user.update(approved: false)
 
-      results = described_class.search_for('username')
+      results = Account.search_for('username')
       expect(results).to eq []
     end
 
@@ -46,7 +46,7 @@ RSpec.shared_examples 'Account::Search' do
 
       match.user.update(confirmed_at: nil)
 
-      results = described_class.search_for('username')
+      results = Account.search_for('username')
       expect(results).to eq []
     end
 
@@ -58,7 +58,7 @@ RSpec.shared_examples 'Account::Search' do
         domain: 'example.com'
       )
 
-      results = described_class.search_for('A?l\i:c e')
+      results = Account.search_for('A?l\i:c e')
       expect(results).to eq [match]
     end
 
@@ -70,7 +70,7 @@ RSpec.shared_examples 'Account::Search' do
         domain: 'example.com'
       )
 
-      results = described_class.search_for('display')
+      results = Account.search_for('display')
       expect(results).to eq [match]
     end
 
@@ -82,7 +82,7 @@ RSpec.shared_examples 'Account::Search' do
         domain: 'example.com'
       )
 
-      results = described_class.search_for('username')
+      results = Account.search_for('username')
       expect(results).to eq [match]
     end
 
@@ -94,20 +94,20 @@ RSpec.shared_examples 'Account::Search' do
         domain: 'example.com'
       )
 
-      results = described_class.search_for('example')
+      results = Account.search_for('example')
       expect(results).to eq [match]
     end
 
     it 'limits via constant by default' do
       stub_const('Account::Search::DEFAULT_LIMIT', 1)
       2.times.each { Fabricate(:account, display_name: 'Display Name') }
-      results = described_class.search_for('display')
+      results = Account.search_for('display')
       expect(results.size).to eq 1
     end
 
     it 'accepts arbitrary limits' do
       2.times.each { Fabricate(:account, display_name: 'Display Name') }
-      results = described_class.search_for('display', limit: 1)
+      results = Account.search_for('display', limit: 1)
       expect(results.size).to eq 1
     end
 
@@ -117,7 +117,7 @@ RSpec.shared_examples 'Account::Search' do
         { display_name: 'Display Name', username: 'username', domain: 'example.com' },
       ].map(&method(:Fabricate).curry(2).call(:account))
 
-      results = described_class.search_for('username')
+      results = Account.search_for('username')
       expect(results).to eq matches
     end
   end
@@ -135,7 +135,7 @@ RSpec.shared_examples 'Account::Search' do
         )
         account.follow!(match)
 
-        results = described_class.advanced_search_for('A?l\i:c e', account, limit: 10, following: true)
+        results = Account.advanced_search_for('A?l\i:c e', account, limit: 10, following: true)
         expect(results).to eq [match]
       end
 
@@ -147,7 +147,7 @@ RSpec.shared_examples 'Account::Search' do
           domain: 'example.com'
         )
 
-        results = described_class.advanced_search_for('A?l\i:c e', account, limit: 10, following: true)
+        results = Account.advanced_search_for('A?l\i:c e', account, limit: 10, following: true)
         expect(results).to eq []
       end
 
@@ -160,7 +160,7 @@ RSpec.shared_examples 'Account::Search' do
           suspended: true
         )
 
-        results = described_class.advanced_search_for('username', account, limit: 10, following: true)
+        results = Account.advanced_search_for('username', account, limit: 10, following: true)
         expect(results).to eq []
       end
 
@@ -173,7 +173,7 @@ RSpec.shared_examples 'Account::Search' do
 
         match.user.update(approved: false)
 
-        results = described_class.advanced_search_for('username', account, limit: 10, following: true)
+        results = Account.advanced_search_for('username', account, limit: 10, following: true)
         expect(results).to eq []
       end
 
@@ -186,7 +186,7 @@ RSpec.shared_examples 'Account::Search' do
 
         match.user.update(confirmed_at: nil)
 
-        results = described_class.advanced_search_for('username', account, limit: 10, following: true)
+        results = Account.advanced_search_for('username', account, limit: 10, following: true)
         expect(results).to eq []
       end
     end
@@ -200,7 +200,7 @@ RSpec.shared_examples 'Account::Search' do
         suspended: true
       )
 
-      results = described_class.advanced_search_for('username', account)
+      results = Account.advanced_search_for('username', account)
       expect(results).to eq []
     end
 
@@ -213,7 +213,7 @@ RSpec.shared_examples 'Account::Search' do
 
       match.user.update(approved: false)
 
-      results = described_class.advanced_search_for('username', account)
+      results = Account.advanced_search_for('username', account)
       expect(results).to eq []
     end
 
@@ -226,7 +226,7 @@ RSpec.shared_examples 'Account::Search' do
 
       match.user.update(confirmed_at: nil)
 
-      results = described_class.advanced_search_for('username', account)
+      results = Account.advanced_search_for('username', account)
       expect(results).to eq []
     end
 
@@ -238,20 +238,20 @@ RSpec.shared_examples 'Account::Search' do
         domain: 'example.com'
       )
 
-      results = described_class.advanced_search_for('A?l\i:c e', account)
+      results = Account.advanced_search_for('A?l\i:c e', account)
       expect(results).to eq [match]
     end
 
     it 'limits result count by default value' do
       stub_const('Account::Search::DEFAULT_LIMIT', 1)
       2.times { Fabricate(:account, display_name: 'Display Name') }
-      results = described_class.advanced_search_for('display', account)
+      results = Account.advanced_search_for('display', account)
       expect(results.size).to eq 1
     end
 
     it 'accepts arbitrary limits' do
       2.times { Fabricate(:account, display_name: 'Display Name') }
-      results = described_class.advanced_search_for('display', account, limit: 1)
+      results = Account.advanced_search_for('display', account, limit: 1)
       expect(results.size).to eq 1
     end
 
@@ -260,7 +260,7 @@ RSpec.shared_examples 'Account::Search' do
       followed_match = Fabricate(:account, username: 'Matcher')
       Fabricate(:follow, account: account, target_account: followed_match)
 
-      results = described_class.advanced_search_for('match', account)
+      results = Account.advanced_search_for('match', account)
       expect(results).to eq [followed_match, match]
       expect(results.first.rank).to be > results.last.rank
     end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Account do
-  it_behaves_like 'Account::Search'
   it_behaves_like 'Reviewable'
 
   describe 'Associations' do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -772,9 +772,6 @@ RSpec.describe Account do
     end
   end
 
-  it_behaves_like 'AccountAvatar', :account
-  it_behaves_like 'AccountHeader', :account
-
   describe '#increment_count!' do
     subject { Fabricate(:account) }
 

--- a/spec/models/status/visibility_spec.rb
+++ b/spec/models/status/visibility_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.shared_examples 'Status::Visibility' do
+RSpec.describe Status::Visibility do
   describe 'Validations' do
     context 'when status is a reblog' do
       subject { Fabricate.build :status, reblog: Fabricate(:status) }

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe Status do
   let(:bob)   { Fabricate(:account, username: 'bob') }
   let(:other) { Fabricate(:status, account: bob, text: 'Skulls for the skull god! The enemy\'s gates are sideways!') }
 
-  it_behaves_like 'Status::Visibility'
-
   describe '#local?' do
     it 'returns true when no remote URI is set' do
       expect(subject.local?).to be true

--- a/spec/models/user/activity_spec.rb
+++ b/spec/models/user/activity_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.shared_examples 'User::Activity' do
+RSpec.describe User::Activity do
   before { stub_const 'User::ACTIVE_DURATION', 7.days }
 
   describe 'Scopes' do
@@ -11,14 +11,14 @@ RSpec.shared_examples 'User::Activity' do
 
     describe '.signed_in_recently' do
       it 'returns users who have signed in during the recent period' do
-        expect(described_class.signed_in_recently)
+        expect(User.signed_in_recently)
           .to contain_exactly(recent_sign_in_user)
       end
     end
 
     describe '.not_signed_in_recently' do
       it 'returns users who have not signed in during the recent period' do
-        expect(described_class.not_signed_in_recently)
+        expect(User.not_signed_in_recently)
           .to contain_exactly(no_recent_sign_in_user)
       end
     end

--- a/spec/models/user/confirmation_spec.rb
+++ b/spec/models/user/confirmation_spec.rb
@@ -2,21 +2,21 @@
 
 require 'rails_helper'
 
-RSpec.shared_examples 'User::Confirmation' do
+RSpec.describe User::Confirmation do
   describe 'Scopes' do
     let!(:unconfirmed_user) { Fabricate :user, confirmed_at: nil }
     let!(:confirmed_user) { Fabricate :user, confirmed_at: Time.now.utc }
 
     describe '.confirmed' do
       it 'returns users who are confirmed' do
-        expect(described_class.confirmed)
+        expect(User.confirmed)
           .to contain_exactly(confirmed_user)
       end
     end
 
     describe '.unconfirmed' do
       it 'returns users who are not confirmed' do
-        expect(described_class.unconfirmed)
+        expect(User.unconfirmed)
           .to contain_exactly(unconfirmed_user)
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe User do
   let(:account) { Fabricate(:account, username: 'alice') }
 
   it_behaves_like 'two_factor_backupable'
-  it_behaves_like 'User::Activity'
-  it_behaves_like 'User::Confirmation'
 
   describe 'otp_secret' do
     it 'encrypts the saved value' do


### PR DESCRIPTION
I noticed while doing https://github.com/mastodon/mastodon/pull/38141 and https://github.com/mastodon/mastodon/pull/38086 that we currently have a mix of styles across the various model concerns. Some of them have their own standalone spec files, while some expose `shared_examples` from `support/`. I suspect this is sort of a historical accident from starting with the shared ones and then copy/pasting into some of the single-use ones instead of making them standalone from the start.

I think what probably makes sense is for the ones which are actually used by multiple models to expose shared examples that are included in those model specs via `behaves_like`; and for the ones which are single-purpose organization only to clean up large model files to have their own standalone specs. This feels conceptually more correct to me, and also may have a small side benefit of providing more targets for the parallel runner to distribute across, since it organizes by file.

This PR updates the previously existing single-model-use concerns to have their own specs, and leaves in place the shared-use ones which expose shared examples. This is consistent with what I did in the linked PRs, and a few similar WIP spots.

This is basically file move/rename diff only, with the exception of some spots where a `described_class` or `fabricator` arg no longer made sense.