### PR TITLE
Extract admin unblock email endpoint to stand-alone

### DIFF
--- a/app/controllers/admin/accounts/email_blocks_controller.rb
+++ b/app/controllers/admin/accounts/email_blocks_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Admin
+  class Accounts::EmailBlocksController < BaseController
+    before_action :set_account
+
+    def destroy
+      authorize @account, :unblock_email?
+
+      CanonicalEmailBlock.where(reference_account: @account).delete_all
+
+      log_action :unblock_email, @account
+
+      redirect_to admin_account_path(@account.id), notice: I18n.t('admin.accounts.unblocked_email_msg', username: @account.acct)
+    end
+
+    private
+
+    def set_account
+      @account = Account.find(params[:account_id])
+    end
+  end
+end

--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -128,16 +128,6 @@ module Admin
       redirect_to admin_account_path(@account.id), notice: I18n.t('admin.accounts.removed_header_msg', username: @account.acct)
     end
 
-    def unblock_email
-      authorize @account, :unblock_email?
-
-      CanonicalEmailBlock.where(reference_account: @account).delete_all
-
-      log_action :unblock_email, @account
-
-      redirect_to admin_account_path(@account.id), notice: I18n.t('admin.accounts.unblocked_email_msg', username: @account.acct)
-    end
-
     private
 
     def set_account

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -22,7 +22,7 @@
 = render 'admin/accounts/counters', account: @account
 
 - if @account.local? && @account.user.nil?
-  = link_to t('admin.accounts.unblock_email'), unblock_email_admin_account_path(@account.id), method: :post, class: 'button' if can?(:unblock_email, @account) && CanonicalEmailBlock.exists?(reference_account_id: @account.id)
+  = link_to t('admin.accounts.unblock_email'), admin_account_email_blocks_path(@account.id), method: :delete, class: 'button' if can?(:unblock_email, @account) && CanonicalEmailBlock.exists?(reference_account_id: @account.id)
 - else
   .table-wrapper
     %table.table.inline-table

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -127,6 +127,10 @@ namespace :admin do
   resources :report_notes, only: [:create, :destroy]
 
   resources :accounts, only: [:index, :show, :destroy], concerns: :batch do
+    scope module: :accounts do
+      resource :email_blocks, only: :destroy
+    end
+
     member do
       post :enable
       post :unsensitive
@@ -138,7 +142,6 @@ namespace :admin do
       post :memorialize
       post :approve
       post :reject
-      post :unblock_email
     end
 
     resource :change_email, only: [:show, :update]

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -230,27 +230,6 @@ RSpec.describe Admin::AccountsController do
     end
   end
 
-  describe 'POST #unblock_email' do
-    subject { post :unblock_email, params: { id: account.id } }
-
-    let(:current_user) { Fabricate(:user, role: role) }
-    let(:account) { Fabricate(:account, suspended: true) }
-
-    before do
-      _email_block = Fabricate(:canonical_email_block, reference_account: account)
-    end
-
-    context 'when user is admin' do
-      let(:role) { UserRole.find_by(name: 'Admin') }
-
-      it 'succeeds in removing email blocks and redirects to admin account path' do
-        expect { subject }.to change { CanonicalEmailBlock.where(reference_account: account).count }.from(1).to(0)
-
-        expect(response).to redirect_to admin_account_path(account.id)
-      end
-    end
-  end
-
   describe 'POST #unsensitive' do
     subject { post :unsensitive, params: { id: account.id } }
 

--- a/spec/requests/admin/accounts/email_blocks_spec.rb
+++ b/spec/requests/admin/accounts/email_blocks_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Accounts Email Blocks' do
+  describe 'DELETE /admin/accounts/:account_id/email_blocks' do
+    let(:account) { Fabricate(:account, suspended: true) }
+
+    before { Fabricate(:canonical_email_block, reference_account: account) }
+
+    context 'when user is not admin' do
+      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
+
+      it 'fails to unblock email' do
+        expect { delete admin_account_email_blocks_path(account_id: account.id) }
+          .to_not change(CanonicalEmailBlock.where(reference_account: account), :count)
+
+        expect(response)
+          .to have_http_status(403)
+      end
+    end
+  end
+end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -128,24 +128,6 @@ RSpec.describe 'Admin Accounts' do
     end
   end
 
-  describe 'POST /admin/accounts/:id/unblock_email' do
-    let(:account) { Fabricate(:account, suspended: true) }
-
-    before { Fabricate(:canonical_email_block, reference_account: account) }
-
-    context 'when user is not admin' do
-      let(:current_user) { Fabricate(:user, role: UserRole.everyone) }
-
-      it 'fails to unblock email' do
-        expect { post unblock_email_admin_account_path(id: account.id) }
-          .to_not change(CanonicalEmailBlock.where(reference_account: account), :count)
-
-        expect(response)
-          .to have_http_status(403)
-      end
-    end
-  end
-
   describe 'POST /admin/accounts/:id/unsensitive' do
     let(:account) { Fabricate(:account, sensitized_at: 1.year.ago) }
 

--- a/spec/system/admin/accounts/email_blocks_spec.rb
+++ b/spec/system/admin/accounts/email_blocks_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Accounts Email Blocks' do
+  before { sign_in user }
+
+  let(:user) { Fabricate(:admin_user) }
+
+  describe 'Deleting email blocks for an account' do
+    let(:account) { Fabricate(:account, user: nil) }
+
+    before { Fabricate :canonical_email_block, reference_account: account }
+
+    it 'succeeds in removing header' do
+      visit admin_account_path(account.id)
+
+      expect { submit_unblock }
+        .to change(CanonicalEmailBlock.where(reference_account: account), :count).by(-1)
+      expect(page)
+        .to have_content I18n.t('admin.accounts.unblocked_email_msg', username: account.acct)
+    end
+
+    def submit_unblock
+      click_on I18n.t('admin.accounts.unblock_email')
+    end
+  end
+end


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/38421

Each of these will probably conflict with the other. Will rebase/update the other if either merges, and then (as mentioned in other one) probably extract a base class here for the before action.