### PR TITLE
Fix ENV string comparison for ENABLE_SIDEKIQ_UNIQUE_JOBS_UI

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'sidekiq_unique_jobs/web' if ENV['ENABLE_SIDEKIQ_UNIQUE_JOBS_UI'] == true
+require 'sidekiq_unique_jobs/web' if ENV['ENABLE_SIDEKIQ_UNIQUE_JOBS_UI'] == 'true'
 require 'sidekiq-scheduler/web'
 
 class RedirectWithVary < ActionDispatch::Routing::PathRedirect


### PR DESCRIPTION
## Summary

- `ENV` values are always strings in Ruby, but `config/routes.rb` compared `ENV['ENABLE_SIDEKIQ_UNIQUE_JOBS_UI']` against boolean `true` instead of the string `'true'`
- This caused the condition to always evaluate to `false`, making it impossible to enable the Sidekiq Unique Jobs web UI via the environment variable
- Fixed by changing the comparison from `== true` to `== 'true'`, consistent with all other ENV comparisons in the codebase

## Test plan

- [x] Set `ENABLE_SIDEKIQ_UNIQUE_JOBS_UI=true` and verify the Sidekiq Unique Jobs web UI is accessible
- [x] Verify the route is not loaded when the env var is unset or set to any other value