### PR TITLE
Handle local/remote collection items differently when deleting

### DIFF
--- a/app/services/delete_collection_item_service.rb
+++ b/app/services/delete_collection_item_service.rb
@@ -5,9 +5,12 @@ class DeleteCollectionItemService
     @collection_item = collection_item
     @collection = collection_item.collection
 
-    revoke ? @collection_item.revoke! : @collection_item.destroy!
-
-    distribute_remove_activity if Mastodon::Feature.collections_federation_enabled?
+    if collection_item.local?
+      revoke ? @collection_item.revoke! : @collection_item.destroy!
+      distribute_remove_activity if Mastodon::Feature.collections_federation_enabled?
+    else
+      collection_item.destroy!
+    end
   end
 
   private

--- a/spec/services/delete_collection_item_service_spec.rb
+++ b/spec/services/delete_collection_item_service_spec.rb
@@ -13,17 +13,30 @@ RSpec.describe DeleteCollectionItemService do
       expect { subject.call(collection_item) }.to change(collection.collection_items, :count).by(-1)
     end
 
-    it 'federates a `Remove` activity', feature: :collections_federation do
-      subject.call(collection_item)
+    context 'when the collection is local' do
+      it 'federates a `Remove` activity', feature: :collections_federation do
+        subject.call(collection_item)
 
-      expect(ActivityPub::AccountRawDistributionWorker).to have_enqueued_sidekiq_job
+        expect(ActivityPub::AccountRawDistributionWorker).to have_enqueued_sidekiq_job
+      end
+
+      context 'when `revoke` is set to true' do
+        it 'revokes the collection item' do
+          subject.call(collection_item, revoke: true)
+
+          expect(collection_item.reload).to be_revoked
+        end
+      end
     end
 
-    context 'when `revoke` is set to true' do
-      it 'revokes the collection item' do
-        subject.call(collection_item, revoke: true)
+    context 'when the collection is remote' do
+      let(:collection) { Fabricate(:remote_collection) }
+      let!(:collection_item) { Fabricate(:collection_item, collection:, state: :accepted) }
 
-        expect(collection_item.reload).to be_revoked
+      it 'destroys the collection withouth federating anything', feature: :collections_federation do
+        expect { subject.call(collection_item, revoke: true) }.to change(collection.collection_items, :count).by(-1)
+
+        expect(ActivityPub::AccountRawDistributionWorker).to_not have_enqueued_sidekiq_job
       end
     end
   end


### PR DESCRIPTION
This service was initially created for local items only, but then re-used to delete remote items upon revocation.

It now cleanly separates the two cases.