### PR TITLE
Add `Mastodon::URI_PARSE_ERRORS` group for shared rescue

### DIFF
--- a/app/lib/delivery_failure_tracker.rb
+++ b/app/lib/delivery_failure_tracker.rb
@@ -56,7 +56,7 @@ class DeliveryFailureTracker
       urls.reject do |url|
         host = Addressable::URI.parse(url).normalized_host
         unavailable_domains_map[host]
-      rescue Addressable::URI::InvalidURIError, IDN::Idna::IdnaError
+      rescue *Mastodon::URI_PARSE_ERRORS
         true
       end
     end

--- a/app/lib/tag_manager.rb
+++ b/app/lib/tag_manager.rb
@@ -29,7 +29,7 @@ class TagManager
     domain = uri.host + (uri.port ? ":#{uri.port}" : '')
 
     TagManager.instance.web_domain?(domain)
-  rescue Addressable::URI::InvalidURIError, IDN::Idna::IdnaError
+  rescue *Mastodon::URI_PARSE_ERRORS
     false
   end
 end

--- a/app/lib/text_formatter.rb
+++ b/app/lib/text_formatter.rb
@@ -73,7 +73,7 @@ class TextFormatter
           tag.span(display_url, class: (cutoff ? 'ellipsis' : '')) +
           tag.span(suffix, class: 'invisible')
       end
-    rescue Addressable::URI::InvalidURIError, IDN::Idna::IdnaError
+    rescue *Mastodon::URI_PARSE_ERRORS
       h(url)
     end
   end

--- a/app/models/account/field.rb
+++ b/app/models/account/field.rb
@@ -46,7 +46,7 @@ class Account::Field < ActiveModelSerializers::Model
       parsed_url.host.present? &&
       parsed_url.normalized_host == parsed_url.host &&
       (parsed_url.path.empty? || parsed_url.path == parsed_url.normalized_path)
-  rescue Addressable::URI::InvalidURIError, IDN::Idna::IdnaError
+  rescue *Mastodon::URI_PARSE_ERRORS
     false
   end
 

--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -73,7 +73,7 @@ class DomainBlock < ApplicationRecord
       variants = segments.map.with_index { |_, i| segments[i..].join('.') }
 
       where(domain: variants).by_domain_length.first
-    rescue Addressable::URI::InvalidURIError, IDN::Idna::IdnaError
+    rescue *Mastodon::URI_PARSE_ERRORS
       nil
     end
   end

--- a/app/models/email_domain_block.rb
+++ b/app/models/email_domain_block.rb
@@ -82,7 +82,7 @@ class EmailDomainBlock < ApplicationRecord
                  end
 
         Addressable::URI.new.tap { |u| u.host = domain.strip } if domain.present?
-      rescue Addressable::URI::InvalidURIError, IDN::Idna::IdnaError
+      rescue *Mastodon::URI_PARSE_ERRORS
         nil
       end
     end

--- a/app/validators/domain_validator.rb
+++ b/app/validators/domain_validator.rb
@@ -27,7 +27,7 @@ class DomainValidator < ActiveModel::EachValidator
     uri = Addressable::URI.new
     uri.host = value
     uri.normalized_host.size < MAX_DOMAIN_LENGTH && uri.normalized_host.split('.').all? { |label| label.size.between?(MIN_LABEL_LENGTH, MAX_LABEL_LENGTH) && label =~ ALLOWED_CHARACTERS_RE }
-  rescue Addressable::URI::InvalidURIError, IDN::Idna::IdnaError
+  rescue *Mastodon::URI_PARSE_ERRORS
     false
   end
 end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -39,6 +39,11 @@ module Mastodon
     end
   end
 
+  URI_PARSE_ERRORS = [
+    Addressable::URI::InvalidURIError,
+    IDN::Idna::IdnaError,
+  ].freeze
+
   HTTP_CONNECTION_ERRORS = [
     HTTP::ConnectionError,
     HTTP::Error,


### PR DESCRIPTION
Suggestion from https://github.com/mastodon/mastodon/pull/35770

As noted there, every single spot which rescues the `IDN` error also rescues the `Addressable` one - but not the other way around. I suspect some of them maybe SHOULD (basically any addressabe parse could throw this?), could review that as followup.