### PR TITLE
Fix vertically written textareas

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1366,6 +1366,7 @@ body > [data-popper-placement] {
   .autosuggest-textarea > .autosuggest-textarea__textarea:lang(#{$lang}) {
     writing-mode: vertical-lr;
     min-height: 209px; // writable
+    max-height: 209px; // suppress autosizing by react-textarea-autosize
   }
 
   .detailed-status > .status__content > .status__content__text:lang(#{$lang}) {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1367,6 +1367,8 @@ body > [data-popper-placement] {
     writing-mode: vertical-lr;
     min-height: 209px; // writable
     max-height: 209px; // suppress autosizing by react-textarea-autosize
+    overflow-x: auto;
+    scrollbar-color: unset;
   }
 
   .detailed-status > .status__content > .status__content__text:lang(#{$lang}) {


### PR DESCRIPTION
This PR fixes bugs caused by https://github.com/mastodon/mastodon/pull/37204. It fixes unexpected behaviors of textareas for posts.

Related: https://github.com/mastodon/mastodon/issues/36405

Before:

https://github.com/user-attachments/assets/1fa54706-f0f7-4147-8fbf-a5d24f5d828d

After:

https://github.com/user-attachments/assets/1de18953-80f0-4b1d-8d4f-3f6c2492e6ac