### PR TITLE
Use `JSON.generate` in backup service

### DIFF
--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -23,7 +23,7 @@ class BackupService < BaseService
     skeleton = serialize(collection_presenter, ActivityPub::CollectionSerializer)
     skeleton[:@context] = full_context
     skeleton[:orderedItems] = ['!PLACEHOLDER!']
-    skeleton = Oj.dump(skeleton)
+    skeleton = JSON.generate(skeleton)
     prepend, append = skeleton.split('"!PLACEHOLDER!"')
     add_comma = false
 
@@ -44,7 +44,7 @@ class BackupService < BaseService
           end
         end
 
-        Oj.dump(item)
+        JSON.generate(item)
       end.join(','))
 
       GC.start
@@ -107,7 +107,7 @@ class BackupService < BaseService
     download_to_zip(zipfile, account.avatar, "avatar#{File.extname(account.avatar.path)}") if account.avatar.exists?
     download_to_zip(zipfile, account.header, "header#{File.extname(account.header.path)}") if account.header.exists?
 
-    json = Oj.dump(actor)
+    json = JSON.generate(actor)
 
     zipfile.get_output_stream('actor.json') do |io|
       io.write(json)
@@ -118,7 +118,7 @@ class BackupService < BaseService
     skeleton = serialize(ActivityPub::CollectionPresenter.new(id: 'likes.json', type: :ordered, size: 0, items: []), ActivityPub::CollectionSerializer)
     skeleton.delete(:totalItems)
     skeleton[:orderedItems] = ['!PLACEHOLDER!']
-    skeleton = Oj.dump(skeleton)
+    skeleton = JSON.generate(skeleton)
     prepend, append = skeleton.split('"!PLACEHOLDER!"')
 
     zipfile.get_output_stream('likes.json') do |io|
@@ -131,7 +131,7 @@ class BackupService < BaseService
         add_comma = true
 
         io.write(statuses.map do |status|
-          Oj.dump(ActivityPub::TagManager.instance.uri_for(status))
+          JSON.generate(ActivityPub::TagManager.instance.uri_for(status))
         end.join(','))
 
         GC.start
@@ -145,7 +145,7 @@ class BackupService < BaseService
     skeleton = serialize(ActivityPub::CollectionPresenter.new(id: 'bookmarks.json', type: :ordered, size: 0, items: []), ActivityPub::CollectionSerializer)
     skeleton.delete(:totalItems)
     skeleton[:orderedItems] = ['!PLACEHOLDER!']
-    skeleton = Oj.dump(skeleton)
+    skeleton = JSON.generate(skeleton)
     prepend, append = skeleton.split('"!PLACEHOLDER!"')
 
     zipfile.get_output_stream('bookmarks.json') do |io|
@@ -157,7 +157,7 @@ class BackupService < BaseService
         add_comma = true
 
         io.write(statuses.map do |status|
-          Oj.dump(ActivityPub::TagManager.instance.uri_for(status))
+          JSON.generate(ActivityPub::TagManager.instance.uri_for(status))
         end.join(','))
 
         GC.start

--- a/spec/services/backup_service_spec.rb
+++ b/spec/services/backup_service_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe BackupService do
 
   def expect_outbox_export
     body = export_json_raw(:outbox)
-    json = Oj.load(body)
+    json = JSON.parse(body)
 
     aggregate_failures do
       expect(body.scan('@context').count).to eq 1
@@ -93,7 +93,7 @@ RSpec.describe BackupService do
   end
 
   def export_json(type)
-    Oj.load(export_json_raw(type))
+    JSON.parse(export_json_raw(type))
   end
 
   def include_create_item(status)


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32704

I did one change at a time and mix of watching the specs and reviewing local debug output ... most of this is just doing a single string (urls) or is converting something which already passed through an AMS serializer.