### PR TITLE
Convert `Oj.load` -> `JSON.parse` in most places

### DIFF
--- a/app/controllers/api/v1/donation_campaigns_controller.rb
+++ b/app/controllers/api/v1/donation_campaigns_controller.rb
@@ -35,7 +35,7 @@ class Api::V1::DonationCampaignsController < Api::BaseController
     return if key.blank?
 
     campaign = Rails.cache.read("donation_campaign:#{key}", raw: true)
-    Oj.load(campaign) if campaign.present?
+    JSON.parse(campaign) if campaign.present?
   end
 
   def save_to_cache!(campaign)
@@ -57,7 +57,7 @@ class Api::V1::DonationCampaignsController < Api::BaseController
       url.query_values = { platform: 'web', seed: seed, locale: locale, environment: Rails.configuration.x.donation_campaigns.environment }.compact
 
       Request.new(:get, url.to_s).perform do |res|
-        return Oj.load(res.body_with_limit, mode: :strict) if res.code == 200
+        return JSON.parse(res.body_with_limit) if res.code == 200
       end
     end
   rescue *Mastodon::HTTP_CONNECTION_ERRORS, Oj::ParseError

--- a/app/helpers/json_ld_helper.rb
+++ b/app/helpers/json_ld_helper.rb
@@ -309,7 +309,7 @@ module JsonLdHelper
   end
 
   def body_to_json(body, compare_id: nil)
-    json = body.is_a?(String) ? Oj.load(body, mode: :strict) : body
+    json = body.is_a?(String) ? JSON.parse(body) : body
 
     return if compare_id.present? && json['id'] != compare_id
 

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -80,7 +80,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
 
   def ffmpeg_version
     version_output = Terrapin::CommandLine.new(Rails.configuration.x.ffprobe_binary, '-show_program_version -v 0 -of json').run
-    version = Oj.load(version_output, mode: :strict, symbol_keys: true).dig(:program_version, :version)
+    version = JSON.parse(version_output, symbolize_names: true).dig(:program_version, :version)
 
     {
       key: 'ffmpeg',

--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -265,7 +265,7 @@ class LinkDetailsExtractor
       next unless structured_data.valid?
 
       structured_data
-    rescue Oj::ParseError, EncodingError
+    rescue JSON::ParserError, EncodingError
       Rails.logger.debug { "Invalid JSON-LD in #{@original_url}" }
       next
     end.first

--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -101,7 +101,7 @@ class LinkDetailsExtractor
     end
 
     def json
-      @json ||= root_array(Oj.load(@data)).compact.find { |obj| SUPPORTED_TYPES.include?(obj['@type']) } || {}
+      @json ||= root_array(JSON.parse(@data)).compact.find { |obj| SUPPORTED_TYPES.include?(obj['@type']) } || {}
     end
   end
 

--- a/app/lib/translation_service/deepl.rb
+++ b/app/lib/translation_service/deepl.rb
@@ -68,7 +68,7 @@ class TranslationService::DeepL < TranslationService
   end
 
   def transform_response(json)
-    data = Oj.load(json, mode: :strict)
+    data = JSON.parse(json)
     raise UnexpectedResponseError unless data.is_a?(Hash)
 
     data['translations'].map do |translation|

--- a/app/lib/translation_service/deepl.rb
+++ b/app/lib/translation_service/deepl.rb
@@ -31,7 +31,7 @@ class TranslationService::DeepL < TranslationService
 
   def fetch_languages(type)
     request(:get, "/v2/languages?type=#{type}") do |res|
-      Oj.load(res.body_with_limit).map { |language| normalize_language(language['language']) }
+      JSON.parse(res.body_with_limit).map { |language| normalize_language(language['language']) }
     end
   end
 

--- a/app/lib/translation_service/libre_translate.rb
+++ b/app/lib/translation_service/libre_translate.rb
@@ -17,7 +17,7 @@ class TranslationService::LibreTranslate < TranslationService
 
   def languages
     request(:get, '/languages') do |res|
-      languages = Oj.load(res.body_with_limit).to_h do |language|
+      languages = JSON.parse(res.body_with_limit).to_h do |language|
         [language['code'], language['targets'].without(language['code'])]
       end
       languages[nil] = languages.values.flatten.uniq.sort
@@ -45,7 +45,7 @@ class TranslationService::LibreTranslate < TranslationService
   end
 
   def transform_response(json, source_language)
-    data = Oj.load(json, mode: :strict)
+    data = JSON.parse(json)
     raise UnexpectedResponseError unless data.is_a?(Hash)
 
     data['translatedText'].map.with_index do |text, index|

--- a/app/lib/video_metadata_extractor.rb
+++ b/app/lib/video_metadata_extractor.rb
@@ -6,7 +6,7 @@ class VideoMetadataExtractor
 
   def initialize(path)
     @path     = path
-    @metadata = Oj.load(ffmpeg_command_output, mode: :strict, symbol_keys: true)
+    @metadata = JSON.parse(ffmpeg_command_output, symbolize_names: true)
 
     parse_metadata
   rescue Terrapin::ExitStatusError, Oj::ParseError

--- a/app/lib/webfinger.rb
+++ b/app/lib/webfinger.rb
@@ -12,7 +12,7 @@ class Webfinger
 
     def initialize(uri, body)
       @uri  = uri
-      @json = Oj.load(body, mode: :strict)
+      @json = JSON.parse(body)
 
       validate_response!
     end

--- a/app/lib/webhooks/payload_renderer.rb
+++ b/app/lib/webhooks/payload_renderer.rb
@@ -58,7 +58,7 @@ class Webhooks::PayloadRenderer
   /iox
 
   def initialize(json)
-    @document = DocumentTraverser.new(Oj.load(json))
+    @document = DocumentTraverser.new(JSON.parse(json))
   end
 
   def render(template)

--- a/app/services/activitypub/process_collection_service.rb
+++ b/app/services/activitypub/process_collection_service.rb
@@ -6,7 +6,7 @@ class ActivityPub::ProcessCollectionService < BaseService
 
   def call(body, actor, **options)
     @account = actor
-    @json    = original_json = Oj.load(body, mode: :strict)
+    @json    = original_json = JSON.parse(body)
     @options = options
 
     return unless @json.is_a?(Hash)

--- a/app/services/software_update_check_service.rb
+++ b/app/services/software_update_check_service.rb
@@ -20,7 +20,7 @@ class SoftwareUpdateCheckService < BaseService
 
   def fetch_update_notices
     Request.new(:get, "#{api_url}?version=#{version}").add_headers('Accept' => 'application/json', 'User-Agent' => 'Mastodon update checker').perform do |res|
-      return Oj.load(res.body_with_limit, mode: :strict) if res.code == 200
+      return JSON.parse(res.body_with_limit) if res.code == 200
     end
   rescue *Mastodon::HTTP_CONNECTION_ERRORS, Oj::ParseError
     nil

--- a/app/validators/reaction_validator.rb
+++ b/app/validators/reaction_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ReactionValidator < ActiveModel::Validator
-  SUPPORTED_EMOJIS = Oj.load_file(Rails.root.join('app', 'javascript', 'mastodon', 'features', 'emoji', 'emoji_map.json').to_s).keys.freeze
+  SUPPORTED_EMOJIS = JSON.load_file(Rails.root.join('app', 'javascript', 'mastodon', 'features', 'emoji', 'emoji_map.json').to_s).keys.freeze
 
   LIMIT = 8
 


### PR DESCRIPTION
For each of these, we do have spec coverage exercising the path, and I did some local debug output checking. I think they are all ok. Preserved symbol keys where used before.

There are a few more like these which are not exercised by specs which I want to check one by one and will do as followups.