### PR TITLE
Do not auto-accept remote collection items

### DIFF
--- a/app/services/add_account_to_collection_service.rb
+++ b/app/services/add_account_to_collection_service.rb
@@ -22,10 +22,8 @@ class AddAccountToCollectionService
   private
 
   def create_collection_item
-    @collection.collection_items.create!(
-      account: @account,
-      state: :accepted
-    )
+    state = @account.local? ? :accepted : :pending
+    @collection.collection_items.create!(account: @account, state:)
   end
 
   def distribute_add_activity

--- a/app/services/create_collection_service.rb
+++ b/app/services/create_collection_service.rb
@@ -36,7 +36,8 @@ class CreateCollectionService
     @accounts_to_add.each do |account_to_add|
       raise Mastodon::NotPermittedError, I18n.t('accounts.errors.cannot_be_added_to_collections') unless AccountPolicy.new(@account, account_to_add).feature?
 
-      @collection.collection_items.build(account: account_to_add, state: :accepted)
+      state = account_to_add.local? ? :accepted : :pending
+      @collection.collection_items.build(account: account_to_add, state:)
     end
   end
 

--- a/spec/services/add_account_to_collection_service_spec.rb
+++ b/spec/services/add_account_to_collection_service_spec.rb
@@ -32,8 +32,11 @@ RSpec.describe AddAccountToCollectionService do
       context 'when the account is remote', feature: :collections_federation do
         let(:account) { Fabricate(:remote_account, feature_approval_policy: (0b10 << 16)) }
 
-        it 'federates a `FeatureRequest` activity' do
+        it 'marks the item as `pending` and federates a `FeatureRequest` activity' do
           subject.call(collection, account)
+
+          new_item = collection.collection_items.last
+          expect(new_item).to be_pending
 
           expect(ActivityPub::FeatureRequestWorker).to have_enqueued_sidekiq_job
         end

--- a/spec/services/create_collection_service_spec.rb
+++ b/spec/services/create_collection_service_spec.rb
@@ -65,8 +65,12 @@ RSpec.describe CreateCollectionService do
         context 'when some accounts are remote' do
           let(:accounts) { Fabricate.times(2, :remote_account, feature_approval_policy: (0b10 << 16)) }
 
-          it 'federates `FeatureRequest` activities', feature: :collections_federation do
+          it 'marks the new items as `pending` and federates `FeatureRequest` activities', feature: :collections_federation do
             subject.call(params, author)
+
+            new_collection = author.collections.last
+            expect(new_collection.collection_items.size).to eq 2
+            expect(new_collection.collection_items).to all(be_pending)
 
             expect(ActivityPub::FeatureRequestWorker).to have_enqueued_sidekiq_job.exactly(2).times
           end


### PR DESCRIPTION
This initially eased testing, but is now completely wrong.