### PR TITLE
Avoid `rubocop:disable` for private address spec

### DIFF
--- a/spec/lib/private_address_check_spec.rb
+++ b/spec/lib/private_address_check_spec.rb
@@ -4,17 +4,11 @@ require 'rails_helper'
 
 RSpec.describe PrivateAddressCheck do
   describe 'private_address?' do
+    let(:private_ips) { %w(192.168.1.7 0.0.0.0 127.0.0.1 ::ffff:0.0.0.1) }
+
     it 'returns true for private addresses' do
-      # rubocop:disable RSpec/ExpectActual
-      expect(
-        [
-          '192.168.1.7',
-          '0.0.0.0',
-          '127.0.0.1',
-          '::ffff:0.0.0.1',
-        ]
-      ).to all satisfy('return true') { |addr| described_class.private_address?(IPAddr.new(addr)) }
-      # rubocop:enable RSpec/ExpectActual
+      expect(private_ips)
+        .to all(satisfy { |addr| described_class.private_address?(IPAddr.new(addr)) })
     end
   end
 end


### PR DESCRIPTION
Despite being the same thing, this apparently does not trigger the cop