### PR TITLE
Add missing h1 headings to Reset Password & Resend Confirmation Link pages

### DIFF
--- a/app/views/auth/confirmations/new.html.haml
+++ b/app/views/auth/confirmations/new.html.haml
@@ -18,6 +18,7 @@
       %p.lead= t('auth.confirmations.awaiting_review', domain: site_hostname)
 - else
   = simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+    %h1.title= t('auth.resend_confirmation', domain: site_hostname)
     = render 'shared/error_messages', object: resource
 
     .fields-group

--- a/app/views/auth/passwords/new.html.haml
+++ b/app/views/auth/passwords/new.html.haml
@@ -2,6 +2,7 @@
   = t('auth.reset_password')
 
 = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+  %h1.title= t('auth.reset_password', domain: site_hostname)
   = render 'shared/error_messages', object: resource
 
   .fields-group

--- a/app/views/auth/sessions/new.html.haml
+++ b/app/views/auth/sessions/new.html.haml
@@ -38,7 +38,10 @@
 
 - if devise_mapping.omniauthable? && resource_class.omniauth_providers.any?
   .simple_form.alternative-login
-    %h2= omniauth_only? ? t('auth.log_in_with') : t('auth.or_log_in_with')
+    - if omniauth_only?
+      %h1= t('auth.log_in_with')
+    - else
+      %h2= t('auth.or_log_in_with')
 
     .actions
       - resource_class.omniauth_providers.each do |provider|


### PR DESCRIPTION
Related to WEB-881

### Changes proposed in this PR:
- Adds missing page headings to the "Reset Password" & "Resend Confirmation Link" pages
- Fixes heading hierarchy on Login page when `omniauth_only` setting is enabled

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="525" height="379" alt="image" src="https://github.com/user-attachments/assets/23527189-790b-4a7c-8e5d-cbabbc275d12" /> | <img width="539" height="438" alt="image" src="https://github.com/user-attachments/assets/beb75862-cdba-4311-a58c-8c84f842781c" /> |
| <img width="528" height="383" alt="image" src="https://github.com/user-attachments/assets/06ed560c-4dce-4e23-8887-3c1decac32dd" /> | <img width="535" height="424" alt="image" src="https://github.com/user-attachments/assets/2ed6eb7b-09b3-4d2b-9027-a05964a479fb" /> |