### PR TITLE
Profile redesign: Add Intl.Segmenter fallback

### DIFF
--- a/app/javascript/mastodon/components/character_counter/index.tsx
+++ b/app/javascript/mastodon/components/character_counter/index.tsx
@@ -1,8 +1,8 @@
-import { useMemo } from 'react';
-
 import { FormattedMessage } from 'react-intl';
 
 import classNames from 'classnames';
+
+import { length } from 'stringz';
 
 import { polymorphicForwardRef } from '@/types/polymorphic';
 
@@ -13,9 +13,6 @@ interface CharacterCounterProps {
   maxLength: number;
   recommended?: boolean;
 }
-
-const segmenter =
-  typeof Intl.Segmenter === 'function' ? new Intl.Segmenter() : null;
 
 export const CharacterCounter = polymorphicForwardRef<
   'span',
@@ -32,12 +29,7 @@ export const CharacterCounter = polymorphicForwardRef<
     },
     ref,
   ) => {
-    const currentLength = useMemo(() => {
-      if (!segmenter) {
-        return currentString.length;
-      }
-      return [...segmenter.segment(currentString)].length;
-    }, [currentString]);
+    const currentLength = length(currentString);
     return (
       <Component
         {...props}

--- a/app/javascript/mastodon/components/character_counter/index.tsx
+++ b/app/javascript/mastodon/components/character_counter/index.tsx
@@ -14,7 +14,8 @@ interface CharacterCounterProps {
   recommended?: boolean;
 }
 
-const segmenter = new Intl.Segmenter();
+const segmenter =
+  typeof Intl.Segmenter === 'function' ? new Intl.Segmenter() : null;
 
 export const CharacterCounter = polymorphicForwardRef<
   'span',
@@ -31,10 +32,12 @@ export const CharacterCounter = polymorphicForwardRef<
     },
     ref,
   ) => {
-    const currentLength = useMemo(
-      () => [...segmenter.segment(currentString)].length,
-      [currentString],
-    );
+    const currentLength = useMemo(() => {
+      if (!segmenter) {
+        return currentString.length;
+      }
+      return [...segmenter.segment(currentString)].length;
+    }, [currentString]);
     return (
       <Component
         {...props}


### PR DESCRIPTION
From bug report here: https://mastodon.social/@meganmariehart/116297509031683310

The issue traces back to Intl.Segmenter as the user is using Firefox 115 from 2023. This replaces Intl.Segmenter with the already installed stringz library, but in the future we'll want to replace this with something else.