### PR TITLE
Add constants for delay in services

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class ActivityPub::Activity::Create < ActivityPub::Activity
+  DISTRIBUTE_DELAY = 1.minute
+  PROCESSING_DELAY = (30.seconds)..(10.minutes)
+
   def perform
     @account.schedule_refresh_if_stale!
 
@@ -73,7 +76,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
   def distribute
     # Spread out crawling randomly to avoid DDoSing the link
-    LinkCrawlWorker.perform_in(rand(1..59).seconds, @status.id)
+    LinkCrawlWorker.perform_in(rand(DISTRIBUTE_DELAY), @status.id)
 
     # Distribute into home and list feeds and notify mentioned accounts
     ::DistributionWorker.perform_async(@status.id, { 'silenced_account_ids' => @silenced_account_ids }) if @options[:override_timestamps] || @status.within_realtime_window?
@@ -315,7 +318,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
         media_attachment.download_thumbnail!
         media_attachment.save
       rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
-        RedownloadMediaWorker.perform_in(rand(30..600).seconds, media_attachment.id)
+        RedownloadMediaWorker.perform_in(rand(PROCESSING_DELAY), media_attachment.id)
       rescue Seahorse::Client::NetworkingError => e
         Rails.logger.warn "Error storing media attachment: #{e}"
         RedownloadMediaWorker.perform_async(media_attachment.id)
@@ -371,7 +374,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
   def resolve_unresolved_mentions(status)
     @unresolved_mentions.uniq.each do |uri|
-      MentionResolveWorker.perform_in(rand(30...600).seconds, status.id, uri, { 'request_id' => @options[:request_id] })
+      MentionResolveWorker.perform_in(rand(PROCESSING_DELAY), status.id, uri, { 'request_id' => @options[:request_id] })
     end
   end
 
@@ -394,7 +397,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     embedded_quote = safe_prefetched_embed(@account, @status_parser.quoted_object, @json['context'])
     ActivityPub::VerifyQuoteService.new.call(@quote, @quote_approval_uri, fetchable_quoted_uri: @quote_uri, prefetched_quoted_object: embedded_quote, request_id: @options[:request_id], depth: @options[:depth])
   rescue Mastodon::RecursionLimitExceededError, Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
-    ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(30..600).seconds, @quote.id, @quote_uri, { 'request_id' => @options[:request_id], 'approval_uri' => @quote_approval_uri })
+    ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(PROCESSING_DELAY), @quote.id, @quote_uri, { 'request_id' => @options[:request_id], 'approval_uri' => @quote_approval_uri })
   end
 
   def conversation_from_uri(uri)

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -10,6 +10,9 @@ class ActivityPub::ProcessAccountService < BaseService
   SUBDOMAINS_RATELIMIT = 10
   DISCOVERIES_PER_REQUEST = 400
 
+  PROCESSING_DELAY = (30.seconds)..(10.minutes)
+  VERIFY_DELAY = 10.minutes
+
   VALID_URI_SCHEMES = %w(http https).freeze
 
   # Should be called with confirmed valid JSON
@@ -152,7 +155,7 @@ class ActivityPub::ProcessAccountService < BaseService
       @account.avatar = nil if @account.avatar_remote_url.blank?
       @account.avatar_description = avatar_description || ''
     rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
-      RedownloadAvatarWorker.perform_in(rand(30..600).seconds, @account.id)
+      RedownloadAvatarWorker.perform_in(rand(PROCESSING_DELAY), @account.id)
     end
     begin
       header_url, header_description = image_url_and_description('image')
@@ -160,7 +163,7 @@ class ActivityPub::ProcessAccountService < BaseService
       @account.header = nil if @account.header_remote_url.blank?
       @account.header_description = header_description || ''
     rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
-      RedownloadHeaderWorker.perform_in(rand(30..600).seconds, @account.id)
+      RedownloadHeaderWorker.perform_in(rand(PROCESSING_DELAY), @account.id)
     end
     @account.statuses_count    = outbox_total_items    if outbox_total_items.present?
     @account.following_count   = following_total_items if following_total_items.present?
@@ -210,7 +213,7 @@ class ActivityPub::ProcessAccountService < BaseService
   end
 
   def check_links!
-    VerifyAccountLinksWorker.perform_in(rand(10.minutes.to_i), @account.id)
+    VerifyAccountLinksWorker.perform_in(rand(VERIFY_DELAY), @account.id)
   end
 
   def process_duplicate_accounts!

--- a/app/services/activitypub/process_featured_item_service.rb
+++ b/app/services/activitypub/process_featured_item_service.rb
@@ -5,6 +5,8 @@ class ActivityPub::ProcessFeaturedItemService
   include Lockable
   include Redisable
 
+  PROCESSING_DELAY = (30.seconds)..(10.minutes)
+
   def call(collection, uri_or_object, position: nil, request_id: nil)
     @collection = collection
     @request_id = request_id
@@ -47,6 +49,6 @@ class ActivityPub::ProcessFeaturedItemService
   def verify_authorization!
     ActivityPub::VerifyFeaturedItemService.new.call(@collection_item, @approval_uri, request_id: @request_id)
   rescue Mastodon::RecursionLimitExceededError, Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
-    ActivityPub::VerifyFeaturedItemWorker.perform_in(rand(30..600).seconds, @collection_item.id, @approval_uri, @request_id)
+    ActivityPub::VerifyFeaturedItemWorker.perform_in(rand(PROCESSING_DELAY), @collection_item.id, @approval_uri, @request_id)
   end
 end

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -5,6 +5,9 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
   include Redisable
   include Lockable
 
+  CRAWL_DELAY = 1.minute
+  PROCESSING_DELAY = (30.seconds)..(10.minutes)
+
   def call(status, activity_json, object_json, request_id: nil)
     raise ArgumentError, 'Status has unsaved changes' if status.changed?
 
@@ -128,7 +131,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
       media_attachment.download_thumbnail! if media_attachment.thumbnail_remote_url_previously_changed?
       media_attachment.save
     rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
-      RedownloadMediaWorker.perform_in(rand(30..600).seconds, media_attachment.id)
+      RedownloadMediaWorker.perform_in(rand(PROCESSING_DELAY), media_attachment.id)
     rescue Seahorse::Client::NetworkingError => e
       Rails.logger.warn "Error storing media attachment: #{e}"
     end
@@ -279,7 +282,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
 
     # Queue unresolved mentions for later
     unresolved_mentions.uniq.each do |uri|
-      MentionResolveWorker.perform_in(rand(30...600).seconds, @status.id, uri, { 'request_id' => @request_id })
+      MentionResolveWorker.perform_in(rand(PROCESSING_DELAY), @status.id, uri, { 'request_id' => @request_id })
     end
   end
 
@@ -361,7 +364,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
     embedded_quote = safe_prefetched_embed(@account, @status_parser.quoted_object, @activity_json['context'])
     ActivityPub::VerifyQuoteService.new.call(quote, approval_uri, fetchable_quoted_uri: quote_uri, prefetched_quoted_object: embedded_quote, request_id: @request_id)
   rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
-    ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(30..600).seconds, quote.id, quote_uri, { 'request_id' => @request_id, 'approval_uri' => approval_uri })
+    ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(PROCESSING_DELAY), quote.id, quote_uri, { 'request_id' => @request_id, 'approval_uri' => approval_uri })
   end
 
   def update_counts!
@@ -419,7 +422,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
 
   def reset_preview_card!
     @status.reset_preview_card!
-    LinkCrawlWorker.perform_in(rand(1..59).seconds, @status.id)
+    LinkCrawlWorker.perform_in(rand(CRAWL_DELAY), @status.id)
   end
 
   def broadcast_updates!


### PR DESCRIPTION
A previous similar PR added constants like this, but also other types of constants, and also some new class methods. This is basically a simpler extraction of just the "delay" related constants from that larger PR. Will rebase and do more as followup.

The `perform_in` method handles both integer values of seconds and AS duration classes, so the slightly different arg here should be fine.