### PR TITLE
Federate new profile settings

### DIFF
--- a/app/helpers/context_helper.rb
+++ b/app/helpers/context_helper.rb
@@ -25,6 +25,12 @@ module ContextHelper
     voters_count: { 'toot' => 'http://joinmastodon.org/ns#', 'votersCount' => 'toot:votersCount' },
     suspended: { 'toot' => 'http://joinmastodon.org/ns#', 'suspended' => 'toot:suspended' },
     attribution_domains: { 'toot' => 'http://joinmastodon.org/ns#', 'attributionDomains' => { '@id' => 'toot:attributionDomains', '@type' => '@id' } },
+    profile_settings: {
+      'toot' => 'http://joinmastodon.org/ns#',
+      'showFeatured' => 'toot:showFeatured',
+      'showMedia' => 'toot:showMedia',
+      'showRepliesInMedia' => 'toot:showRepliesInMedia',
+    },
     quote_requests: { 'QuoteRequest' => 'https://w3id.org/fep/044f#QuoteRequest' },
     quotes: {
       'quote' => 'https://w3id.org/fep/044f#quote',

--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -8,7 +8,7 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
 
   context_extensions :manually_approves_followers, :featured, :also_known_as,
                      :moved_to, :property_value, :discoverable, :suspended,
-                     :memorial, :indexable, :attribution_domains
+                     :memorial, :indexable, :attribution_domains, :profile_settings
 
   context_extensions :interaction_policies if Mastodon::Feature.collections_enabled?
 
@@ -16,7 +16,10 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
              :inbox, :outbox, :featured, :featured_tags,
              :preferred_username, :name, :summary,
              :url, :manually_approves_followers,
-             :discoverable, :indexable, :published, :memorial
+             :discoverable, :indexable, :published, :memorial,
+             :show_featured, :show_media
+
+  attribute :show_media_replies, key: :show_replies_in_media
 
   attribute :interaction_policy, if: -> { Mastodon::Feature.collections_enabled? }
   attribute :featured_collections, if: -> { Mastodon::Feature.collections_enabled? }

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -134,6 +134,9 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.discoverable            = @json['discoverable'] || false
     @account.indexable               = @json['indexable'] || false
     @account.memorial                = @json['memorial'] || false
+    @account.show_featured           = @json['showFeatured'] if @json.key?('showFeatured')
+    @account.show_media              = @json['showMedia'] if @json.key?('showMedia')
+    @account.show_media_replies      = @json['showRepliesInMedia'] if @json.key?('showRepliesInMedia')
     @account.attribution_domains     = as_array(@json['attributionDomains'] || []).take(Account::ATTRIBUTION_DOMAINS_HARD_LIMIT).map { |item| value_or_id(item) }
   end
 

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -111,6 +111,30 @@ RSpec.describe ActivityPub::ProcessAccountService do
     end
   end
 
+  context 'with profile settings' do
+    let(:payload) do
+      {
+        id: 'https://foo.test',
+        type: 'Actor',
+        inbox: 'https://foo.test/inbox',
+        showMedia: true,
+        showRepliesInMedia: false,
+        showFeatured: false,
+      }.with_indifferent_access
+    end
+
+    it 'sets the profile settings as expected' do
+      account = subject.call('alice', 'example.com', payload)
+
+      expect(account)
+        .to have_attributes(
+          show_media: true,
+          show_media_replies: false,
+          show_featured: false
+        )
+    end
+  end
+
   context 'with inlined feature collection' do
     let(:payload) do
       {


### PR DESCRIPTION
Add the following attributes to Actor, all in the `http://joinmastodon.org/ns#` namespace:
- `showFeatured`: whether to show the “featured” tab in the profile
- `showMedia`: whether to show the “media” tab in the profile
- `showRepliesInMedia`: whether to include replies in the “media” tab of the profile