### PR TITLE
Fix username prefix search not finding results in full-text search

### DIFF
--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -131,11 +131,10 @@ class AccountSearchService < BaseService
         dis_max: {
           queries: [
             {
-              match: {
-                username: {
-                  query: @query,
-                  analyzer: 'word_join_analyzer',
-                },
+              multi_match: {
+                query: @query,
+                type: 'most_fields',
+                fields: %w(username username.*),
               },
             },
 
@@ -145,6 +144,14 @@ class AccountSearchService < BaseService
                   query: @query,
                   analyzer: 'word_join_analyzer',
                 },
+              },
+            },
+
+            {
+              multi_match: {
+                query: @query,
+                type: 'most_fields',
+                fields: %w(display_name display_name.*),
               },
             },
 


### PR DESCRIPTION
## Summary

When using the main search bar to search for the beginning of a username (e.g. searching @BestThings to find @BestThingsBot), no results are returned even though the user exists. This only affects instances using Elasticsearch/OpenSearch.

## Root cause

AccountSearchService has two query builders for Elasticsearch:
- AutocompleteQueryBuilder — used for the @mention autocomplete in the compose box
- FullQueryBuilder — used for the main search UI (passed use_searchable_text: true by SearchService)

AutocompleteQueryBuilder correctly queries username.*, which includes the username.edge_ngram subfield, enabling prefix matching. FullQueryBuilder only queried the base username field with word_join_analyzer, which does not perform prefix matching — so estthings would never match the indexed token estthingsbot.

## Changes

In FullQueryBuilder#core_query:

- Replace the match { username: { analyzer: word_join_analyzer } } with a multi_match on username username.*, which includes the edge_ngram subfield and enables prefix matching  
- Keep the word_join_analyzer match for display_name (necessary for joining multi-word display names)
- Add a multi_match on display_name display_name.* alongside it for display name prefix matching

## Steps to reproduce (before fix)

1. Set up a Mastodon instance with Elasticsearch enabled
2. Create an account @BestThingsBot
3. In the main search bar, search for @BestThings
4. Observe: no results returned

After this fix, step 4 returns @BestThingsBot in the results.

Fixes #38439