### PR TITLE
Profile editing: Add notice in profile preferences

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -442,6 +442,41 @@ $content-width: 840px;
       }
     }
   }
+
+  .callout {
+    display: flex;
+    align-items: start;
+    padding: 12px;
+    gap: 8px;
+    background-color: var(--color-bg-brand-softest);
+    color: var(--color-text-primary);
+    border-radius: 12px;
+    font-size: 15px;
+    margin-bottom: 30px;
+
+    .icon {
+      padding: 4px;
+      border-radius: 9999px;
+      width: 1rem;
+      height: 1rem;
+      margin-top: -2px;
+      background-color: var(--color-bg-brand-soft);
+    }
+
+    .body {
+      flex-grow: 1;
+    }
+
+    .title {
+      font-weight: 600;
+      margin-bottom: 8px;
+    }
+
+    a {
+      color: inherit;
+      font-weight: 600;
+    }
+  }
 }
 
 hr.spacer {

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -463,6 +463,18 @@ $content-width: 840px;
       background-color: var(--color-bg-brand-soft);
     }
 
+    .content {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      flex-grow: 1;
+      padding: 0;
+
+      @media screen and (width >= 630px) {
+        flex-direction: row;
+      }
+    }
+
     .body {
       flex-grow: 1;
     }

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -8,10 +8,11 @@
 - if Mastodon::Feature.profile_redesign_enabled?
   %aside.callout
     = material_symbol 'info'
-    .body
-      %p.title= t('edit_profile.redesign_title')
-      %p= t('edit_profile.redesign_body')
-    = link_to t('edit_profile.redesign_button'), '/profile/edit'
+    .content
+      .body
+        %p.title= t('edit_profile.redesign_title')
+        %p= t('edit_profile.redesign_body')
+      = link_to t('edit_profile.redesign_button'), '/profile/edit'
 
 = simple_form_for @account, url: settings_profile_path, html: { id: :edit_profile } do |f|
   = render 'shared/error_messages', object: @account

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -5,6 +5,14 @@
   %h1= t('settings.profile')
   = render partial: 'settings/shared/profile_navigation'
 
+- if Mastodon::Feature.profile_redesign_enabled?
+  %aside.callout
+    = material_symbol 'info'
+    .body
+      %p.title= t('edit_profile.redesign_title')
+      %p= t('edit_profile.redesign_body')
+    = link_to t('edit_profile.redesign_button'), '/profile/edit'
+
 = simple_form_for @account, url: settings_profile_path, html: { id: :edit_profile } do |f|
   = render 'shared/error_messages', object: @account
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1419,11 +1419,11 @@ en:
       your_appeal_rejected: Your appeal has been rejected
   edit_profile:
     basic_information: Basic information
-    redesign_title: There’s a new profile editing experience
-    redesign_body: Profile editing can now be accessed directly from the profile page.
-    redesign_button: Go there
     hint_html: "<strong>Customize what people see on your public profile and next to your posts.</strong> Other people are more likely to follow you back and interact with you when you have a filled out profile and a profile picture."
     other: Other
+    redesign_body: Profile editing can now be accessed directly from the profile page.
+    redesign_button: Go there
+    redesign_title: There’s a new profile editing experience
   email_subscription_mailer:
     confirmation:
       action: Confirm email address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1419,6 +1419,9 @@ en:
       your_appeal_rejected: Your appeal has been rejected
   edit_profile:
     basic_information: Basic information
+    redesign_title: There’s a new profile editing experience
+    redesign_body: Profile editing can now be accessed directly from the profile page.
+    redesign_button: Go there
     hint_html: "<strong>Customize what people see on your public profile and next to your posts.</strong> Other people are more likely to follow you back and interact with you when you have a filled out profile and a profile picture."
     other: Other
   email_subscription_mailer:


### PR DESCRIPTION
Fixes WEB-884.

This adds a notice when the `profile_redesign` flag is enabled that informs people of the new profile editor.

<img width="1866" height="722" alt="Screenshot 2026-03-25 at 17 27 51" src="https://github.com/user-attachments/assets/9399690c-5ed7-4fce-94e4-f02b1080ed1e" />
<img width="1866" height="722" alt="Screenshot 2026-03-25 at 17 29 03" src="https://github.com/user-attachments/assets/fcf25e40-bd05-4892-9e39-63ae00c99e91" />
