### PR TITLE
Use `to_json` call for accounts API

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -38,7 +38,7 @@ class Api::V1::AccountsController < Api::BaseController
 
     headers.merge!(response.headers)
 
-    self.response_body = Oj.dump(response.body)
+    self.response_body = response.body.to_json
     self.status        = response.status
   rescue ActiveRecord::RecordInvalid => e
     render json: ValidationErrorFormatter.new(e, 'account.username': :username, 'invite_request.text': :reason).as_json, status: 422

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -185,7 +185,12 @@ RSpec.describe '/api/v1/accounts' do
         expect(response).to have_http_status(200)
         expect(response.content_type)
           .to start_with('application/json')
-        expect(response.parsed_body[:access_token]).to_not be_blank
+        expect(response.parsed_body)
+          .to include(
+            access_token: be_present,
+            created_at: be_a(Integer),
+            token_type: 'Bearer'
+          )
 
         user = User.find_by(email: 'hello@world.tld')
         expect(user).to_not be_nil


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

There is a hash from `TokenReponse` here. The response does have a timestamp, but its an integer not an ISO8601.