### PR TITLE
Prefer `to_json` over JSON.generate when simple strings in stub request

### DIFF
--- a/spec/lib/activitypub/activity/announce_spec.rb
+++ b/spec/lib/activitypub/activity/announce_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ActivityPub::Activity::Announce do
     context 'when sender is followed by a local account' do
       before do
         Fabricate(:account).follow!(sender)
-        stub_request(:get, 'https://example.com/actor/hello-world').to_return(body: JSON.generate(unknown_object_json), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/actor/hello-world').to_return(body: unknown_object_json.to_json, headers: { 'Content-Type': 'application/activity+json' })
         subject.perform
       end
 
@@ -120,7 +120,7 @@ RSpec.describe ActivityPub::Activity::Announce do
       let(:object_json) { 'https://example.com/actor/hello-world' }
 
       before do
-        stub_request(:get, 'https://example.com/actor/hello-world').to_return(body: JSON.generate(unknown_object_json), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/actor/hello-world').to_return(body: unknown_object_json.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       context 'when the relay is enabled' do

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -1028,8 +1028,8 @@ RSpec.describe ActivityPub::Activity::Create do
           )
         end
 
-        before do
-          stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate({
+        let(:quote_authorization_json) do
+          {
             '@context': [
               'https://www.w3.org/ns/activitystreams',
               {
@@ -1054,7 +1054,11 @@ RSpec.describe ActivityPub::Activity::Create do
             attributedTo: ActivityPub::TagManager.instance.uri_for(quoted_status.account),
             interactingObject: object_json[:id],
             interactionTarget: ActivityPub::TagManager.instance.uri_for(quoted_status),
-          }))
+          }
+        end
+
+        before do
+          stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: quote_authorization_json.to_json)
         end
 
         it 'creates a status with a verified quote' do
@@ -1084,8 +1088,8 @@ RSpec.describe ActivityPub::Activity::Create do
           )
         end
 
-        before do
-          stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate({
+        let(:quote_authorization_json) do
+          {
             '@context': [
               'https://www.w3.org/ns/activitystreams',
               {
@@ -1110,7 +1114,11 @@ RSpec.describe ActivityPub::Activity::Create do
             attributedTo: ActivityPub::TagManager.instance.uri_for(quoted_status.account),
             interactingObject: object_json[:id],
             interactionTarget: ActivityPub::TagManager.instance.uri_for(quoted_status),
-          }))
+          }
+        end
+
+        before do
+          stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: quote_authorization_json.to_json)
         end
 
         it 'creates a status without the verified quote' do
@@ -1217,7 +1225,7 @@ RSpec.describe ActivityPub::Activity::Create do
       before do
         stub_request(:get, object_json[:id])
           .with(headers: { Authorization: "Bearer #{token}" })
-          .to_return(body: JSON.generate(object_json), headers: { 'Content-Type': 'application/activity+json' })
+          .to_return(body: object_json.to_json, headers: { 'Content-Type': 'application/activity+json' })
 
         subject.perform
       end

--- a/spec/lib/activitypub/activity/quote_request_spec.rb
+++ b/spec/lib/activitypub/activity/quote_request_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe ActivityPub::Activity::QuoteRequest do
 
     context 'when trying to quote a quotable local status' do
       before do
-        stub_request(:get, 'https://example.com/unknown-status').to_return(status: 200, body: JSON.generate(status_json), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/unknown-status').to_return(status: 200, body: status_json.to_json, headers: { 'Content-Type': 'application/activity+json' })
         quoted_post.update(quote_approval_policy: InteractionPolicy::POLICY_FLAGS[:public] << 16)
       end
 

--- a/spec/lib/activitypub/activity_spec.rb
+++ b/spec/lib/activitypub/activity_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe ActivityPub::Activity do
     before do
       sender.update(uri: ActivityPub::TagManager.instance.uri_for(sender))
 
-      stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate(approval_payload))
+      stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: approval_payload.to_json)
     end
 
     context 'when getting them in order' do

--- a/spec/lib/activitypub/dereferencer_spec.rb
+++ b/spec/lib/activitypub/dereferencer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ActivityPub::Dereferencer do
     let(:uri) { nil }
 
     before do
-      stub_request(:get, 'https://example.com/foo').to_return(body: JSON.generate(object), headers: { 'Content-Type' => 'application/activity+json' })
+      stub_request(:get, 'https://example.com/foo').to_return(body: object.to_json, headers: { 'Content-Type' => 'application/activity+json' })
     end
 
     context 'with a URI' do

--- a/spec/lib/activitypub/forwarder_spec.rb
+++ b/spec/lib/activitypub/forwarder_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe ActivityPub::Forwarder do
 
     it 'correctly forwards to expected remote followers' do
       expect { subject.forward! }
-        .to enqueue_sidekiq_job(ActivityPub::LowPriorityDeliveryWorker).with(JSON.generate(payload), anything, eve.preferred_inbox_url)
-        .and enqueue_sidekiq_job(ActivityPub::LowPriorityDeliveryWorker).with(JSON.generate(payload), anything, mallory.preferred_inbox_url)
+        .to enqueue_sidekiq_job(ActivityPub::LowPriorityDeliveryWorker).with(payload.to_json, anything, eve.preferred_inbox_url)
+        .and enqueue_sidekiq_job(ActivityPub::LowPriorityDeliveryWorker).with(payload.to_json, anything, mallory.preferred_inbox_url)
     end
   end
 end

--- a/spec/lib/mastodon/cli/domains_spec.rb
+++ b/spec/lib/mastodon/cli/domains_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Mastodon::CLI::Domains do
         end
 
         def json_summary
-          JSON.generate('host.example': { activity: {} })
+          { 'host.example': { activity: {} } }.to_json
         end
       end
     end

--- a/spec/lib/webhooks/payload_renderer_spec.rb
+++ b/spec/lib/webhooks/payload_renderer_spec.rb
@@ -3,27 +3,34 @@
 require 'rails_helper'
 
 RSpec.describe Webhooks::PayloadRenderer do
-  subject(:renderer) { described_class.new(json) }
+  subject(:renderer) { described_class.new(payload.to_json) }
 
   let(:event)   { Webhooks::EventPresenter.new(type, object) }
   let(:payload) { ActiveModelSerializers::SerializableResource.new(event, serializer: REST::Admin::WebhookEventSerializer, scope: nil, scope_name: :current_user).as_json }
-  let(:json)    { JSON.generate(payload) }
 
   describe '#render' do
+    subject { renderer.render(template) }
+
     context 'when event is account.approved' do
       let(:type)   { 'account.approved' }
-      let(:object) { Fabricate(:account, display_name: 'Foo"') }
+      let(:object) { Fabricate(:account, display_name: 'Foo"', username: 'foofoobarbar') }
 
-      it 'renders event-related variables into template' do
-        expect(renderer.render('foo={{event}}')).to eq 'foo=account.approved'
+      context 'with event-related variables' do
+        let(:template) { 'foo={{event}}' }
+
+        it { is_expected.to eq('foo=account.approved') }
       end
 
-      it 'renders event-specific variables into template' do
-        expect(renderer.render('foo={{object.username}}')).to eq "foo=#{object.username}"
+      context 'with event-specific variables' do
+        let(:template) { 'foo={{object.username}}' }
+
+        it { is_expected.to eq('foo=foofoobarbar') }
       end
 
-      it 'escapes values for use in JSON' do
-        expect(renderer.render('foo={{object.account.display_name}}')).to eq 'foo=Foo\\"'
+      context 'with values needing JSON escape' do
+        let(:template) { 'foo={{object.account.display_name}}' }
+
+        it { is_expected.to eq('foo=Foo\\"') }
       end
     end
   end

--- a/spec/requests/api/v1/donation_campaigns_spec.rb
+++ b/spec/requests/api/v1/donation_campaigns_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'Donation campaigns' do
         end
 
         before do
-          stub_request(:get, "#{api_url}?platform=web&seed=#{seed}&locale=en").to_return(body: JSON.generate(campaign_json), status: 200)
+          stub_request(:get, "#{api_url}?platform=web&seed=#{seed}&locale=en").to_return(body: campaign_json.to_json, status: 200)
         end
 
         it 'returns the expected campaign' do

--- a/spec/services/activitypub/fetch_featured_collection_service_spec.rb
+++ b/spec/services/activitypub/fetch_featured_collection_service_spec.rb
@@ -75,11 +75,11 @@ RSpec.describe ActivityPub::FetchFeaturedCollectionService do
 
     shared_examples 'sets pinned posts' do
       before do
-        stub_request(:get, 'https://example.com/account/pinned/known').to_return(status: 200, body: JSON.generate(status_json_pinned_known), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, 'https://example.com/account/pinned/unknown-inlined').to_return(status: 200, body: JSON.generate(status_json_pinned_unknown_inlined), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/account/pinned/known').to_return(status: 200, body: status_json_pinned_known.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/account/pinned/unknown-inlined').to_return(status: 200, body: status_json_pinned_unknown_inlined.to_json, headers: { 'Content-Type': 'application/activity+json' })
         stub_request(:get, 'https://example.com/account/pinned/unknown-unreachable').to_return(status: 404)
-        stub_request(:get, 'https://example.com/account/pinned/unknown-reachable').to_return(status: 200, body: JSON.generate(status_json_pinned_unknown_reachable), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, 'https://example.com/account/collections/featured').to_return(status: 200, body: JSON.generate(featured_with_null), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/account/pinned/unknown-reachable').to_return(status: 200, body: status_json_pinned_unknown_reachable.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/account/collections/featured').to_return(status: 200, body: featured_with_null.to_json, headers: { 'Content-Type': 'application/activity+json' })
 
         subject
       end
@@ -101,7 +101,7 @@ RSpec.describe ActivityPub::FetchFeaturedCollectionService do
         let(:collection_or_uri) { actor.featured_collection_url }
 
         before do
-          stub_request(:get, actor.featured_collection_url).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+          stub_request(:get, actor.featured_collection_url).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
         end
 
         it_behaves_like 'sets pinned posts'
@@ -122,7 +122,7 @@ RSpec.describe ActivityPub::FetchFeaturedCollectionService do
 
     context 'when the endpoint is a Collection' do
       before do
-        stub_request(:get, actor.featured_collection_url).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, actor.featured_collection_url).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it_behaves_like 'sets pinned posts'
@@ -139,7 +139,7 @@ RSpec.describe ActivityPub::FetchFeaturedCollectionService do
       end
 
       before do
-        stub_request(:get, actor.featured_collection_url).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, actor.featured_collection_url).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it_behaves_like 'sets pinned posts'
@@ -148,11 +148,12 @@ RSpec.describe ActivityPub::FetchFeaturedCollectionService do
         let(:items) { 'https://example.com/account/pinned/unknown-reachable' }
 
         before do
-          stub_request(:get, 'https://example.com/account/pinned/unknown-reachable').to_return(status: 200, body: JSON.generate(status_json_pinned_unknown_reachable), headers: { 'Content-Type': 'application/activity+json' })
-          subject
+          stub_request(:get, 'https://example.com/account/pinned/unknown-reachable').to_return(status: 200, body: status_json_pinned_unknown_reachable.to_json, headers: { 'Content-Type': 'application/activity+json' })
         end
 
         it 'sets expected posts as pinned posts' do
+          subject
+
           expect(actor.pinned_statuses.pluck(:uri)).to contain_exactly(
             'https://example.com/account/pinned/unknown-reachable'
           )
@@ -175,7 +176,7 @@ RSpec.describe ActivityPub::FetchFeaturedCollectionService do
       end
 
       before do
-        stub_request(:get, actor.featured_collection_url).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, actor.featured_collection_url).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it_behaves_like 'sets pinned posts'
@@ -184,11 +185,12 @@ RSpec.describe ActivityPub::FetchFeaturedCollectionService do
         let(:items) { 'https://example.com/account/pinned/unknown-reachable' }
 
         before do
-          stub_request(:get, 'https://example.com/account/pinned/unknown-reachable').to_return(status: 200, body: JSON.generate(status_json_pinned_unknown_reachable), headers: { 'Content-Type': 'application/activity+json' })
-          subject
+          stub_request(:get, 'https://example.com/account/pinned/unknown-reachable').to_return(status: 200, body: status_json_pinned_unknown_reachable.to_json, headers: { 'Content-Type': 'application/activity+json' })
         end
 
         it 'sets expected posts as pinned posts' do
+          subject
+
           expect(actor.pinned_statuses.pluck(:uri)).to contain_exactly(
             'https://example.com/account/pinned/unknown-reachable'
           )

--- a/spec/services/activitypub/fetch_featured_tags_collection_service_spec.rb
+++ b/spec/services/activitypub/fetch_featured_tags_collection_service_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ActivityPub::FetchFeaturedTagsCollectionService do
   describe '#call' do
     context 'when the endpoint is a Collection' do
       before do
-        stub_request(:get, collection_url).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, collection_url).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it_behaves_like 'sets featured tags'
@@ -46,7 +46,7 @@ RSpec.describe ActivityPub::FetchFeaturedTagsCollectionService do
 
     context 'when the account already has featured tags' do
       before do
-        stub_request(:get, collection_url).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, collection_url).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
 
         actor.featured_tags.create!(name: 'FoO')
         actor.featured_tags.create!(name: 'baz')
@@ -67,7 +67,7 @@ RSpec.describe ActivityPub::FetchFeaturedTagsCollectionService do
       end
 
       before do
-        stub_request(:get, collection_url).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, collection_url).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it_behaves_like 'sets featured tags'
@@ -88,7 +88,7 @@ RSpec.describe ActivityPub::FetchFeaturedTagsCollectionService do
       end
 
       before do
-        stub_request(:get, collection_url).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, collection_url).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it_behaves_like 'sets featured tags'

--- a/spec/services/activitypub/fetch_remote_account_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_account_service_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe ActivityPub::FetchRemoteAccountService do
       before do
         actor[:inbox] = nil
 
-        stub_request(:get, 'https://example.com/alice').to_return(body: JSON.generate(actor), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://example.com/alice').to_return(body: actor.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
       end
 
       it 'fetches resource and looks up webfinger and returns nil' do
@@ -54,8 +54,8 @@ RSpec.describe ActivityPub::FetchRemoteAccountService do
       let!(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/alice', type: 'application/activity+json' }] } }
 
       before do
-        stub_request(:get, 'https://example.com/alice').to_return(body: JSON.generate(actor), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://example.com/alice').to_return(body: actor.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
       end
 
       it 'fetches resource and looks up webfinger and sets attributes' do
@@ -75,9 +75,9 @@ RSpec.describe ActivityPub::FetchRemoteAccountService do
       let!(:webfinger) { { subject: 'acct:alice@iscool.af', links: [{ rel: 'self', href: 'https://example.com/alice', type: 'application/activity+json' }] } }
 
       before do
-        stub_request(:get, 'https://example.com/alice').to_return(body: JSON.generate(actor), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
-        stub_request(:get, 'https://iscool.af/.well-known/webfinger?resource=acct:alice@iscool.af').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://example.com/alice').to_return(body: actor.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://iscool.af/.well-known/webfinger?resource=acct:alice@iscool.af').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
       end
 
       it 'fetches resource and looks up webfinger and follows redirection and sets attributes' do
@@ -98,8 +98,8 @@ RSpec.describe ActivityPub::FetchRemoteAccountService do
       let!(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/bob', type: 'application/activity+json' }] } }
 
       before do
-        stub_request(:get, 'https://example.com/alice').to_return(body: JSON.generate(actor), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://example.com/alice').to_return(body: actor.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
       end
 
       it 'fetches resource and looks up webfinger and does not create account' do
@@ -114,9 +114,9 @@ RSpec.describe ActivityPub::FetchRemoteAccountService do
       let!(:webfinger) { { subject: 'acct:alice@iscool.af', links: [{ rel: 'self', href: 'https://example.com/bob', type: 'application/activity+json' }] } }
 
       before do
-        stub_request(:get, 'https://example.com/alice').to_return(body: JSON.generate(actor), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
-        stub_request(:get, 'https://iscool.af/.well-known/webfinger?resource=acct:alice@iscool.af').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://example.com/alice').to_return(body: actor.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://iscool.af/.well-known/webfinger?resource=acct:alice@iscool.af').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
       end
 
       it 'fetches resource and looks up webfinger and follows redirect and does not create account' do
@@ -130,7 +130,7 @@ RSpec.describe ActivityPub::FetchRemoteAccountService do
 
     context 'with wrong id' do
       it 'does not create account' do
-        expect(subject.call('https://fake.address/@foo', prefetched_body: JSON.generate(actor))).to be_nil
+        expect(subject.call('https://fake.address/@foo', prefetched_body: actor.to_json)).to be_nil
       end
     end
   end

--- a/spec/services/activitypub/fetch_remote_actor_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_actor_service_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe ActivityPub::FetchRemoteActorService do
       before do
         actor[:inbox] = nil
 
-        stub_request(:get, 'https://example.com/alice').to_return(body: JSON.generate(actor), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://example.com/alice').to_return(body: actor.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
       end
 
       it 'fetches resource and looks up webfinger and returns nil' do
@@ -54,8 +54,8 @@ RSpec.describe ActivityPub::FetchRemoteActorService do
       let!(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/alice', type: 'application/activity+json' }] } }
 
       before do
-        stub_request(:get, 'https://example.com/alice').to_return(body: JSON.generate(actor), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://example.com/alice').to_return(body: actor.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
       end
 
       it 'fetches resource and looks up webfinger and sets values' do
@@ -75,9 +75,9 @@ RSpec.describe ActivityPub::FetchRemoteActorService do
       let!(:webfinger) { { subject: 'acct:alice@iscool.af', links: [{ rel: 'self', href: 'https://example.com/alice', type: 'application/activity+json' }] } }
 
       before do
-        stub_request(:get, 'https://example.com/alice').to_return(body: JSON.generate(actor), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
-        stub_request(:get, 'https://iscool.af/.well-known/webfinger?resource=acct:alice@iscool.af').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://example.com/alice').to_return(body: actor.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://iscool.af/.well-known/webfinger?resource=acct:alice@iscool.af').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
       end
 
       it 'fetches resource and looks up webfinger and follows redirect and sets values' do
@@ -98,8 +98,8 @@ RSpec.describe ActivityPub::FetchRemoteActorService do
       let!(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/bob', type: 'application/activity+json' }] } }
 
       before do
-        stub_request(:get, 'https://example.com/alice').to_return(body: JSON.generate(actor), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://example.com/alice').to_return(body: actor.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
       end
 
       it 'fetches resource and looks up webfinger and does not create account' do
@@ -114,9 +114,9 @@ RSpec.describe ActivityPub::FetchRemoteActorService do
       let!(:webfinger) { { subject: 'acct:alice@iscool.af', links: [{ rel: 'self', href: 'https://example.com/bob', type: 'application/activity+json' }] } }
 
       before do
-        stub_request(:get, 'https://example.com/alice').to_return(body: JSON.generate(actor), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
-        stub_request(:get, 'https://iscool.af/.well-known/webfinger?resource=acct:alice@iscool.af').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://example.com/alice').to_return(body: actor.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://iscool.af/.well-known/webfinger?resource=acct:alice@iscool.af').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
       end
 
       it 'fetches resource and looks up webfinger and follows redirect and does not create account' do
@@ -130,7 +130,7 @@ RSpec.describe ActivityPub::FetchRemoteActorService do
 
     context 'with wrong id' do
       it 'does not create account' do
-        expect(subject.call('https://fake.address/@foo', prefetched_body: JSON.generate(actor))).to be_nil
+        expect(subject.call('https://fake.address/@foo', prefetched_body: actor.to_json)).to be_nil
       end
     end
   end

--- a/spec/services/activitypub/fetch_remote_key_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_key_service_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe ActivityPub::FetchRemoteKeyService do
   end
 
   before do
-    stub_request(:get, 'https://example.com/alice').to_return(body: JSON.generate(actor), headers: { 'Content-Type': 'application/activity+json' })
-    stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+    stub_request(:get, 'https://example.com/alice').to_return(body: actor.to_json, headers: { 'Content-Type': 'application/activity+json' })
+    stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
   end
 
   describe '#call' do
@@ -59,7 +59,7 @@ RSpec.describe ActivityPub::FetchRemoteKeyService do
 
     context 'when the key is a sub-object from the actor' do
       before do
-        stub_request(:get, public_key_id).to_return(body: JSON.generate(actor), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, public_key_id).to_return(body: actor.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it 'returns the expected account' do
@@ -71,7 +71,7 @@ RSpec.describe ActivityPub::FetchRemoteKeyService do
       let(:public_key_id) { 'https://example.com/alice-public-key.json' }
 
       before do
-        stub_request(:get, public_key_id).to_return(body: JSON.generate(key_json.merge({ '@context': ['https://w3id.org/security/v1'] })), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, public_key_id).to_return(body: key_json.merge({ '@context': ['https://w3id.org/security/v1'] }).to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it 'returns the expected account' do
@@ -84,7 +84,7 @@ RSpec.describe ActivityPub::FetchRemoteKeyService do
       let(:actor_public_key) { 'https://example.com/alice-public-key.json' }
 
       before do
-        stub_request(:get, public_key_id).to_return(body: JSON.generate(key_json.merge({ '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'] })), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, public_key_id).to_return(body: key_json.merge({ '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'] }).to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it 'returns the nil' do

--- a/spec/services/activitypub/fetch_remote_status_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_status_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ActivityPub::FetchRemoteStatusService do
 
   let(:follower) { Fabricate(:account, username: 'alice') }
   let(:follow) { nil }
-  let(:response) { { body: JSON.generate(object), headers: { 'content-type': 'application/activity+json' } } }
+  let(:response) { { body: object.to_json, headers: { 'content-type': 'application/activity+json' } } }
   let(:existing_status) { nil }
 
   let(:note) do
@@ -369,7 +369,7 @@ RSpec.describe ActivityPub::FetchRemoteStatusService do
       end
 
       it 'creates statuses but not more than limit allows' do
-        expect { subject.call(object[:id], prefetched_body: JSON.generate(object)) }
+        expect { subject.call(object[:id], prefetched_body: object.to_json) }
           .to change { sender.statuses.count }.by_at_least(2)
           .and change { sender.statuses.count }.by_at_most(3)
       end
@@ -419,7 +419,7 @@ RSpec.describe ActivityPub::FetchRemoteStatusService do
       end
 
       it 'creates statuses but not more than limit allows' do
-        expect { subject.call(object[:id], prefetched_body: JSON.generate(object)) }
+        expect { subject.call(object[:id], prefetched_body: object.to_json) }
           .to change { sender.statuses.count }.by_at_least(2)
           .and change { sender.statuses.count }.by_at_most(3)
       end

--- a/spec/services/activitypub/fetch_replies_service_spec.rb
+++ b/spec/services/activitypub/fetch_replies_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe ActivityPub::FetchRepliesService do
 
       context 'when passing the URL to the collection' do
         before do
-          stub_request(:get, collection_uri).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+          stub_request(:get, collection_uri).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
         end
 
         it 'spawns workers for up to 5 replies on the same server' do
@@ -93,7 +93,7 @@ RSpec.describe ActivityPub::FetchRepliesService do
 
       context 'when passing the URL to the collection' do
         before do
-          stub_request(:get, collection_uri).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+          stub_request(:get, collection_uri).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
         end
 
         it 'spawns workers for up to 5 replies on the same server' do
@@ -132,7 +132,7 @@ RSpec.describe ActivityPub::FetchRepliesService do
 
       context 'when passing the URL to the collection' do
         before do
-          stub_request(:get, collection_uri).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+          stub_request(:get, collection_uri).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
         end
 
         it 'spawns workers for up to 5 replies on the same server' do

--- a/spec/services/activitypub/process_collection_service_spec.rb
+++ b/spec/services/activitypub/process_collection_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ActivityPub::ProcessCollectionService do
     }
   end
 
-  let(:json) { JSON.generate(payload) }
+  let(:json) { payload.to_json }
 
   describe '#call' do
     context 'when actor is suspended' do

--- a/spec/services/activitypub/process_status_update_service_spec.rb
+++ b/spec/services/activitypub/process_status_update_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
       ],
     }
   end
-  let(:json) { JSON.parse(JSON.generate(payload)) }
+  let(:json) { JSON.parse(payload.to_json) }
 
   let(:alice) { Fabricate(:account) }
   let(:bob) { Fabricate(:account) }
@@ -544,8 +544,8 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
       }
     end
 
-    before do
-      stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate({
+    let(:quote_authorization_json) do
+      {
         '@context': [
           'https://www.w3.org/ns/activitystreams',
           {
@@ -570,7 +570,11 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
         attributedTo: ActivityPub::TagManager.instance.uri_for(quoted_status.account),
         interactingObject: ActivityPub::TagManager.instance.uri_for(status),
         interactionTarget: ActivityPub::TagManager.instance.uri_for(quoted_status),
-      }))
+      }
+    end
+
+    before do
+      stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: quote_authorization_json.to_json)
     end
 
     it 'updates the approval URI and verifies the quote' do
@@ -609,8 +613,8 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
       }
     end
 
-    before do
-      stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate({
+    let(:quote_authorization_json) do
+      {
         '@context': [
           'https://www.w3.org/ns/activitystreams',
           {
@@ -635,7 +639,11 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
         attributedTo: ActivityPub::TagManager.instance.uri_for(quoted_status.account),
         interactingObject: ActivityPub::TagManager.instance.uri_for(status),
         interactionTarget: ActivityPub::TagManager.instance.uri_for(quoted_status),
-      }))
+      }
+    end
+
+    before do
+      stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: quote_authorization_json.to_json)
     end
 
     it 'updates the approval URI and verifies the quote' do
@@ -818,8 +826,8 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
       }
     end
 
-    before do
-      stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate({
+    let(:quote_authorization_json) do
+      {
         '@context': [
           'https://www.w3.org/ns/activitystreams',
           {
@@ -844,7 +852,11 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
         attributedTo: ActivityPub::TagManager.instance.uri_for(quoted_status.account),
         interactingObject: ActivityPub::TagManager.instance.uri_for(status),
         interactionTarget: ActivityPub::TagManager.instance.uri_for(quoted_status),
-      }))
+      }
+    end
+
+    before do
+      stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: quote_authorization_json.to_json)
     end
 
     it 'updates the approval URI and verifies the quote' do
@@ -883,8 +895,8 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
       }
     end
 
-    before do
-      stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate({
+    let(:quote_authorization_json) do
+      {
         '@context': [
           'https://www.w3.org/ns/activitystreams',
           {
@@ -909,7 +921,11 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
         attributedTo: ActivityPub::TagManager.instance.uri_for(quoted_status.account),
         interactingObject: ActivityPub::TagManager.instance.uri_for(status),
         interactionTarget: ActivityPub::TagManager.instance.uri_for(quoted_status),
-      }))
+      }
+    end
+
+    before do
+      stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: quote_authorization_json.to_json)
     end
 
     it 'updates the approval URI but does not verify the quote' do
@@ -1126,8 +1142,8 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
       }
     end
 
-    before do
-      stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate({
+    let(:quote_authorization_json) do
+      {
         '@context': [
           'https://www.w3.org/ns/activitystreams',
           {
@@ -1152,7 +1168,11 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
         attributedTo: ActivityPub::TagManager.instance.uri_for(quoted_status.account),
         interactingObject: ActivityPub::TagManager.instance.uri_for(status),
         interactionTarget: ActivityPub::TagManager.instance.uri_for(quoted_status),
-      }))
+      }
+    end
+
+    before do
+      stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: quote_authorization_json.to_json)
     end
 
     it 'updates the URI and unverifies the quote' do
@@ -1234,8 +1254,8 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
       }
     end
 
-    before do
-      stub_request(:get, second_approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate({
+    let(:quote_authorization_json) do
+      {
         '@context': [
           'https://www.w3.org/ns/activitystreams',
           {
@@ -1260,7 +1280,11 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
         attributedTo: ActivityPub::TagManager.instance.uri_for(second_quoted_status.account),
         interactingObject: ActivityPub::TagManager.instance.uri_for(status),
         interactionTarget: ActivityPub::TagManager.instance.uri_for(second_quoted_status),
-      }))
+      }
+    end
+
+    before do
+      stub_request(:get, second_approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: quote_authorization_json.to_json)
     end
 
     it 'updates the URI and unverifies the quote' do

--- a/spec/services/activitypub/synchronize_followers_service_spec.rb
+++ b/spec/services/activitypub/synchronize_followers_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
 
     context 'when the endpoint is a Collection of actor URIs' do
       before do
-        stub_request(:get, collection_uri).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, collection_uri).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it_behaves_like 'synchronizes followers'
@@ -72,7 +72,7 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
       end
 
       before do
-        stub_request(:get, collection_uri).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, collection_uri).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it_behaves_like 'synchronizes followers'
@@ -93,7 +93,7 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
       end
 
       before do
-        stub_request(:get, collection_uri).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, collection_uri).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it_behaves_like 'synchronizes followers'
@@ -102,31 +102,31 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
     context 'when the endpoint is a paginated Collection of actor URIs split across multiple pages' do
       before do
         stub_request(:get, 'https://example.com/partial-followers')
-          .to_return(status: 200, headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate({
+          .to_return(status: 200, headers: { 'Content-Type': 'application/activity+json' }, body: {
             '@context': 'https://www.w3.org/ns/activitystreams',
             type: 'Collection',
             id: 'https://example.com/partial-followers',
             first: 'https://example.com/partial-followers/1',
-          }))
+          }.to_json)
 
         stub_request(:get, 'https://example.com/partial-followers/1')
-          .to_return(status: 200, headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate({
+          .to_return(status: 200, headers: { 'Content-Type': 'application/activity+json' }, body: {
             '@context': 'https://www.w3.org/ns/activitystreams',
             type: 'CollectionPage',
             id: 'https://example.com/partial-followers/1',
             partOf: 'https://example.com/partial-followers',
             next: 'https://example.com/partial-followers/2',
             items: [alice, eve].map { |account| ActivityPub::TagManager.instance.uri_for(account) },
-          }))
+          }.to_json)
 
         stub_request(:get, 'https://example.com/partial-followers/2')
-          .to_return(status: 200, headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate({
+          .to_return(status: 200, headers: { 'Content-Type': 'application/activity+json' }, body: {
             '@context': 'https://www.w3.org/ns/activitystreams',
             type: 'CollectionPage',
             id: 'https://example.com/partial-followers/2',
             partOf: 'https://example.com/partial-followers',
             items: ActivityPub::TagManager.instance.uri_for(mallory),
-          }))
+          }.to_json)
       end
 
       it_behaves_like 'synchronizes followers'
@@ -135,22 +135,22 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
     context 'when the endpoint is a paginated Collection of actor URIs split across, but one page errors out' do
       before do
         stub_request(:get, 'https://example.com/partial-followers')
-          .to_return(status: 200, headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate({
+          .to_return(status: 200, headers: { 'Content-Type': 'application/activity+json' }, body: {
             '@context': 'https://www.w3.org/ns/activitystreams',
             type: 'Collection',
             id: 'https://example.com/partial-followers',
             first: 'https://example.com/partial-followers/1',
-          }))
+          }.to_json)
 
         stub_request(:get, 'https://example.com/partial-followers/1')
-          .to_return(status: 200, headers: { 'Content-Type': 'application/activity+json' }, body: JSON.generate({
+          .to_return(status: 200, headers: { 'Content-Type': 'application/activity+json' }, body: {
             '@context': 'https://www.w3.org/ns/activitystreams',
             type: 'CollectionPage',
             id: 'https://example.com/partial-followers/1',
             partOf: 'https://example.com/partial-followers',
             next: 'https://example.com/partial-followers/2',
             items: [mallory].map { |account| ActivityPub::TagManager.instance.uri_for(account) },
-          }))
+          }.to_json)
 
         stub_request(:get, 'https://example.com/partial-followers/2')
           .to_return(status: 404)
@@ -185,7 +185,7 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
 
       before do
         stub_const('ActivityPub::SynchronizeFollowersService::MAX_COLLECTION_PAGES', 1)
-        stub_request(:get, collection_uri).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, collection_uri).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it 'confirms pending follow request but does not remove extra followers' do
@@ -213,7 +213,7 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
 
       context 'when the endpoint is a Collection of actor URIs' do
         before do
-          stub_request(:get, collection_uri).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+          stub_request(:get, collection_uri).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
         end
 
         it_behaves_like 'synchronizes followers'
@@ -230,7 +230,7 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
         end
 
         before do
-          stub_request(:get, collection_uri).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+          stub_request(:get, collection_uri).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
         end
 
         it_behaves_like 'synchronizes followers'
@@ -251,7 +251,7 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
         end
 
         before do
-          stub_request(:get, collection_uri).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+          stub_request(:get, collection_uri).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
         end
 
         it_behaves_like 'synchronizes followers'
@@ -263,7 +263,7 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
 
       context 'when the endpoint is a Collection of actor URIs' do
         before do
-          stub_request(:get, collection_uri).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+          stub_request(:get, collection_uri).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
         end
 
         it 'does not remove followers' do
@@ -286,7 +286,7 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
         end
 
         before do
-          stub_request(:get, collection_uri).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+          stub_request(:get, collection_uri).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
         end
 
         it 'does not remove followers' do
@@ -313,7 +313,7 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
         end
 
         before do
-          stub_request(:get, collection_uri).to_return(status: 200, body: JSON.generate(payload), headers: { 'Content-Type': 'application/activity+json' })
+          stub_request(:get, collection_uri).to_return(status: 200, body: payload.to_json, headers: { 'Content-Type': 'application/activity+json' })
         end
 
         it 'does not remove followers' do

--- a/spec/services/activitypub/verify_quote_service_spec.rb
+++ b/spec/services/activitypub/verify_quote_service_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe ActivityPub::VerifyQuoteService do
 
     before do
       stub_request(:get, approval_uri)
-        .to_return(status: 200, body: JSON.generate(json), headers: { 'Content-Type': 'application/activity+json' })
+        .to_return(status: 200, body: json.to_json, headers: { 'Content-Type': 'application/activity+json' })
     end
 
     context 'with a valid activity for already-fetched posts' do
@@ -179,7 +179,7 @@ RSpec.describe ActivityPub::VerifyQuoteService do
 
     context 'with a valid activity for already-fetched posts, with a pre-fetched approval' do
       it 'updates the status without fetching the activity' do
-        expect { subject.call(quote, prefetched_approval: JSON.generate(json)) }
+        expect { subject.call(quote, prefetched_approval: json.to_json) }
           .to change(quote, :state).to('accepted')
 
         expect(a_request(:get, approval_uri))

--- a/spec/services/fetch_remote_status_service_spec.rb
+++ b/spec/services/fetch_remote_status_service_spec.rb
@@ -19,17 +19,15 @@ RSpec.describe FetchRemoteStatusService do
   context 'when protocol is :activitypub' do
     subject { described_class.new.call(note[:id], prefetched_body: prefetched_body) }
 
-    let(:prefetched_body) { JSON.generate(note) }
-
-    before do
-      subject
-    end
+    let(:prefetched_body) { note.to_json }
 
     it 'creates status' do
-      status = account.statuses.first
+      expect { subject }
+        .to change(Status, :count).by(1)
 
-      expect(status).to_not be_nil
-      expect(status.text).to eq 'Lorem ipsum'
+      expect(account.statuses.first)
+        .to be_present
+        .and have_attributes(text: 'Lorem ipsum')
     end
   end
 end

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe ResolveAccountService do
   end
 
   context 'with webfinger response subject missing a host value' do
-    let(:body) { JSON.generate({ subject: 'user@' }) }
+    let(:body) { { subject: 'user@' }.to_json }
     let(:url) { 'https://host.example/.well-known/webfinger?resource=acct:user@host.example' }
 
     before do

--- a/spec/services/software_update_check_service_spec.rb
+++ b/spec/services/software_update_check_service_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe SoftwareUpdateCheckService do
       end
 
       before do
-        stub_request(:get, full_update_check_url).to_return(body: JSON.generate(server_json))
+        stub_request(:get, full_update_check_url).to_return(body: server_json.to_json)
       end
 
       it 'updates the list of known updates' do

--- a/spec/workers/activitypub/fetch_all_replies_worker_spec.rb
+++ b/spec/workers/activitypub/fetch_all_replies_worker_spec.rb
@@ -126,11 +126,11 @@ RSpec.describe ActivityPub::FetchAllRepliesWorker do
     all_items.each do |item|
       next if [top_note_uri, reply_note_uri].include? item
 
-      stub_request(:get, item).to_return(status: 200, body: JSON.generate(empty_object), headers: { 'Content-Type': 'application/activity+json' })
+      stub_request(:get, item).to_return(status: 200, body: empty_object.to_json, headers: { 'Content-Type': 'application/activity+json' })
     end
 
-    stub_request(:get, top_note_uri).to_return(status: 200, body: JSON.generate(top_object), headers: { 'Content-Type': 'application/activity+json' })
-    stub_request(:get, reply_note_uri).to_return(status: 200, body: JSON.generate(reply_object), headers: { 'Content-Type': 'application/activity+json' })
+    stub_request(:get, top_note_uri).to_return(status: 200, body: top_object.to_json, headers: { 'Content-Type': 'application/activity+json' })
+    stub_request(:get, reply_note_uri).to_return(status: 200, body: reply_object.to_json, headers: { 'Content-Type': 'application/activity+json' })
   end
 
   shared_examples 'fetches all replies' do
@@ -180,8 +180,8 @@ RSpec.describe ActivityPub::FetchAllRepliesWorker do
       end
 
       before do
-        stub_request(:get, top_collection_uri).to_return(status: 200, body: JSON.generate(replies_top), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, reply_collection_uri).to_return(status: 200, body: JSON.generate(replies_nested), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, top_collection_uri).to_return(status: 200, body: replies_top.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, reply_collection_uri).to_return(status: 200, body: replies_nested.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it_behaves_like 'fetches all replies'
@@ -254,8 +254,8 @@ RSpec.describe ActivityPub::FetchAllRepliesWorker do
       end
 
       before do
-        stub_request(:get, top_page_2_uri).to_return(status: 200, body: JSON.generate(top_page_two), headers: { 'Content-Type': 'application/activity+json' })
-        stub_request(:get, reply_page_2_uri).to_return(status: 200, body: JSON.generate(reply_page_two), headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, top_page_2_uri).to_return(status: 200, body: top_page_two.to_json, headers: { 'Content-Type': 'application/activity+json' })
+        stub_request(:get, reply_page_2_uri).to_return(status: 200, body: reply_page_two.to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
       it_behaves_like 'fetches all replies'

--- a/spec/workers/activitypub/fetch_replies_worker_spec.rb
+++ b/spec/workers/activitypub/fetch_replies_worker_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ActivityPub::FetchRepliesWorker do
     }
   end
 
-  let(:json) { JSON.generate(payload) }
+  let(:json) { payload.to_json }
 
   describe 'perform' do
     it 'performs a request if the collection URI is from the same host' do


### PR DESCRIPTION
I didn't really notice this pattern until part way through changes yesterday, so this is basically a cleanup change on all that which I didn't realize I could have been doing all along in those. The majority of the changes are just to prefer `to_json` when we have local string/hash vars created right in the spec (we have a mix right now).

Other lightweight cleanup while in there:

- In a few spots, extract a `let` var to hold a large hash
- In a few spots, move `subject` out of before and into example
- In payload renderer spec, avoid interpolating string in a spec which is in some part verifying how we interpolate strings
- Add `change` check to fetch remote status service spec