### PR TITLE
Prefer `to_json` when interacting with escaping

### DIFF
--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -171,10 +171,10 @@ class FanOutOnWriteService < BaseService
   end
 
   def anonymous_payload
-    @anonymous_payload ||= JSON.generate({
+    @anonymous_payload ||= {
       event: update? ? :'status.update' : :update,
       payload: rendered_status,
-    }.as_json)
+    }.to_json
   end
 
   def rendered_status

--- a/app/workers/push_update_worker.rb
+++ b/app/workers/push_update_worker.rb
@@ -23,10 +23,10 @@ class PushUpdateWorker
   end
 
   def message
-    JSON.generate({
+    {
       event: update? ? :'status.update' : :update,
       payload: @payload,
-    }.as_json)
+    }.to_json
   end
 
   def publish!


### PR DESCRIPTION
I had noted in https://github.com/mastodon/mastodon/pull/38222 and https://github.com/mastodon/mastodon/pull/38208 about having taken the approach of wrapping an `as_json` (to get correct TWZ serialization) with the `JSON.generate` (to avoid rails escaping out of caution).

This PR removes that caution, but I'd like thoughts on whether this is ok? I suspect yes, but here are the details via small excerpt. This example is from the push update worker, but its the same thing in each of them.

With the wrapped approach prior to this PR, the ouput includes:

```json
{"content":"<p>Test Post</p>" }
```

After the change with escaping applied;

```json
{"content":"\u003cp\u003eTest Post\u003c/p\u003e" }
```

Note the escaping of special characters. This is part of Rails XSS defenses, and both are valid (and equivalent) in the JSON spec, I believe -- they are sufficiently the same that a) the specs still pass with both, b) comparing equality of `JSON.parse` of both comes back true.