### PR TITLE
Use `to_json` call for AP::Follow reject path

### DIFF
--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -39,7 +39,7 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
   end
 
   def reject_follow_request!(target_account)
-    json = Oj.dump(serialize_payload(FollowRequest.new(account: @account, target_account: target_account, uri: @json['id']), ActivityPub::RejectFollowSerializer))
+    json = serialize_payload(FollowRequest.new(account: @account, target_account: target_account, uri: @json['id']), ActivityPub::RejectFollowSerializer).to_json
     ActivityPub::DeliveryWorker.perform_async(json, target_account.id, @account.inbox_url)
   end
 end

--- a/spec/lib/activitypub/activity/follow_spec.rb
+++ b/spec/lib/activitypub/activity/follow_spec.rb
@@ -84,6 +84,23 @@ RSpec.describe ActivityPub::Activity::Follow do
       end
     end
 
+    context 'when recipient blocks sender' do
+      before { Fabricate :block, account: recipient, target_account: sender }
+
+      it 'sends a reject and does not follow' do
+        subject.perform
+
+        expect(sender.requested?(recipient))
+          .to be false
+        expect(ActivityPub::DeliveryWorker)
+          .to have_enqueued_sidekiq_job(
+            match_json_values(type: 'Reject', object: include(type: 'Follow')),
+            recipient.id,
+            anything
+          )
+      end
+    end
+
     context 'when a follow relationship already exists' do
       before do
         sender.active_relationships.create!(target_account: recipient, uri: 'bar')


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

This response does not have a timestamp. Added spec to exercise this reject path which we were not hitting before. Local debug output looks the same before/after.