### PR TITLE
Use `JSON.generate` call for fan out service

### DIFF
--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -171,10 +171,10 @@ class FanOutOnWriteService < BaseService
   end
 
   def anonymous_payload
-    @anonymous_payload ||= Oj.dump(
+    @anonymous_payload ||= JSON.generate({
       event: update? ? :'status.update' : :update,
-      payload: rendered_status
-    )
+      payload: rendered_status,
+    }.as_json)
   end
 
   def rendered_status

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -54,11 +54,18 @@ RSpec.describe FanOutOnWriteService do
         .and be_in(home_feed_of(bob))
         .and be_in(home_feed_of(tom))
 
-      expect(redis).to have_received(:publish).with('timeline:hashtag:hoge', anything)
-      expect(redis).to have_received(:publish).with('timeline:hashtag:hoge:local', anything)
-      expect(redis).to have_received(:publish).with('timeline:public', anything)
-      expect(redis).to have_received(:publish).with('timeline:public:local', anything)
-      expect(redis).to have_received(:publish).with('timeline:public:media', anything)
+      expected_payload = { event: 'update', payload: include(id: status.id.to_s, created_at: status.created_at.iso8601(3), content: /<p>Hello/) }
+
+      expect(redis)
+        .to have_received(:publish).with('timeline:hashtag:hoge', match_json_values(expected_payload))
+      expect(redis)
+        .to have_received(:publish).with('timeline:hashtag:hoge:local', match_json_values(expected_payload))
+      expect(redis)
+        .to have_received(:publish).with('timeline:public', match_json_values(expected_payload))
+      expect(redis)
+        .to have_received(:publish).with('timeline:public:local', match_json_values(expected_payload))
+      expect(redis)
+        .to have_received(:publish).with('timeline:public:media', match_json_values(expected_payload))
     end
 
     context 'with silenced_account_ids' do


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

Same dynamic as https://github.com/mastodon/mastodon/pull/38208 -- the inner `as_json` here ensures we get the timestamps encoded properly, and the outer `JSON.generate` (as opposed to just using `to_json` on the hash) ensures we skip over rails html entity escaping. I actually think that might not matter here (it swaps out things like `<` with unicode equivalents, for example) but am attempting to have zero change in this pass.

Updated spec to be a little more tight on ISO8601 format check and other attrs.