### PR TITLE
Make sure collection exists before items are added

### DIFF
--- a/app/services/activitypub/process_featured_collection_service.rb
+++ b/app/services/activitypub/process_featured_collection_service.rb
@@ -17,19 +17,14 @@ class ActivityPub::ProcessFeaturedCollectionService
       Collection.transaction do
         @collection = @account.collections.find_or_initialize_by(uri: @json['id'])
 
-        @collection.update!(
-          local: false,
-          name: (@json['name'] || '')[0, Collection::NAME_LENGTH_HARD_LIMIT],
-          description_html: truncated_summary,
-          language:,
-          sensitive: @json['sensitive'],
-          discoverable: @json['discoverable'],
-          original_number_of_items: @json['totalItems'] || 0,
-          tag_name: @json.dig('topic', 'name')
-        )
+        @collection.update!(collection_attributes)
 
-        process_items!
+        @items = (@json['orderedItems'] || [])[0, ITEMS_LIMIT]
+        item_uris = @items.filter_map { |i| value_or_id(i) }
+        @collection.collection_items.where.not(uri: item_uris).delete_all
       end
+
+      process_items!
 
       @collection
     end
@@ -46,14 +41,22 @@ class ActivityPub::ProcessFeaturedCollectionService
     @json['summaryMap']&.keys&.first
   end
 
+  def collection_attributes
+    {
+      local: false,
+      name: (@json['name'] || '')[0, Collection::NAME_LENGTH_HARD_LIMIT],
+      description_html: truncated_summary,
+      language:,
+      sensitive: @json['sensitive'],
+      discoverable: @json['discoverable'],
+      original_number_of_items: @json['totalItems'] || 0,
+      tag_name: @json.dig('topic', 'name'),
+    }
+  end
+
   def process_items!
-    uris = []
-    items = @json['orderedItems'] || []
-    items.take(ITEMS_LIMIT).each_with_index do |item_json, index|
-      uris << value_or_id(item_json)
+    @items.each_with_index do |item_json, index|
       ActivityPub::ProcessFeaturedItemWorker.perform_async(@collection.id, item_json, index + 1, @request_id)
     end
-    uris.compact!
-    @collection.collection_items.where.not(uri: uris).delete_all
   end
 end


### PR DESCRIPTION
This pulls the queueing of item processing jobs out of the database transaction that creates the collection. Otherwise, sidekiq could process the job before postgres has fully committed the transaction in which case the item would be lost.