### PR TITLE
Handle both string and array values for v1/apps `scopes` param

### DIFF
--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -24,6 +24,6 @@ class Api::V1::AppsController < Api::BaseController
   end
 
   def app_params
-    params.permit(:client_name, :scopes, :website, :redirect_uris, redirect_uris: [])
+    params.permit(:client_name, :scopes, :website, :redirect_uris, redirect_uris: [], scopes: [])
   end
 end

--- a/spec/requests/api/v1/apps_spec.rb
+++ b/spec/requests/api/v1/apps_spec.rb
@@ -73,25 +73,54 @@ RSpec.describe 'Apps' do
       end
     end
 
-    # FIXME: This is a bug: https://github.com/mastodon/mastodon/issues/30152
-    context 'with scopes as an array' do
-      let(:scopes) { %w(read write follow) }
+    context 'with scopes as a string' do
+      let(:scopes) { 'read write follow' }
 
-      it 'creates an OAuth App with the default scope' do
-        subject
+      it 'creates an OAuth App with the supplied scopes' do
+        expect { subject }
+          .to change(Doorkeeper::Application, :count).by(1)
 
-        expect(response).to have_http_status(200)
-        expect(response.content_type)
-          .to start_with('application/json')
+        expect(response)
+          .to have_http_status(200)
+        expect(response.media_type)
+          .to eq('application/json')
 
         app = Doorkeeper::Application.find_by(name: client_name)
 
-        expect(app).to be_present
-        expect(app.scopes.to_s).to eq 'read'
+        expect(app)
+          .to be_present
+        expect(app.scopes.to_s)
+          .to eq('read write follow')
 
         expect(response.parsed_body)
           .to include(
-            scopes: %w(read)
+            scopes: eq(%w(read write follow))
+          )
+      end
+    end
+
+    context 'with scopes as an array' do
+      let(:scopes) { %w(read write follow) }
+
+      it 'creates an OAuth App with the supplied scopes' do
+        expect { subject }
+          .to change(Doorkeeper::Application, :count).by(1)
+
+        expect(response)
+          .to have_http_status(200)
+        expect(response.media_type)
+          .to eq('application/json')
+
+        app = Doorkeeper::Application.find_by(name: client_name)
+
+        expect(app)
+          .to be_present
+        expect(app.scopes.to_s)
+          .to eq('read write follow')
+
+        expect(response.parsed_body)
+          .to include(
+            scopes: eq(%w(read write follow))
           )
       end
     end


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/30152 (probably!?!)

The linked issue talks about a discrepancy in the handling of passed in scopes when creating a doorkeeper app record. There are sort of two separate issues, and this only addresses one:

- Larger issue -- 1) using `scope` vs `scopes` and 2) accepting an array at all (instead of a space separated string) are both arguably against the spec.
- Smaller issue -- in current app when you DO pass in an array for scopes, because of how the params are handled it gets set to nil and then reset to default scope. This is non-intuitive because if you send an array of scopes and do NOT get an error code, you should expect that your scopes were used.

The change here fixes the latter issue, and I believe makes it so that both string and array param are handled appropriately. This is technically an API change, but I'd argue its a bugfix change in line with both docs and what an intuitive expectation would be.

In my opinion tackling the larger issue (param naming and/or rejecting array) is too big to call a bugfix and would merit an api version bump.