### PR TITLE
Use progress total tracker in accounts CLI

### DIFF
--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -17,7 +17,6 @@ module Mastodon::CLI
     LONG_DESC
     def rotate(username = nil)
       if options[:all]
-        processed = 0
         delay     = 0
         scope     = Account.local.without_suspended
         progress  = create_progress_bar(scope.count)
@@ -26,14 +25,13 @@ module Mastodon::CLI
           accounts.each do |account|
             rotate_keys_for_account(account, delay)
             progress.increment
-            processed += 1
           end
 
           delay += 5.minutes
         end
 
         progress.finish
-        say("OK, rotated keys for #{processed} accounts", :green)
+        say("OK, rotated keys for #{progress.progress} accounts", :green)
       elsif username.present?
         rotate_keys_for_account(Account.find_local(username))
         say('OK', :green)
@@ -442,7 +440,6 @@ module Mastodon::CLI
       total    += account.following.reorder(nil).count if options[:follows]
       total    += account.followers.reorder(nil).count if options[:followers]
       progress  = create_progress_bar(total)
-      processed = 0
 
       if options[:follows]
         account.following.reorder(nil).find_each do |target_account|
@@ -451,7 +448,6 @@ module Mastodon::CLI
           progress.log pastel.red("Error processing #{target_account.id}: #{e}")
         ensure
           progress.increment
-          processed += 1
         end
 
         BootstrapTimelineWorker.perform_async(account.id)
@@ -464,12 +460,11 @@ module Mastodon::CLI
           progress.log pastel.red("Error processing #{target_account.id}: #{e}")
         ensure
           progress.increment
-          processed += 1
         end
       end
 
       progress.finish
-      say("Processed #{processed} relationships", :green, true)
+      say("Processed #{progress.progress} relationships", :green, true)
     end
 
     option :number, type: :numeric, aliases: [:n]


### PR DESCRIPTION
The progress bar object here keeps a running total of `increment` calls, which we can use at the end to report the total.

There are a few other spots in the CLI (in other actions) which do a similar `processed` accumulator loop sort of thing, but a) some of them are working in batches, b) some of them dont have progress bars currently.  Possible future work on both fronts.