### PR TITLE
Use `to_json` call for Relay enable/disable

### DIFF
--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -31,7 +31,7 @@ class Relay < ApplicationRecord
 
   def enable!
     activity_id = ActivityPub::TagManager.instance.generate_uri_for(nil)
-    payload     = Oj.dump(follow_activity(activity_id))
+    payload     = follow_activity(activity_id).to_json
 
     update!(state: :pending, follow_activity_id: activity_id)
     reset_delivery_tracker
@@ -40,7 +40,7 @@ class Relay < ApplicationRecord
 
   def disable!
     activity_id = ActivityPub::TagManager.instance.generate_uri_for(nil)
-    payload     = Oj.dump(unfollow_activity(activity_id))
+    payload     = unfollow_activity(activity_id).to_json
 
     update!(state: :idle, follow_activity_id: nil)
     reset_delivery_tracker

--- a/spec/models/relay_spec.rb
+++ b/spec/models/relay_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Relay do
         .to change { relay.reload.state }.to('idle')
         .and change { relay.reload.follow_activity_id }.to(be_nil)
       expect(ActivityPub::DeliveryWorker)
-        .to have_received(:perform_async).with(match('Undo'), Account.representative.id, relay.inbox_url)
+        .to have_received(:perform_async).with(match_json_values(type: 'Undo'), Account.representative.id, relay.inbox_url)
       expect(DeliveryFailureTracker)
         .to have_received(:reset!).with(relay.inbox_url)
     end
@@ -94,7 +94,7 @@ RSpec.describe Relay do
         .to change { relay.reload.state }.to('pending')
         .and change { relay.reload.follow_activity_id }.to(be_present)
       expect(ActivityPub::DeliveryWorker)
-        .to have_received(:perform_async).with(match('Follow'), Account.representative.id, relay.inbox_url)
+        .to have_received(:perform_async).with(match_json_values(type: 'Follow'), Account.representative.id, relay.inbox_url)
       expect(DeliveryFailureTracker)
         .to have_received(:reset!).with(relay.inbox_url)
     end


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

These responses do not have a timestamp, and both enable/disable have coverage on the json passed to the worker. Made slightly more detailed in spec. Local debug output looks same before/after change.