### PR TITLE
Use `to_json` call for webhook service

### DIFF
--- a/app/services/webhook_service.rb
+++ b/app/services/webhook_service.rb
@@ -17,6 +17,8 @@ class WebhookService < BaseService
   end
 
   def serialize_event
-    Oj.dump(ActiveModelSerializers::SerializableResource.new(@event, serializer: REST::Admin::WebhookEventSerializer, scope: nil, scope_name: :current_user).as_json)
+    ActiveModelSerializers::SerializableResource
+      .new(@event, serializer: REST::Admin::WebhookEventSerializer, scope: nil, scope_name: :current_user)
+      .to_json
   end
 end

--- a/spec/services/webhook_service_spec.rb
+++ b/spec/services/webhook_service_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe WebhookService do
       let!(:report) { Fabricate(:report) }
       let!(:webhook) { Fabricate(:webhook, events: ['report.created']) }
 
+      before { freeze_time Time.current }
+
       it 'finds and delivers webhook payloads' do
         expect { subject.call('report.created', report) }
           .to enqueue_sidekiq_job(Webhooks::DeliveryWorker)
           .with(
             webhook.id,
-            anything
+            match_json_values(event: 'report.created', created_at: Time.current.iso8601(3))
           )
       end
     end


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

Updated spec to be a little more tight on ISO8601 format check, etc. Local debug output looks same before/after.