### PR TITLE
Use `JSON.generate` in db migrations

### DIFF
--- a/db/migrate/20180608213548_reject_following_blocked_users.rb
+++ b/db/migrate/20180608213548_reject_following_blocked_users.rb
@@ -28,7 +28,7 @@ class RejectFollowingBlockedUsers < ActiveRecord::Migration[5.2]
 
       next follow.destroy! if blocked_account.local?
 
-      reject_follow_json = Oj.dump(ActivityPub::LinkedDataSignature.new(ActiveModelSerializers::SerializableResource.new(follow, serializer: ActivityPub::RejectFollowSerializer, adapter: ActivityPub::Adapter).as_json).sign!(followed_account))
+      reject_follow_json = JSON.generate(ActivityPub::LinkedDataSignature.new(ActiveModelSerializers::SerializableResource.new(follow, serializer: ActivityPub::RejectFollowSerializer, adapter: ActivityPub::Adapter).as_json).sign!(followed_account))
 
       ActivityPub::DeliveryWorker.perform_async(reject_follow_json, followed_account, blocked_account.inbox_url)
 

--- a/db/migrate/20230215074423_move_user_settings.rb
+++ b/db/migrate/20230215074423_move_user_settings.rb
@@ -80,7 +80,7 @@ class MoveUserSettings < ActiveRecord::Migration[6.1]
           end
         end
 
-        user.update_column('settings', Oj.dump(user_settings))
+        user.update_column('settings', JSON.generate(user_settings))
       end
     end
   end

--- a/db/migrate/20240304090449_migrate_interaction_settings_to_policy.rb
+++ b/db/migrate/20240304090449_migrate_interaction_settings_to_policy.rb
@@ -21,7 +21,7 @@ class MigrateInteractionSettingsToPolicy < ActiveRecord::Migration[7.1]
   private
 
   def policy_for_user(user)
-    deserialized_settings = Oj.load(user.attributes_before_type_cast['settings'])
+    deserialized_settings = JSON.parse(user.attributes_before_type_cast['settings'])
     return if deserialized_settings.nil?
 
     requires_new_policy = false

--- a/db/migrate/20250911163952_fill_default_quote_policy_setting.rb
+++ b/db/migrate/20250911163952_fill_default_quote_policy_setting.rb
@@ -26,7 +26,7 @@ class FillDefaultQuotePolicySetting < ActiveRecord::Migration[8.0]
         should_update_settings = true
       end
 
-      user.update_column('settings', Oj.dump(settings)) if should_update_settings
+      user.update_column('settings', JSON.generate(settings)) if should_update_settings
     end
   end
 end

--- a/db/migrate/20250911163952_fill_default_quote_policy_setting.rb
+++ b/db/migrate/20250911163952_fill_default_quote_policy_setting.rb
@@ -8,7 +8,7 @@ class FillDefaultQuotePolicySetting < ActiveRecord::Migration[8.0]
 
   def up
     User.where.not(settings: nil).find_each do |user|
-      settings = Oj.load(user.attributes_before_type_cast['settings'])
+      settings = JSON.parse(user.attributes_before_type_cast['settings'])
       next if settings.nil?
 
       should_update_settings = false

--- a/db/migrate/20260209143308_migrate_user_theme.rb
+++ b/db/migrate/20260209143308_migrate_user_theme.rb
@@ -8,7 +8,7 @@ class MigrateUserTheme < ActiveRecord::Migration[8.0]
 
   def up
     User.where.not(settings: nil).find_each do |user|
-      settings = Oj.load(user.attributes_before_type_cast['settings'])
+      settings = JSON.parse(user.attributes_before_type_cast['settings'])
       next if settings.nil? || settings['theme'].blank? || %w(system default mastodon-light contrast).exclude?(settings['theme'])
 
       case settings['theme']

--- a/db/migrate/20260209143308_migrate_user_theme.rb
+++ b/db/migrate/20260209143308_migrate_user_theme.rb
@@ -25,7 +25,7 @@ class MigrateUserTheme < ActiveRecord::Migration[8.0]
 
       settings['theme'] = 'default'
 
-      user.update_column('settings', Oj.dump(settings))
+      user.update_column('settings', JSON.generate(settings))
     end
   end
 end

--- a/db/post_migrate/20230904134623_fix_kmr_locale_settings.rb
+++ b/db/post_migrate/20230904134623_fix_kmr_locale_settings.rb
@@ -11,7 +11,7 @@ class FixKmrLocaleSettings < ActiveRecord::Migration[7.0]
     MigrationUser.reset_column_information
 
     MigrationUser.where.not(settings: [nil, '{}']).find_each do |user|
-      user_settings = Oj.load(user.settings)
+      user_settings = JSON.parse(user.settings)
       next unless user_settings['default_language'] == 'kmr'
 
       user_settings['default_language'] = 'ku'

--- a/db/post_migrate/20230904134623_fix_kmr_locale_settings.rb
+++ b/db/post_migrate/20230904134623_fix_kmr_locale_settings.rb
@@ -15,7 +15,7 @@ class FixKmrLocaleSettings < ActiveRecord::Migration[7.0]
       next unless user_settings['default_language'] == 'kmr'
 
       user_settings['default_language'] = 'ku'
-      user.update!(settings: Oj.dump(user_settings))
+      user.update!(settings: JSON.generate(user_settings))
     end
 
     MigrationUser.where.not(chosen_languages: nil).where('chosen_languages && ?', '{kmr}').find_each do |user|

--- a/db/post_migrate/20240321160706_migrate_interaction_settings_to_policy_again.rb
+++ b/db/post_migrate/20240321160706_migrate_interaction_settings_to_policy_again.rb
@@ -21,7 +21,7 @@ class MigrateInteractionSettingsToPolicyAgain < ActiveRecord::Migration[7.1]
   private
 
   def policy_for_user(user)
-    deserialized_settings = Oj.load(user.attributes_before_type_cast['settings'])
+    deserialized_settings = JSON.parse(user.attributes_before_type_cast['settings'])
     return if deserialized_settings.nil?
     return if user.notification_policy.present?
 


### PR DESCRIPTION
One of these is working on an AMS serialized hash, and the rest are user settings within the migration. With the exception of the recent user theme one, its likely that none of these wil actually run again in production anywhere.

Ran the migration test script locally, will watch that on CI again as well.