### PR TITLE
Persist activity URI of a `FeatureRequest`

### DIFF
--- a/app/lib/activitypub/activity/feature_request.rb
+++ b/app/lib/activitypub/activity/feature_request.rb
@@ -23,8 +23,7 @@ class ActivityPub::Activity::FeatureRequest < ActivityPub::Activity
 
   def accept_request!
     collection_item = @collection.collection_items.create!(
-      account: @featured_account,
-      state: :accepted
+      collection_item_attributes(:accepted)
     )
 
     queue_delivery!(collection_item, ActivityPub::AcceptFeatureRequestSerializer)
@@ -32,11 +31,14 @@ class ActivityPub::Activity::FeatureRequest < ActivityPub::Activity
 
   def reject_request!
     collection_item = @collection.collection_items.build(
-      account: @featured_account,
-      state: :rejected
+      collection_item_attributes(:rejected)
     )
 
     queue_delivery!(collection_item, ActivityPub::RejectFeatureRequestSerializer)
+  end
+
+  def collection_item_attributes(state = :accepted)
+    { account: @featured_account, activity_uri: @json['id'], state: }
   end
 
   def queue_delivery!(collection_item, serializer)

--- a/spec/lib/activitypub/activity/feature_request_spec.rb
+++ b/spec/lib/activitypub/activity/feature_request_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe ActivityPub::Activity::FeatureRequest do
           .with(satisfying do |body|
             response_json = JSON.parse(body)
             response_json['type'] == 'Accept' &&
+              response_json['object'] == 'https://example.com/feature_requests/1' &&
               response_json['to'] == sender.uri
           end, recipient.id, sender.inbox_url)
       end
@@ -46,6 +47,7 @@ RSpec.describe ActivityPub::Activity::FeatureRequest do
           .with(satisfying do |body|
             response_json = JSON.parse(body)
             response_json['type'] == 'Reject' &&
+              response_json['object'] == 'https://example.com/feature_requests/1' &&
               response_json['to'] == sender.uri
           end, recipient.id, sender.inbox_url)
       end


### PR DESCRIPTION
As it is needed in the activity serializers.