### PR TITLE
Hide empty state of topic suggestions dropdown in Collection editor

### DIFF
--- a/app/javascript/mastodon/features/collections/editor/details.tsx
+++ b/app/javascript/mastodon/features/collections/editor/details.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useMemo, useState } from 'react';
+import { Fragment, useCallback, useMemo } from 'react';
 
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -10,7 +10,6 @@ import { languages } from '@/mastodon/initial_state';
 import {
   hasSpecialCharacters,
   inputToHashtag,
-  trimHashFromStart,
 } from '@/mastodon/utils/hashtags';
 import type {
   ApiCreateCollectionPayload,
@@ -297,14 +296,7 @@ export const CollectionDetails: React.FC = () => {
 const TopicField: React.FC = () => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
-  const { id, topic } = useAppSelector((state) => state.collections.editor);
-
-  const collection = useAppSelector((state) =>
-    id ? state.collections.collections[id] : undefined,
-  );
-  const [isInitialValue, setIsInitialValue] = useState(
-    () => trimHashFromStart(topic) === (collection?.tag?.name ?? ''),
-  );
+  const { topic } = useAppSelector((state) => state.collections.editor);
 
   const { tags, isLoading, searchTags } = useSearchTags({
     query: topic,
@@ -312,7 +304,6 @@ const TopicField: React.FC = () => {
 
   const handleTopicChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setIsInitialValue(false);
       dispatch(
         updateCollectionEditorField({
           field: 'topic',
@@ -379,7 +370,7 @@ const TopicField: React.FC = () => {
             }
           : undefined
       }
-      suppressMenu={isInitialValue}
+      suppressMenu={!tags.length}
     />
   );
 };


### PR DESCRIPTION
### Changes proposed in this PR:
- Changes the topic suggestions dropdown in the Collection editor so that the menu is never shown when there are no suggestions, rather than only hiding it when it's at its initial value. This is more appropriate as the selector is not a search field primarily, and there's nothing wrong with there being no suggestions.

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="564" height="177" alt="image" src="https://github.com/user-attachments/assets/8fdfca2e-4c7c-452a-9584-0db87118dc6a" /> | <img width="576" height="174" alt="image" src="https://github.com/user-attachments/assets/e19bb83c-58b3-4d8f-b55e-d912a297cb8e" /> |