### PR TITLE
Clean up some route declarations

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,7 +200,7 @@ Rails.application.routes.draw do
   resources :emojis, only: [:show]
   resources :invites, only: [:index, :create, :destroy]
   resources :filters, except: [:show] do
-    resources :statuses, only: [:index], controller: 'filters/statuses' do
+    resources :statuses, only: [:index], module: :filters do
       collection do
         post :batch
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,7 +219,9 @@ Rails.application.routes.draw do
   resource :statuses_cleanup, controller: :statuses_cleanup, only: [:show, :update]
 
   get '/media_proxy/:id/(*any)', to: 'media_proxy#show', as: :media_proxy, format: false
-  get '/backups/:id/download', to: 'backups#download', as: :download_backup, format: false
+  resources :backups, only: [] do
+    member { get :download, format: false }
+  end
 
   resource :authorize_interaction, only: [:show]
   resource :share, only: [:show]

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -114,7 +114,7 @@ namespace :admin do
   end
 
   resources :reports, only: [:index, :show] do
-    resources :actions, only: [:create], controller: 'reports/actions' do
+    resources :actions, only: [:create], module: :reports do
       collection do
         post :preview
       end

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -92,7 +92,7 @@ namespace :admin do
       post :stop_delivery
     end
 
-    resources :moderation_notes, controller: 'instances/moderation_notes', only: [:create, :destroy]
+    resources :moderation_notes, module: :instances, only: [:create, :destroy]
   end
 
   resources :rules, only: [:index, :new, :create, :edit, :update, :destroy] do

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -108,7 +108,7 @@ namespace :admin do
       post :disable
     end
 
-    resource :secret, only: [], controller: 'webhooks/secrets' do
+    resource :secret, only: [], module: :webhooks do
       post :rotate
     end
   end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -258,7 +258,7 @@ namespace :api, format: false do
     end
 
     namespace :featured_tags do
-      get :suggestions, to: 'suggestions#index'
+      resources :suggestions, only: :index
     end
 
     resources :featured_tags, only: [:index, :create, :destroy]

--- a/config/routes/settings.rb
+++ b/config/routes/settings.rb
@@ -9,7 +9,7 @@ namespace :settings do
 
   namespace :preferences do
     resource :appearance, only: [:show, :update], controller: :appearance
-    resource :posting_defaults, only: [:show, :update], controller: :posting_defaults
+    resource :posting_defaults, only: [:show, :update]
     resource :notifications, only: [:show, :update]
     resource :other, only: [:show, :update], controller: :other
   end


### PR DESCRIPTION
Noticed while doing https://github.com/mastodon/mastodon/pull/38416

Changes here:

- In a few spots, allow controller name to be inferred from resource declaration
- Use `member` for backup download

These are basically all slightly terser/compact forms. Running `bin/rails routes | shasum` is the same before/after.

Sort of related -- in some earlier version of rails I think `resource` used to go to the singularized controller name, and that changed at some point. As a result we have to specify a few controller names in the settings/prefs and admin/settings areas which used to be inferred but now are not. If we ever exhausted all other fun and games, these controllers could be renamed which would be satisfying to everyone involved when those options could be removed.