### PR TITLE
Use `normalizes` for custom emoji shortcode value

### DIFF
--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -45,6 +45,7 @@ class CustomEmoji < ApplicationRecord
   has_attached_file :image, styles: { static: { format: 'png', convert_options: '-coalesce +profile "!icc,*" +set date:modify +set date:create +set date:timestamp', file_geometry_parser: FastGeometryParser } }, validate_media_type: false, processors: [:lazy_thumbnail]
 
   normalizes :domain, with: ->(domain) { domain.downcase.strip }
+  normalizes :shortcode, with: ->(value) { value.strip }
 
   validates_attachment :image, content_type: { content_type: IMAGE_MIME_TYPES }, presence: true, size: { less_than: LIMIT }
   validates :shortcode, uniqueness: { scope: :domain }, format: { with: SHORTCODE_ONLY_RE }, length: { minimum: MINIMUM_SHORTCODE_SIZE, maximum: MAX_FEDERATED_SHORTCODE_SIZE }
@@ -95,6 +96,7 @@ class CustomEmoji < ApplicationRecord
     end
 
     def search(shortcode)
+      shortcode = normalize_value_for(:shortcode, shortcode)
       where(arel_table[:shortcode].matches("%#{sanitize_sql_like(shortcode)}%"))
     end
   end

--- a/app/models/custom_emoji_filter.rb
+++ b/app/models/custom_emoji_filter.rb
@@ -39,7 +39,7 @@ class CustomEmojiFilter
     when 'by_domain'
       CustomEmoji.where(domain: value)
     when 'shortcode'
-      CustomEmoji.search(value.strip)
+      CustomEmoji.search(value)
     else
       raise Mastodon::InvalidParameterError, "Unknown filter: #{key}"
     end

--- a/spec/models/custom_emoji_spec.rb
+++ b/spec/models/custom_emoji_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe CustomEmoji, :attachment_processing do
       end
     end
 
+    context 'when search term is not normalized' do
+      let(:shortcode) { 'blobpats' }
+      let(:search_term) { '  blobpats  ' }
+
+      it { is_expected.to include(custom_emoji) }
+    end
+
     context 'when shortcode is partial' do
       let(:shortcode) { 'blobpats' }
       let(:search_term) { 'blob' }
@@ -83,6 +90,8 @@ RSpec.describe CustomEmoji, :attachment_processing do
       it { is_expected.to normalize(:domain).from('  www.mastodon.host   ').to('www.mastodon.host') }
       it { is_expected.to normalize(:domain).from('wWw.MaStOdOn.CoM').to('www.mastodon.com') }
       it { is_expected.to normalize(:domain).from(nil).to(nil) }
+
+      it { is_expected.to normalize(:shortcode).from('  test   ').to('test') }
     end
   end
 


### PR DESCRIPTION
Similar to this https://github.com/mastodon/mastodon/pull/38405 which did something similar for `Tag.search_for` ... update specs around handling padding/strip/normalize