### PR TITLE
Don't install recommended packages in CI tasks

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y libicu-dev libidn11-dev libvips42 ${{ inputs.additional-system-dependencies }}
+        sudo apt-get install --no-install-recommends -y libicu-dev libidn11-dev libvips42 ${{ inputs.additional-system-dependencies }}
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@4eb9f110bac952a8b68ecf92e3b5c7a987594ba6 # v1


### PR DESCRIPTION
I have noticed that lately a lot of CI time is spent on downloading dependencies. While the download speed is sometimes surprisingly slow (~50kB/s) regardless of the number of packages, some relatively large dependencies, like `pocketsphinx-en-us`, are definitely not needed.

This PR reduces the number of downloaded dependencies from 121 dependencies to 108, reducing the download size from 102MB to 69.2MB.