### PR TITLE
Use `to_json` call in web/push notification worker

### DIFF
--- a/app/workers/web/push_notification_worker.rb
+++ b/app/workers/web/push_notification_worker.rb
@@ -101,7 +101,7 @@ class Web::PushNotificationWorker
 
   def push_notification_json
     I18n.with_locale(@subscription.locale.presence || I18n.default_locale) do
-      Oj.dump(serialized_notification.as_json)
+      serialized_notification.to_json
     end
   end
 


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

This one is verified by local debug inspection only. The spec completely stubs out this method so there's not a good spot there to verify anything. I'm reasonably confident because the serializer is pretty straightforward, does not contain any times, etc. Open to other ideas to be sure.

Unrelated to this JSON stuff, improving this spec (remove the SUT stub, etc) would be good.