### PR TITLE
Clean up `Webfinger` lib spec

### DIFF
--- a/spec/lib/webfinger_spec.rb
+++ b/spec/lib/webfinger_spec.rb
@@ -3,45 +3,72 @@
 require 'rails_helper'
 
 RSpec.describe Webfinger do
-  describe 'self link' do
+  describe '#initialize' do
+    subject { described_class.new(uri) }
+
+    context 'when called with local account' do
+      let(:uri) { 'acct:alice' }
+
+      it 'handles value and raises error' do
+        expect { subject }.to raise_error(ArgumentError, /for local account/)
+      end
+    end
+
+    context 'when called with remote account' do
+      let(:uri) { 'acct:alice@host.example' }
+
+      it 'handles value and sets attributes' do
+        expect { subject }.to_not raise_error
+      end
+    end
+  end
+
+  describe '#perform' do
     subject { described_class.new('acct:alice@example.com').perform }
 
     context 'when self link is specified with type application/activity+json' do
-      let!(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/alice', type: 'application/activity+json' }] } }
+      let(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/alice', type: 'application/activity+json' }] } }
+
+      before do
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
+      end
 
       it 'correctly parses the response' do
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
-
         expect(subject.self_link_href).to eq 'https://example.com/alice'
       end
     end
 
     context 'when self link is specified with type application/ld+json' do
-      let!(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/alice', type: 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' }] } }
+      let(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/alice', type: 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' }] } }
+
+      before do
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
+      end
 
       it 'correctly parses the response' do
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
-
         expect(subject.self_link_href).to eq 'https://example.com/alice'
       end
     end
 
     context 'when self link is specified with incorrect type' do
-      let!(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/alice', type: 'application/json"' }] } }
+      let(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/alice', type: 'application/json"' }] } }
+
+      before do
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
+      end
 
       it 'raises an error' do
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
-
         expect { subject }
           .to raise_error(Webfinger::Error)
       end
     end
 
     context 'when response body is not parsable' do
-      it 'raises an error' do
-        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com')
-          .to_return(body: 'XXX', headers: { 'Content-Type': 'application/jrd+json' })
+      before do
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: 'XXX', headers: { 'Content-Type': 'application/jrd+json' })
+      end
 
+      it 'raises an error' do
         expect { subject }
           .to raise_error(Webfinger::Error)
       end
@@ -63,7 +90,7 @@ RSpec.describe Webfinger do
 
         before do
           stub_request(:get, 'https://example.com/.well-known/host-meta').to_return(body: host_meta, headers: { 'Content-Type': 'application/jrd+json' })
-          stub_request(:get, 'https://example.com/.well-known/nonStandardWebfinger?resource=acct:alice@example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+          stub_request(:get, 'https://example.com/.well-known/nonStandardWebfinger?resource=acct:alice@example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
         end
 
         it 'uses host meta details' do

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe ResolveAccountService do
   context 'with a legitimate webfinger redirection' do
     before do
       webfinger = { subject: 'acct:foo@ap.example.com', links: [{ rel: 'self', href: 'https://ap.example.com/users/foo', type: 'application/activity+json' }] }
-      stub_request(:get, 'https://redirected.example.com/.well-known/webfinger?resource=acct:Foo@redirected.example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+      stub_request(:get, 'https://redirected.example.com/.well-known/webfinger?resource=acct:Foo@redirected.example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
     end
 
     it 'returns new remote account' do
@@ -121,7 +121,7 @@ RSpec.describe ResolveAccountService do
   context 'with a misconfigured redirection' do
     before do
       webfinger = { subject: 'acct:Foo@redirected.example.com', links: [{ rel: 'self', href: 'https://ap.example.com/users/foo', type: 'application/activity+json' }] }
-      stub_request(:get, 'https://redirected.example.com/.well-known/webfinger?resource=acct:Foo@redirected.example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+      stub_request(:get, 'https://redirected.example.com/.well-known/webfinger?resource=acct:Foo@redirected.example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
     end
 
     it 'returns new remote account' do
@@ -139,9 +139,9 @@ RSpec.describe ResolveAccountService do
   context 'with too many webfinger redirections' do
     before do
       webfinger = { subject: 'acct:foo@evil.example.com', links: [{ rel: 'self', href: 'https://ap.example.com/users/foo', type: 'application/activity+json' }] }
-      stub_request(:get, 'https://redirected.example.com/.well-known/webfinger?resource=acct:Foo@redirected.example.com').to_return(body: JSON.generate(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+      stub_request(:get, 'https://redirected.example.com/.well-known/webfinger?resource=acct:Foo@redirected.example.com').to_return(body: webfinger.to_json, headers: { 'Content-Type': 'application/jrd+json' })
       webfinger2 = { subject: 'acct:foo@ap.example.com', links: [{ rel: 'self', href: 'https://ap.example.com/users/foo', type: 'application/activity+json' }] }
-      stub_request(:get, 'https://evil.example.com/.well-known/webfinger?resource=acct:foo@evil.example.com').to_return(body: JSON.generate(webfinger2), headers: { 'Content-Type': 'application/jrd+json' })
+      stub_request(:get, 'https://evil.example.com/.well-known/webfinger?resource=acct:foo@evil.example.com').to_return(body: webfinger2.to_json, headers: { 'Content-Type': 'application/jrd+json' })
     end
 
     it 'does not return a new remote account' do


### PR DESCRIPTION
Followup on some stuff I noticed yesterday:

- Add coverage for initialize method (and change method to handle nil)
- Make some `let!` into `let` where not needed early
- Remove `JSON.generate(...)` wrappers in spots where we have very simple string hashes built right in the spec ... this is sort of a style clean up from recent Oj/JSON PRs, and I'll have 1-2 more along same lines

Similar to https://github.com/mastodon/mastodon/pull/38258