### PR TITLE
Extract header/avatar destroy endpoints to separate controllers

### DIFF
--- a/app/controllers/admin/accounts/avatars_controller.rb
+++ b/app/controllers/admin/accounts/avatars_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Admin
+  class Accounts::AvatarsController < BaseController
+    before_action :set_account
+
+    def destroy
+      authorize @account, :remove_avatar?
+
+      @account.avatar = nil
+      @account.save!
+
+      log_action :remove_avatar, @account.user
+
+      redirect_to admin_account_path(@account.id), notice: t('admin.accounts.removed_avatar_msg', username: @account.acct)
+    end
+
+    private
+
+    def set_account
+      @account = Account.find(params[:account_id])
+    end
+  end
+end

--- a/app/controllers/admin/accounts/headers_controller.rb
+++ b/app/controllers/admin/accounts/headers_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Admin
+  class Accounts::HeadersController < BaseController
+    before_action :set_account
+
+    def destroy
+      authorize @account, :remove_header?
+
+      @account.header = nil
+      @account.save!
+
+      log_action :remove_header, @account.user
+
+      redirect_to admin_account_path(@account.id), notice: t('admin.accounts.removed_header_msg', username: @account.acct)
+    end
+
+    private
+
+    def set_account
+      @account = Account.find(params[:account_id])
+    end
+  end
+end

--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -106,28 +106,6 @@ module Admin
       redirect_to admin_account_path(@account.id), notice: I18n.t('admin.accounts.redownloaded_msg', username: @account.acct)
     end
 
-    def remove_avatar
-      authorize @account, :remove_avatar?
-
-      @account.avatar = nil
-      @account.save!
-
-      log_action :remove_avatar, @account.user
-
-      redirect_to admin_account_path(@account.id), notice: I18n.t('admin.accounts.removed_avatar_msg', username: @account.acct)
-    end
-
-    def remove_header
-      authorize @account, :remove_header?
-
-      @account.header = nil
-      @account.save!
-
-      log_action :remove_header, @account.user
-
-      redirect_to admin_account_path(@account.id), notice: I18n.t('admin.accounts.removed_header_msg', username: @account.acct)
-    end
-
     def unblock_email
       authorize @account, :unblock_email?
 

--- a/app/views/admin/accounts/_local_account.html.haml
+++ b/app/views/admin/accounts/_local_account.html.haml
@@ -1,12 +1,12 @@
 - if account.avatar?
   %tr
     %th= t('admin.accounts.avatar')
-    %td= table_link_to 'delete', t('admin.accounts.remove_avatar'), remove_avatar_admin_account_path(account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:remove_avatar, account)
+    %td= table_link_to 'delete', t('admin.accounts.remove_avatar'), admin_account_avatar_path(account.id), method: :delete, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:remove_avatar, account)
     %td
 - if account.header?
   %tr
     %th= t('admin.accounts.header')
-    %td= table_link_to 'delete', t('admin.accounts.remove_header'), remove_header_admin_account_path(account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:remove_header, account)
+    %td= table_link_to 'delete', t('admin.accounts.remove_header'), admin_account_header_path(account.id), method: :delete, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:remove_header, account)
     %td
 %tr
   %th= t('admin.accounts.role')

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -127,14 +127,17 @@ namespace :admin do
   resources :report_notes, only: [:create, :destroy]
 
   resources :accounts, only: [:index, :show, :destroy], concerns: :batch do
+    scope module: :accounts do
+      resource :header, only: :destroy
+      resource :avatar, only: :destroy
+    end
+
     member do
       post :enable
       post :unsensitive
       post :unsilence
       post :unsuspend
       post :redownload
-      post :remove_avatar
-      post :remove_header
       post :memorialize
       post :approve
       post :reject

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -215,21 +215,6 @@ RSpec.describe Admin::AccountsController do
     end
   end
 
-  describe 'POST #remove_avatar' do
-    subject { post :remove_avatar, params: { id: account.id } }
-
-    let(:current_user) { Fabricate(:user, role: role) }
-    let(:account) { Fabricate(:account) }
-
-    context 'when user is admin' do
-      let(:role) { UserRole.find_by(name: 'Admin') }
-
-      it 'succeeds in removing avatar' do
-        expect(subject).to redirect_to admin_account_path(account.id)
-      end
-    end
-  end
-
   describe 'POST #unblock_email' do
     subject { post :unblock_email, params: { id: account.id } }
 

--- a/spec/requests/admin/accounts/avatar_spec.rb
+++ b/spec/requests/admin/accounts/avatar_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Accounts Avatar' do
+  before { sign_in user }
+
+  describe 'DELETE #destroy' do
+    let(:user) { Fabricate(:user, role: role) }
+    let(:account) { Fabricate(:account, avatar: fixture_file_upload('avatar.gif', 'image/gif')) }
+
+    context 'when user is not admin' do
+      let(:role) { UserRole.everyone }
+
+      it 'fails to remove avatar' do
+        delete "/admin/accounts/#{account.id}/avatar"
+
+        expect(response)
+          .to have_http_status 403
+      end
+    end
+  end
+end

--- a/spec/requests/admin/accounts/header_spec.rb
+++ b/spec/requests/admin/accounts/header_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Accounts Header' do
+  before { sign_in user }
+
+  describe 'DELETE #destroy' do
+    let(:user) { Fabricate(:user, role: role) }
+    let(:account) { Fabricate(:account, header: fixture_file_upload('attachment.jpg', 'image/jpeg')) }
+
+    context 'when user is not admin' do
+      let(:role) { UserRole.everyone }
+
+      it 'fails to remove header' do
+        delete "/admin/accounts/#{account.id}/header"
+
+        expect(response)
+          .to have_http_status 403
+      end
+    end
+  end
+end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -96,38 +96,6 @@ RSpec.describe 'Admin Accounts' do
     end
   end
 
-  describe 'POST /admin/accounts/:id/remove_avatar' do
-    let(:account) { Fabricate(:account) }
-
-    context 'when user is not admin' do
-      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
-
-      it 'fails to remove avatar' do
-        expect { post remove_avatar_admin_account_path(id: account.id) }
-          .to_not change(Admin::ActionLog.where(action: 'remove_avatar'), :count)
-
-        expect(response)
-          .to have_http_status(403)
-      end
-    end
-  end
-
-  describe 'POST /admin/accounts/:id/remove_header' do
-    let(:account) { Fabricate(:account) }
-
-    context 'when user is not admin' do
-      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
-
-      it 'fails to remove header' do
-        expect { post remove_header_admin_account_path(id: account.id) }
-          .to_not change(Admin::ActionLog.where(action: 'remove_header'), :count)
-
-        expect(response)
-          .to have_http_status(403)
-      end
-    end
-  end
-
   describe 'POST /admin/accounts/:id/unblock_email' do
     let(:account) { Fabricate(:account, suspended: true) }
 

--- a/spec/system/admin/accounts/avatar_spec.rb
+++ b/spec/system/admin/accounts/avatar_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Accounts Avatar' do
+  before { sign_in user }
+
+  let(:user) { Fabricate(:admin_user) }
+
+  describe 'Deleting an account avatar' do
+    let(:account) { Fabricate(:account, avatar: fixture_file_upload('avatar.gif', 'image/gif')) }
+
+    it 'succeeds in removing avatar' do
+      visit admin_account_path(account.id)
+
+      expect { submit_delete }
+        .to change { account.reload.avatar_file_name }.to(be_blank)
+        .and change(Admin::ActionLog, :count).by(1)
+      expect(page)
+        .to have_content I18n.t('admin.accounts.removed_avatar_msg', username: account.acct)
+    end
+
+    def submit_delete
+      click_on I18n.t('admin.accounts.remove_avatar')
+    end
+  end
+end

--- a/spec/system/admin/accounts/header_spec.rb
+++ b/spec/system/admin/accounts/header_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Accounts Header' do
+  before { sign_in user }
+
+  let(:user) { Fabricate(:admin_user) }
+
+  describe 'Deleting an account header' do
+    let(:account) { Fabricate(:account, header: fixture_file_upload('attachment.jpg', 'image/jpeg')) }
+
+    it 'succeeds in removing header' do
+      visit admin_account_path(account.id)
+
+      expect { submit_delete }
+        .to change { account.reload.header_file_name }.to(be_blank)
+        .and change(Admin::ActionLog, :count).by(1)
+      expect(page)
+        .to have_content I18n.t('admin.accounts.removed_header_msg', username: account.acct)
+    end
+
+    def submit_delete
+      click_on I18n.t('admin.accounts.remove_header')
+    end
+  end
+end


### PR DESCRIPTION
Mixed changes/movitations:

- With https://github.com/mastodon/mastodon/pull/38367 merged and https://github.com/mastodon/mastodon/pull/38348 approved, this admin/accounts is the next-largest controller, and thus must be en-small-ified next
- Use more restful naming routes/conventions with move to `DELETE destroy` from `POST remove_*`
- Update specs to use request specs for permissions fail path, system specs to see the UI pages actually work

If we add another couple controllers like this at some point I'd add an admin/accounts/base controller and put the `set_account` before there.