### PR TITLE
Fix styling regressions: familiar followers layout & alert action hover color

### DIFF
--- a/app/javascript/mastodon/components/edited_timestamp/index.tsx
+++ b/app/javascript/mastodon/components/edited_timestamp/index.tsx
@@ -121,6 +121,7 @@ export const EditedTimestamp: React.FC<{
               />
             ),
           }}
+          tagName='span'
         />
       </button>
     </Dropdown>

--- a/app/javascript/mastodon/features/account_timeline/components/familiar_followers.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/familiar_followers.tsx
@@ -69,7 +69,9 @@ export const FamiliarFollowers: React.FC<{ accountId: string }> = ({
           <Avatar withLink key={account.id} account={account} size={28} />
         ))}
       </AvatarGroup>
-      <FamiliarFollowersReadout familiarFollowers={familiarFollowers} />
+      <span>
+        <FamiliarFollowersReadout familiarFollowers={familiarFollowers} />
+      </span>
     </div>
   );
 };

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10400,9 +10400,13 @@ noscript {
   padding: 0 4px;
 
   &:hover,
-  &:focus,
   &:active {
-    background: var(--color-bg-brand-softest);
+    background: rgb(from var(--color-text-inverted) r g b / 10%);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-text-brand-on-inverted);
+    outline-offset: 2px;
   }
 }
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes broken layouts of "Familiar followers" widget and the "Last edited" timestamp (a regression from #38398)
- Fixes hover color of alert action (a regression from #38387)

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="584" height="128" alt="image" src="https://github.com/user-attachments/assets/a0b8ca39-e145-483b-a70f-e867dde2b3c4" /> | <img width="591" height="127" alt="image" src="https://github.com/user-attachments/assets/038771e3-d1db-4594-ad37-ea203630b62d" /> |
| <img width="264" height="106" alt="image" src="https://github.com/user-attachments/assets/887067ea-758d-4ad8-af8f-79238405e54c" /> | <img width="271" height="103" alt="image" src="https://github.com/user-attachments/assets/9b488903-eee0-4ad9-8a52-c82e8c4433af" /> |
| <img width="210" height="92" alt="image" src="https://github.com/user-attachments/assets/9e8fb55d-99e5-404b-a2bb-86128cd5fb89" /> | <img width="221" height="101" alt="image" src="https://github.com/user-attachments/assets/47ec05bb-d275-4a07-a678-d1776c1672ab" /> |
| <img width="211" height="97" alt="image" src="https://github.com/user-attachments/assets/01a67f3a-5977-4e61-9128-d5fcae571f28" /> | <img width="213" height="96" alt="image" src="https://github.com/user-attachments/assets/8542b8ae-bc7c-457c-be34-526d13b37bdd" /> |