### PR TITLE
Disable extraneous devise strategies if `DISABLE_DEVISE_TWO_STRATEGIES` is set to `true`

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -98,8 +98,11 @@ Devise.setup do |config|
     manager.default_strategies(scope: :user).unshift :two_factor_ldap_authenticatable if Devise.ldap_authentication
     manager.default_strategies(scope: :user).unshift :two_factor_pam_authenticatable  if Devise.pam_authentication
     manager.default_strategies(scope: :user).unshift :session_activation_rememberable
-    manager.default_strategies(scope: :user).unshift :two_factor_authenticatable
-    manager.default_strategies(scope: :user).unshift :two_factor_backupable
+
+    unless ENV['DISABLE_DEVISE_TWO_STRATEGIES'] == 'true'
+      manager.default_strategies(scope: :user).unshift :two_factor_authenticatable
+      manager.default_strategies(scope: :user).unshift :two_factor_backupable
+    end
   end
 
   # The secret key used by Devise. Devise uses this key to generate


### PR DESCRIPTION
As far as I can tell, we actually do not use these strategies, as we handle log-in in our own two-step flow.