### PR TITLE
Use more granular content check via `parsed_body`

### DIFF
--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -63,11 +63,12 @@ RSpec.describe Admin::AccountsController do
         note2 = Fabricate(:account_moderation_note, target_account: account, content: 'Note 2 remarks')
 
         get :show, params: { id: account.id }
-        expect(response).to have_http_status(200)
 
-        expect(response.body)
-          .to include(note1.content)
-          .and include(note2.content)
+        expect(response)
+          .to have_http_status(200)
+        expect(response.parsed_body)
+          .to have_css("#account_moderation_note_#{note1.id}", text: note1.content)
+          .and have_css("#account_moderation_note_#{note2.id}", text: note2.content)
       end
     end
 

--- a/spec/controllers/admin/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/admin/disputes/appeals_controller_spec.rb
@@ -23,9 +23,11 @@ RSpec.describe Admin::Disputes::AppealsController do
     it 'returns a page that lists details of appeals' do
       get :index
 
-      expect(response).to have_http_status(:success)
-      expect(response.body).to include("<span class=\"username\">#{strike.account.username}</span>")
-      expect(response.body).to include("<span class=\"target\">#{appeal.account.username}</span>")
+      expect(response)
+        .to have_http_status(:success)
+      expect(response.parsed_body)
+        .to have_css('span.username', text: strike.account.username)
+        .and have_css('span.target', text: appeal.account.username)
     end
   end
 

--- a/spec/controllers/admin/instances_controller_spec.rb
+++ b/spec/controllers/admin/instances_controller_spec.rb
@@ -47,11 +47,11 @@ RSpec.describe Admin::InstancesController do
     it 'shows an instance page' do
       get :show, params: { id: account_popular_main.domain }
 
-      expect(response).to have_http_status(200)
-
-      expect(response.body)
-        .to include(I18n.t('admin.instances.totals_time_period_hint_html'))
-        .and include(I18n.t('accounts.nothing_here'))
+      expect(response)
+        .to have_http_status(200)
+      expect(response.parsed_body)
+        .to have_css('p', text: I18n.t('admin.instances.totals_time_period_hint_html'))
+        .and have_css('p', text: I18n.t('accounts.nothing_here'))
 
       expect(Admin::ActionLogFilter).to have_received(:new).with(target_domain: account_popular_main.domain)
     end

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -226,8 +226,8 @@ RSpec.describe Auth::SessionsController do
           end
 
           it 'renders two factor authentication page' do
-            expect(response.body)
-              .to include(I18n.t('simple_form.hints.sessions.otp'))
+            expect(response.parsed_body)
+              .to have_css('p.hint.authentication-hint', text: I18n.t('simple_form.hints.sessions.otp'))
           end
         end
 
@@ -242,8 +242,8 @@ RSpec.describe Auth::SessionsController do
           end
 
           it 'renders two factor authentication page' do
-            expect(response.body)
-              .to include(I18n.t('simple_form.hints.sessions.otp'))
+            expect(response.parsed_body)
+              .to have_css('p.hint.authentication-hint', text: I18n.t('simple_form.hints.sessions.otp'))
           end
         end
 
@@ -253,8 +253,8 @@ RSpec.describe Auth::SessionsController do
           end
 
           it 'renders two factor authentication page' do
-            expect(response.body)
-              .to include(I18n.t('simple_form.hints.sessions.otp'))
+            expect(response.parsed_body)
+              .to have_css('p.hint.authentication-hint', text: I18n.t('simple_form.hints.sessions.otp'))
           end
         end
 
@@ -387,8 +387,8 @@ RSpec.describe Auth::SessionsController do
           end
 
           it 'renders webauthn authentication page' do
-            expect(response.body)
-              .to include(I18n.t('simple_form.title.sessions.webauthn'))
+            expect(response.parsed_body)
+              .to have_css('h3.title', text: I18n.t('simple_form.title.sessions.webauthn'))
           end
         end
 
@@ -398,8 +398,8 @@ RSpec.describe Auth::SessionsController do
           end
 
           it 'renders webauthn authentication page' do
-            expect(response.body)
-              .to include(I18n.t('simple_form.title.sessions.webauthn'))
+            expect(response.parsed_body)
+              .to have_css('h3.title', text: I18n.t('simple_form.title.sessions.webauthn'))
           end
         end
 

--- a/spec/controllers/concerns/account_controller_concern_spec.rb
+++ b/spec/controllers/concerns/account_controller_concern_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe AccountControllerConcern do
         .to have_http_status(200)
         .and have_http_link_header(webfinger_url(resource: account.to_webfinger_s)).for(rel: 'lrdd', type: 'application/jrd+json')
         .and have_http_link_header(ActivityPub::TagManager.instance.uri_for(account)).for(rel: 'alternate', type: 'application/activity+json')
-      expect(response.body)
-        .to include(account.username)
+      expect(response.parsed_body)
+        .to eq(account.username)
     end
   end
 end

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Settings::ImportsController do
     it 'assigns the expected imports', :aggregate_failures do
       expect(response).to have_http_status(200)
       expect(response.headers['Cache-Control']).to include('private, no-store')
-      expect(response.body)
-        .to include("bulk_import_#{import.id}")
+      expect(response.parsed_body)
+        .to have_css("#bulk_import_#{import.id}")
         .and not_include("bulk_import_#{other_import.id}")
     end
   end

--- a/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Settings::TwoFactorAuthentication::ConfirmationsController do
       expect(response).to have_http_status(200)
       expect(response.body)
         .to include(qr_code_markup)
-        .and include(I18n.t('settings.two_factor_authentication'))
+      expect(response.parsed_body)
+        .to have_title(I18n.t('settings.two_factor_authentication'))
     end
 
     def qr_code_markup

--- a/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe Settings::TwoFactorAuthentication::ConfirmationsController do
           it 'renders page with error message' do
             subject
 
-            expect(response.body)
-              .to include(I18n.t('otp_authentication.wrong_code'))
+            expect(response.parsed_body)
+              .to have_css('.flash-message', text: I18n.t('otp_authentication.wrong_code'))
           end
 
           it_behaves_like 'renders expected page'

--- a/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
@@ -81,7 +81,8 @@ RSpec.describe Settings::TwoFactorAuthentication::ConfirmationsController do
               .to have_http_status(200)
             expect(response.body)
               .to include(*otp_backup_codes)
-              .and include(I18n.t('settings.two_factor_authentication'))
+            expect(response.parsed_body)
+              .to have_title(I18n.t('settings.two_factor_authentication'))
           end
         end
 


### PR DESCRIPTION
Once over across various spots where I suspect the specs predate the existence of `parsed_body` but we can use it to be more confident in the content being on the visible/parsable page and not merely in the response body. In 1-2 spots also an improved selector syntax by not building raw html.