### PR TITLE
Skip non-collection urls in process links service

### DIFF
--- a/app/services/process_links_service.rb
+++ b/app/services/process_links_service.rb
@@ -25,6 +25,7 @@ class ProcessLinksService < BaseService
 
     urls.each do |url|
       # We only support `FeaturedCollection` at this time
+      next if ActivityPub::TagManager.instance.uri_to_local_collection(url.to_s).blank?
 
       # TODO: We probably want to resolve unknown objects at authoring time
       object = ActivityPub::TagManager.instance.uri_to_resource(url.to_s, Collection)

--- a/app/services/process_links_service.rb
+++ b/app/services/process_links_service.rb
@@ -25,10 +25,10 @@ class ProcessLinksService < BaseService
 
     urls.each do |url|
       # We only support `FeaturedCollection` at this time
-      next if ActivityPub::TagManager.instance.uri_to_local_collection(url.to_s).blank?
 
       # TODO: We probably want to resolve unknown objects at authoring time
       object = ActivityPub::TagManager.instance.uri_to_resource(url.to_s, Collection)
+      next if object.nil?
 
       tagged_object = @previous_objects.find { |x| x.object == object || x.uri == url }
       tagged_object ||= @current_objects.find { |x| x.object == object || x.uri == url }

--- a/spec/services/process_links_service_spec.rb
+++ b/spec/services/process_links_service_spec.rb
@@ -16,4 +16,13 @@ RSpec.describe ProcessLinksService do
         .to change { status.tagged_objects.count }.by(1)
     end
   end
+
+  context 'when status has a generic link' do
+    let(:status) { Fabricate(:status, account: account, text: 'Hello check out my personal web page: https://example.com/test', visibility: :public) }
+
+    it 'skips the link and does not create a tagged object' do
+      expect { expect { subject.call(status) }.to_not raise_error }
+        .to not_change { status.tagged_objects.count }.from(0)
+    end
+  end
 end


### PR DESCRIPTION
Two things here:

- Spec to show that a generic non-collection link flowing through the process links service can pass through w/out being processed
- The most naive possible solution to this I could think of, based in part on surrounding comment/context

In this PR from earlier today there's a seemingly stray comment - https://github.com/mastodon/mastodon/pull/38115/changes#diff-b5dfc4c37d81cb3ae57ba08ce0b041eb59ede42f53bc1b5cbbd7dd263e72f7a9R27 - I'm sort of guessing here that there should have been a check added here to only process collections? I'm not totally up to speed on this feature or the intentions/usage of that PR.

So - I think the spec does capture a thing that's real and broken on main now (I can replicate the statuses API throwing error on any link-containing text), but I'm only half guessing at solution. Happy to update this with better ideas, and/or contribute just the spec and let someone else with context resolve it.