### PR TITLE
Update dependency `bcrypt`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       rexml
     base64 (0.3.0)
     bcp47_spec (0.2.1)
-    bcrypt (3.1.21)
+    bcrypt (3.1.22)
     benchmark (0.5.0)
     better_errors (2.10.1)
       erubi (>= 1.0.0)


### PR DESCRIPTION
We are not affected as we don't use JRuby (though I suppose some forks could), and I doubt we are using 31 iterations anywhere, but `bundler-audit` flags `bcrypt` because of https://github.com/advisories/GHSA-f27w-vcwj-c954, adding noise to all our dependency PRs.