### PR TITLE
Improve relative time display when post time is in the future

### DIFF
--- a/app/javascript/mastodon/components/status/header.tsx
+++ b/app/javascript/mastodon/components/status/header.tsx
@@ -56,7 +56,10 @@ export const StatusHeader: FC<StatusHeaderProps> = ({
         className='status__relative-time'
       >
         <StatusVisibility visibility={status.get('visibility')} />
-        <RelativeTimestamp timestamp={status.get('created_at') as string} />
+        <RelativeTimestamp
+          timestamp={status.get('created_at') as string}
+          noFuture
+        />
         {editedAt && <StatusEditedAt editedAt={editedAt} />}
       </Link>
 

--- a/app/javascript/mastodon/features/account_timeline/v2/status_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/v2/status_header.tsx
@@ -36,7 +36,10 @@ export const AccountStatusHeader: FC<StatusHeaderProps> = ({
         className='status__relative-time'
       >
         <StatusVisibility visibility={status.get('visibility')} />
-        <RelativeTimestamp timestamp={status.get('created_at') as string} />
+        <RelativeTimestamp
+          timestamp={status.get('created_at') as string}
+          noFuture
+        />
         {editedAt && <StatusEditedAt editedAt={editedAt} />}
       </Link>
 


### PR DESCRIPTION
When the post date/time is in the future relative to the client's local clock, the text defined under `time_remaining.*` is displayed.

While this wording is appropriate for displaying time remaining on things like polls, it feels slightly unnatural in the context of post timestamps. This PR adds a `noFuture` parameter to the `RelativeTimestamp` component so that future dates fall back to displaying the text defined under `relative_time.full.just_now`  or `relative_time.just_now`  instead.