### PR TITLE
Use bundler version 4.0.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -773,7 +773,7 @@ GEM
     rubocop-capybara (2.22.1)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
-    rubocop-i18n (3.2.3)
+    rubocop-i18n (3.3.0)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
     rubocop-performance (1.26.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       llhttp-ffi (~> 0.5.0)
-    http-cookie (1.1.0)
+    http-cookie (1.1.2)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     http_accept_language (2.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -828,7 +828,7 @@ GEM
     sidekiq-scheduler (6.0.1)
       rufus-scheduler (~> 3.2)
       sidekiq (>= 7.3, < 9)
-    sidekiq-unique-jobs (8.0.13)
+    sidekiq-unique-jobs (8.1.0)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 7.0.0, < 9.0.0)
       thor (>= 1.0, < 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    css_parser (1.21.1)
+    css_parser (2.0.0)
       addressable
     csv (3.3.5)
     database_cleaner-active_record (2.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -905,7 +905,7 @@ GEM
     vite_rails (3.0.20)
       railties (>= 5.1, < 9)
       vite_ruby (~> 3.0, >= 3.2.2)
-    vite_ruby (3.9.3)
+    vite_ruby (3.10.2)
       dry-cli (>= 0.7, < 2)
       logger (~> 1.6)
       mutex_m

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     ast (2.4.3)
     attr_required (1.0.2)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1237.0)
+    aws-partitions (1.1238.0)
     aws-sdk-core (3.244.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,7 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
-    excon (1.4.0)
+    excon (1.4.2)
       logger
     fabrication (3.0.0)
     faker (3.6.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -590,7 +590,7 @@ GEM
     ox (2.14.23)
       bigdecimal (>= 3.0)
     parallel (1.27.0)
-    parser (3.3.10.2)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     parslet (2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,7 +454,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
-    multi_json (1.20.0)
+    multi_json (1.20.1)
     mutex_m (0.3.0)
     net-http (0.6.0)
       uri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -712,7 +712,7 @@ GEM
       redis-client (>= 0.22.0)
     redis-client (0.28.0)
       connection_pool
-    regexp_parser (2.11.3)
+    regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
     request_store (1.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,9 +292,9 @@ GEM
       activesupport (>= 5.1)
       haml (>= 4.0.6)
       railties (>= 5.1)
-    haml_lint (0.72.0)
+    haml_lint (0.73.0)
       haml (>= 5.0)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       rainbow
       rubocop (>= 1.0)
       sysexits (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -589,7 +589,7 @@ GEM
     ostruct (0.6.3)
     ox (2.14.23)
       bigdecimal (>= 3.0)
-    parallel (1.27.0)
+    parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -605,7 +605,7 @@ GEM
       mime-types (>= 3.0)
     pp (0.6.3)
       prettyprint
-    premailer (1.27.0)
+    premailer (1.29.0)
       addressable
       css_parser (>= 1.19.0)
       htmlentities (>= 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       llhttp-ffi (~> 0.5.0)
-    http-cookie (1.1.2)
+    http-cookie (1.1.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     http_accept_language (2.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     ast (2.4.3)
     attr_required (1.0.2)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1236.0)
+    aws-partitions (1.1237.0)
     aws-sdk-core (3.244.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,7 +247,7 @@ GEM
       net-http (~> 0.5)
     fast_blank (1.0.1)
     fastimage (2.4.1)
-    ffi (1.17.3)
+    ffi (1.17.4)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       playwright-ruby-client (>= 1.16.0)
     case_transform (0.2)
       activesupport
-    cbor (0.5.10.1)
+    cbor (0.5.10.2)
     cgi (0.5.1)
     charlock_holmes (0.7.9)
     chewy (8.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -691,7 +691,7 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.1)
     rdf (3.3.4)
       bcp47_spec (~> 0.2)
       bigdecimal (~> 3.1, >= 3.1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
     dotenv (3.2.0)
     drb (2.2.3)
     dry-cli (1.4.1)
-    elastic-transport (8.4.1)
+    elastic-transport (8.5.1)
       faraday (< 3)
       multi_json
     elasticsearch (8.19.3)
@@ -454,7 +454,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
-    multi_json (1.19.1)
+    multi_json (1.20.0)
     mutex_m (0.3.0)
     net-http (0.6.0)
       uri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1100,4 +1100,4 @@ RUBY VERSION
   ruby 4.0.2
 
 BUNDLED WITH
-  4.0.8
+  4.0.10


### PR DESCRIPTION
This includes some currently open PRs (rails, sidekiq, maybe more), but also includes both premailer and css_parser, which both require ruby 3.3+, and thus this needs to wait on the 3.2 drop PR to merge. Will keep this rebased as those others process.