### PR TITLE
Add `tagged_objects` to reblog section of status association cache

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -185,6 +185,7 @@ class Status < ApplicationRecord
                      preview_cards_status: { preview_card: { author_account: [:account_stat, user: :role] } },
                      account: [:account_stat, user: :role],
                      active_mentions: :account,
+                     tagged_objects: :object,
                    ],
                    thread: :account
 


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/38115#discussion_r2975218959

If you are intrigued by brevity, de-duplication, and it being marginally easier to keep these in sync, enjoy: https://github.com/mastodon/mastodon/pull/35285