### PR TITLE
Add API admin/base class

### DIFF
--- a/app/controllers/api/v1/admin/account_actions_controller.rb
+++ b/app/controllers/api/v1/admin/account_actions_controller.rb
@@ -4,8 +4,6 @@ class Api::V1::Admin::AccountActionsController < Api::V1::Admin::BaseController
   before_action -> { authorize_if_got_token! :'admin:write', :'admin:write:accounts' }
   before_action :set_account
 
-  after_action :verify_authorized
-
   def create
     authorize @account, :show?
 

--- a/app/controllers/api/v1/admin/account_actions_controller.rb
+++ b/app/controllers/api/v1/admin/account_actions_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::AccountActionsController < Api::BaseController
-  include Authorization
-
+class Api::V1::Admin::AccountActionsController < Api::V1::Admin::BaseController
   before_action -> { authorize_if_got_token! :'admin:write', :'admin:write:accounts' }
   before_action :set_account
 

--- a/app/controllers/api/v1/admin/accounts_controller.rb
+++ b/app/controllers/api/v1/admin/accounts_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::AccountsController < Api::BaseController
-  include Authorization
-  include AccountableConcern
-
+class Api::V1::Admin::AccountsController < Api::V1::Admin::BaseController
   LIMIT = 100
 
   before_action -> { authorize_if_got_token! :'admin:read', :'admin:read:accounts' }, only: [:index, :show]

--- a/app/controllers/api/v1/admin/accounts_controller.rb
+++ b/app/controllers/api/v1/admin/accounts_controller.rb
@@ -9,7 +9,6 @@ class Api::V1::Admin::AccountsController < Api::V1::Admin::BaseController
   before_action :set_account, except: :index
   before_action :require_local_account!, only: [:enable, :approve, :reject]
 
-  after_action :verify_authorized
   after_action :insert_pagination_headers, only: :index
 
   FILTER_PARAMS = %i(

--- a/app/controllers/api/v1/admin/base_controller.rb
+++ b/app/controllers/api/v1/admin/base_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Api::V1::Admin::BaseController < Api::BaseController
+  include Authorization
+  include AccountableConcern
+end

--- a/app/controllers/api/v1/admin/base_controller.rb
+++ b/app/controllers/api/v1/admin/base_controller.rb
@@ -3,4 +3,6 @@
 class Api::V1::Admin::BaseController < Api::BaseController
   include Authorization
   include AccountableConcern
+
+  after_action :verify_authorized
 end

--- a/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::CanonicalEmailBlocksController < Api::BaseController
-  include Authorization
-  include AccountableConcern
-
+class Api::V1::Admin::CanonicalEmailBlocksController < Api::V1::Admin::BaseController
   LIMIT = 100
 
   before_action -> { authorize_if_got_token! :'admin:read', :'admin:read:canonical_email_blocks' }, only: [:index, :show, :test]

--- a/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
@@ -10,7 +10,6 @@ class Api::V1::Admin::CanonicalEmailBlocksController < Api::V1::Admin::BaseContr
   before_action :set_canonical_email_blocks_from_test, only: [:test]
   before_action :set_canonical_email_block, only: [:show, :destroy]
 
-  after_action :verify_authorized
   after_action :insert_pagination_headers, only: :index
 
   def index

--- a/app/controllers/api/v1/admin/dimensions_controller.rb
+++ b/app/controllers/api/v1/admin/dimensions_controller.rb
@@ -4,8 +4,6 @@ class Api::V1::Admin::DimensionsController < Api::V1::Admin::BaseController
   before_action -> { authorize_if_got_token! :'admin:read' }
   before_action :set_dimensions
 
-  after_action :verify_authorized
-
   def create
     authorize :dashboard, :index?
     render json: @dimensions, each_serializer: REST::Admin::DimensionSerializer

--- a/app/controllers/api/v1/admin/dimensions_controller.rb
+++ b/app/controllers/api/v1/admin/dimensions_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::DimensionsController < Api::BaseController
-  include Authorization
-
+class Api::V1::Admin::DimensionsController < Api::V1::Admin::BaseController
   before_action -> { authorize_if_got_token! :'admin:read' }
   before_action :set_dimensions
 

--- a/app/controllers/api/v1/admin/domain_allows_controller.rb
+++ b/app/controllers/api/v1/admin/domain_allows_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::DomainAllowsController < Api::BaseController
-  include Authorization
-  include AccountableConcern
-
+class Api::V1::Admin::DomainAllowsController < Api::V1::Admin::BaseController
   LIMIT = 100
   MAX_LIMIT = 500
 

--- a/app/controllers/api/v1/admin/domain_allows_controller.rb
+++ b/app/controllers/api/v1/admin/domain_allows_controller.rb
@@ -9,7 +9,6 @@ class Api::V1::Admin::DomainAllowsController < Api::V1::Admin::BaseController
   before_action :set_domain_allows, only: :index
   before_action :set_domain_allow, only: [:show, :destroy]
 
-  after_action :verify_authorized
   after_action :insert_pagination_headers, only: :index
 
   def index

--- a/app/controllers/api/v1/admin/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/domain_blocks_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::DomainBlocksController < Api::BaseController
-  include Authorization
-  include AccountableConcern
-
+class Api::V1::Admin::DomainBlocksController < Api::V1::Admin::BaseController
   LIMIT = 100
   MAX_LIMIT = 500
 

--- a/app/controllers/api/v1/admin/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/domain_blocks_controller.rb
@@ -9,7 +9,6 @@ class Api::V1::Admin::DomainBlocksController < Api::V1::Admin::BaseController
   before_action :set_domain_blocks, only: :index
   before_action :set_domain_block, only: [:show, :update, :destroy]
 
-  after_action :verify_authorized
   after_action :insert_pagination_headers, only: :index
 
   def index

--- a/app/controllers/api/v1/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/email_domain_blocks_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::EmailDomainBlocksController < Api::BaseController
-  include Authorization
-  include AccountableConcern
-
+class Api::V1::Admin::EmailDomainBlocksController < Api::V1::Admin::BaseController
   LIMIT = 100
 
   before_action -> { authorize_if_got_token! :'admin:read', :'admin:read:email_domain_blocks' }, only: [:index, :show]

--- a/app/controllers/api/v1/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/email_domain_blocks_controller.rb
@@ -8,7 +8,6 @@ class Api::V1::Admin::EmailDomainBlocksController < Api::V1::Admin::BaseControll
   before_action :set_email_domain_blocks, only: :index
   before_action :set_email_domain_block, only: [:show, :destroy]
 
-  after_action :verify_authorized
   after_action :insert_pagination_headers, only: :index
 
   def index

--- a/app/controllers/api/v1/admin/ip_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/ip_blocks_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::IpBlocksController < Api::BaseController
-  include Authorization
-  include AccountableConcern
-
+class Api::V1::Admin::IpBlocksController < Api::V1::Admin::BaseController
   LIMIT = 100
 
   before_action -> { authorize_if_got_token! :'admin:read', :'admin:read:ip_blocks' }, only: [:index, :show]

--- a/app/controllers/api/v1/admin/ip_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/ip_blocks_controller.rb
@@ -8,7 +8,6 @@ class Api::V1::Admin::IpBlocksController < Api::V1::Admin::BaseController
   before_action :set_ip_blocks, only: :index
   before_action :set_ip_block, only: [:show, :update, :destroy]
 
-  after_action :verify_authorized
   after_action :insert_pagination_headers, only: :index
 
   def index

--- a/app/controllers/api/v1/admin/measures_controller.rb
+++ b/app/controllers/api/v1/admin/measures_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::MeasuresController < Api::BaseController
-  include Authorization
-
+class Api::V1::Admin::MeasuresController < Api::V1::Admin::BaseController
   before_action -> { authorize_if_got_token! :'admin:read' }
   before_action :set_measures
 

--- a/app/controllers/api/v1/admin/measures_controller.rb
+++ b/app/controllers/api/v1/admin/measures_controller.rb
@@ -4,8 +4,6 @@ class Api::V1::Admin::MeasuresController < Api::V1::Admin::BaseController
   before_action -> { authorize_if_got_token! :'admin:read' }
   before_action :set_measures
 
-  after_action :verify_authorized
-
   def create
     authorize :dashboard, :index?
     render json: @measures, each_serializer: REST::Admin::MeasureSerializer

--- a/app/controllers/api/v1/admin/reports_controller.rb
+++ b/app/controllers/api/v1/admin/reports_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::ReportsController < Api::BaseController
-  include Authorization
-  include AccountableConcern
-
+class Api::V1::Admin::ReportsController < Api::V1::Admin::BaseController
   LIMIT = 100
 
   before_action -> { authorize_if_got_token! :'admin:read', :'admin:read:reports' }, only: [:index, :show]

--- a/app/controllers/api/v1/admin/reports_controller.rb
+++ b/app/controllers/api/v1/admin/reports_controller.rb
@@ -8,7 +8,6 @@ class Api::V1::Admin::ReportsController < Api::V1::Admin::BaseController
   before_action :set_reports, only: :index
   before_action :set_report, except: :index
 
-  after_action :verify_authorized
   after_action :insert_pagination_headers, only: :index
 
   FILTER_PARAMS = %i(

--- a/app/controllers/api/v1/admin/retention_controller.rb
+++ b/app/controllers/api/v1/admin/retention_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::RetentionController < Api::BaseController
-  include Authorization
-
+class Api::V1::Admin::RetentionController < Api::V1::Admin::BaseController
   before_action -> { authorize_if_got_token! :'admin:read' }
   before_action :set_cohorts
 

--- a/app/controllers/api/v1/admin/retention_controller.rb
+++ b/app/controllers/api/v1/admin/retention_controller.rb
@@ -4,8 +4,6 @@ class Api::V1::Admin::RetentionController < Api::V1::Admin::BaseController
   before_action -> { authorize_if_got_token! :'admin:read' }
   before_action :set_cohorts
 
-  after_action :verify_authorized
-
   def create
     authorize :dashboard, :index?
     render json: @cohorts, each_serializer: REST::Admin::CohortSerializer

--- a/app/controllers/api/v1/admin/tags_controller.rb
+++ b/app/controllers/api/v1/admin/tags_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::TagsController < Api::BaseController
-  include Authorization
-
+class Api::V1::Admin::TagsController < Api::V1::Admin::BaseController
   before_action -> { authorize_if_got_token! :'admin:read' }, only: [:index, :show]
   before_action -> { authorize_if_got_token! :'admin:write' }, only: :update
 

--- a/app/controllers/api/v1/admin/tags_controller.rb
+++ b/app/controllers/api/v1/admin/tags_controller.rb
@@ -8,7 +8,6 @@ class Api::V1::Admin::TagsController < Api::V1::Admin::BaseController
   before_action :set_tag, except: :index
 
   after_action :insert_pagination_headers, only: :index
-  after_action :verify_authorized
 
   LIMIT = 100
 


### PR DESCRIPTION
Follows the pattern of what the non-api admin controllers do.

Excludes the api/v1/admin/trends/* which already have a separate inheritance path (and dont use accountable).
