### PR TITLE
Add simple language selector to collection editor

### DIFF
--- a/app/javascript/mastodon/features/collections/editor/details.tsx
+++ b/app/javascript/mastodon/features/collections/editor/details.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { Fragment, useCallback, useMemo, useState } from 'react';
 
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -418,6 +418,13 @@ const LanguageField: React.FC = () => {
       value={selectedLanguage}
       onChange={handleLanguageChange}
     >
+      <option value=''>
+        <FormattedMessage
+          id='collections.collection_language_none'
+          defaultMessage='None'
+          tagName={Fragment}
+        />
+      </option>
       {languages?.map(([code, name, localName]) => (
         <option key={code} value={code}>
           {localName} ({name})

--- a/app/javascript/mastodon/features/collections/editor/details.tsx
+++ b/app/javascript/mastodon/features/collections/editor/details.tsx
@@ -6,6 +6,7 @@ import { useHistory } from 'react-router-dom';
 
 import { isFulfilled } from '@reduxjs/toolkit';
 
+import { languages } from '@/mastodon/initial_state';
 import {
   hasSpecialCharacters,
   inputToHashtag,
@@ -22,6 +23,7 @@ import {
   Fieldset,
   FormStack,
   RadioButtonField,
+  SelectField,
   TextAreaField,
 } from 'mastodon/components/form_fields';
 import { TextInputField } from 'mastodon/components/form_fields/text_input_field';
@@ -201,6 +203,8 @@ export const CollectionDetails: React.FC = () => {
 
         <TopicField />
 
+        <LanguageField />
+
         <Fieldset
           legend={
             <FormattedMessage
@@ -356,7 +360,7 @@ const TopicField: React.FC = () => {
       value={topic}
       items={tags}
       isLoading={isLoading}
-      renderItem={renderItem}
+      renderItem={renderTagItem}
       onSelectItem={handleSelectTopicSuggestion}
       onChange={handleTopicChange}
       autoCapitalize='off'
@@ -380,4 +384,45 @@ const TopicField: React.FC = () => {
   );
 };
 
-const renderItem = (item: TagSearchResult) => item.label ?? `#${item.name}`;
+const renderTagItem = (item: TagSearchResult) => item.label ?? `#${item.name}`;
+
+const LanguageField: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const initialLanguage = useAppSelector(
+    (state) => state.compose.get('default_language') as string,
+  );
+  const { language } = useAppSelector((state) => state.collections.editor);
+
+  const selectedLanguage = language ?? initialLanguage;
+
+  const handleLanguageChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      dispatch(
+        updateCollectionEditorField({
+          field: 'language',
+          value: event.target.value,
+        }),
+      );
+    },
+    [dispatch],
+  );
+
+  return (
+    <SelectField
+      label={
+        <FormattedMessage
+          id='collections.collection_language'
+          defaultMessage='Language'
+        />
+      }
+      value={selectedLanguage}
+      onChange={handleLanguageChange}
+    >
+      {languages?.map(([code, name, localName]) => (
+        <option key={code} value={code}>
+          {localName} ({name})
+        </option>
+      ))}
+    </SelectField>
+  );
+};

--- a/app/javascript/mastodon/initial_state.ts
+++ b/app/javascript/mastodon/initial_state.ts
@@ -153,7 +153,7 @@ export const languages = initialState?.languages.map((lang) => {
     lang[0],
     displayNames?.of(lang[0].replace('zh-YUE', 'yue')) ?? lang[1],
     lang[2],
-  ];
+  ] as InitialStateLanguage;
 });
 
 export function getAccessToken(): string | undefined {

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -350,6 +350,7 @@
   "collections.accounts.empty_title": "This collection is empty",
   "collections.collection_description": "Description",
   "collections.collection_language": "Language",
+  "collections.collection_language_none": "None",
   "collections.collection_name": "Name",
   "collections.collection_topic": "Topic",
   "collections.confirm_account_removal": "Are you sure you want to remove this account from this collection?",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -349,6 +349,7 @@
   "collections.accounts.empty_description": "Add up to {count} accounts you follow",
   "collections.accounts.empty_title": "This collection is empty",
   "collections.collection_description": "Description",
+  "collections.collection_language": "Language",
   "collections.collection_name": "Name",
   "collections.collection_topic": "Topic",
   "collections.confirm_account_removal": "Are you sure you want to remove this account from this collection?",


### PR DESCRIPTION
Fixes WEB-853

### Changes proposed in this PR:
- Adds a simple language selector to the collection editor.
   - It's using a simple select element for now – I want to refactor the composer's language selector (with search, sorting & auto-language detection) to be more accessible & reusable & then we'll be able to use it here, too.

### Screenshots

<img width="591" height="329" alt="image" src="https://github.com/user-attachments/assets/22cc4b16-f5e0-4663-8518-a878513dfeb3" />
<img width="585" height="608" alt="image" src="https://github.com/user-attachments/assets/094122f8-e2a8-4a21-8eed-9b3138ceb1a0" />
