### PR TITLE
Disable locales with Vite 8

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -26,9 +26,10 @@ import { modes } from './modes';
 import '../app/javascript/styles/application.scss';
 import './styles.css';
 
-const localeFiles = import.meta.glob('@/mastodon/locales/*.json', {
-  query: { as: 'json' },
-});
+// Disabling locales in Storybook as it's breaking with Vite 8.
+// const localeFiles = import.meta.glob('@/mastodon/locales/*.json', {
+//   query: { as: 'json' },
+// });
 
 // Initialize MSW
 initialize({
@@ -39,17 +40,17 @@ const preview: Preview = {
   // Auto-generate docs: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
   globalTypes: {
-    locale: {
-      description: 'Locale for the story',
-      toolbar: {
-        title: 'Locale',
-        icon: 'globe',
-        items: Object.keys(localeFiles).map((path) =>
-          path.replace('/mastodon/locales/', '').replace('.json', ''),
-        ),
-        dynamicTitle: true,
-      },
-    },
+    // locale: {
+    //   description: 'Locale for the story',
+    //   toolbar: {
+    //     title: 'Locale',
+    //     icon: 'globe',
+    //     items: Object.keys(localeFiles).map((path) =>
+    //       path.replace('/mastodon/locales/', '').replace('.json', ''),
+    //     ),
+    //     dynamicTitle: true,
+    //   },
+    // },
     theme: {
       description: 'Theme for the story',
       toolbar: {


### PR DESCRIPTION
Fixes a bug with #38174 where Storybook won't build with locales. This just disables them for now till we can come up with a permanent fix.