### PR TITLE
Add error notice when bundle load fails

### DIFF
--- a/app/javascript/mastodon/features/ui/components/bundle.jsx
+++ b/app/javascript/mastodon/features/ui/components/bundle.jsx
@@ -69,6 +69,7 @@ class Bundle extends PureComponent {
         this.setState({ mod: mod.default });
       })
       .catch((error) => {
+        console.error('Bundle fetching error:', error);
         this.setState({ mod: null });
       });
   };


### PR DESCRIPTION
When there's an error inside a component loaded by the Bundle component, the network error page shows but the error message is not displayed. This can be very confusing, as errors can be parsing errors and not just network issues!