### PR TITLE
Refactor: Remove Status unsafe lifecycles

### DIFF
--- a/app/javascript/mastodon/features/status/index.jsx
+++ b/app/javascript/mastodon/features/status/index.jsx
@@ -158,22 +158,9 @@ class Status extends ImmutablePureComponent {
     newRepliesIds: [],
   };
 
-  UNSAFE_componentWillMount () {
+  componentDidMount() {
     this.props.dispatch(fetchStatus(this.props.params.statusId, { forceFetch: true }));
-  }
-
-  componentDidMount () {
     attachFullscreenListener(this.onFullScreenChange);
-  }
-
-  UNSAFE_componentWillReceiveProps (nextProps) {
-    if (nextProps.params.statusId !== this.props.params.statusId && nextProps.params.statusId) {
-      this.props.dispatch(fetchStatus(nextProps.params.statusId, { forceFetch: true }));
-    }
-
-    if (nextProps.status && nextProps.status.get('id') !== this.state.loadedStatusId) {
-      this.setState({ showMedia: defaultMediaVisibility(nextProps.status), loadedStatusId: nextProps.status.get('id') });
-    }
   }
 
   handleToggleMediaVisibility = () => {
@@ -493,8 +480,8 @@ class Status extends ImmutablePureComponent {
     this.statusNode = c;
   };
 
-  componentDidUpdate (prevProps) {
-    const { status, descendantsIds } = this.props;
+  componentDidUpdate(prevProps) {
+    const { status, descendantsIds, params } = this.props;
 
     const isSameStatus = status && (prevProps.status?.get('id') === status.get('id'));
 
@@ -505,6 +492,14 @@ class Status extends ImmutablePureComponent {
       if (newRepliesIds.length) {
         this.setState({newRepliesIds});
       }
+    }
+
+    if (params.statusId && prevProps.params.statusId !== params.statusId) {
+      this.props.dispatch(fetchStatus(params.statusId, { forceFetch: true }));
+    }
+
+    if (status && status.get('id') !== this.state.loadedStatusId) {
+      this.setState({ showMedia: defaultMediaVisibility(this.props.status), loadedStatusId: status.get('id') });
     }
   }
 


### PR DESCRIPTION
Fixes WEB-876.

The status component uses two deprecated lifecycle methods to fetch status data before initial mount or props change. With this PR, fetching logic is after the component mounts, but otherwise should be the same.