### PR TITLE
Clarify preview card CLI command handles media only

### DIFF
--- a/lib/mastodon/cli/preview_cards.rb
+++ b/lib/mastodon/cli/preview_cards.rb
@@ -11,18 +11,17 @@ module Mastodon::CLI
     option :verbose, type: :boolean, aliases: [:v]
     option :dry_run, type: :boolean, default: false
     option :link, type: :boolean, default: false
-    desc 'remove', 'Remove preview cards'
+    desc 'remove', 'Remove preview card media'
     long_desc <<-DESC
       Removes local thumbnails for preview cards.
 
-      The --days option specifies how old preview cards have to be before
-      they are removed. It defaults to 180 days. Since preview cards will
-      not be re-fetched unless the link is re-posted after 2 weeks from
-      last time, it is not recommended to delete preview cards within the
-      last 14 days.
+      The --days option sets the age a preview card must be before attached
+      media will be removed. Preview cards will not be re-fetched unless the
+      link is posted again two weeks after the last usage, so it is not
+      recommended to delete preview card media from within the last 14 days.
 
-      With the --link option, only link-type preview cards will be deleted,
-      leaving video and photo cards untouched.
+      With the --link option, only media from link-type preview cards will be
+      deleted, skipping video and photo cards.
     DESC
     def remove
       time_ago = options[:days].days.ago
@@ -44,7 +43,7 @@ module Mastodon::CLI
         size
       end
 
-      say("Removed #{processed} #{link}preview cards (approx. #{number_to_human_size(aggregate)})#{dry_run_mode_suffix}", :green, true)
+      say("Removed media from #{processed} #{link}preview cards (approx. #{number_to_human_size(aggregate)})#{dry_run_mode_suffix}", :green, true)
     end
   end
 end

--- a/spec/lib/mastodon/cli/preview_cards_spec.rb
+++ b/spec/lib/mastodon/cli/preview_cards_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Mastodon::CLI::PreviewCards do
         it 'deletes thumbnails for local preview cards' do
           expect { subject }
             .to output_results(
-              'Removed 2 preview cards',
+              'Removed media from 2 preview cards',
               'approx. 119 KB'
             )
         end
@@ -38,7 +38,7 @@ RSpec.describe Mastodon::CLI::PreviewCards do
         it 'deletes thumbnails for local preview cards' do
           expect { subject }
             .to output_results(
-              'Removed 1 link-type preview cards',
+              'Removed media from 1 link-type preview cards',
               'approx. 59.6 KB'
             )
         end
@@ -50,7 +50,7 @@ RSpec.describe Mastodon::CLI::PreviewCards do
         it 'deletes thumbnails for local preview cards' do
           expect { subject }
             .to output_results(
-              'Removed 1 preview cards',
+              'Removed media from 1 preview cards',
               'approx. 59.6 KB'
             )
         end


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/issues/38349#issuecomment-4116140786

This handles the "clarify what this does" portion of that issue.

Possible followups would be to a) also remove the cards, b) add option to also remove the cards, c) document somewhere that we dont remove the cards, and why, etc...

This is effectively a copy writing change PR only, w/out any code/behavior changes.