### PR TITLE
Expand coverage for `Tag.search_for` method

### DIFF
--- a/app/models/admin/tag_filter.rb
+++ b/app/models/admin/tag_filter.rb
@@ -32,7 +32,7 @@ class Admin::TagFilter
     when :status
       status_scope(value)
     when :name
-      Tag.search_for(value.to_s.strip, params[:limit], params[:offset], exclude_unlistable: false)
+      Tag.search_for(value, params[:limit], params[:offset], exclude_unlistable: false)
     when :order
       order_scope(value)
     else

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -128,7 +128,7 @@ class Tag < ApplicationRecord
     end
 
     def search_for(term, limit = 5, offset = 0, options = {})
-      stripped_term = term.strip
+      stripped_term = term.to_s.strip
       options.reverse_merge!({ exclude_unlistable: true, exclude_unreviewed: false })
 
       query = Tag.matches_name(stripped_term)

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -338,6 +338,23 @@ RSpec.describe Tag do
       expect(results).to eq [tag]
     end
 
+    it 'finds tag records from padded term queries' do
+      tag = Fabricate(:tag, name: 'MATCH')
+      _miss_tag = Fabricate(:tag, name: 'miss')
+
+      results = described_class.search_for('  match  ')
+
+      expect(results)
+        .to contain_exactly(tag)
+    end
+
+    it 'handles nil query' do
+      results = described_class.search_for(nil)
+
+      expect(results)
+        .to be_empty
+    end
+
     it 'finds the exact matching tag as the first item' do
       similar_tag = Fabricate(:tag, name: 'matchlater', reviewed_at: Time.now.utc)
       tag = Fabricate(:tag, name: 'match', reviewed_at: Time.now.utc)
@@ -363,6 +380,17 @@ RSpec.describe Tag do
       results = described_class.search_for('match', 5, 0, exclude_unlistable: false)
 
       expect(results).to eq [tag, unlisted_tag]
+    end
+
+    it 'excludes non reviewed tags via option' do
+      tag = Fabricate(:tag, name: 'match', reviewed_at: 5.days.ago)
+      unreviewed_tag = Fabricate(:tag, name: 'matchreviewed', reviewed_at: nil)
+
+      results = described_class.search_for('match', 5, 0, exclude_unreviewed: true)
+
+      expect(results)
+        .to include(tag)
+        .and not_include(unreviewed_tag)
     end
   end
 end


### PR DESCRIPTION
This is some leftovers from a previous Tag normalize branch. I had some refactor to the searching/matching methods ... not sure if those are quite to the point where its worth pushing them up, but pulling out some remnants here:

- Spec for padded query search
- Spec for sending in nil
- Spec for the `exclude_unreviewed` path which want exercised before
- Code change to one call site and the method to get rid of a repeated `strip` and move normalizing inside the method