### PR TITLE
Add timestamp spec for markers API response

### DIFF
--- a/app/controllers/api/v1/markers_controller.rb
+++ b/app/controllers/api/v1/markers_controller.rb
@@ -32,13 +32,7 @@ class Api::V1::MarkersController < Api::BaseController
   private
 
   def serialize_map(map)
-    serialized = {}
-
-    map.each_pair do |key, value|
-      serialized[key] = ActiveModelSerializers::SerializableResource.new(value, serializer: REST::MarkerSerializer).as_json
-    end
-
-    Oj.dump(serialized)
+    map.transform_values { |value| ActiveModelSerializers::SerializableResource.new(value, serializer: REST::MarkerSerializer) }
   end
 
   def resource_params

--- a/spec/requests/api/v1/markers_spec.rb
+++ b/spec/requests/api/v1/markers_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe 'API Markers' do
 
   describe 'GET /api/v1/markers' do
     before do
-      Fabricate(:marker, timeline: 'home', last_read_id: 123, user: user)
-      Fabricate(:marker, timeline: 'notifications', last_read_id: 456, user: user)
+      travel_to DateTime.parse('2026-03-15T12:34:56.789Z'), with_usec: true do
+        Fabricate(:marker, timeline: 'home', last_read_id: 123, user: user)
+        Fabricate(:marker, timeline: 'notifications', last_read_id: 456, user: user)
+      end
 
       get '/api/v1/markers', headers: headers, params: { timeline: %w(home notifications) }
     end
@@ -22,6 +24,11 @@ RSpec.describe 'API Markers' do
           home: include(last_read_id: '123'),
           notifications: include(last_read_id: '456')
         )
+    end
+
+    it 'uses a specific style of IS08601 timestamps' do
+      expect(response.parsed_body)
+        .to include(home: include(updated_at: eq('2026-03-15T12:34:56.789Z')))
     end
   end
 


### PR DESCRIPTION
Two things here:

- Add very strict format assertion to confirm we arent breaking the specific ISO8601 style
- In controller, rely on implicit JSON encoding from the `render json: ...` call to turn our timeline-name-key-indexed hash into a response

Local debug output confirms both index/create responses look the same ... but let me know if more specific stuff in specs would be helpful.

Related to https://github.com/mastodon/mastodon/pull/32704
