### PR TITLE
Use `normalizes` for PA IDs in AccountConversation

### DIFF
--- a/app/models/account_conversation.rb
+++ b/app/models/account_conversation.rb
@@ -26,9 +26,11 @@ class AccountConversation < ApplicationRecord
   belongs_to :conversation
   belongs_to :last_status, class_name: 'Status'
 
-  def participant_account_ids=(arr)
-    self[:participant_account_ids] = arr.sort
+  normalizes :participant_account_ids, with: ->(values) { Array(values).sort }
+
+  def participant_account_ids=(*)
     @participant_accounts = nil
+    super
   end
 
   def participant_accounts

--- a/spec/models/account_conversation_spec.rb
+++ b/spec/models/account_conversation_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe AccountConversation do
+  describe 'Normalizations' do
+    it { is_expected.to normalize(:participant_account_ids).from([3, 2, 1]).to([1, 2, 3]) }
+  end
+
   describe '.add_status' do
     let!(:alice) { Fabricate(:account, username: 'alice') }
     let!(:bob)   { Fabricate(:account, username: 'bob') }

--- a/spec/models/account_conversation_spec.rb
+++ b/spec/models/account_conversation_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe AccountConversation do
-  let!(:alice) { Fabricate(:account, username: 'alice') }
-  let!(:bob)   { Fabricate(:account, username: 'bob') }
-  let!(:mark)  { Fabricate(:account, username: 'mark') }
-
   describe '.add_status' do
+    let!(:alice) { Fabricate(:account, username: 'alice') }
+    let!(:bob)   { Fabricate(:account, username: 'bob') }
+    let!(:mark)  { Fabricate(:account, username: 'mark') }
+
     it 'creates new record when no others exist' do
       status = Fabricate(:status, account: alice, visibility: :direct)
       status.mentions.create(account: bob)
@@ -52,6 +52,9 @@ RSpec.describe AccountConversation do
   end
 
   describe '.remove_status' do
+    let!(:alice) { Fabricate(:account, username: 'alice') }
+    let!(:bob)   { Fabricate(:account, username: 'bob') }
+
     it 'updates last status to a previous value' do
       last_status  = Fabricate(:status, account: alice, visibility: :direct)
       status       = Fabricate(:status, account: alice, visibility: :direct)

--- a/spec/models/account_conversation_spec.rb
+++ b/spec/models/account_conversation_spec.rb
@@ -7,6 +7,24 @@ RSpec.describe AccountConversation do
     it { is_expected.to normalize(:participant_account_ids).from([3, 2, 1]).to([1, 2, 3]) }
   end
 
+  describe '#participant_accounts' do
+    subject { account_conversation.participant_accounts }
+
+    let(:account_conversation) { Fabricate.build :account_conversation, account: }
+    let(:accounts) { Fabricate.times 2, :account }
+    let(:account) { Fabricate :account }
+
+    context 'with IDs present' do
+      before { account_conversation.participant_account_ids = accounts.map(&:id) }
+
+      it { is_expected.to match_array(accounts) }
+    end
+
+    context 'without any IDs present' do
+      it { is_expected.to contain_exactly(account) }
+    end
+  end
+
   describe '.add_status' do
     let!(:alice) { Fabricate(:account, username: 'alice') }
     let!(:bob)   { Fabricate(:account, username: 'bob') }


### PR DESCRIPTION
In spec:

- Move top level `let` into relevant describe sections
- Add coverage for desired array sorting behaviour
- Add coverage for related participant_accounts method

In model:

- Preserve memoization reset for method below, but use normalizer for the sort