### PR TITLE
Profile editing: Minor size fixes

### DIFF
--- a/app/javascript/mastodon/features/account_edit/styles.module.scss
+++ b/app/javascript/mastodon/features/account_edit/styles.module.scss
@@ -13,7 +13,6 @@
 
   > img {
     object-fit: cover;
-    object-position: top center;
     width: 100%;
     height: 100%;
   }
@@ -26,7 +25,7 @@
 
 .avatar {
   margin-top: -64px;
-  margin-left: 18px;
+  margin-left: 22px;
   position: relative;
   width: 82px;
 
@@ -251,7 +250,7 @@
 // Section component
 
 .section {
-  padding: 20px;
+  padding: 24px;
   border-bottom: 1px solid var(--color-border-primary);
   font-size: 15px;
 }


### PR DESCRIPTION
Fixes #38433.

Tweaks the padding between viewing and editing of profiles to be more consistently 24px, adjusts the offset of the avatar, and ensures the image offset for the header is consistent.