### PR TITLE
Convert mix of `JSON.parse` and `JSON.load_file`

### DIFF
--- a/app/services/fetch_oembed_service.rb
+++ b/app/services/fetch_oembed_service.rb
@@ -86,14 +86,14 @@ class FetchOEmbedService
     end
 
     validate(parse_for_format(body)) if body.present?
-  rescue Oj::ParseError, Ox::ParseError
+  rescue JSON::ParserError, Ox::ParseError
     nil
   end
 
   def parse_for_format(body)
     case @format
     when :json
-      Oj.load(body, mode: :strict)&.with_indifferent_access
+      JSON.parse(body)&.with_indifferent_access
     when :xml
       Ox.load(body, mode: :hash_no_attrs)&.with_indifferent_access&.dig(:oembed)
     end

--- a/lib/mastodon/cli/domains.rb
+++ b/lib/mastodon/cli/domains.rb
@@ -140,13 +140,13 @@ module Mastodon::CLI
           Request.new(:get, "https://#{domain}/api/v1/instance").perform do |res|
             next unless res.code == 200
 
-            stats[domain] = Oj.load(res.to_s)
+            stats[domain] = JSON.parse(res.to_s)
           end
 
           Request.new(:get, "https://#{domain}/api/v1/instance/peers").perform do |res|
             next unless res.code == 200
 
-            Oj.load(res.to_s).reject { |peer| stats.key?(peer) }.each do |peer|
+            JSON.parse(res.to_s).reject { |peer| stats.key?(peer) }.each do |peer|
               pool.post(peer, &work_unit)
             end
           end
@@ -154,7 +154,7 @@ module Mastodon::CLI
           Request.new(:get, "https://#{domain}/api/v1/instance/activity").perform do |res|
             next unless res.code == 200
 
-            stats[domain]['activity'] = Oj.load(res.to_s)
+            stats[domain]['activity'] = JSON.parse(res.to_s)
           end
         rescue
           failed.increment

--- a/lib/tasks/emojis.rake
+++ b/lib/tasks/emojis.rake
@@ -193,7 +193,7 @@ namespace :emojis do
     require 'vips'
 
     src = Rails.root.join('app', 'javascript', 'mastodon', 'features', 'emoji', 'emoji_data.json')
-    sheet = Oj.load(File.read(src))
+    sheet = JSON.load_file(src)
 
     max = 0
     sheet['emojis'].each_value do |row|

--- a/lib/tasks/emojis.rake
+++ b/lib/tasks/emojis.rake
@@ -109,7 +109,7 @@ namespace :emojis do
     emojis_light = '👽⚾🐔☁️💨🕊️👀🍥👻🐐❕❔⛸️🌩️🔊🔇📃🌧️🐏🍚🍙🐓🐑💀☠️🌨️🔉🔈💬💭🏐🏳️⚪⬜◽◻️▫️🪽🪿'
     emojis_dark = '🎱🐜⚫🖤⬛◼️◾◼️✒️▪️💣🎳📷📸♣️🕶️✴️🔌💂‍♀️📽️🍳🦍💂🔪🕳️🕹️🕋🖊️🖋️💂‍♂️🎤🎓🎥🎼♠️🎩🦃📼📹🎮🐃🏴🐞🕺📱📲🚲🪮🐦‍⬛'
 
-    map = Oj.load(File.read(src))
+    map = JSON.parse(File.read(src))
 
     emojis_light.each_grapheme_cluster do |emoji|
       gen_border map[emoji], 'black'

--- a/lib/tasks/repo.rake
+++ b/lib/tasks/repo.rake
@@ -68,7 +68,7 @@ namespace :repo do
                   end
                 end
 
-                pull_request = Oj.load(response.to_s)
+                pull_request = JSON.parse(response.to_s)
                 pull_request['user']['login']
               end
 

--- a/lib/tasks/repo.rake
+++ b/lib/tasks/repo.rake
@@ -22,7 +22,7 @@ namespace :repo do
 
     while url.present?
       response     = HTTP.get(url)
-      contributors = Oj.load(response.body)
+      contributors = JSON.parse(response.body)
 
       contributors.each do |c|
         file << "* [#{c['login']}](#{c['html_url']})\n" if c['login']

--- a/lib/vite_ruby/sri_extensions.rb
+++ b/lib/vite_ruby/sri_extensions.rb
@@ -15,7 +15,7 @@ module ViteRuby::ManifestIntegrityExtension
   end
 
   def load_name_lookup_cache
-    Oj.load(config.build_output_dir.join('.vite/manifest-lookup.json').read)
+    JSON.load_file(config.build_output_dir.join('.vite/manifest-lookup.json'))
   end
 
   # Upstream's `virtual` type is a hack, re-implement it with efficient exact name lookup

--- a/spec/lib/activitypub/activity/quote_request_spec.rb
+++ b/spec/lib/activitypub/activity/quote_request_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ActivityPub::Activity::QuoteRequest do
         expect { subject.perform }
           .to enqueue_sidekiq_job(ActivityPub::DeliveryWorker)
           .with(satisfying do |body|
-            outgoing_json = Oj.load(body)
+            outgoing_json = JSON.parse(body)
             outgoing_json['type'] == 'Reject' && %w(type id actor object instrument).all? { |key| json[key] == outgoing_json['object'][key] }
           end, recipient.id, sender.inbox_url)
       end
@@ -78,7 +78,7 @@ RSpec.describe ActivityPub::Activity::QuoteRequest do
         expect { subject.perform }
           .to enqueue_sidekiq_job(ActivityPub::DeliveryWorker)
           .with(satisfying do |body|
-            outgoing_json = Oj.load(body)
+            outgoing_json = JSON.parse(body)
             outgoing_json['type'] == 'Reject' && json['instrument']['id'] == outgoing_json['object']['instrument'] && %w(type id actor object).all? { |key| json[key] == outgoing_json['object'][key] }
           end, recipient.id, sender.inbox_url)
       end
@@ -95,7 +95,7 @@ RSpec.describe ActivityPub::Activity::QuoteRequest do
           .to change { quoted_post.reload.quotes.accepted.count }.by(1)
           .and enqueue_sidekiq_job(ActivityPub::DeliveryWorker)
           .with(satisfying do |body|
-            outgoing_json = Oj.load(body)
+            outgoing_json = JSON.parse(body)
             outgoing_json['type'] == 'Accept' && %w(type id actor object instrument).all? { |key| json[key] == outgoing_json['object'][key] }
           end, recipient.id, sender.inbox_url)
       end
@@ -113,7 +113,7 @@ RSpec.describe ActivityPub::Activity::QuoteRequest do
           .to change { quoted_post.reload.quotes.accepted.count }.by(1)
           .and enqueue_sidekiq_job(ActivityPub::DeliveryWorker)
           .with(satisfying do |body|
-            outgoing_json = Oj.load(body)
+            outgoing_json = JSON.parse(body)
             outgoing_json['type'] == 'Accept' && json['instrument']['id'] == outgoing_json['object']['instrument'] && %w(type id actor object).all? { |key| json[key] == outgoing_json['object'][key] }
           end, recipient.id, sender.inbox_url)
       end

--- a/spec/requests/api/v1/donation_campaigns_spec.rb
+++ b/spec/requests/api/v1/donation_campaigns_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Donation campaigns' do
           expect(Rails.cache.read("donation_campaign_request:#{seed}:en", raw: true))
             .to eq 'campaign-1:en'
 
-          expect(Oj.load(Rails.cache.read('donation_campaign:campaign-1:en', raw: true)))
+          expect(JSON.parse(Rails.cache.read('donation_campaign:campaign-1:en', raw: true)))
             .to match(campaign_json)
         end
       end

--- a/spec/services/activitypub/process_status_update_service_spec.rb
+++ b/spec/services/activitypub/process_status_update_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
       ],
     }
   end
-  let(:json) { Oj.load(JSON.generate(payload)) }
+  let(:json) { JSON.parse(JSON.generate(payload)) }
 
   let(:alice) { Fabricate(:account) }
   let(:bob) { Fabricate(:account) }

--- a/spec/support/streaming_client.rb
+++ b/spec/support/streaming_client.rb
@@ -161,8 +161,8 @@ class StreamingClient
 
   def wait_for_message
     message = @connection.wait_for_event(:message)
-    event = Oj.load(message)
-    event['payload'] = Oj.load(event['payload']) if event['payload']
+    event = JSON.parse(message)
+    event['payload'] = JSON.parse(event['payload']) if event['payload']
 
     event.deep_symbolize_keys
   end


### PR DESCRIPTION
Sort of a grab-bag of stuff which was not in a previous PR logical group all mixed together.

Some of these are specs themselves or rake tasks, so watching specs fail/pass/log wasnt totally relelvant ... that said, I tried to do SOMETHING, if possible, for each of them, to get some reassurances.

Notes:

- The fetch oembed service just stubs out the endpoint and we never actually process json. I temporarily gave it a response to see the change worked the same, and then rolled it back. Might be worth another pass there to add actual xml/json responses where relevant.
- I actually ran the domains tootctl against an instance and confirm the before/after were same
- During one of the emoji tasks, the parsed json was not the same when changed, but the resulting generated file was the same. I chose not to explore this further (the data is huge, I assume its an order/format issue) ... but could if wanted
- Vite manifest appears the same
- There is a very funny line in the process status update service spec