### PR TITLE
Drop support for `ENABLE_SIDEKIQ_UNIQUE_JOBS_UI`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'sidekiq_unique_jobs/web' if ENV['ENABLE_SIDEKIQ_UNIQUE_JOBS_UI'] == true
 require 'sidekiq-scheduler/web'
 
 class RedirectWithVary < ActionDispatch::Routing::PathRedirect


### PR DESCRIPTION
Back in #29199, we disabled `sidekiq-unique-jobs`'s Web UI, and provided an environment variable to re-enable it.

However, as #38319 made it apparent, this environment variable never worked as intended. Yet, nobody ever complained about it, and the fix was most likely submitted after an automated scan of the codebase for issues.

Since nobody uses this feature and we have concerns about it, drop it altogether.