### PR TITLE
Sign-up server rules: Show different icon on toggle button when description is expanded

### DIFF
--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -85,6 +85,14 @@ $fluid-breakpoint: $maximum-width + 20px;
       display: none;
     }
 
+    &[aria-expanded='true'] .icon-expand {
+      display: none;
+    }
+
+    &[aria-expanded='false'] .icon-collapse {
+      display: none;
+    }
+
     .icon {
       width: 1lh;
       height: 1lh;

--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -85,10 +85,7 @@ $fluid-breakpoint: $maximum-width + 20px;
       display: none;
     }
 
-    &[aria-expanded='true'] .icon-expand {
-      display: none;
-    }
-
+    &[aria-expanded='true'] .icon-expand,
     &[aria-expanded='false'] .icon-collapse {
       display: none;
     }

--- a/app/views/auth/rule_translations/_rule_translation.html.haml
+++ b/app/views/auth/rule_translations/_rule_translation.html.haml
@@ -4,5 +4,6 @@
     .rules-list__hint{ tabIndex: -1 }
       %span.rules-list__hint-text= rule_translation.hint
       %button.rules-list__toggle-button{ type: 'button', hidden: true, 'aria-expanded': 'false' }
-        = material_symbol('more_horiz')
+        = material_symbol('keyboard_arrow_up', { class: 'icon-collapse' })
+        = material_symbol('more_horiz', { class: 'icon-expand' })
         %span.sr-only= t('auth.rules.read_more')


### PR DESCRIPTION
Addresses @ChaosExAnima's [comment](https://github.com/mastodon/mastodon/pull/38257#pullrequestreview-3966827980) on #38257

### Changes proposed in this PR:
- Shows a different icon on the toggle button for long rule descriptions when the rule is expanded. (The accessible label is not changed as the button's status is conveyed via `aria-expanded`.)

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="430" height="171" alt="image" src="https://github.com/user-attachments/assets/6d65a90a-41e9-4837-bd68-22ec5984a1b2" /> | <img width="423" height="171" alt="image" src="https://github.com/user-attachments/assets/eb38e335-bd9c-48ec-9c73-64c003857ff5" /> |

https://github.com/user-attachments/assets/adfed3ea-c42b-4483-813a-3be7e14d7d1a