### PR TITLE
Use `to_json` call in donation campaigns

### DIFF
--- a/app/controllers/api/v1/donation_campaigns_controller.rb
+++ b/app/controllers/api/v1/donation_campaigns_controller.rb
@@ -44,7 +44,7 @@ class Api::V1::DonationCampaignsController < Api::BaseController
     Rails.cache.write_multi(
       {
         request_key => campaign_key(campaign),
-        "donation_campaign:#{campaign_key(campaign)}" => Oj.dump(campaign),
+        "donation_campaign:#{campaign_key(campaign)}" => campaign.to_json,
       },
       expires_in: 1.hour,
       raw: true

--- a/spec/requests/api/v1/donation_campaigns_spec.rb
+++ b/spec/requests/api/v1/donation_campaigns_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Donation campaigns' do
         end
 
         before do
-          stub_request(:get, "#{api_url}?platform=web&seed=#{seed}&locale=en").to_return(body: Oj.dump(campaign_json), status: 200)
+          stub_request(:get, "#{api_url}?platform=web&seed=#{seed}&locale=en").to_return(body: JSON.generate(campaign_json), status: 200)
         end
 
         it 'returns the expected campaign' do


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

I think this is a safe one, just serializing a hash. The spec passed after just the code change (ie, before converting `Oj.dump`...). Assuming the hash in the spec is representative of typical replies, there are no timestamps in here to worry about, but if there were they would be correctly ISO8601 encoded in the response.