### PR TITLE
Only federate accepted collection items

### DIFF
--- a/app/controllers/activitypub/featured_collections_controller.rb
+++ b/app/controllers/activitypub/featured_collections_controller.rb
@@ -33,7 +33,9 @@ class ActivityPub::FeaturedCollectionsController < ApplicationController
 
   def set_collections
     authorize @account, :index_collections?
-    @collections = @account.collections.page(params[:page]).per(PER_PAGE)
+    @collections = @account.collections
+      .includes(:accepted_collection_items)
+      .page(params[:page]).per(PER_PAGE)
   rescue Mastodon::NotPermittedError
     not_found
   end

--- a/app/serializers/activitypub/featured_collection_serializer.rb
+++ b/app/serializers/activitypub/featured_collection_serializer.rb
@@ -46,4 +46,8 @@ class ActivityPub::FeaturedCollectionSerializer < ActivityPub::Serializer
   def language_present?
     object.language.present?
   end
+
+  def collection_items
+    object.accepted_collection_items
+  end
 end

--- a/spec/serializers/activitypub/featured_collection_serializer_spec.rb
+++ b/spec/serializers/activitypub/featured_collection_serializer_spec.rb
@@ -67,4 +67,17 @@ RSpec.describe ActivityPub::FeaturedCollectionSerializer do
       expect(subject).to_not have_key('summary')
     end
   end
+
+  context 'when not all items are accepted' do
+    before do
+      collection_items.first.update!(state: :pending)
+    end
+
+    it 'only includes accepted items' do
+      items = subject['orderedItems']
+
+      expect(items.size).to eq 1
+      expect(items.first['id']).to eq ActivityPub::TagManager.instance.uri_for(collection_items.last)
+    end
+  end
 end


### PR DESCRIPTION
Since we do not include the state, only accepted items should ever appear in publicly visible data.