### PR TITLE
Revoke access tokens before destroying session activations in Auth::PasswordsController#update

### DIFF
--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -9,9 +9,8 @@ class Auth::PasswordsController < Devise::PasswordsController
   def update
     super do |resource|
       if resource.errors.empty?
-        resource.session_activations.destroy_all
-
         resource.revoke_access!
+        resource.session_activations.destroy_all
       end
     end
   end


### PR DESCRIPTION
Sessions are deleted before they can be used to send a "revoke_access" signal.