### PR TITLE
Change avatar and account header description limit and expose it in API

### DIFF
--- a/app/models/concerns/account/avatar.rb
+++ b/app/models/concerns/account/avatar.rb
@@ -3,6 +3,7 @@
 module Account::Avatar
   extend ActiveSupport::Concern
 
+  MAX_DESCRIPTION_LENGTH = 150
   AVATAR_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].freeze
   AVATAR_LIMIT = 8.megabytes
   AVATAR_DIMENSIONS = [400, 400].freeze
@@ -25,7 +26,7 @@ module Account::Avatar
     validates_attachment_size :avatar, less_than: AVATAR_LIMIT
     remotable_attachment :avatar, AVATAR_LIMIT, suppress_errors: false
 
-    validates :avatar_description, length: { maximum: MediaAttachment::MAX_DESCRIPTION_LENGTH }, if: -> { local? && will_save_change_to_avatar_description? }
+    validates :avatar_description, length: { maximum: MAX_DESCRIPTION_LENGTH }, if: -> { local? && will_save_change_to_avatar_description? }
   end
 
   def avatar_original_url

--- a/app/models/concerns/account/header.rb
+++ b/app/models/concerns/account/header.rb
@@ -3,6 +3,7 @@
 module Account::Header
   extend ActiveSupport::Concern
 
+  MAX_DESCRIPTION_LENGTH = 150
   HEADER_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].freeze
   HEADER_LIMIT = 8.megabytes
   HEADER_DIMENSIONS = [1500, 500].freeze
@@ -26,7 +27,7 @@ module Account::Header
     validates_attachment_size :header, less_than: HEADER_LIMIT
     remotable_attachment :header, HEADER_LIMIT, suppress_errors: false
 
-    validates :header_description, length: { maximum: MediaAttachment::MAX_DESCRIPTION_LENGTH }, if: -> { local? && will_save_change_to_header_description? }
+    validates :header_description, length: { maximum: MAX_DESCRIPTION_LENGTH }, if: -> { local? && will_save_change_to_header_description? }
   end
 
   def header_original_url

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -71,6 +71,8 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       accounts: {
         max_display_name_length: Account::DISPLAY_NAME_LENGTH_LIMIT,
         max_note_length: Account::NOTE_LENGTH_LIMIT,
+        max_avatar_description_length: Account::Avatar::MAX_DESCRIPTION_LENGTH,
+        max_header_description_length: Account::Header::MAX_DESCRIPTION_LENGTH,
         max_featured_tags: FeaturedTag::LIMIT,
         max_pinned_statuses: StatusPinValidator::PIN_LIMIT,
         max_profile_fields: Account::DEFAULT_FIELDS_SIZE,

--- a/spec/requests/api/v2/instance_spec.rb
+++ b/spec/requests/api/v2/instance_spec.rb
@@ -66,8 +66,15 @@ RSpec.describe 'Instances' do
       include(
         configuration: include(
           accounts: include(
+            max_display_name_length: Account::DISPLAY_NAME_LENGTH_LIMIT,
+            max_note_length: Account::NOTE_LENGTH_LIMIT,
+            max_avatar_description_length: Account::Avatar::MAX_DESCRIPTION_LENGTH,
+            max_header_description_length: Account::Header::MAX_DESCRIPTION_LENGTH,
             max_featured_tags: FeaturedTag::LIMIT,
-            max_pinned_statuses: StatusPinValidator::PIN_LIMIT
+            max_pinned_statuses: StatusPinValidator::PIN_LIMIT,
+            max_profile_fields: Account::DEFAULT_FIELDS_SIZE,
+            profile_field_name_limit: Account::Field::MAX_CHARACTERS_LOCAL,
+            profile_field_value_limit: Account::Field::MAX_CHARACTERS_LOCAL
           ),
           statuses: include(
             max_characters: StatusLengthValidator::MAX_CHARS,


### PR DESCRIPTION
This changes the limit for account avatar and header description to 150 characters, with the number being exposed in `/api/v2/instance` alongside other limits as `configuration.account.max_avatar_description_length` and `configuration.account.max_header_description_length`.

Fixes WEB-915