### PR TITLE
Revamp heading levels in settings & admin pages

### DIFF
--- a/app/javascript/mastodon/components/admin/Dimension.jsx
+++ b/app/javascript/mastodon/components/admin/Dimension.jsx
@@ -85,7 +85,7 @@ export default class Dimension extends PureComponent {
 
     return (
       <div className='dimension'>
-        <h4>{label}</h4>
+        <h2>{label}</h2>
 
         {content}
       </div>

--- a/app/javascript/mastodon/components/admin/ImpactReport.jsx
+++ b/app/javascript/mastodon/components/admin/ImpactReport.jsx
@@ -49,7 +49,7 @@ export default class ImpactReport extends PureComponent {
 
     return (
       <div className='dimension'>
-        <h2><FormattedMessage id='admin.impact_report.title' defaultMessage='Impact summary' /></h2>
+        <FormattedMessage id='admin.impact_report.title' defaultMessage='Impact summary' tagName="h2" />
 
         <table>
           <tbody>

--- a/app/javascript/mastodon/components/admin/ImpactReport.jsx
+++ b/app/javascript/mastodon/components/admin/ImpactReport.jsx
@@ -49,7 +49,7 @@ export default class ImpactReport extends PureComponent {
 
     return (
       <div className='dimension'>
-        <h4><FormattedMessage id='admin.impact_report.title' defaultMessage='Impact summary' /></h4>
+        <h2><FormattedMessage id='admin.impact_report.title' defaultMessage='Impact summary' /></h2>
 
         <table>
           <tbody>

--- a/app/javascript/mastodon/components/admin/Retention.jsx
+++ b/app/javascript/mastodon/components/admin/Retention.jsx
@@ -145,7 +145,7 @@ export default class Retention extends PureComponent {
 
     return (
       <div className='retention'>
-        <h4>{title}</h4>
+        <h2>{title}</h2>
 
         {content}
       </div>

--- a/app/javascript/mastodon/components/admin/Trends.jsx
+++ b/app/javascript/mastodon/components/admin/Trends.jsx
@@ -66,7 +66,7 @@ export default class Trends extends PureComponent {
 
     return (
       <div className='trends trends--compact'>
-        <h2><FormattedMessage id='trends.trending_now' defaultMessage='Trending now' /></h2>
+        <FormattedMessage id='trends.trending_now' defaultMessage='Trending now' tagName='h2' />
 
         {content}
       </div>

--- a/app/javascript/mastodon/components/admin/Trends.jsx
+++ b/app/javascript/mastodon/components/admin/Trends.jsx
@@ -66,7 +66,7 @@ export default class Trends extends PureComponent {
 
     return (
       <div className='trends trends--compact'>
-        <h4><FormattedMessage id='trends.trending_now' defaultMessage='Trending now' /></h4>
+        <h2><FormattedMessage id='trends.trending_now' defaultMessage='Trending now' /></h2>
 
         {content}
       </div>

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -268,7 +268,7 @@ $content-width: 840px;
         }
       }
 
-      h2 small {
+      h1 small {
         font-size: 12px;
         display: block;
         font-weight: 500;
@@ -282,22 +282,16 @@ $content-width: 840px;
       }
     }
 
-    h2 {
+    :where(h1),
+    .heading-large {
       color: var(--color-text-primary);
       font-size: 24px;
       line-height: 36px;
       font-weight: 700;
     }
 
-    h3 {
-      color: var(--color-text-primary);
-      font-size: 20px;
-      line-height: 28px;
-      font-weight: 400;
-      margin-bottom: 30px;
-    }
-
-    h4 {
+    :where(h2):not(.heading-medium),
+    .heading-small {
       text-transform: uppercase;
       font-size: 13px;
       font-weight: 700;
@@ -305,6 +299,14 @@ $content-width: 840px;
       padding-top: 24px;
       margin-bottom: 8px;
       border-top: 1px solid var(--color-border-primary);
+    }
+
+    .heading-medium {
+      color: var(--color-text-primary);
+      font-size: 20px;
+      line-height: 28px;
+      font-weight: 400;
+      margin-bottom: 30px;
     }
 
     h6 {

--- a/app/views/admin/fasp/debug/callbacks/index.html.haml
+++ b/app/views/admin/fasp/debug/callbacks/index.html.haml
@@ -2,7 +2,7 @@
   = t('admin.fasp.debug.callbacks.title')
 
 - content_for :heading do
-  %h2= t('admin.fasp.debug.callbacks.title')
+  %h1= t('admin.fasp.debug.callbacks.title')
   = render 'admin/fasp/shared/links'
 
 - unless @callbacks.empty?

--- a/app/views/admin/fasp/providers/edit.html.haml
+++ b/app/views/admin/fasp/providers/edit.html.haml
@@ -4,7 +4,7 @@
 = simple_form_for [:admin, @provider] do |f|
   = render 'shared/error_messages', object: @provider
 
-  %h4= t('admin.fasp.providers.select_capabilities')
+  %h2= t('admin.fasp.providers.select_capabilities')
 
   .fields_group
     = f.fields_for :capabilities do |cf|

--- a/app/views/admin/fasp/providers/index.html.haml
+++ b/app/views/admin/fasp/providers/index.html.haml
@@ -2,7 +2,7 @@
   = t('admin.fasp.providers.title')
 
 - content_for :heading do
-  %h2= t('admin.fasp.providers.title')
+  %h1= t('admin.fasp.providers.title')
   = render 'admin/fasp/shared/links'
 
 - unless @providers.empty?

--- a/app/views/admin/roles/_form.html.haml
+++ b/app/views/admin/roles/_form.html.haml
@@ -40,7 +40,7 @@
       %span.hint= t('simple_form.hints.user_role.permissions_as_keys')
 
     - (form.object.everyone? ? UserRole::Flags::CATEGORIES.slice(:invites) : UserRole::Flags::CATEGORIES).each do |category, permissions|
-      %h4= t(category, scope: 'admin.roles.categories')
+      %h2= t(category, scope: 'admin.roles.categories')
 
       = form.input :permissions_as_keys,
                    as: :check_boxes,

--- a/app/views/admin/rules/edit.html.haml
+++ b/app/views/admin/rules/edit.html.haml
@@ -8,7 +8,7 @@
 
   %hr.spacer/
 
-  %h4= t('admin.rules.translations')
+  %h2= t('admin.rules.translations')
 
   %p.hint= t('admin.rules.translations_explanation')
 

--- a/app/views/admin/settings/about/show.html.haml
+++ b/app/views/admin/settings/about/show.html.haml
@@ -2,7 +2,7 @@
   = t('admin.settings.about.title')
 
 - content_for :heading do
-  %h2= t('admin.settings.title')
+  %h1= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
 = simple_form_for @admin_settings, url: admin_settings_about_path do |f|

--- a/app/views/admin/settings/appearance/show.html.haml
+++ b/app/views/admin/settings/appearance/show.html.haml
@@ -2,7 +2,7 @@
   = t('admin.settings.appearance.title')
 
 - content_for :heading do
-  %h2= t('admin.settings.title')
+  %h1= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
 = simple_form_for @admin_settings, url: admin_settings_appearance_path do |f|

--- a/app/views/admin/settings/branding/show.html.haml
+++ b/app/views/admin/settings/branding/show.html.haml
@@ -2,7 +2,7 @@
   = t('admin.settings.branding.title')
 
 - content_for :heading do
-  %h2= t('admin.settings.title')
+  %h1= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
 = simple_form_for @admin_settings, url: admin_settings_branding_path do |f|

--- a/app/views/admin/settings/content_retention/show.html.haml
+++ b/app/views/admin/settings/content_retention/show.html.haml
@@ -2,7 +2,7 @@
   = t('admin.settings.content_retention.title')
 
 - content_for :heading do
-  %h2= t('admin.settings.title')
+  %h1= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
 = simple_form_for @admin_settings, url: admin_settings_content_retention_path do |f|
@@ -18,7 +18,7 @@
               input_html: { pattern: '[0-9]+' },
               wrapper: :with_block_label
 
-  %h4= t('admin.settings.content_retention.danger_zone')
+  %h2= t('admin.settings.content_retention.danger_zone')
 
   .fields-group
     = f.input :content_cache_retention_period,

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -2,7 +2,7 @@
   = t('admin.settings.discovery.title')
 
 - content_for :heading do
-  %h2= t('admin.settings.title')
+  %h1= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
 = simple_form_for @admin_settings, url: admin_settings_discovery_path do |f|
@@ -10,7 +10,7 @@
 
   %p.lead= t('admin.settings.discovery.preamble')
 
-  %h4= t('admin.settings.discovery.trends')
+  %h2= t('admin.settings.discovery.trends')
 
   .fields-group
     = f.input :trends,
@@ -23,7 +23,7 @@
               wrapper: :with_label,
               recommended: :not_recommended
 
-  %h4= t('admin.settings.discovery.public_timelines')
+  %h2= t('admin.settings.discovery.public_timelines')
 
   .fields-row
     .fields-row__column.fields-row__column-6.fields-group
@@ -55,7 +55,7 @@
                 label_method: ->(mode) { I18n.t("admin.settings.feed_access.modes.#{mode}") },
                 wrapper: :with_label
 
-  %h4= t('admin.settings.discovery.privacy')
+  %h2= t('admin.settings.discovery.privacy')
 
   .fields-group
     = f.input :noindex,
@@ -71,7 +71,7 @@
               label: t('admin.settings.allow_referrer_origin.title'),
               wrapper: :with_label
 
-  %h4= t('admin.settings.discovery.publish_statistics')
+  %h2= t('admin.settings.discovery.publish_statistics')
 
   .fields-group
     = f.input :activity_api_enabled,
@@ -85,7 +85,7 @@
               wrapper: :with_label,
               recommended: :recommended
 
-  %h4= t('admin.settings.security.federation_authentication')
+  %h2= t('admin.settings.security.federation_authentication')
 
   .fields-group
     = f.input :authorized_fetch,
@@ -97,20 +97,20 @@
               warning_hint: discovery_warning_hint_text,
               wrapper: :with_label
 
-  %h4= t('admin.settings.discovery.follow_recommendations')
+  %h2= t('admin.settings.discovery.follow_recommendations')
 
   .fields-group
     = f.input :bootstrap_timeline_accounts,
               wrapper: :with_block_label
 
-  %h4= t('admin.settings.discovery.profile_directory')
+  %h2= t('admin.settings.discovery.profile_directory')
 
   .fields-group
     = f.input :profile_directory,
               as: :boolean,
               wrapper: :with_label
 
-  %h4= t('admin.settings.discovery.wrapstodon')
+  %h2= t('admin.settings.discovery.wrapstodon')
 
   .fields-group
     = f.input :wrapstodon,

--- a/app/views/admin/settings/registrations/show.html.haml
+++ b/app/views/admin/settings/registrations/show.html.haml
@@ -2,7 +2,7 @@
   = t('admin.settings.registrations.title')
 
 - content_for :heading do
-  %h2= t('admin.settings.title')
+  %h1= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
 = simple_form_for @admin_settings, url: admin_settings_registrations_path do |f|

--- a/app/views/admin/terms_of_service/drafts/show.html.haml
+++ b/app/views/admin/terms_of_service/drafts/show.html.haml
@@ -2,7 +2,7 @@
   = t('admin.terms_of_service.title')
 
 - content_for :heading do
-  %h2= t('admin.terms_of_service.title')
+  %h1= t('admin.terms_of_service.title')
   = render partial: 'admin/terms_of_service/links'
 
 = simple_form_for @terms_of_service, url: admin_terms_of_service_draft_path, method: :put do |form|

--- a/app/views/admin/terms_of_service/histories/show.html.haml
+++ b/app/views/admin/terms_of_service/histories/show.html.haml
@@ -2,7 +2,7 @@
   = t('admin.terms_of_service.history')
 
 - content_for :heading do
-  %h2= t('admin.terms_of_service.title')
+  %h1= t('admin.terms_of_service.title')
   = render partial: 'admin/terms_of_service/links'
 
 - if @terms_of_service.empty?

--- a/app/views/admin/terms_of_service/index.html.haml
+++ b/app/views/admin/terms_of_service/index.html.haml
@@ -2,7 +2,7 @@
   = t('admin.terms_of_service.title')
 
 - content_for :heading do
-  %h2= t('admin.terms_of_service.title')
+  %h1= t('admin.terms_of_service.title')
   = render partial: 'links'
 
 - if @terms_of_service.present?
@@ -31,7 +31,7 @@
 
   %hr.spacer/
 
-  %h3= t('admin.terms_of_service.changelog')
+  %h2.heading-medium= t('admin.terms_of_service.changelog')
 
   .prose
     = markdown(@terms_of_service.changelog)

--- a/app/views/admin/webhooks/show.html.haml
+++ b/app/views/admin/webhooks/show.html.haml
@@ -3,7 +3,7 @@
 
 - content_for :heading do
   .content__heading__row
-    %h2
+    %h1
       %small
         = material_symbol 'inbox'
         = t('admin.webhooks.webhook')

--- a/app/views/auth/registrations/_status.html.haml
+++ b/app/views/auth/registrations/_status.html.haml
@@ -10,7 +10,7 @@
     = t('auth.status.redirecting_to', acct: user.account.moved_to_account.pretty_acct)
     = link_to t('migrations.cancel'), settings_migration_path
 
-%h3= t('auth.status.account_status')
+%h2.heading-medium= t('auth.status.account_status')
 
 %p.hint
   - if user.account.suspended?

--- a/app/views/auth/registrations/edit.html.haml
+++ b/app/views/auth/registrations/edit.html.haml
@@ -7,7 +7,7 @@
 - else
   = render partial: 'status', locals: { user: @user, strikes: @strikes }
 
-%h3= t('auth.security')
+%h2.heading-medium= t('auth.security')
 
 = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'auth_edit', novalidate: false }) do |f|
   = render 'shared/error_messages', object: resource
@@ -57,15 +57,15 @@
 - unless current_account.suspended? || self_destruct?
   %hr.spacer/
 
-  %h3= t('auth.migrate_account')
+  %h2.heading-medium= t('auth.migrate_account')
   %p.muted-hint= t('auth.migrate_account_html', path: settings_migration_path)
 
   %hr.spacer/
 
-  %h3= t('migrations.incoming_migrations')
+  %h2.heading-medium= t('migrations.incoming_migrations')
   %p.muted-hint= t('migrations.incoming_migrations_html', path: settings_aliases_path)
 
   %hr.spacer/
 
-  %h3= t('auth.delete_account')
+  %h2.heading-medium= t('auth.delete_account')
   %p.muted-hint= t('auth.delete_account_html', path: settings_delete_path)

--- a/app/views/auth/sessions/new.html.haml
+++ b/app/views/auth/sessions/new.html.haml
@@ -38,7 +38,7 @@
 
 - if devise_mapping.omniauthable? && resource_class.omniauth_providers.any?
   .simple_form.alternative-login
-    %h4= omniauth_only? ? t('auth.log_in_with') : t('auth.or_log_in_with')
+    %h2= omniauth_only? ? t('auth.log_in_with') : t('auth.or_log_in_with')
 
     .actions
       - resource_class.omniauth_providers.each do |provider|

--- a/app/views/filters/_filter_fields.html.haml
+++ b/app/views/filters/_filter_fields.html.haml
@@ -36,13 +36,13 @@
 %hr.spacer/
 
 - unless f.object.statuses.empty?
-  %h4= t('filters.edit.statuses')
+  %h2= t('filters.edit.statuses')
 
   %p.muted-hint= t('filters.edit.statuses_hint_html', path: filter_statuses_path(f.object))
 
   %hr.spacer/
 
-%h4= t('filters.edit.keywords')
+%h2= t('filters.edit.keywords')
 
 .table-wrapper
   %table.table.keywords-table

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -31,7 +31,7 @@
             = yield :heading
           - else
             .content__heading__row
-              %h2= yield :page_title
+              %h1= yield :page_title
 
               - if content_for?(:heading_actions)
                 .content__heading__actions

--- a/app/views/settings/featured_tags/index.html.haml
+++ b/app/views/settings/featured_tags/index.html.haml
@@ -2,7 +2,7 @@
   = t('settings.featured_tags')
 
 - content_for :heading do
-  %h2= t('settings.profile')
+  %h1= t('settings.profile')
   = render partial: 'settings/shared/profile_navigation'
 
 = simple_form_for @featured_tag, url: settings_featured_tags_path do |f|
@@ -23,7 +23,7 @@
 - @featured_tags.each do |featured_tag|
   .directory__tag
     %div
-      %h4
+      %h2
         = material_symbol 'tag'
         = featured_tag.display_name
         %small

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -69,7 +69,7 @@
       = link_to t('appearance.localization.guide_link_text'), t('appearance.localization.guide_link'), target: '_blank', rel: 'noopener'
 
   = f.simple_fields_for :settings, current_user.settings do |ff|
-    %h4= t 'appearance.animations_and_accessibility'
+    %h2= t 'appearance.animations_and_accessibility'
 
     .fields-group
       = ff.input :'web.use_pending_items',
@@ -85,12 +85,12 @@
       = ff.input :'web.use_system_font', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_system_font_ui')
       = ff.input :'web.use_system_scrollbars', wrapper: :with_label, hint: I18n.t('simple_form.hints.defaults.setting_system_scrollbars_ui'), label: I18n.t('simple_form.labels.defaults.setting_system_scrollbars_ui')
 
-    %h4= t 'appearance.discovery'
+    %h2= t 'appearance.discovery'
 
     .fields-group
       = ff.input :'web.trends', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_trends')
 
-    %h4= t 'appearance.boosting_preferences'
+    %h2= t 'appearance.boosting_preferences'
 
     .fields-group
       = ff.input :'web.reblog_modal',
@@ -104,7 +104,7 @@
                  wrapper: :with_label
     .flash-message.hidden-on-touch-devices= t('appearance.boosting_preferences_info_html', icon: material_symbol('repeat'))
 
-    %h4= t 'appearance.sensitive_content'
+    %h2= t 'appearance.sensitive_content'
 
     .fields-group
       = ff.input :'web.display_media',
@@ -127,7 +127,7 @@
     .fields-group
       = ff.input :'web.expand_content_warnings', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_expand_spoilers')
 
-    %h4= t 'appearance.advanced_settings'
+    %h2= t 'appearance.advanced_settings'
 
     .fields-group
       = ff.input :'web.advanced_layout',

--- a/app/views/settings/preferences/notifications/show.html.haml
+++ b/app/views/settings/preferences/notifications/show.html.haml
@@ -7,7 +7,7 @@
 = simple_form_for current_user, url: settings_preferences_notifications_path, html: { id: :edit_notification } do |f|
   = render 'shared/error_messages', object: current_user
 
-  %h4= t 'notifications.email_events'
+  %h2= t 'notifications.email_events'
 
   %p.hint= t 'notifications.email_events_hint'
 
@@ -24,7 +24,7 @@
       = ff.input :always_send_emails, wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_always_send_emails'), hint: I18n.t('simple_form.hints.defaults.setting_always_send_emails')
 
     - if current_user.can?(:manage_reports, :manage_appeals, :manage_users, :manage_taxonomies) || (SoftwareUpdate.check_enabled? && current_user.can?(:view_devops))
-      %h4= t 'notifications.administration_emails'
+      %h2= t 'notifications.administration_emails'
 
       .fields-group
         = ff.input :'notification_emails.report', wrapper: :with_label, label: I18n.t('simple_form.labels.notification_emails.report') if current_user.can?(:manage_reports)

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -15,7 +15,7 @@
                  recommended: true,
                  wrapper: :with_label
 
-  %h4= t 'preferences.public_timelines'
+  %h2= t 'preferences.public_timelines'
 
   .fields-group
     = f.input :chosen_languages,

--- a/app/views/settings/privacy/show.html.haml
+++ b/app/views/settings/privacy/show.html.haml
@@ -2,14 +2,14 @@
   = t('privacy.title')
 
 - content_for :heading do
-  %h2= t('privacy.title')
+  %h1= t('privacy.title')
 
 = simple_form_for @account, url: settings_privacy_path do |f|
   = render 'shared/error_messages', object: @account
 
   %p.lead= t('privacy.hint_html')
 
-  %h4= t('privacy.reach')
+  %h2= t('privacy.reach')
 
   %p.lead= t('privacy.reach_hint_html')
 
@@ -19,7 +19,7 @@
   .fields-group
     = f.input :unlocked, as: :boolean, wrapper: :with_label
 
-  %h4= t('privacy.search')
+  %h2= t('privacy.search')
 
   %p.lead= t('privacy.search_hint_html')
 
@@ -30,7 +30,7 @@
     .fields-group
       = ff.input :indexable, wrapper: :with_label
 
-  %h4= t('privacy.privacy')
+  %h2= t('privacy.privacy')
 
   %p.lead= t('privacy.privacy_hint_html')
 

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -2,7 +2,7 @@
   = t('settings.edit_profile')
 
 - content_for :heading do
-  %h2= t('settings.profile')
+  %h1= t('settings.profile')
   = render partial: 'settings/shared/profile_navigation'
 
 = simple_form_for @account, url: settings_profile_path, html: { id: :edit_profile } do |f|
@@ -10,7 +10,7 @@
 
   %p.lead= t('edit_profile.hint_html')
 
-  %h4= t('edit_profile.basic_information')
+  %h2= t('edit_profile.basic_information')
 
   .fields-row
     .fields-row__column.fields-row__column-6
@@ -62,7 +62,7 @@
             = material_symbol 'delete'
             = t('generic.delete')
 
-  %h4= t('edit_profile.other')
+  %h2= t('edit_profile.other')
 
   .fields-group
     = f.input :bot, as: :boolean, wrapper: :with_label, hint: t('simple_form.hints.defaults.bot')

--- a/app/views/settings/verifications/show.html.haml
+++ b/app/views/settings/verifications/show.html.haml
@@ -2,15 +2,15 @@
   = t('verification.verification')
 
 - content_for :heading do
-  %h2= t('settings.profile')
+  %h1= t('settings.profile')
   = render partial: 'settings/shared/profile_navigation'
 
 .simple_form.form-section
-  %h3= t('verification.website_verification')
+  %h2.heading-medium= t('verification.website_verification')
 
   %p.lead= t('verification.hint_html')
 
-  %h4= t('verification.here_is_how')
+  %h3.heading-small= t('verification.here_is_how')
 
   %p.lead= t('verification.instructions_html')
 
@@ -22,7 +22,7 @@
   %p.lead= t('verification.extra_instructions_html')
 
   - if @verified_links.any?
-    %h4= t('verification.verified_links')
+    %h3.heading-small= t('verification.verified_links')
 
     %ul.lead
       - @verified_links.each do |field|
@@ -34,7 +34,7 @@
 = simple_form_for @account, url: settings_verification_path, html: { class: 'form-section' } do |f|
   = render 'shared/error_messages', object: @account
 
-  %h3= t('author_attribution.title')
+  %h2.heading-medium= t('author_attribution.title')
 
   %p.lead= t('author_attribution.hint_html')
 
@@ -53,7 +53,7 @@
         = logo_as_symbol(:icon)
         = t('author_attribution.more_from_html', name: author_attribution_name(@account))
 
-  %h4= t('verification.here_is_how')
+  %h3.heading-small= t('verification.here_is_how')
 
   %p.lead= t('author_attribution.instructions')
 

--- a/app/views/statuses_cleanup/show.html.haml
+++ b/app/views/statuses_cleanup/show.html.haml
@@ -24,7 +24,7 @@
 
   .flash-message= t('statuses_cleanup.explanation')
 
-  %h4= t('statuses_cleanup.exceptions')
+  %h2= t('statuses_cleanup.exceptions')
 
   .fields-row
     .fields-row__column.fields-row__column-6.fields-group
@@ -68,7 +68,7 @@
                 label: t('statuses_cleanup.keep_media'),
                 wrapper: :with_label
 
-  %h4= t('statuses_cleanup.interaction_exceptions')
+  %h2= t('statuses_cleanup.interaction_exceptions')
 
   .fields-row
     .fields-row__column.fields-row__column-6.fields-group

--- a/spec/system/admin/fasp/debug/callbacks_spec.rb
+++ b/spec/system/admin/fasp/debug/callbacks_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe 'Debug FASP Callback Management', feature: :fasp do
     it 'displays callbacks and allows to delete them' do
       visit admin_fasp_debug_callbacks_path
 
-      expect(page).to have_css('h2', text: I18n.t('admin.fasp.debug.callbacks.title'))
+      expect(page).to have_css('h1', text: I18n.t('admin.fasp.debug.callbacks.title'))
       expect(page).to have_css('td', text: 'debug prov')
       expect(page).to have_css('code', text: 'called back')
 
       expect do
         click_on I18n.t('admin.fasp.debug.callbacks.delete')
 
-        expect(page).to have_css('h2', text: I18n.t('admin.fasp.debug.callbacks.title'))
+        expect(page).to have_css('h1', text: I18n.t('admin.fasp.debug.callbacks.title'))
       end.to change(Fasp::DebugCallback, :count).by(-1)
     end
   end

--- a/spec/system/admin/fasp/debug_calls_spec.rb
+++ b/spec/system/admin/fasp/debug_calls_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe 'FASP Debug Calls', feature: :fasp do
     it 'makes a debug call to the provider' do
       visit admin_fasp_providers_path
 
-      expect(page).to have_css('h2', text: I18n.t('admin.fasp.providers.title'))
+      expect(page).to have_css('h1', text: I18n.t('admin.fasp.providers.title'))
       expect(page).to have_css('td', text: provider.name)
 
       within 'table#providers' do
         click_on I18n.t('admin.fasp.providers.callback')
       end
 
-      expect(page).to have_css('h2', text: I18n.t('admin.fasp.providers.title'))
+      expect(page).to have_css('h1', text: I18n.t('admin.fasp.providers.title'))
       expect(debug_call).to have_been_requested
     end
   end

--- a/spec/system/admin/fasp/providers_spec.rb
+++ b/spec/system/admin/fasp/providers_spec.rb
@@ -34,30 +34,30 @@ RSpec.describe 'FASP Management', feature: :fasp do
     it 'allows enabling and disabling of capabilities' do
       visit admin_fasp_providers_path
 
-      expect(page).to have_css('h2', text: I18n.t('admin.fasp.providers.title'))
+      expect(page).to have_css('h1', text: I18n.t('admin.fasp.providers.title'))
       expect(page).to have_css('td', text: provider.name)
 
       click_on I18n.t('admin.fasp.providers.edit')
 
-      expect(page).to have_css('h2', text: I18n.t('admin.fasp.providers.edit'))
+      expect(page).to have_css('h1', text: I18n.t('admin.fasp.providers.edit'))
 
       check 'callback'
 
       click_on I18n.t('admin.fasp.providers.save')
 
-      expect(page).to have_css('h2', text: I18n.t('admin.fasp.providers.title'))
+      expect(page).to have_css('h1', text: I18n.t('admin.fasp.providers.title'))
       expect(provider.reload).to be_capability_enabled('callback')
       expect(enable_call).to have_been_requested
 
       click_on I18n.t('admin.fasp.providers.edit')
 
-      expect(page).to have_css('h2', text: I18n.t('admin.fasp.providers.edit'))
+      expect(page).to have_css('h1', text: I18n.t('admin.fasp.providers.edit'))
 
       uncheck 'callback'
 
       click_on I18n.t('admin.fasp.providers.save')
 
-      expect(page).to have_css('h2', text: I18n.t('admin.fasp.providers.title'))
+      expect(page).to have_css('h1', text: I18n.t('admin.fasp.providers.title'))
       expect(provider.reload).to_not be_capability_enabled('callback')
       expect(disable_call).to have_been_requested
     end
@@ -69,12 +69,12 @@ RSpec.describe 'FASP Management', feature: :fasp do
     it 'allows to completely remove a provider' do
       visit admin_fasp_providers_path
 
-      expect(page).to have_css('h2', text: I18n.t('admin.fasp.providers.title'))
+      expect(page).to have_css('h1', text: I18n.t('admin.fasp.providers.title'))
       expect(page).to have_css('td', text: provider.name)
 
       click_on I18n.t('admin.fasp.providers.delete')
 
-      expect(page).to have_css('h2', text: I18n.t('admin.fasp.providers.title'))
+      expect(page).to have_css('h1', text: I18n.t('admin.fasp.providers.title'))
       expect(page).to have_no_css('td', text: provider.name)
     end
   end

--- a/spec/system/admin/fasp/registrations_spec.rb
+++ b/spec/system/admin/fasp/registrations_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'FASP registration', feature: :fasp do
 
       click_on I18n.t('admin.fasp.providers.registrations.confirm')
 
-      expect(page).to have_css('h2', text: I18n.t('admin.fasp.providers.edit'))
+      expect(page).to have_css('h1', text: I18n.t('admin.fasp.providers.edit'))
 
       expect(provider.reload).to be_confirmed
     end


### PR DESCRIPTION
Related to WEB-881

### Changes proposed in this PR:
- Revamps the heading structure in the settings & admin pages, ensuring that the top-level page heading is a level 1, and that subheadings follow an appropriate hierarchy. (Previously, the top-level heading on these pages was an `h2`, and subheadings usually `h4`, skipping `h3` entirely.)
   - The current admin styles are tightly coupled to heading levels, which isn't great, but for now I've added a few new classes `.heading-large`, `.heading-medium`, and `.heading-small` that allow assigning the default styles of a different heading level to an element of another level
   - There should be no visual changes and I've checked all pages, but it's possible that there are page states with headings that now have the wrong styling
   - I focused on the top-level headings `h1`-`h4` here – there are some item lists that use `h5` for their items, those will have to be addressed later