### PR TITLE
Remove column header button

### DIFF
--- a/app/javascript/mastodon/components/column_header.tsx
+++ b/app/javascript/mastodon/components/column_header.tsx
@@ -294,7 +294,13 @@ export const ColumnHeader: React.FC<Props> = ({
               </button>
             )}
             {!onClick && (
-              <span className='column-header__title'>{titleContents}</span>
+              <span
+                className='column-header__title'
+                tabIndex={-1}
+                id={getColumnSkipLinkId(columnIndex)}
+              >
+                {titleContents}
+              </span>
             )}
           </>
         )}

--- a/app/javascript/mastodon/components/column_header.tsx
+++ b/app/javascript/mastodon/components/column_header.tsx
@@ -267,6 +267,15 @@ export const ColumnHeader: React.FC<Props> = ({
   const hasTitle = (hasIcon || backButton) && title;
   const columnIndex = useColumnIndexContext();
 
+  const titleContents = (
+    <>
+      {!backButton && hasIcon && (
+        <Icon id={icon} icon={iconComponent} className='column-header__icon' />
+      )}
+      {title}
+    </>
+  );
+
   const component = (
     <div className={wrapperClassName}>
       <h1 className={buttonClassName}>
@@ -274,21 +283,19 @@ export const ColumnHeader: React.FC<Props> = ({
           <>
             {backButton}
 
-            <button
-              onClick={handleTitleClick}
-              className='column-header__title'
-              type='button'
-              id={getColumnSkipLinkId(columnIndex)}
-            >
-              {!backButton && hasIcon && (
-                <Icon
-                  id={icon}
-                  icon={iconComponent}
-                  className='column-header__icon'
-                />
-              )}
-              {title}
-            </button>
+            {onClick && (
+              <button
+                onClick={handleTitleClick}
+                className='column-header__title'
+                type='button'
+                id={getColumnSkipLinkId(columnIndex)}
+              >
+                {titleContents}
+              </button>
+            )}
+            {!onClick && (
+              <span className='column-header__title'>{titleContents}</span>
+            )}
           </>
         )}
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4608,7 +4608,6 @@ a.status-card {
   border: 1px solid var(--color-border-primary);
   border-radius: 4px 4px 0 0;
   flex: 0 0 auto;
-  cursor: pointer;
   position: relative;
   z-index: 2;
   outline: 0;


### PR DESCRIPTION
Fixes WEB-891.

When the ColumnHeader component doesn't have an `onClick` prop, the title text should not be a button.