### PR TITLE
Clarify that language filter does not impact home/lists

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -154,7 +154,7 @@ en:
         jurisdiction: List the country where whoever pays the bills lives. If it’s a company or other entity, list the country where it’s incorporated, and the city, region, territory or state as appropriate.
         min_age: Should not be below the minimum age required by the laws of your jurisdiction.
       user:
-        chosen_languages: When checked, only posts in selected languages will be displayed in public timelines
+        chosen_languages: When checked, only posts in selected languages will be displayed in public timelines. This setting does not affect your Home timeline and lists.
         date_of_birth:
           one: We have to make sure you're at least %{count} to use %{domain}. We won't store this.
           other: We have to make sure you're at least %{count} to use %{domain}. We won't store this.


### PR DESCRIPTION
This PR (by someone else) was approved, but the contributor indicated lack of ability to properly rebase -- https://github.com/mastodon/mastodon/pull/29349

So this is just a rebase of those changes, presumably also approved. I've preserved authorship on the commit.

Related: https://github.com/mastodon/mastodon/issues/20241