### PR TITLE
Fix profile field text overflow in field modal

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/modals/field_modal.tsx
+++ b/app/javascript/mastodon/features/account_timeline/modals/field_modal.tsx
@@ -28,6 +28,7 @@ export const AccountFieldModal: FC<{
           as='h2'
           htmlString={field.name_emojified}
           onElement={handleLabelElement}
+          className={classes.fieldName}
         />
         <EmojiHTML
           as='p'

--- a/app/javascript/mastodon/features/account_timeline/modals/styles.module.css
+++ b/app/javascript/mastodon/features/account_timeline/modals/styles.module.css
@@ -20,8 +20,15 @@
   outline-offset: 2px;
 }
 
+.fieldName {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
 .fieldValue {
   color: var(--color-text-primary);
   font-weight: 600;
   margin-top: 4px;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }


### PR DESCRIPTION
## Summary

Profile fields with long continuous strings (e.g. 255 characters without spaces) overflow horizontally in the field modal when 'Show full content' is clicked. The text wraps on word boundaries but not on character boundaries, so unbroken strings escape the modal container.

## Changes

- Added \overflow-wrap: break-word\ and \word-break: break-word\ to \.fieldValue\ in the field modal stylesheet so long continuous values wrap correctly
- Added a \.fieldName\ class with the same properties and applied it to the \h2\ heading element so the field name also wraps

## Steps to reproduce (before fix)

1. Set a profile field name and value to a 255-character string with no spaces
2. View a profile page and click the '...' overflow button on the field
3. Notice the modal text overflows horizontally

Fixes #38469