### PR TITLE
Remove overeager unique index

### DIFF
--- a/db/migrate/20260326112324_remove_unique_index_on_collection_item_object_uris.rb
+++ b/db/migrate/20260326112324_remove_unique_index_on_collection_item_object_uris.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveUniqueIndexOnCollectionItemObjectUris < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :collection_items, :object_uri, unique: true, where: '(activity_uri IS NOT NULL)'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_25_151755) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_26_112324) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -373,7 +373,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_151755) do
     t.index ["account_id"], name: "index_collection_items_on_account_id"
     t.index ["approval_uri"], name: "index_collection_items_on_approval_uri", unique: true, where: "(approval_uri IS NOT NULL)"
     t.index ["collection_id"], name: "index_collection_items_on_collection_id"
-    t.index ["object_uri"], name: "index_collection_items_on_object_uri", unique: true, where: "(activity_uri IS NOT NULL)"
     t.index ["uri"], name: "index_collection_items_on_uri", unique: true, where: "(uri IS NOT NULL)"
   end
 


### PR DESCRIPTION
I cannot for the life of me remember why I added this. But looking at it again, this could prevent the same remote object being included in more than one collection. But this is definitely allowed (expected even).