### PR TITLE
Add `have_attachment` matcher for attached file exports

### DIFF
--- a/spec/controllers/admin/export_domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_blocks_controller_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Admin::ExportDomainBlocksController do
 
       get :export, params: { format: :csv }
       expect(response).to have_http_status(200)
+      expect(response)
+        .to have_attachment('domain_blocks.csv')
       expect(response.body).to eq(domain_blocks_csv_file)
     end
 

--- a/spec/controllers/concerns/settings/export_controller_concern_spec.rb
+++ b/spec/controllers/concerns/settings/export_controller_concern_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Settings::ExportControllerConcern do
 
       expect(response).to have_http_status(200)
       expect(response.media_type).to eq 'text/csv'
-      expect(response.headers['Content-Disposition']).to start_with 'attachment; filename="anonymous.csv"'
+      expect(response)
+        .to have_attachment('anonymous.csv')
       expect(response.body).to eq 'body data value'
     end
 

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Settings::ImportsController do
   describe 'GET #failures' do
     subject { get :failures, params: { id: bulk_import.id }, format: :csv }
 
-    shared_examples 'export failed rows' do |expected_contents|
+    shared_examples 'export failed rows' do |filename, expected_contents|
       let(:bulk_import) { Fabricate(:bulk_import, account: user.account, type: import_type, state: :finished) }
 
       before do
@@ -147,8 +147,12 @@ RSpec.describe Settings::ImportsController do
       it 'returns expected contents', :aggregate_failures do
         subject
 
-        expect(response).to have_http_status(200)
-        expect(response.body).to eq expected_contents
+        expect(response)
+          .to have_http_status(200)
+        expect(response)
+          .to have_attachment(filename)
+        expect(response.body)
+          .to eq expected_contents
       end
     end
 
@@ -162,7 +166,7 @@ RSpec.describe Settings::ImportsController do
         ]
       end
 
-      it_behaves_like 'export failed rows', "Account address,Show boosts,Notify on new posts,Languages\nfoo@bar,true,false,\nuser@bar,false,true,\"fr, de\"\n"
+      it_behaves_like 'export failed rows', 'following_accounts_failures.csv', "Account address,Show boosts,Notify on new posts,Languages\nfoo@bar,true,false,\nuser@bar,false,true,\"fr, de\"\n"
     end
 
     context 'with blocks' do
@@ -175,7 +179,7 @@ RSpec.describe Settings::ImportsController do
         ]
       end
 
-      it_behaves_like 'export failed rows', "foo@bar\nuser@bar\n"
+      it_behaves_like 'export failed rows', 'blocked_accounts_failures.csv', "foo@bar\nuser@bar\n"
     end
 
     context 'with mutes' do
@@ -188,7 +192,7 @@ RSpec.describe Settings::ImportsController do
         ]
       end
 
-      it_behaves_like 'export failed rows', "Account address,Hide notifications\nfoo@bar,true\nuser@bar,false\n"
+      it_behaves_like 'export failed rows', 'muted_accounts_failures.csv', "Account address,Hide notifications\nfoo@bar,true\nuser@bar,false\n"
     end
 
     context 'with domain blocks' do
@@ -201,7 +205,7 @@ RSpec.describe Settings::ImportsController do
         ]
       end
 
-      it_behaves_like 'export failed rows', "bad.domain\nevil.domain\n"
+      it_behaves_like 'export failed rows', 'blocked_domains_failures.csv', "bad.domain\nevil.domain\n"
     end
 
     context 'with bookmarks' do
@@ -214,7 +218,7 @@ RSpec.describe Settings::ImportsController do
         ]
       end
 
-      it_behaves_like 'export failed rows', "https://foo.com/1\nhttps://foo.com/2\n"
+      it_behaves_like 'export failed rows', 'bookmarks_failures.csv', "https://foo.com/1\nhttps://foo.com/2\n"
     end
 
     context 'with lists' do
@@ -227,7 +231,7 @@ RSpec.describe Settings::ImportsController do
         ]
       end
 
-      it_behaves_like 'export failed rows', "Amigos,user@example.com\nFrenemies,user@org.org\n"
+      it_behaves_like 'export failed rows', 'lists_failures.csv', "Amigos,user@example.com\nFrenemies,user@org.org\n"
     end
   end
 

--- a/spec/requests/admin/export_domain_allows_spec.rb
+++ b/spec/requests/admin/export_domain_allows_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe 'Admin Export Domain Allows' do
         .to have_http_status(200)
       expect(response.body)
         .to eq(domain_allows_csv_file)
+      expect(response)
+        .to have_attachment('domain_allows.csv')
       expect(response.media_type)
         .to eq('text/csv')
     end

--- a/spec/requests/severed_relationships_spec.rb
+++ b/spec/requests/severed_relationships_spec.rb
@@ -16,10 +16,8 @@ RSpec.describe 'Severed Relationships' do
         .to have_http_status(200)
       expect(response.content_type)
         .to start_with('text/csv')
-      expect(response.headers['Content-Disposition'])
-        .to match(<<~FILENAME.squish)
-          attachment; filename="following-example.com-#{Date.current}.csv"
-        FILENAME
+      expect(response)
+        .to have_attachment("following-example.com-#{Date.current}.csv")
       expect(response.body)
         .to include('Account address')
     end
@@ -44,10 +42,8 @@ RSpec.describe 'Severed Relationships' do
         .to have_http_status(200)
       expect(response.content_type)
         .to start_with('text/csv')
-      expect(response.headers['Content-Disposition'])
-        .to match(<<~FILENAME.squish)
-          attachment; filename="followers-example.com-#{Date.current}.csv"
-        FILENAME
+      expect(response)
+        .to have_attachment("followers-example.com-#{Date.current}.csv")
       expect(response.body)
         .to include('Account address')
     end

--- a/spec/support/matchers/attachments.rb
+++ b/spec/support/matchers/attachments.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :have_attachment do |value|
+  match do |response|
+    expect(response.headers['Content-Disposition'])
+      .to match(<<~FILENAME.squish)
+        attachment; filename="#{value}"
+      FILENAME
+  end
+
+  failure_message do |response|
+    <<~ERROR
+      Expected response to have file attachment of `#{value}` but was:
+      Content-Disposition: #{response.headers['Content-Disposition']}
+    ERROR
+  end
+end


### PR DESCRIPTION
Nice tidy up for the few spots already doing this check, and add a check to spots which were not.