### PR TITLE
Update outer spacing of new profile page

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
@@ -130,7 +130,7 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
   position: sticky;
   bottom: var(--mobile-bottom-nav-height);
   padding: 12px 16px;
-  margin: 0 -20px;
+  margin: 0 -16px;
 
   @container (width >= #{$button-breakpoint}) {
     display: none;
@@ -393,7 +393,7 @@ svg.badgeIcon {
   padding: 0 24px;
 
   @container (width < 500px) {
-    padding: 0 12px;
+    padding: 0 16px;
 
     a {
       flex: 1 1 0px;

--- a/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
@@ -9,6 +9,11 @@
 
 .barWrapper {
   border-bottom: none;
+  padding-inline: 24px;
+
+  @container (width < 500px) {
+    padding-inline: 16px;
+  }
 }
 
 .avatarWrapper {


### PR DESCRIPTION
### Changes proposed in this PR:
- Matches the outer horizontal spacing of the new profile page to the specs, aligning elements to a consistent left edge

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="612" height="707" alt="image" src="https://github.com/user-attachments/assets/b6d3abc6-e40a-4212-89f6-bb06c817258b" /> | <img width="618" height="711" alt="image" src="https://github.com/user-attachments/assets/0b9c340a-759a-4224-888a-2f2d7786dabf" /> |
| <img width="357" height="739" alt="image" src="https://github.com/user-attachments/assets/d00b26c4-85a7-4feb-aaaf-a14eed8e1bdc" /> | <img width="372" height="719" alt="image" src="https://github.com/user-attachments/assets/eaec5c07-894f-42ea-98d8-ab2d201f064d" /> |