### PR TITLE
Extract `api/v1/statuses#context` to standalone controller

### DIFF
--- a/app/controllers/api/v1/statuses/contexts_controller.rb
+++ b/app/controllers/api/v1/statuses/contexts_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class Api::V1::Statuses::ContextsController < Api::BaseController
+  include Authorization
+  include AsyncRefreshesConcern
+
+  before_action -> { authorize_if_got_token! :read, :'read:statuses' }
+  before_action :set_status
+
+  # This API was originally unlimited, pagination cannot be introduced without
+  # breaking backwards-compatibility. Arbitrarily high number to cover most
+  # conversations as quasi-unlimited, it would be too much work to render more
+  # than this anyway
+  CONTEXT_LIMIT = 4_096
+
+  # This remains expensive and we don't want to show everything to logged-out users
+  ANCESTORS_LIMIT         = 40
+  DESCENDANTS_LIMIT       = 60
+  DESCENDANTS_DEPTH_LIMIT = 20
+
+  def show
+    cache_if_unauthenticated!
+
+    ancestors_limit         = CONTEXT_LIMIT
+    descendants_limit       = CONTEXT_LIMIT
+    descendants_depth_limit = nil
+
+    if current_account.nil?
+      ancestors_limit         = ANCESTORS_LIMIT
+      descendants_limit       = DESCENDANTS_LIMIT
+      descendants_depth_limit = DESCENDANTS_DEPTH_LIMIT
+    end
+
+    ancestors_results   = @status.in_reply_to_id.nil? ? [] : @status.ancestors(ancestors_limit, current_account)
+    descendants_results = @status.descendants(descendants_limit, current_account, descendants_depth_limit)
+    loaded_ancestors    = preload_collection(ancestors_results, Status)
+    loaded_descendants  = preload_collection(descendants_results, Status)
+
+    @context = Context.new(ancestors: loaded_ancestors, descendants: loaded_descendants)
+    statuses = [@status] + @context.ancestors + @context.descendants
+
+    refresh_key = "context:#{@status.id}:refresh"
+    async_refresh = AsyncRefresh.new(refresh_key)
+
+    if async_refresh.running?
+      add_async_refresh_header(async_refresh)
+    elsif !current_account.nil? && @status.should_fetch_replies?
+      add_async_refresh_header(AsyncRefresh.create(refresh_key, count_results: true))
+
+      WorkerBatch.new.within do |batch|
+        batch.connect(refresh_key, threshold: 1.0)
+        ActivityPub::FetchAllRepliesWorker.perform_async(@status.id, { 'batch_id' => batch.id })
+      end
+    end
+
+    render json: @context, serializer: REST::ContextSerializer, relationships: StatusRelationshipsPresenter.new(statuses, current_user&.account_id)
+  end
+
+  private
+
+  def set_status
+    @status = Status.find(params[:status_id])
+    authorize @status, :show?
+  rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
+    not_found
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -28,6 +28,7 @@ namespace :api, format: false do
         resources :reblogged_by, controller: :reblogged_by_accounts, only: :index
         resources :favourited_by, controller: :favourited_by_accounts, only: :index
         resource :reblog, only: :create
+        resource :context, only: :show
         post :unreblog, to: 'reblogs#destroy'
 
         resources :quotes, only: :index do
@@ -54,10 +55,6 @@ namespace :api, format: false do
         resource :interaction_policy, only: :update
 
         post :translate, to: 'translations#create'
-      end
-
-      member do
-        get :context
       end
     end
 

--- a/spec/requests/api/v1/statuses/contexts_spec.rb
+++ b/spec/requests/api/v1/statuses/contexts_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API V1 Statuses Contexts' do
+  describe 'GET /api/v1/statuses/:status_id/context' do
+    context 'with an oauth token' do
+      let(:user) { Fabricate(:user) }
+      let(:client_app) { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
+      let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, application: client_app, scopes: scopes) }
+      let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
+
+      let(:scopes) { 'read:statuses' }
+
+      context 'with a public status' do
+        let(:status) { Fabricate(:status, account: user.account) }
+
+        before { Fabricate(:status, account: user.account, thread: status) }
+
+        it 'returns http success' do
+          get "/api/v1/statuses/#{status.id}/context", headers: headers
+
+          expect(response)
+            .to have_http_status(200)
+          expect(response.media_type)
+            .to eq('application/json')
+          expect(response.parsed_body)
+            .to include(ancestors: be_an(Array).and(be_empty))
+            .and include(descendants: be_an(Array).and(be_present))
+        end
+      end
+
+      context 'with a public status that is a reply' do
+        let(:status) { Fabricate(:status, account: user.account, thread: Fabricate(:status)) }
+
+        before { Fabricate(:status, account: user.account, thread: status) }
+
+        it 'returns http success' do
+          get "/api/v1/statuses/#{status.id}/context", headers: headers
+
+          expect(response)
+            .to have_http_status(200)
+          expect(response.media_type)
+            .to eq('application/json')
+          expect(response.parsed_body)
+            .to include(ancestors: be_an(Array).and(be_present))
+            .and include(descendants: be_an(Array).and(be_present))
+        end
+      end
+    end
+
+    context 'without an oauth token' do
+      context 'with a public status' do
+        let(:status) { Fabricate(:status, visibility: :public) }
+
+        before { Fabricate(:status, thread: status) }
+
+        it 'returns http success' do
+          get "/api/v1/statuses/#{status.id}/context"
+
+          expect(response)
+            .to have_http_status(200)
+          expect(response.media_type)
+            .to eq('application/json')
+          expect(response.parsed_body)
+            .to include(ancestors: be_an(Array).and(be_empty))
+            .and include(descendants: be_an(Array).and(be_present))
+        end
+      end
+
+      context 'with a public status that is a reply' do
+        let(:status) { Fabricate(:status, visibility: :public, thread: Fabricate(:status)) }
+
+        before { Fabricate(:status, thread: status) }
+
+        it 'returns http success' do
+          get "/api/v1/statuses/#{status.id}/context"
+
+          expect(response)
+            .to have_http_status(200)
+          expect(response.media_type)
+            .to eq('application/json')
+          expect(response.parsed_body)
+            .to include(ancestors: be_an(Array).and(be_present))
+            .and include(descendants: be_an(Array).and(be_present))
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -132,38 +132,6 @@ RSpec.describe '/api/v1/statuses' do
       end
     end
 
-    describe 'GET /api/v1/statuses/:id/context' do
-      let(:scopes) { 'read:statuses' }
-      let(:status) { Fabricate(:status, account: user.account) }
-
-      before do
-        Fabricate(:status, account: user.account, thread: status)
-      end
-
-      it 'returns http success' do
-        get "/api/v1/statuses/#{status.id}/context", headers: headers
-
-        expect(response).to have_http_status(200)
-        expect(response.content_type)
-          .to start_with('application/json')
-        expect(response.headers['Mastodon-Async-Refresh']).to be_nil
-      end
-
-      context 'with a remote status' do
-        let(:status) { Fabricate(:status, account: Fabricate(:account, domain: 'example.com'), created_at: 1.hour.ago, updated_at: 1.hour.ago) }
-
-        it 'returns http success and queues discovery of new posts' do
-          expect { get "/api/v1/statuses/#{status.id}/context", headers: headers }
-            .to enqueue_sidekiq_job(ActivityPub::FetchAllRepliesWorker)
-
-          expect(response).to have_http_status(200)
-          expect(response.content_type)
-            .to start_with('application/json')
-          expect(response.headers['Mastodon-Async-Refresh']).to match(/result_count=0/)
-        end
-      end
-    end
-
     describe 'POST /api/v1/statuses' do
       subject do
         post '/api/v1/statuses', headers: headers, params: params
@@ -556,20 +524,6 @@ RSpec.describe '/api/v1/statuses' do
             .to start_with('application/json')
         end
       end
-
-      describe 'GET /api/v1/statuses/:id/context' do
-        before do
-          Fabricate(:status, thread: status)
-        end
-
-        it 'returns http unauthorized' do
-          get "/api/v1/statuses/#{status.id}/context"
-
-          expect(response).to have_http_status(404)
-          expect(response.content_type)
-            .to start_with('application/json')
-        end
-      end
     end
 
     context 'with a public status' do
@@ -578,20 +532,6 @@ RSpec.describe '/api/v1/statuses' do
       describe 'GET /api/v1/statuses/:id' do
         it 'returns http success' do
           get "/api/v1/statuses/#{status.id}"
-
-          expect(response).to have_http_status(200)
-          expect(response.content_type)
-            .to start_with('application/json')
-        end
-      end
-
-      describe 'GET /api/v1/statuses/:id/context' do
-        before do
-          Fabricate(:status, thread: status)
-        end
-
-        it 'returns http success' do
-          get "/api/v1/statuses/#{status.id}/context"
 
           expect(response).to have_http_status(200)
           expect(response.content_type)


### PR DESCRIPTION
As part of the now-abandoned `Metrics/` cop cleanup, I had done a [previous larger version](https://github.com/mastodon/mastodon/pull/35812) of this which also included substantial refactoring (to handle the Metrics cops) and was not reviewed. Tried to pare this back to the smallest possible extraction/move, leaving the refactor/cleanup out for now.

As a side effect of updating the routes declaration the named route method name changes, but the external facing URLs (possibly only called from the JS?) is preserved.

Motivations:

- The `api/v1/statuses` is largest (by LOC) controller class, this pulls out ~70 lines
- This action seems sort of bolted on here, and thus easy to remove ... the context action is the only thing using async-refresh ... and the only thing NOT using interaction policy
- Context has its own model and serializer and so on, and feels more like first-class object, not just aspect of a status

Possible followup, some of which was in original PR:

- This method was a large contributor to all the `Metrics/` violations when we were attempting to clean that up. If that effort is abandoned, so be it - but if not, there's room for more cleanup here. At minimum, the various "limit"/results logic could be smaller private methods.
- Definitely room for better coverage here (just pulled over the existing in this PR)