### PR TITLE
Use `JSON.generate` call in push update worker

### DIFF
--- a/app/workers/push_update_worker.rb
+++ b/app/workers/push_update_worker.rb
@@ -23,10 +23,10 @@ class PushUpdateWorker
   end
 
   def message
-    Oj.dump(
+    JSON.generate({
       event: update? ? :'status.update' : :update,
-      payload: @payload
-    )
+      payload: @payload,
+    }.as_json)
   end
 
   def publish!

--- a/spec/workers/push_update_worker_spec.rb
+++ b/spec/workers/push_update_worker_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PushUpdateWorker do
 
     context 'with valid records' do
       let(:account) { Fabricate :account }
-      let(:status) { Fabricate :status }
+      let(:status) { Fabricate :status, text: 'Test Post' }
 
       before { allow(redis).to receive(:publish) }
 
@@ -25,7 +25,16 @@ RSpec.describe PushUpdateWorker do
 
         expect(redis)
           .to have_received(:publish)
-          .with(redis_key, anything)
+          .with(
+            redis_key,
+            match_json_values(
+              event: 'update',
+              payload: include(
+                created_at: status.created_at.iso8601(3),
+                content: eq('<p>Test Post</p>')
+              )
+            )
+          )
       end
 
       def redis_key


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

The inner `as_json` here ensures we get the timestamps encoded properly, and the outer `JSON.generate` (as opposed to just using `to_json` on the hash) ensures we skip over rails html entity escaping. I actually think that might not matter here (it swaps out things like `<` with unicode equivalents, for example - and the spec passes both ways) but am attempting to have zero change in this pass.

Updated spec to be a little more tight on ISO8601 format check, etc.