### PR TITLE
Fix item count

### DIFF
--- a/app/serializers/activitypub/featured_collection_serializer.rb
+++ b/app/serializers/activitypub/featured_collection_serializer.rb
@@ -32,7 +32,7 @@ class ActivityPub::FeaturedCollectionSerializer < ActivityPub::Serializer
   end
 
   def total_items
-    object.collection_items.size
+    object.accepted_collection_items.size
   end
 
   def published

--- a/spec/serializers/activitypub/featured_collection_serializer_spec.rb
+++ b/spec/serializers/activitypub/featured_collection_serializer_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe ActivityPub::FeaturedCollectionSerializer do
     it 'only includes accepted items' do
       items = subject['orderedItems']
 
+      expect(subject['totalItems']).to eq 1
       expect(items.size).to eq 1
       expect(items.first['id']).to eq ActivityPub::TagManager.instance.uri_for(collection_items.last)
     end


### PR DESCRIPTION
Follow-up to #38385 where I limited the serialized items to `accepted` ones, but forgot to adjust the count.