### PR TITLE
Add `with_forgery_protection` framework spec helper

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -112,6 +112,7 @@ RSpec.configure do |config|
   config.include Chewy::Rspec::Helpers
   config.include Redisable
   config.include DomainHelpers
+  config.include FrameworkConfigurationHelpers
   config.include ThreadingHelpers
   config.include SignedRequestHelpers, type: :request
   config.include CommandLineHelpers, type: :cli

--- a/spec/requests/anonymous_cookies_spec.rb
+++ b/spec/requests/anonymous_cookies_spec.rb
@@ -4,12 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Anonymous visits' do
   around do |example|
-    old = ActionController::Base.allow_forgery_protection
-    ActionController::Base.allow_forgery_protection = true
-
-    example.run
-
-    ActionController::Base.allow_forgery_protection = old
+    with_forgery_protection { example.run }
   end
 
   describe 'account pages' do

--- a/spec/requests/cache_spec.rb
+++ b/spec/requests/cache_spec.rb
@@ -159,12 +159,7 @@ RSpec.describe 'Caching behavior' do
   # Enable CSRF protection like it is in production, as it can cause cookies
   # to be set and thus mess with cache.
   around do |example|
-    old = ActionController::Base.allow_forgery_protection
-    ActionController::Base.allow_forgery_protection = true
-
-    example.run
-
-    ActionController::Base.allow_forgery_protection = old
+    with_forgery_protection { example.run }
   end
 
   let(:alice) { Account.find_by(username: 'alice') }

--- a/spec/requests/unsubscriptions_spec.rb
+++ b/spec/requests/unsubscriptions_spec.rb
@@ -71,12 +71,7 @@ RSpec.describe 'UnsubscriptionsController' do
 
   describe 'unsubscribing with List-Unsubscribe-Post' do
     around do |example|
-      old = ActionController::Base.allow_forgery_protection
-      ActionController::Base.allow_forgery_protection = true
-
-      example.run
-
-      ActionController::Base.allow_forgery_protection = old
+      with_forgery_protection { example.run }
     end
 
     before do

--- a/spec/support/framework_configuration_helpers.rb
+++ b/spec/support/framework_configuration_helpers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module FrameworkConfigurationHelpers
+  def with_forgery_protection
+    ActionController::Base.allow_forgery_protection.tap do |original|
+      ActionController::Base.allow_forgery_protection = true
+      yield
+      ActionController::Base.allow_forgery_protection = original
+    end
+  end
+end


### PR DESCRIPTION
Putting this in a slightly generically named support file because I think there are more to add fitting this pattern.