### PR TITLE
Normalize `current_username` on account redirect form

### DIFF
--- a/app/models/form/redirect.rb
+++ b/app/models/form/redirect.rb
@@ -2,14 +2,19 @@
 
 class Form::Redirect
   include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Attributes::Normalization
 
-  attr_accessor :account, :target_account, :current_password,
-                :current_username
+  attr_accessor :account, :target_account, :current_password
 
-  attr_reader :acct
+  attribute :acct, :string
+  attribute :current_username, :string
 
   validates :acct, presence: true, domain: { acct: true }
   validate :validate_target_account
+
+  normalizes :acct, with: ->(value) { value.to_s.strip.gsub(/\A@/, '') }, apply_to_nil: true
+  normalizes :current_username, with: ->(value) { value.strip.delete_prefix('@') }
 
   def valid_with_challenge?(current_user)
     if current_user.encrypted_password.present?
@@ -22,10 +27,6 @@ class Form::Redirect
 
     set_target_account
     valid?
-  end
-
-  def acct=(val)
-    @acct = val.to_s.strip.gsub(/\A@/, '')
   end
 
   private

--- a/spec/models/form/redirect_spec.rb
+++ b/spec/models/form/redirect_spec.rb
@@ -29,4 +29,11 @@ RSpec.describe Form::Redirect do
       end
     end
   end
+
+  describe 'Normalizations' do
+    it { is_expected.to normalize(:acct).from(nil).to('') }
+    it { is_expected.to normalize(:acct).from('  @username  ').to('username') }
+
+    it { is_expected.to normalize(:current_username).from('  @username  ').to('username') }
+  end
 end

--- a/spec/system/settings/migration/redirects_spec.rb
+++ b/spec/system/settings/migration/redirects_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe 'Settings Migration Redirects' do
         .to have_content(I18n.t('migrations.cancelled_msg'))
     end
 
+    context 'when user has blank encrypted password' do
+      before { user.update! encrypted_password: '' }
+
+      it 'saves a redirect via username confirmation' do
+        visit new_settings_migration_redirect_path
+
+        fill_in 'form_redirect_acct', with: 'new@example.host'
+        fill_in 'form_redirect_current_username', with: "  @#{user.account.username} "
+        expect { click_on I18n.t('migrations.set_redirect') }
+          .to(change { user.reload.account.moved_to_account_id }.from(nil))
+      end
+    end
+
     private
 
     def stub_resolver


### PR DESCRIPTION
Related things happening here:

- The same use case and system spec workflow as https://github.com/mastodon/mastodon/pull/38183 -- deal with the scenario where a user does not have encrypted password and is prompted for current username instead, confirm it works, handle incoming values better
- To enable that, turn the `current_username` into an attribute, and normalize it (this is NOT an ActiveRecord, but starting in rails 8.1 the normalize api is available via activemodel)
- While in there, noticed that  the `acct` setter could benefit from same thing, so did both