### PR TITLE
Use `to_json` call for worker payloads

### DIFF
--- a/app/workers/activitypub/distribute_poll_update_worker.rb
+++ b/app/workers/activitypub/distribute_poll_update_worker.rb
@@ -43,7 +43,7 @@ class ActivityPub::DistributePollUpdateWorker
   end
 
   def payload
-    @payload ||= Oj.dump(serialize_payload(@status, ActivityPub::UpdatePollSerializer, signer: @account))
+    @payload ||= serialize_payload(@status, ActivityPub::UpdatePollSerializer, signer: @account).to_json
   end
 
   def relay!

--- a/app/workers/activitypub/distribution_worker.rb
+++ b/app/workers/activitypub/distribution_worker.rb
@@ -24,7 +24,7 @@ class ActivityPub::DistributionWorker < ActivityPub::RawDistributionWorker
   end
 
   def payload
-    @payload ||= Oj.dump(serialize_payload(@status, activity_serializer, serializer_options.merge(signer: @account)))
+    @payload ||= serialize_payload(@status, activity_serializer, serializer_options.merge(signer: @account)).to_json
   end
 
   def activity_serializer

--- a/app/workers/activitypub/feature_request_worker.rb
+++ b/app/workers/activitypub/feature_request_worker.rb
@@ -17,6 +17,6 @@ class ActivityPub::FeatureRequestWorker < ActivityPub::RawDistributionWorker
   end
 
   def payload
-    @payload ||= Oj.dump(serialize_payload(@collection_item, ActivityPub::FeatureRequestSerializer, signer: @account))
+    @payload ||= serialize_payload(@collection_item, ActivityPub::FeatureRequestSerializer, signer: @account).to_json
   end
 end

--- a/app/workers/activitypub/move_distribution_worker.rb
+++ b/app/workers/activitypub/move_distribution_worker.rb
@@ -28,6 +28,6 @@ class ActivityPub::MoveDistributionWorker
   end
 
   def signed_payload
-    @signed_payload ||= Oj.dump(serialize_payload(@migration, ActivityPub::MoveSerializer, signer: @account))
+    @signed_payload ||= serialize_payload(@migration, ActivityPub::MoveSerializer, signer: @account).to_json
   end
 end

--- a/app/workers/activitypub/quote_request_worker.rb
+++ b/app/workers/activitypub/quote_request_worker.rb
@@ -17,6 +17,6 @@ class ActivityPub::QuoteRequestWorker < ActivityPub::RawDistributionWorker
   end
 
   def payload
-    @payload ||= Oj.dump(serialize_payload(@quote, ActivityPub::QuoteRequestSerializer, signer: @account, allow_post_inlining: true))
+    @payload ||= serialize_payload(@quote, ActivityPub::QuoteRequestSerializer, signer: @account, allow_post_inlining: true).to_json
   end
 end

--- a/app/workers/activitypub/update_distribution_worker.rb
+++ b/app/workers/activitypub/update_distribution_worker.rb
@@ -23,6 +23,6 @@ class ActivityPub::UpdateDistributionWorker < ActivityPub::RawDistributionWorker
   end
 
   def payload
-    @payload ||= Oj.dump(serialize_payload(@account, ActivityPub::UpdateActorSerializer, signer: @account, sign_with: @options[:sign_with]))
+    @payload ||= serialize_payload(@account, ActivityPub::UpdateActorSerializer, signer: @account, sign_with: @options[:sign_with]).to_json
   end
 end


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

Most of these tend to have at least some `match_json_values` checks to make sure the json string we pass into the delivery worker is as expected. Similar to the services one, the result of `serialize_payload` in these has already run through an AMS/as_json pass.