### PR TITLE
Improve resilience of `tootctl maintenance fix-duplicates` command

### DIFF
--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -282,7 +282,6 @@ module Mastodon::CLI
           deduplicate_remote_accounts!(accounts)
         end
       end
-
     ensure
       say 'Restoring index_accounts_on_username_and_domain_lower…'
 
@@ -399,7 +398,7 @@ module Mastodon::CLI
         AccountIdentityProof.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
     ensure
-      return unless ActiveRecord::Base.connection.table_exists?(:account_identity_proofs)
+      return unless db_table_exists?(:account_identity_proofs)
 
       say 'Restoring account identity proofs indexes…'
       database_connection.add_index :account_identity_proofs, %w(account_id provider provider_username), name: 'index_account_proofs_on_account_and_provider_and_username', unique: true
@@ -415,7 +414,7 @@ module Mastodon::CLI
         AnnouncementReaction.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
     ensure
-      return unless ActiveRecord::Base.connection.table_exists?(:announcement_reactions)
+      return unless db_table_exists?(:announcement_reactions)
 
       say 'Restoring announcement_reactions indexes…'
       database_connection.add_index :announcement_reactions, %w(account_id announcement_id name), name: 'index_announcement_reactions_on_account_id_and_announcement_id', unique: true
@@ -533,7 +532,7 @@ module Mastodon::CLI
         UnavailableDomain.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
     ensure
-      return unless ActiveRecord::Base.connection.table_exists?(:unavailable_domains)
+      return unless db_table_exists?(:unavailable_domains)
 
       say 'Restoring unavailable_domains indexes…'
       database_connection.add_index :unavailable_domains, ['domain'], name: 'index_unavailable_domains_on_domain', unique: true
@@ -638,7 +637,7 @@ module Mastodon::CLI
         WebauthnCredential.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
     ensure
-      return unless ActiveRecord::Base.connection.table_exists?(:webauthn_credentials)
+      return unless db_table_exists?(:webauthn_credentials)
 
       say 'Restoring webauthn_credentials indexes…'
       database_connection.add_index :webauthn_credentials, ['external_id'], name: 'index_webauthn_credentials_on_external_id', unique: true
@@ -654,7 +653,7 @@ module Mastodon::CLI
         Webhook.where(id: row['ids'].split(',')).order(id: :desc).drop(1).each(&:destroy)
       end
     ensure
-      return unless ActiveRecord::Base.connection.table_exists?(:webhooks)
+      return unless db_table_exists?(:webhooks)
 
       say 'Restoring webhooks indexes…'
       database_connection.add_index :webhooks, ['url'], name: 'index_webhooks_on_url', unique: true

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -398,10 +398,10 @@ module Mastodon::CLI
         AccountIdentityProof.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
     ensure
-      return unless db_table_exists?(:account_identity_proofs)
-
-      say 'Restoring account identity proofs indexes…'
-      database_connection.add_index :account_identity_proofs, %w(account_id provider provider_username), name: 'index_account_proofs_on_account_and_provider_and_username', unique: true
+      if db_table_exists?(:account_identity_proofs)
+        say 'Restoring account identity proofs indexes…'
+        database_connection.add_index :account_identity_proofs, %w(account_id provider provider_username), name: 'index_account_proofs_on_account_and_provider_and_username', unique: true
+      end
     end
 
     def deduplicate_announcement_reactions!
@@ -414,10 +414,10 @@ module Mastodon::CLI
         AnnouncementReaction.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
     ensure
-      return unless db_table_exists?(:announcement_reactions)
-
-      say 'Restoring announcement_reactions indexes…'
-      database_connection.add_index :announcement_reactions, %w(account_id announcement_id name), name: 'index_announcement_reactions_on_account_id_and_announcement_id', unique: true
+      if db_table_exists?(:announcement_reactions)
+        say 'Restoring announcement_reactions indexes…'
+        database_connection.add_index :announcement_reactions, %w(account_id announcement_id name), name: 'index_announcement_reactions_on_account_id_and_announcement_id', unique: true
+      end
     end
 
     def deduplicate_conversations!
@@ -532,10 +532,10 @@ module Mastodon::CLI
         UnavailableDomain.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
     ensure
-      return unless db_table_exists?(:unavailable_domains)
-
-      say 'Restoring unavailable_domains indexes…'
-      database_connection.add_index :unavailable_domains, ['domain'], name: 'index_unavailable_domains_on_domain', unique: true
+      if db_table_exists?(:unavailable_domains)
+        say 'Restoring unavailable_domains indexes…'
+        database_connection.add_index :unavailable_domains, ['domain'], name: 'index_unavailable_domains_on_domain', unique: true
+      end
     end
 
     def deduplicate_email_domain_blocks!
@@ -637,10 +637,10 @@ module Mastodon::CLI
         WebauthnCredential.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
     ensure
-      return unless db_table_exists?(:webauthn_credentials)
-
-      say 'Restoring webauthn_credentials indexes…'
-      database_connection.add_index :webauthn_credentials, ['external_id'], name: 'index_webauthn_credentials_on_external_id', unique: true
+      if db_table_exists?(:webauthn_credentials)
+        say 'Restoring webauthn_credentials indexes…'
+        database_connection.add_index :webauthn_credentials, ['external_id'], name: 'index_webauthn_credentials_on_external_id', unique: true
+      end
     end
 
     def deduplicate_webhooks!
@@ -653,10 +653,10 @@ module Mastodon::CLI
         Webhook.where(id: row['ids'].split(',')).order(id: :desc).drop(1).each(&:destroy)
       end
     ensure
-      return unless db_table_exists?(:webhooks)
-
-      say 'Restoring webhooks indexes…'
-      database_connection.add_index :webhooks, ['url'], name: 'index_webhooks_on_url', unique: true
+      if db_table_exists?(:webhooks)
+        say 'Restoring webhooks indexes…'
+        database_connection.add_index :webhooks, ['url'], name: 'index_webhooks_on_url', unique: true
+      end
     end
 
     def deduplicate_software_updates!

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -283,7 +283,9 @@ module Mastodon::CLI
         end
       end
 
+    ensure
       say 'Restoring index_accounts_on_username_and_domain_lower…'
+
       if migrator_version < 2020_06_20_164023
         database_connection.add_index :accounts, 'lower (username), lower(domain)', name: 'index_accounts_on_username_and_domain_lower', unique: true
       else
@@ -309,8 +311,9 @@ module Mastodon::CLI
       deduplicate_users_process_confirmation_token
       deduplicate_users_process_remember_token
       deduplicate_users_process_password_token
-
+    ensure
       say 'Restoring users indexes…'
+
       database_connection.add_index :users, ['confirmation_token'], name: 'index_users_on_confirmation_token', unique: true
       database_connection.add_index :users, ['email'], name: 'index_users_on_email', unique: true
       database_connection.add_index :users, ['remember_token'], name: 'index_users_on_remember_token', unique: true if migrator_version < 2022_01_18_183010
@@ -380,8 +383,9 @@ module Mastodon::CLI
       duplicate_record_ids(:account_domain_blocks, 'account_id, domain').each do |row|
         AccountDomainBlock.where(id: row['ids'].split(',').drop(1)).delete_all
       end
-
+    ensure
       say 'Restoring account domain blocks indexes…'
+
       database_connection.add_index :account_domain_blocks, %w(account_id domain), name: 'index_account_domain_blocks_on_account_id_and_domain', unique: true
     end
 
@@ -394,6 +398,8 @@ module Mastodon::CLI
       duplicate_record_ids(:account_identity_proofs, 'account_id, provider, provider_username').each do |row|
         AccountIdentityProof.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
+    ensure
+      return unless ActiveRecord::Base.connection.table_exists?(:account_identity_proofs)
 
       say 'Restoring account identity proofs indexes…'
       database_connection.add_index :account_identity_proofs, %w(account_id provider provider_username), name: 'index_account_proofs_on_account_and_provider_and_username', unique: true
@@ -408,6 +414,8 @@ module Mastodon::CLI
       duplicate_record_ids(:announcement_reactions, 'account_id, announcement_id, name').each do |row|
         AnnouncementReaction.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
+    ensure
+      return unless ActiveRecord::Base.connection.table_exists?(:announcement_reactions)
 
       say 'Restoring announcement_reactions indexes…'
       database_connection.add_index :announcement_reactions, %w(account_id announcement_id name), name: 'index_announcement_reactions_on_account_id_and_announcement_id', unique: true
@@ -427,8 +435,9 @@ module Mastodon::CLI
           other.destroy
         end
       end
-
+    ensure
       say 'Restoring conversations indexes…'
+
       if migrator_version < 2022_03_07_083603
         database_connection.add_index :conversations, ['uri'], name: 'index_conversations_on_uri', unique: true
       else
@@ -450,8 +459,9 @@ module Mastodon::CLI
           other.destroy
         end
       end
-
+    ensure
       say 'Restoring custom_emojis indexes…'
+
       database_connection.add_index :custom_emojis, %w(shortcode domain), name: 'index_custom_emojis_on_shortcode_and_domain', unique: true
     end
 
@@ -469,8 +479,9 @@ module Mastodon::CLI
           other.destroy
         end
       end
-
+    ensure
       say 'Restoring custom_emoji_categories indexes…'
+
       database_connection.add_index :custom_emoji_categories, ['name'], name: 'index_custom_emoji_categories_on_name', unique: true
     end
 
@@ -481,8 +492,9 @@ module Mastodon::CLI
       duplicate_record_ids(:domain_allows, 'domain').each do |row|
         DomainAllow.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
-
+    ensure
       say 'Restoring domain_allows indexes…'
+
       database_connection.add_index :domain_allows, ['domain'], name: 'index_domain_allows_on_domain', unique: true
     end
 
@@ -505,8 +517,9 @@ module Mastodon::CLI
 
         domain_blocks.each(&:destroy)
       end
-
+    ensure
       say 'Restoring domain_blocks indexes…'
+
       database_connection.add_index :domain_blocks, ['domain'], name: 'index_domain_blocks_on_domain', unique: true
     end
 
@@ -519,6 +532,8 @@ module Mastodon::CLI
       duplicate_record_ids(:unavailable_domains, 'domain').each do |row|
         UnavailableDomain.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
+    ensure
+      return unless ActiveRecord::Base.connection.table_exists?(:unavailable_domains)
 
       say 'Restoring unavailable_domains indexes…'
       database_connection.add_index :unavailable_domains, ['domain'], name: 'index_unavailable_domains_on_domain', unique: true
@@ -532,8 +547,9 @@ module Mastodon::CLI
         domain_blocks = EmailDomainBlock.where(id: row['ids'].split(',')).order(EmailDomainBlock.arel_table[:parent_id].asc.nulls_first).to_a
         domain_blocks.drop(1).each(&:destroy)
       end
-
+    ensure
       say 'Restoring email_domain_blocks indexes…'
+
       database_connection.add_index :email_domain_blocks, ['domain'], name: 'index_email_domain_blocks_on_domain', unique: true
     end
 
@@ -544,8 +560,9 @@ module Mastodon::CLI
       duplicate_record_ids_without_nulls(:media_attachments, 'shortcode').each do |row|
         MediaAttachment.where(id: row['ids'].split(',').drop(1)).update_all(shortcode: nil)
       end
-
+    ensure
       say 'Restoring media_attachments indexes…'
+
       if migrator_version < 2022_03_10_060626
         database_connection.add_index :media_attachments, ['shortcode'], name: 'index_media_attachments_on_shortcode', unique: true
       else
@@ -560,8 +577,9 @@ module Mastodon::CLI
       duplicate_record_ids(:preview_cards, 'url').each do |row|
         PreviewCard.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
-
+    ensure
       say 'Restoring preview_cards indexes…'
+
       database_connection.add_index :preview_cards, ['url'], name: 'index_preview_cards_on_url', unique: true
     end
 
@@ -577,8 +595,9 @@ module Mastodon::CLI
           status.destroy
         end
       end
-
+    ensure
       say 'Restoring statuses indexes…'
+
       if migrator_version < 2022_03_10_060706
         database_connection.add_index :statuses, ['uri'], name: 'index_statuses_on_uri', unique: true
       else
@@ -599,8 +618,9 @@ module Mastodon::CLI
           tag.destroy
         end
       end
-
+    ensure
       say 'Restoring tags indexes…'
+
       if migrator_version < 2021_04_21_121431
         database_connection.add_index :tags, 'lower((name)::text)', name: 'index_tags_on_name_lower', unique: true
       else
@@ -617,6 +637,8 @@ module Mastodon::CLI
       duplicate_record_ids(:webauthn_credentials, 'external_id').each do |row|
         WebauthnCredential.where(id: row['ids'].split(',')).order(id: :desc).to_a.drop(1).each(&:destroy)
       end
+    ensure
+      return unless ActiveRecord::Base.connection.table_exists?(:webauthn_credentials)
 
       say 'Restoring webauthn_credentials indexes…'
       database_connection.add_index :webauthn_credentials, ['external_id'], name: 'index_webauthn_credentials_on_external_id', unique: true
@@ -631,6 +653,8 @@ module Mastodon::CLI
       duplicate_record_ids(:webhooks, 'url').each do |row|
         Webhook.where(id: row['ids'].split(',')).order(id: :desc).drop(1).each(&:destroy)
       end
+    ensure
+      return unless ActiveRecord::Base.connection.table_exists?(:webhooks)
 
       say 'Restoring webhooks indexes…'
       database_connection.add_index :webhooks, ['url'], name: 'index_webhooks_on_url', unique: true

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -188,9 +188,6 @@ module Mastodon::CLI
     def fix_duplicates
       verify_system_ready!
 
-      # Just in case the server's configuration sets a timeout
-      ActiveRecord::Base.connection.execute 'SET statement_timeout = 0'
-
       process_deduplications
 
       deduplication_cleanup_tasks

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -188,6 +188,9 @@ module Mastodon::CLI
     def fix_duplicates
       verify_system_ready!
 
+      # Just in case the server's configuration sets a timeout
+      ActiveRecord::Base.connection.execute 'SET statement_timeout = 0'
+
       process_deduplications
 
       deduplication_cleanup_tasks


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/23317

That PR did two things:

- Disable timeouts -- this was extracted and merged in https://github.com/mastodon/mastodon/pull/33484
- Add `ensure` block to restore deleted indexes on error -- this was blocked on review feedback and some lint errors

Changes here:

-  Start with that PR branch, rebase against main, which removes the timeout
- Use db helper method added after that PR was created
- Work around the lint errors by converting `return unless...` into `if ...` in a few spots