### PR TITLE
Use pretty text wrapping for post contents

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1049,6 +1049,7 @@ body > [data-popper-placement] {
   overflow: hidden;
   text-overflow: ellipsis;
   text-autospace: normal;
+  text-wrap: pretty;
   font-size: 15px;
   line-height: 22px;
   padding-top: 2px;


### PR DESCRIPTION
Modals already use `text-wrap: balance` but that can look bad with multi-paragraph text as different paragraphs become different-sized boxes.

`text-wrap: pretty` is not yet supported by Firefox (it's ignored) but in other browsers it prevents short words from hanging at the end of lines, and makes sure the last line does not end up with a single-word runt unless it's unavoidable.