### PR TITLE
Add counting convenience methods on `BulkImport`

### DIFF
--- a/app/services/bulk_import_service.rb
+++ b/app/services/bulk_import_service.rb
@@ -20,7 +20,7 @@ class BulkImportService < BaseService
       import_lists!
     end
 
-    @import.update!(state: :finished, finished_at: Time.now.utc) if @import.processed_items == @import.total_items
+    @import.update!(state: :finished, finished_at: Time.now.utc) if @import.processing_complete?
   rescue
     @import.update!(state: :finished, finished_at: Time.now.utc)
 

--- a/app/views/settings/imports/index.html.haml
+++ b/app/views/settings/imports/index.html.haml
@@ -60,9 +60,6 @@
                 = l(import.created_at)
 
             %td
-              - num_failed = import.processed_items - import.imported_items
-              - if num_failed.positive?
-                - if import.state_finished?
-                  = link_to num_failed, failures_settings_import_path(import, format: 'csv')
-                - else
-                  = num_failed
+              - if import.failure_count.positive?
+                = link_to_if import.state_finished?, import.failure_count, failures_settings_import_path(import, format: :csv) do
+                  = import.failure_count

--- a/spec/models/bulk_import_spec.rb
+++ b/spec/models/bulk_import_spec.rb
@@ -39,4 +39,28 @@ RSpec.describe BulkImport do
       end
     end
   end
+
+  describe '#failure_count' do
+    subject { described_class.new(processed_items: 100, imported_items: 90).failure_count }
+
+    it { is_expected.to eq(10) }
+  end
+
+  describe '#processing_complete?' do
+    subject { Fabricate.build :bulk_import, processed_items:, total_items: }
+
+    context 'when processed and total are the same' do
+      let(:processed_items) { 100 }
+      let(:total_items) { 100 }
+
+      it { is_expected.to be_processing_complete }
+    end
+
+    context 'when processed and total are not the same' do
+      let(:processed_items) { 100 }
+      let(:total_items) { 200 }
+
+      it { is_expected.to_not be_processing_complete }
+    end
+  end
 end


### PR DESCRIPTION
Avoid reaching into the model from views and other services. Changes here:

- Roll up the repeated "does processed equal total" comparison into a query method
- Move failure count out of inline ruby in view template and into model method as well
