### PR TITLE
Improve contrast for `text-warning` and `text-success` tokens

### DIFF
--- a/app/javascript/styles/mastodon/theme/_dark.scss
+++ b/app/javascript/styles/mastodon/theme/_dark.scss
@@ -18,9 +18,9 @@
   --color-text-brand-on-inverted: var(--color-indigo-600); // legacy
   --color-text-error: var(--color-red-300);
   --color-text-on-error-base: var(--color-white);
-  --color-text-warning: var(--color-yellow-400); // legacy
+  --color-text-warning: var(--color-yellow-400);
   --color-text-on-warning-base: var(--color-white);
-  --color-text-success: var(--color-green-400); // legacy
+  --color-text-success: var(--color-green-400);
   --color-text-on-success-base: var(--color-white);
   --color-text-disabled: var(--color-grey-600); // legacy
   --color-text-on-disabled: var(--color-grey-400); // legacy

--- a/app/javascript/styles/mastodon/theme/_light.scss
+++ b/app/javascript/styles/mastodon/theme/_light.scss
@@ -18,9 +18,9 @@
   --color-text-brand-on-inverted: var(--color-indigo-400); // legacy
   --color-text-error: var(--color-red-800);
   --color-text-on-error-base: var(--color-white);
-  --color-text-warning: var(--color-yellow-600); // legacy
+  --color-text-warning: var(--color-yellow-700);
   --color-text-on-warning-base: var(--color-white);
-  --color-text-success: var(--color-green-600); // legacy
+  --color-text-success: var(--color-green-700);
   --color-text-on-success-base: var(--color-white);
   --color-text-disabled: var(--color-grey-300); // legacy
   --color-text-on-disabled: var(--color-grey-200); // legacy


### PR DESCRIPTION
Related to WEB-932

### Changes proposed in this PR:
- Improves contrast for our `text-warning` and `text-success` tokens and removes their "legacy" status, as they're being added to our core design system tokens
