### PR TITLE
Fix `Layout/EmptyLineAfterGuardClause` cop in `PollExpirationNotifyWorker`

### DIFF
--- a/app/workers/poll_expiration_notify_worker.rb
+++ b/app/workers/poll_expiration_notify_worker.rb
@@ -9,6 +9,7 @@ class PollExpirationNotifyWorker
     @poll = Poll.find(poll_id)
 
     return if missing_expiration?
+
     requeue! && return if not_due_yet?
 
     notify_remote_voters_and_owner! if @poll.local?


### PR DESCRIPTION
There are multiple open PRs linked to https://github.com/mastodon/mastodon/pull/37988 in order to prep for 1.85.x

This one fixes what I think is the only new issue from 1.86.0