### PR TITLE
Use implicit `to_json` call in app/services

### DIFF
--- a/app/services/activitypub/synchronize_followers_service.rb
+++ b/app/services/activitypub/synchronize_followers_service.rb
@@ -62,7 +62,7 @@ class ActivityPub::SynchronizeFollowersService < BaseService
   end
 
   def build_undo_follow_json(follow)
-    Oj.dump(serialize_payload(follow, ActivityPub::UndoFollowSerializer))
+    serialize_payload(follow, ActivityPub::UndoFollowSerializer).to_json
   end
 
   # Only returns true if the whole collection has been processed

--- a/app/services/after_block_domain_from_account_service.rb
+++ b/app/services/after_block_domain_from_account_service.rb
@@ -54,7 +54,7 @@ class AfterBlockDomainFromAccountService < BaseService
 
     return unless follow.account.activitypub?
 
-    ActivityPub::DeliveryWorker.perform_async(Oj.dump(serialize_payload(follow, ActivityPub::RejectFollowSerializer)), @account.id, follow.account.inbox_url)
+    ActivityPub::DeliveryWorker.perform_async(serialize_payload(follow, ActivityPub::RejectFollowSerializer).to_json, @account.id, follow.account.inbox_url)
   end
 
   def notify_of_severed_relationships!

--- a/app/services/authorize_follow_service.rb
+++ b/app/services/authorize_follow_service.rb
@@ -22,6 +22,6 @@ class AuthorizeFollowService < BaseService
   end
 
   def build_json(follow_request)
-    Oj.dump(serialize_payload(follow_request, ActivityPub::AcceptFollowSerializer))
+    serialize_payload(follow_request, ActivityPub::AcceptFollowSerializer).to_json
   end
 end

--- a/app/services/block_service.rb
+++ b/app/services/block_service.rb
@@ -26,6 +26,6 @@ class BlockService < BaseService
   end
 
   def build_json(block)
-    Oj.dump(serialize_payload(block, ActivityPub::BlockSerializer))
+    serialize_payload(block, ActivityPub::BlockSerializer).to_json
   end
 end

--- a/app/services/create_featured_tag_service.rb
+++ b/app/services/create_featured_tag_service.rb
@@ -26,6 +26,6 @@ class CreateFeaturedTagService < BaseService
   private
 
   def build_json(featured_tag)
-    Oj.dump(serialize_payload(featured_tag, ActivityPub::AddHashtagSerializer, signer: @account))
+    serialize_payload(featured_tag, ActivityPub::AddHashtagSerializer, signer: @account).to_json
   end
 end

--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -114,7 +114,7 @@ class DeleteAccountService < BaseService
     # we have to force it to unfollow them.
 
     ActivityPub::DeliveryWorker.push_bulk(Follow.where(account: @account)) do |follow|
-      [Oj.dump(serialize_payload(follow, ActivityPub::RejectFollowSerializer)), follow.target_account_id, @account.inbox_url]
+      [serialize_payload(follow, ActivityPub::RejectFollowSerializer).to_json, follow.target_account_id, @account.inbox_url]
     end
   end
 
@@ -126,7 +126,7 @@ class DeleteAccountService < BaseService
     # if the remote account gets un-suspended.
 
     ActivityPub::DeliveryWorker.push_bulk(Follow.where(target_account: @account)) do |follow|
-      [Oj.dump(serialize_payload(follow, ActivityPub::UndoFollowSerializer)), follow.account_id, @account.inbox_url]
+      [serialize_payload(follow, ActivityPub::UndoFollowSerializer).to_json, follow.account_id, @account.inbox_url]
     end
   end
 
@@ -285,7 +285,7 @@ class DeleteAccountService < BaseService
   end
 
   def delete_actor_json
-    @delete_actor_json ||= Oj.dump(serialize_payload(@account, ActivityPub::DeleteActorSerializer, signer: @account, always_sign: true))
+    @delete_actor_json ||= serialize_payload(@account, ActivityPub::DeleteActorSerializer, signer: @account, always_sign: true).to_json
   end
 
   def delivery_inboxes

--- a/app/services/favourite_service.rb
+++ b/app/services/favourite_service.rb
@@ -42,6 +42,6 @@ class FavouriteService < BaseService
   end
 
   def build_json(favourite)
-    Oj.dump(serialize_payload(favourite, ActivityPub::LikeSerializer))
+    serialize_payload(favourite, ActivityPub::LikeSerializer).to_json
   end
 end

--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -90,7 +90,7 @@ class FollowService < BaseService
   end
 
   def build_json(follow_request)
-    Oj.dump(serialize_payload(follow_request, ActivityPub::FollowSerializer))
+    serialize_payload(follow_request, ActivityPub::FollowSerializer).to_json
   end
 
   def follow_options

--- a/app/services/reject_follow_service.rb
+++ b/app/services/reject_follow_service.rb
@@ -17,6 +17,6 @@ class RejectFollowService < BaseService
   end
 
   def build_json(follow_request)
-    Oj.dump(serialize_payload(follow_request, ActivityPub::RejectFollowSerializer))
+    serialize_payload(follow_request, ActivityPub::RejectFollowSerializer).to_json
   end
 end

--- a/app/services/remove_domains_from_followers_service.rb
+++ b/app/services/remove_domains_from_followers_service.rb
@@ -18,6 +18,6 @@ class RemoveDomainsFromFollowersService < BaseService
   end
 
   def build_json(follow)
-    Oj.dump(serialize_payload(follow, ActivityPub::RejectFollowSerializer))
+    serialize_payload(follow, ActivityPub::RejectFollowSerializer).to_json
   end
 end

--- a/app/services/remove_featured_tag_service.rb
+++ b/app/services/remove_featured_tag_service.rb
@@ -26,6 +26,6 @@ class RemoveFeaturedTagService < BaseService
   private
 
   def build_json(featured_tag)
-    Oj.dump(serialize_payload(featured_tag, ActivityPub::RemoveHashtagSerializer, signer: @account))
+    serialize_payload(featured_tag, ActivityPub::RemoveHashtagSerializer, signer: @account).to_json
   end
 end

--- a/app/services/remove_from_followers_service.rb
+++ b/app/services/remove_from_followers_service.rb
@@ -18,6 +18,6 @@ class RemoveFromFollowersService < BaseService
   end
 
   def build_json(follow)
-    Oj.dump(serialize_payload(follow, ActivityPub::RejectFollowSerializer))
+    serialize_payload(follow, ActivityPub::RejectFollowSerializer).to_json
   end
 end

--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -103,7 +103,7 @@ class RemoveStatusService < BaseService
   end
 
   def signed_activity_json
-    @signed_activity_json ||= Oj.dump(serialize_payload(@status, @status.reblog? ? ActivityPub::UndoAnnounceSerializer : ActivityPub::DeleteNoteSerializer, signer: @account, always_sign: true))
+    @signed_activity_json ||= serialize_payload(@status, @status.reblog? ? ActivityPub::UndoAnnounceSerializer : ActivityPub::DeleteNoteSerializer, signer: @account, always_sign: true).to_json
   end
 
   def remove_reblogs

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -98,7 +98,7 @@ class ReportService < BaseService
   end
 
   def payload
-    Oj.dump(serialize_payload(@report, ActivityPub::FlagSerializer, account: some_local_account))
+    serialize_payload(@report, ActivityPub::FlagSerializer, account: some_local_account).to_json
   end
 
   def some_local_account

--- a/app/services/revoke_collection_item_service.rb
+++ b/app/services/revoke_collection_item_service.rb
@@ -19,6 +19,6 @@ class RevokeCollectionItemService < BaseService
   end
 
   def signed_activity_json
-    @signed_activity_json ||= Oj.dump(serialize_payload(@collection_item, ActivityPub::DeleteFeatureAuthorizationSerializer, signer: @account, always_sign: true))
+    @signed_activity_json ||= serialize_payload(@collection_item, ActivityPub::DeleteFeatureAuthorizationSerializer, signer: @account, always_sign: true).to_json
   end
 end

--- a/app/services/revoke_quote_service.rb
+++ b/app/services/revoke_quote_service.rb
@@ -39,6 +39,6 @@ class RevokeQuoteService < BaseService
   end
 
   def signed_activity_json
-    @signed_activity_json ||= Oj.dump(serialize_payload(@quote, ActivityPub::DeleteQuoteAuthorizationSerializer, signer: @account, always_sign: true, force_approval_id: true))
+    @signed_activity_json ||= serialize_payload(@quote, ActivityPub::DeleteQuoteAuthorizationSerializer, signer: @account, always_sign: true, force_approval_id: true).to_json
   end
 end

--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -34,7 +34,7 @@ class SuspendAccountService < BaseService
 
     Follow.where(account: @account).find_in_batches do |follows|
       ActivityPub::DeliveryWorker.push_bulk(follows) do |follow|
-        [Oj.dump(serialize_payload(follow, ActivityPub::RejectFollowSerializer)), follow.target_account_id, @account.inbox_url]
+        [serialize_payload(follow, ActivityPub::RejectFollowSerializer).to_json, follow.target_account_id, @account.inbox_url]
       end
 
       follows.each(&:destroy)
@@ -72,6 +72,6 @@ class SuspendAccountService < BaseService
   end
 
   def signed_activity_json
-    @signed_activity_json ||= Oj.dump(serialize_payload(@account, ActivityPub::UpdateActorSerializer, signer: @account))
+    @signed_activity_json ||= serialize_payload(@account, ActivityPub::UpdateActorSerializer, signer: @account).to_json
   end
 end

--- a/app/services/unblock_service.rb
+++ b/app/services/unblock_service.rb
@@ -18,6 +18,6 @@ class UnblockService < BaseService
   end
 
   def build_json(unblock)
-    Oj.dump(serialize_payload(unblock, ActivityPub::UndoBlockSerializer))
+    serialize_payload(unblock, ActivityPub::UndoBlockSerializer).to_json
   end
 end

--- a/app/services/unfavourite_service.rb
+++ b/app/services/unfavourite_service.rb
@@ -18,6 +18,6 @@ class UnfavouriteService < BaseService
   end
 
   def build_json(favourite)
-    Oj.dump(serialize_payload(favourite, ActivityPub::UndoLikeSerializer))
+    serialize_payload(favourite, ActivityPub::UndoLikeSerializer).to_json
   end
 end

--- a/app/services/unfollow_service.rb
+++ b/app/services/unfollow_service.rb
@@ -68,10 +68,10 @@ class UnfollowService < BaseService
   end
 
   def build_json(follow)
-    Oj.dump(serialize_payload(follow, ActivityPub::UndoFollowSerializer))
+    serialize_payload(follow, ActivityPub::UndoFollowSerializer).to_json
   end
 
   def build_reject_json(follow)
-    Oj.dump(serialize_payload(follow, ActivityPub::RejectFollowSerializer))
+    serialize_payload(follow, ActivityPub::RejectFollowSerializer).to_json
   end
 end

--- a/app/services/unsuspend_account_service.rb
+++ b/app/services/unsuspend_account_service.rb
@@ -63,6 +63,6 @@ class UnsuspendAccountService < BaseService
   end
 
   def signed_activity_json
-    @signed_activity_json ||= Oj.dump(serialize_payload(@account, ActivityPub::UpdateActorSerializer, signer: @account))
+    @signed_activity_json ||= serialize_payload(@account, ActivityPub::UpdateActorSerializer, signer: @account).to_json
   end
 end

--- a/app/services/vote_service.rb
+++ b/app/services/vote_service.rb
@@ -65,7 +65,7 @@ class VoteService < BaseService
   end
 
   def build_json(vote)
-    Oj.dump(serialize_payload(vote, ActivityPub::VoteSerializer))
+    serialize_payload(vote, ActivityPub::VoteSerializer).to_json
   end
 
   def increment_voters_count!


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

All of these follow a pattern where the service has some "build" methods which ultimately pass a `String` of built JSON to one of the delivery/distribution worker classes.

I turned on some local debug output and inspected the generated payloads ... things look the same before/after as far as I can tell. There's a mix of coverage on these ... most service classes have at least something in place, but there are not always assertions around the workers being called and/or what they received.

The thing returned by `serialize_payload` is an AMS serializable resource which has called `as_json` already.
