### PR TITLE
Remove unused react component helper method

### DIFF
--- a/app/helpers/react_component_helper.rb
+++ b/app/helpers/react_component_helper.rb
@@ -2,33 +2,16 @@
 
 module ReactComponentHelper
   def react_component(name, props = {}, &block)
-    data = { component: name.to_s.camelcase, props: Oj.dump(props) }
-    if block.nil?
-      div_tag_with_data(data)
+    data = { component: name.to_s.camelcase, props: }
+    if block_given?
+      tag.div data:, &block
     else
-      content_tag(:div, data: data, &block)
+      tag.div nil, data:
     end
   end
 
   def react_admin_component(name, props = {})
-    data = { 'admin-component': name.to_s.camelcase, props: Oj.dump(props) }
-    div_tag_with_data(data)
-  end
-
-  def serialized_media_attachments(media_attachments)
-    media_attachments.map { |attachment| serialized_attachment(attachment) }
-  end
-
-  private
-
-  def div_tag_with_data(data)
-    content_tag(:div, nil, data: data)
-  end
-
-  def serialized_attachment(attachment)
-    ActiveModelSerializers::SerializableResource.new(
-      attachment,
-      serializer: REST::MediaAttachmentSerializer
-    ).as_json
+    data = { 'admin-component': name.to_s.camelcase, props: }
+    tag.div nil, data:
   end
 end


### PR DESCRIPTION
Two changes here:

- The only usage of `serialized_media_attachments` was removed in https://github.com/mastodon/mastodon/pull/34872/changes#diff-b8423294a9974f86e281d530defd81193f23b73be77377e9bb4d4e00a73b6df2L15 and not used elsewhere, remove it
- Rails will automatically JSON encode values in the `data:` attributes called with the tag helpers, so rely on that

We have decent coverage on these helper methods, and did some local debug output to confirm they look the same (preserved html encoding, etc)

Related to https://github.com/mastodon/mastodon/pull/32704
