### PR TITLE
Refactor ProcessMentionsService to remove `save_records` parameter

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -77,7 +77,7 @@ class PostStatusService < BaseService
 
   def process_status!
     @status = @account.statuses.new(status_attributes)
-    process_mentions_service.call(@status, save_records: false)
+    process_mentions_service.call(@status)
     safeguard_mentions!(@status)
     safeguard_private_mention_quote!(@status)
     attach_quote!(@status)

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -6,10 +6,8 @@ class ProcessMentionsService < BaseService
   # Scan status for mentions and fetch remote mentioned users,
   # and create local mention pointers
   # @param [Status] status
-  # @param [Boolean] save_records Whether to save records in database
-  def call(status, save_records: true)
+  def call(status)
     @status = status
-    @save_records = save_records
 
     return unless @status.local?
 
@@ -64,7 +62,7 @@ class ProcessMentionsService < BaseService
       "@#{mentioned_account.acct}"
     end
 
-    @status.save! if @save_records
+    @status.save! if @status.persisted?
   end
 
   def assign_mentions!
@@ -79,8 +77,10 @@ class ProcessMentionsService < BaseService
       dropped_mentions.each(&:destroy)
     end
 
+    return unless @status.persisted?
+
     @current_mentions.each do |mention|
-      mention.save if (mention.new_record? || mention.silent_changed?) && @save_records
+      mention.save if mention.new_record? || mention.silent_changed?
     end
 
     # If previous mentions are no longer contained in the text, convert them

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe PostStatusService do
     status = subject.call(account, text: 'test status update')
 
     expect(ProcessMentionsService).to have_received(:new)
-    expect(mention_service).to have_received(:call).with(status, save_records: false)
+    expect(mention_service).to have_received(:call).with(status)
   end
 
   it 'safeguards mentions' do

--- a/spec/services/process_mentions_service_spec.rb
+++ b/spec/services/process_mentions_service_spec.rb
@@ -54,10 +54,10 @@ RSpec.describe ProcessMentionsService do
 
       context 'when mentioning a user several times when not saving records' do
         let!(:remote_user) { Fabricate(:account, username: 'remote_user', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
-        let(:status)       { Fabricate(:status, account: account, text: "Hello @#{remote_user.acct} @#{remote_user.acct} @#{remote_user.acct}", visibility: :public) }
+        let(:status)       { Fabricate.build(:status, account: account, text: "Hello @#{remote_user.acct} @#{remote_user.acct} @#{remote_user.acct}", visibility: :public) }
 
         it 'creates exactly one mention' do
-          subject.call(status, save_records: false)
+          subject.call(status)
 
           expect(status.mentions.size).to eq 1
         end


### PR DESCRIPTION
Context: https://github.com/mastodon/mastodon/pull/38115#discussion_r2952278873