### PR TITLE
Use `to_json` call for pins API

### DIFF
--- a/app/controllers/api/v1/statuses/pins_controller.rb
+++ b/app/controllers/api/v1/statuses/pins_controller.rb
@@ -30,7 +30,7 @@ class Api::V1::Statuses::PinsController < Api::V1::Statuses::BaseController
       adapter: ActivityPub::Adapter
     ).as_json
 
-    ActivityPub::RawDistributionWorker.perform_async(Oj.dump(json), current_account.id)
+    ActivityPub::RawDistributionWorker.perform_async(json.to_json, current_account.id)
   end
 
   def distribute_remove_activity!
@@ -40,6 +40,6 @@ class Api::V1::Statuses::PinsController < Api::V1::Statuses::BaseController
       adapter: ActivityPub::Adapter
     ).as_json
 
-    ActivityPub::RawDistributionWorker.perform_async(Oj.dump(json), current_account.id)
+    ActivityPub::RawDistributionWorker.perform_async(json.to_json, current_account.id)
   end
 end

--- a/spec/requests/api/v1/statuses/pins_spec.rb
+++ b/spec/requests/api/v1/statuses/pins_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe 'Pins' do
         expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, pinned: true)
         )
+        expect(ActivityPub::RawDistributionWorker)
+          .to have_enqueued_sidekiq_job(match_json_values(type: 'Add'), user.account.id)
       end
     end
 
@@ -118,6 +120,8 @@ RSpec.describe 'Pins' do
         expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, pinned: false)
         )
+        expect(ActivityPub::RawDistributionWorker)
+          .to have_enqueued_sidekiq_job(match_json_values(type: 'Remove'), user.account.id)
       end
     end
 


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

Probably further refactor opportunity here to pull out the nearly identical serialize/as_json blocks from the methods right above these lines to new method which takes a serializer arg.