### PR TITLE
Let test pass with different Account::DEFAULT_FIELDS_SIZE

### DIFF
--- a/spec/models/account/fields_spec.rb
+++ b/spec/models/account/fields_spec.rb
@@ -174,10 +174,10 @@ RSpec.describe Account, '#fields' do
         expect(account.attributes['fields'])
           .to be_an(Array)
           .and contain_exactly(
-            include('name' => /Name/),
-            include('name' => /Name/),
-            include('name' => ''),
-            include('name' => '')
+            *(
+              ([include('name' => /Name/)] * 2) +
+              ([include('name' => '')] * (Account::DEFAULT_FIELDS_SIZE - 2))
+            )
           )
       end
     end


### PR DESCRIPTION
The example:
  Account#fields #build_fields when fields partially full returns nil without updating fields
now passes with Account::DEFAULT_FIELDS_SIZE 3 or higher.