### PR TITLE
Handle `Update` of a `FeaturedCollection`

### DIFF
--- a/app/lib/activitypub/activity/update.rb
+++ b/app/lib/activitypub/activity/update.rb
@@ -13,6 +13,8 @@ class ActivityPub::Activity::Update < ActivityPub::Activity
       update_account
     elsif supported_object_type? || converted_object_type?
       update_status
+    elsif equals_or_includes_any?(@object['type'], ['FeaturedCollection'])
+      update_collection
     end
   end
 
@@ -39,6 +41,12 @@ class ActivityPub::Activity::Update < ActivityPub::Activity
     return if @status.nil?
 
     ActivityPub::ProcessStatusUpdateService.new.call(@status, @json, @object, request_id: @options[:request_id])
+  end
+
+  def update_collection
+    return reject_payload! if non_matching_uri_hosts?(@account.uri, object_uri)
+
+    ActivityPub::ProcessFeaturedCollectionService.new.call(@account, @object)
   end
 
   def object_too_old?

--- a/app/lib/activitypub/activity/update.rb
+++ b/app/lib/activitypub/activity/update.rb
@@ -13,7 +13,7 @@ class ActivityPub::Activity::Update < ActivityPub::Activity
       update_account
     elsif supported_object_type? || converted_object_type?
       update_status
-    elsif equals_or_includes_any?(@object['type'], ['FeaturedCollection'])
+    elsif equals_or_includes_any?(@object['type'], ['FeaturedCollection']) && Mastodon::Feature.collections_federation_enabled?
       update_collection
     end
   end

--- a/spec/lib/activitypub/activity/update_spec.rb
+++ b/spec/lib/activitypub/activity/update_spec.rb
@@ -256,5 +256,45 @@ RSpec.describe ActivityPub::Activity::Update do
         end
       end
     end
+
+    context 'with a `FeaturedCollection` object' do
+      let(:collection) { Fabricate(:remote_collection, account: sender, name: 'old name', discoverable: false) }
+      let(:featured_collection_json) do
+        {
+          '@context' => 'https://www.w3.org/ns/activitystreams',
+          'id' => collection.uri,
+          'type' => 'FeaturedCollection',
+          'attributedTo' => sender.uri,
+          'name' => 'Cool people',
+          'summary' => 'People you should follow.',
+          'totalItems' => 0,
+          'sensitive' => false,
+          'discoverable' => true,
+          'published' => '2026-03-09T15:19:25Z',
+          'updated' => Time.zone.now.iso8601,
+        }
+      end
+      let(:json) do
+        {
+          '@context' => 'https://www.w3.org/ns/activitystreams',
+          'type' => 'Update',
+          'actor' => sender.uri,
+          'object' => featured_collection_json,
+        }
+      end
+      let(:stubbed_service) do
+        instance_double(ActivityPub::ProcessFeaturedCollectionService, call: true)
+      end
+
+      before do
+        allow(ActivityPub::ProcessFeaturedCollectionService).to receive(:new).and_return(stubbed_service)
+      end
+
+      it 'updates the collection' do
+        subject.perform
+
+        expect(stubbed_service).to have_received(:call).with(sender, featured_collection_json)
+      end
+    end
   end
 end

--- a/spec/lib/activitypub/activity/update_spec.rb
+++ b/spec/lib/activitypub/activity/update_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe ActivityPub::Activity::Update do
       end
     end
 
-    context 'with a `FeaturedCollection` object' do
+    context 'with a `FeaturedCollection` object', feature: :collections_federation do
       let(:collection) { Fabricate(:remote_collection, account: sender, name: 'old name', discoverable: false) }
       let(:featured_collection_json) do
         {


### PR DESCRIPTION
Now that `ActivityPub::ProcessFeaturedCollectionService` can update existing Collections, this should be really simple.

Fixes WEB-674