### PR TITLE
Add `Marker.record` to update last read

### DIFF
--- a/app/controllers/api/v1/markers_controller.rb
+++ b/app/controllers/api/v1/markers_controller.rb
@@ -15,14 +15,7 @@ class Api::V1::MarkersController < Api::BaseController
   end
 
   def create
-    Marker.transaction do
-      @markers = {}
-
-      resource_params.each_pair do |timeline, timeline_params|
-        @markers[timeline] = current_user.markers.find_or_create_by(timeline: timeline)
-        @markers[timeline].update!(timeline_params)
-      end
-    end
+    @markers = Marker.record(current_user, resource_params)
 
     render json: serialize_map(@markers)
   rescue ActiveRecord::StaleObjectError

--- a/app/models/marker.rb
+++ b/app/models/marker.rb
@@ -20,4 +20,15 @@ class Marker < ApplicationRecord
 
   validates :timeline, :last_read_id, presence: true
   validates :timeline, inclusion: { in: TIMELINES }
+
+  def self.record(user, pairs)
+    {}.tap do |markers|
+      transaction do
+        pairs.each_pair do |timeline, params|
+          markers[timeline] = user.markers.find_or_create_by(timeline:)
+          markers[timeline].update!(params)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/marker_spec.rb
+++ b/spec/models/marker_spec.rb
@@ -3,7 +3,36 @@
 require 'rails_helper'
 
 RSpec.describe Marker do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:user) }
+  end
+
   describe 'Validations' do
+    it { is_expected.to validate_presence_of(:timeline) }
     it { is_expected.to validate_inclusion_of(:timeline).in_array(described_class::TIMELINES) }
+  end
+
+  describe '.record' do
+    subject { described_class.record(user, args) }
+
+    let(:user) { Fabricate :user }
+    let(:args) { { home: { last_read_id: '123456' } } }
+
+    context 'with a user that does not have markers' do
+      it 'creates markers for the user' do
+        expect { expect(subject).to include(home: be_a(described_class)) }
+          .to change { user.markers.count }.by(1)
+      end
+    end
+
+    context 'with a user that has markers' do
+      before { Fabricate :marker, timeline: 'home', last_read_id: 999, user: }
+
+      it 'updates markers for the user' do
+        expect { expect(subject).to include(home: be_a(described_class)) }
+          .to not_change { user.markers.count }
+          .and(change { user.markers.first.last_read_id })
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/markers_spec.rb
+++ b/spec/requests/api/v1/markers_spec.rb
@@ -34,31 +34,54 @@ RSpec.describe 'API Markers' do
 
   describe 'POST /api/v1/markers' do
     context 'when no marker exists' do
-      before do
-        post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '69420' } }
-      end
+      subject { post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '69420' } } }
 
       it 'creates a marker', :aggregate_failures do
-        expect(response).to have_http_status(200)
-        expect(response.content_type)
-          .to start_with('application/json')
-        expect(user.markers.first.timeline).to eq 'home'
-        expect(user.markers.first.last_read_id).to eq 69_420
+        expect { subject }
+          .to change { user.markers.count }.by(1)
+        expect(response)
+          .to have_http_status(200)
+        expect(response.media_type)
+          .to eq('application/json')
+        expect(user.markers.first)
+          .to have_attributes(timeline: 'home', last_read_id: 69_420)
+      end
+    end
+
+    context 'with multiple timelines' do
+      subject { post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '69420' }, notifications: { last_read_id: '89345' } } }
+
+      it 'creates a marker', :aggregate_failures do
+        expect { subject }
+          .to change { user.markers.count }.by(2)
+        expect(response)
+          .to have_http_status(200)
+        expect(response.media_type)
+          .to eq('application/json')
+        expect(user.markers.first)
+          .to have_attributes(timeline: 'home', last_read_id: 69_420)
+        expect(user.markers.last)
+          .to have_attributes(timeline: 'notifications', last_read_id: 89_345)
       end
     end
 
     context 'when a marker exists' do
+      subject { post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '70120' } } }
+
       before do
         post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '69420' } }
-        post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '70120' } }
       end
 
       it 'updates a marker', :aggregate_failures do
-        expect(response).to have_http_status(200)
-        expect(response.content_type)
-          .to start_with('application/json')
-        expect(user.markers.first.timeline).to eq 'home'
-        expect(user.markers.first.last_read_id).to eq 70_120
+        expect { subject }
+          .to_not(change { user.markers.count })
+
+        expect(response)
+          .to have_http_status(200)
+        expect(response.media_type)
+          .to eq('application/json')
+        expect(user.markers.first)
+          .to have_attributes(timeline: 'home', last_read_id: 70_120)
       end
     end
 
@@ -71,8 +94,8 @@ RSpec.describe 'API Markers' do
       it 'returns error json' do
         expect(response)
           .to have_http_status(409)
-        expect(response.content_type)
-          .to start_with('application/json')
+        expect(response.media_type)
+          .to eq('application/json')
         expect(response.parsed_body)
           .to include(error: /Conflict during update/)
       end


### PR DESCRIPTION
Noticed this while doing the `to_json` stuff for markers in https://github.com/mastodon/mastodon/pull/38206

At first I thought this could be an upsert, but because we are using the serializer for both index and create here, we need to return `Marker` instances which upsert does not do. I guess this at MOST two queries (?) so maybe thats ok.

- Add method which wraps the transaction and returns hash of "timeline => Marker", nudging complexity into model
- Expand existing coverage a bit for API and model