### PR TITLE
Fetch unknown collection when handling `FeatureRequest` activity

### DIFF
--- a/app/lib/activitypub/activity/feature_request.rb
+++ b/app/lib/activitypub/activity/feature_request.rb
@@ -7,7 +7,7 @@ class ActivityPub::Activity::FeatureRequest < ActivityPub::Activity
     return unless Mastodon::Feature.collections_federation_enabled?
     return if non_matching_uri_hosts?(@account.uri, @json['id'])
 
-    @collection = @account.collections.find_by(uri: value_or_id(@json['instrument']))
+    @collection = find_or_fetch_collection
     @featured_account = ActivityPub::TagManager.instance.uris_to_local_accounts([value_or_id(@json['object'])]).first
 
     return if @collection.nil? || @featured_account.nil?
@@ -35,6 +35,17 @@ class ActivityPub::Activity::FeatureRequest < ActivityPub::Activity
     )
 
     queue_delivery!(collection_item, ActivityPub::RejectFeatureRequestSerializer)
+  end
+
+  def find_or_fetch_collection
+    uri = value_or_id(@json['instrument'])
+    collection = @account.collections.find_by(uri:)
+    return collection if collection.present?
+
+    collection = ActivityPub::FetchRemoteFeaturedCollectionService.new.call(uri)
+    return collection if collection.present? && collection.account == @account
+
+    nil
   end
 
   def collection_item_attributes(state = :accepted)

--- a/spec/lib/activitypub/activity/feature_request_spec.rb
+++ b/spec/lib/activitypub/activity/feature_request_spec.rb
@@ -52,5 +52,28 @@ RSpec.describe ActivityPub::Activity::FeatureRequest do
           end, recipient.id, sender.inbox_url)
       end
     end
+
+    context 'when the collection is not yet known' do
+      let(:discoverable) { true }
+      let(:collection) { instance_double(Collection, uri: 'https://example.com/collections/1') }
+      let(:stubbed_service) do
+        service = instance_double(ActivityPub::FetchRemoteFeaturedCollectionService)
+        allow(service).to receive(:call) do
+          Fabricate(:remote_collection, account: sender, uri: collection.uri)
+        end
+        service
+      end
+
+      before do
+        allow(ActivityPub::FetchRemoteFeaturedCollectionService).to receive(:new).and_return(stubbed_service)
+      end
+
+      it 'fetches the collection before handling the request' do
+        subject.perform
+
+        expect(ActivityPub::DeliveryWorker).to have_enqueued_sidekiq_job
+        expect(stubbed_service).to have_received(:call)
+      end
+    end
   end
 end


### PR DESCRIPTION
When a `FeatureRequest` activity arrives, the collection it references might not yet be known to the server. In this case it needs to be fetched and processed first.