### PR TITLE
Use `to_json` in simple view hash data-props build locations

### DIFF
--- a/app/views/shared/_web_app.html.haml
+++ b/app/views/shared/_web_app.html.haml
@@ -8,7 +8,7 @@
   = render_initial_state
   = vite_typescript_tag 'application.ts', crossorigin: 'anonymous'
 
-.notranslate.app-holder#mastodon{ data: { props: Oj.dump(default_props) } }
+.notranslate.app-holder#mastodon{ data: { props: default_props.to_json } }
   %noscript
     = image_tag frontend_asset_path('images/logo.svg'), alt: 'Mastodon'
 

--- a/app/views/shares/show.html.haml
+++ b/app/views/shares/show.html.haml
@@ -2,4 +2,4 @@
   = render_initial_state
   = vite_typescript_tag 'share.tsx', crossorigin: 'anonymous'
 
-#mastodon-compose{ data: { props: Oj.dump(default_props) } }
+#mastodon-compose{ data: { props: default_props.to_json } }

--- a/app/views/statuses/embed.html.haml
+++ b/app/views/statuses/embed.html.haml
@@ -1,1 +1,1 @@
-#mastodon-status{ data: { props: Oj.dump(default_props.merge(id: @status.id.to_s)) } }
+#mastodon-status{ data: { props: default_props.merge(id: @status.id.to_s).to_json } }

--- a/spec/requests/statuses/embed_spec.rb
+++ b/spec/requests/statuses/embed_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe 'Status embed' do
           .to have_http_status(200)
         expect(response.parsed_body.at('body.embed'))
           .to be_present
+        expect(response.parsed_body.at('#mastodon-status')['data-props'])
+          .to eq({ locale: 'en', id: status.id.to_s }.to_json)
         expect(response.headers).to include(
           'Vary' => 'Accept, Accept-Language, Cookie',
           'Cache-Control' => include('public'),

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe 'Home page' do
       expect(page)
         .to have_css('noscript', text: /Mastodon/)
         .and have_css('body', class: 'app-body')
+      expect(find('.app-holder#mastodon')['data-props'])
+        .to eq('{"locale":"en"}')
     end
   end
 

--- a/spec/system/share_entrypoint_spec.rb
+++ b/spec/system/share_entrypoint_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe 'Share page', :js, :streaming do
       .to have_css('.modal-layout__mastodon')
       .and have_css('div#mastodon-compose')
       .and have_css('.compose-form__submit')
+    expect(find_by_id('mastodon-compose')['data-props'])
+      .to eq('{"locale":"en"}')
 
     fill_in_form
 


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

In a few views building very simple hashes, just call `to_json` on the hash to build a string for the html data props.

Added some coverage.