### PR TITLE
Fix serialization when an account is missing

### DIFF
--- a/app/serializers/rest/collection_with_accounts_serializer.rb
+++ b/app/serializers/rest/collection_with_accounts_serializer.rb
@@ -10,6 +10,6 @@ class REST::CollectionWithAccountsSerializer < ActiveModel::Serializer
   end
 
   def accounts
-    [object.account] + object.collection_items.map(&:account)
+    [object.account] + object.collection_items.filter_map(&:account)
   end
 end

--- a/spec/serializers/rest/collection_with_accounts_serializer_spec.rb
+++ b/spec/serializers/rest/collection_with_accounts_serializer_spec.rb
@@ -26,11 +26,14 @@ RSpec.describe REST::CollectionWithAccountsSerializer do
               discoverable: false,
               tag:)
   end
-
-  before do
-    accounts[1..2].each do |account|
+  let(:collection_items) do
+    accounts[1..2].map do |account|
       Fabricate(:collection_item, collection:, account:)
     end
+  end
+
+  before do
+    collection_items
     collection.reload
   end
 
@@ -55,5 +58,15 @@ RSpec.describe REST::CollectionWithAccountsSerializer do
         })
       )
     expect(subject['accounts'].size).to eq 3
+  end
+
+  context 'when collection includes pending items without account' do
+    let(:collection_items) do
+      [Fabricate(:collection_item, collection:, account: nil, object_uri: 'https://example.com/actor/1', state: :pending)]
+    end
+
+    it 'renders successfully' do
+      expect(subject).to be_a Hash
+    end
   end
 end


### PR DESCRIPTION
Not sure if this can really happen in practice, but it can currently occur as part of another bug and it surely does not hurt to play it safe.