### PR TITLE
Make it possible to retrieve both resolved and unresolved reports by api

### DIFF
--- a/app/controllers/api/v1/admin/reports_controller.rb
+++ b/app/controllers/api/v1/admin/reports_controller.rb
@@ -16,6 +16,7 @@ class Api::V1::Admin::ReportsController < Api::BaseController
 
   FILTER_PARAMS = %i(
     resolved
+    unresolved
     account_id
     target_account_id
   ).freeze

--- a/app/models/report_filter.rb
+++ b/app/models/report_filter.rb
@@ -3,6 +3,7 @@
 class ReportFilter
   KEYS = %i(
     resolved
+    unresolved
     account_id
     target_account_id
     by_target_domain
@@ -16,7 +17,7 @@ class ReportFilter
   end
 
   def results
-    scope = Report.unresolved
+    scope = status_scope
 
     relevant_params.each do |key, value|
       scope = scope.merge scope_for(key, value)
@@ -28,7 +29,7 @@ class ReportFilter
   private
 
   def relevant_params
-    params.tap do |args|
+    params.except(:resolved, :unresolved).tap do |args|
       args.delete(:target_origin) if origin_is_remote_and_domain_present?
     end
   end
@@ -37,12 +38,24 @@ class ReportFilter
     params[:target_origin] == 'remote' && params[:by_target_domain].present?
   end
 
+  def status_scope
+    resolved = params.key?(:resolved)
+    unresolved = params.key?(:unresolved)
+
+    return Report.all if resolved && unresolved
+    return Report.resolved if resolved
+
+    Report.unresolved
+  end
+
   def scope_for(key, value)
     case key.to_sym
     when :by_target_domain
       Report.where(target_account: Account.where(domain: value))
     when :resolved
       Report.resolved
+    when :unresolved
+      Report.unresolved
     when :account_id
       Report.where(account_id: value)
     when :target_account_id

--- a/app/models/report_filter.rb
+++ b/app/models/report_filter.rb
@@ -52,10 +52,6 @@ class ReportFilter
     case key.to_sym
     when :by_target_domain
       Report.where(target_account: Account.where(domain: value))
-    when :resolved
-      Report.resolved
-    when :unresolved
-      Report.unresolved
     when :account_id
       Report.where(account_id: value)
     when :target_account_id

--- a/spec/requests/api/v1/admin/reports_spec.rb
+++ b/spec/requests/api/v1/admin/reports_spec.rb
@@ -78,6 +78,17 @@ RSpec.describe 'Reports' do
         end
       end
 
+      context 'with both resolved and unresolved params' do
+        let(:params) { { resolved: true, unresolved: true } }
+        let(:scope)  { Report.all }
+
+        it 'returns all reports' do
+          subject
+
+          expect(response.parsed_body).to match_array(expected_response)
+        end
+      end
+
       context 'with account_id param' do
         let(:params) { { account_id: reporter.id } }
         let(:scope)  { Report.unresolved.where(account: reporter) }


### PR DESCRIPTION
The current implementation of `/api/v1/admin/reports` relies on a really unintuitive check for the presence of `resolved` param to display resolved reports instead of checking for the truthiness of the param. This commit makes it possible to retrieve both resolved and unresolved reports in a single request, without introducing breaking changes.