### PR TITLE
Remove archive screenshots step from search CI job

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -384,10 +384,3 @@ jobs:
         with:
           name: test-search-logs-${{ matrix.ruby-version }}
           path: log/
-
-      - name: Archive test screenshots
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        if: failure()
-        with:
-          name: test-search-screenshots
-          path: tmp/capybara/


### PR DESCRIPTION
Noticed this in https://github.com/mastodon/mastodon/pull/38324 ... I dont think theres a scenario where one of the search specs produces a screenshot? Assuming this is copy/paste from initial setup of the search job from E2E section right above that does produce screenshots on fail.