### PR TITLE
Prefer `to_json` in self destruct scheduler

### DIFF
--- a/app/workers/scheduler/self_destruct_scheduler.rb
+++ b/app/workers/scheduler/self_destruct_scheduler.rb
@@ -55,13 +55,10 @@ class Scheduler::SelfDestructScheduler
   end
 
   def delete_account!(account)
-    payload = ActiveModelSerializers::SerializableResource.new(
-      account,
-      serializer: ActivityPub::DeleteActorSerializer,
-      adapter: ActivityPub::Adapter
-    ).as_json
-
-    json = JSON.generate(ActivityPub::LinkedDataSignature.new(payload).sign!(account))
+    json = ActivityPub::LinkedDataSignature
+      .new(deletion_payload(account))
+      .sign!(account)
+      .to_json
 
     ActivityPub::DeliveryWorker.push_bulk(inboxes, limit: 1_000) do |inbox_url|
       [json, account.id, inbox_url]
@@ -69,5 +66,13 @@ class Scheduler::SelfDestructScheduler
 
     # Do not call `Account#suspend!` because we don't want to issue a deletion request
     account.update!(suspended_at: Time.now.utc, suspension_origin: :local)
+  end
+
+  def deletion_payload(account)
+    ActiveModelSerializers::SerializableResource.new(
+      account,
+      serializer: ActivityPub::DeleteActorSerializer,
+      adapter: ActivityPub::Adapter
+    ).as_json
   end
 end

--- a/spec/workers/scheduler/self_destruct_scheduler_spec.rb
+++ b/spec/workers/scheduler/self_destruct_scheduler_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe Scheduler::SelfDestructScheduler do
       end
 
       context 'when sidekiq is operational' do
+        let!(:other_account) { Fabricate :account, inbox_url: 'https://host.example/inbox', domain: 'host.example', protocol: :activitypub }
+
         it 'suspends local non-suspended accounts' do
           worker.perform
 
@@ -50,6 +52,9 @@ RSpec.describe Scheduler::SelfDestructScheduler do
           deletion_request = Fabricate(:account_deletion_request, account: account)
 
           worker.perform
+
+          expect(ActivityPub::DeliveryWorker)
+            .to have_enqueued_sidekiq_job(match_json_values(type: 'Delete', signature: be_present), account.id, other_account.inbox_url)
 
           expect(account.reload.suspended_at).to be > 1.day.ago
           expect { deletion_request.reload }.to raise_error(ActiveRecord::RecordNotFound)


### PR DESCRIPTION
This wraps an AMS serializer which has already as_json'd itself, so should be safe.

Pulled out private method to build the payload, added basic spec to see the bulk delivery happen.