### PR TITLE
Use `to_json` call for AP::QuoteRequest accept/reject paths

### DIFF
--- a/app/lib/activitypub/activity/quote_request.rb
+++ b/app/lib/activitypub/activity/quote_request.rb
@@ -31,7 +31,7 @@ class ActivityPub::Activity::QuoteRequest < ActivityPub::Activity
     status.quote.update!(activity_uri: @json['id'])
     status.quote.accept!
 
-    json = Oj.dump(serialize_payload(status.quote, ActivityPub::AcceptQuoteRequestSerializer))
+    json = serialize_payload(status.quote, ActivityPub::AcceptQuoteRequestSerializer).to_json
     ActivityPub::DeliveryWorker.perform_async(json, quoted_status.account_id, @account.inbox_url)
 
     # Ensure the user is notified
@@ -60,7 +60,7 @@ class ActivityPub::Activity::QuoteRequest < ActivityPub::Activity
       account: @account,
       activity_uri: @json['id']
     )
-    json = Oj.dump(serialize_payload(quote, ActivityPub::RejectQuoteRequestSerializer))
+    json = serialize_payload(quote, ActivityPub::RejectQuoteRequestSerializer).to_json
     ActivityPub::DeliveryWorker.perform_async(json, quoted_status.account_id, @account.inbox_url)
   end
 


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

These responses do not have a timestamp, and both accept/reject have pretty detailed assertions in spec re: what the delivery worker receives. Local debug output looks the same.