### PR TITLE
WIP: Fix translatability of email_subscription_mailer.notification.subject

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1444,6 +1444,11 @@ en:
           one: New post from "%{name}"
           other: New posts from %{name}
         single: 'New post: "%{excerpt}"'
+      title:
+        multiple:
+          one: New post from "%{name}"
+          other: New posts from %{name}
+        single: 'New post: "%{excerpt}"'
   email_subscriptions:
     active: Active
     confirmations:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1440,11 +1440,10 @@ en:
         one: Interact with this post and discover more like it.
         other: Interact with these posts and discover more.
       subject:
-        one: 'New post: "%{excerpt}"'
-        other: New posts from %{name}
-      title:
-        one: 'New post: "%{excerpt}"'
-        other: New posts from %{name}
+        multiple:
+          one: New post from "%{name}"
+          other: New posts from %{name}
+        single: 'New post: "%{excerpt}"'
   email_subscriptions:
     active: Active
     confirmations:

--- a/spec/mailers/email_subscription_mailer_spec.rb
+++ b/spec/mailers/email_subscription_mailer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe EmailSubscriptionMailer do
           .to send_email(
             to: email_subscription.email,
             from: 'notifications@localhost',
-            subject: I18n.t('email_subscription_mailer.notification.subject', count: statuses.size, name: email_subscription.account.display_name, excerpt: statuses.first.text.truncate(17))
+            subject: I18n.t('email_subscription_mailer.notification.subject.single', name: email_subscription.account.display_name, excerpt: statuses.first.text.truncate(17))
           )
       end
     end
@@ -43,7 +43,7 @@ RSpec.describe EmailSubscriptionMailer do
           .to send_email(
             to: email_subscription.email,
             from: 'notifications@localhost',
-            subject: I18n.t('email_subscription_mailer.notification.subject', count: statuses.size, name: email_subscription.account.display_name, excerpt: ActionController::Base.helpers.truncate(statuses.first.text, length: 17))
+            subject: I18n.t('email_subscription_mailer.notification.subject.multiple', count: statuses.size, name: email_subscription.account.display_name)
           )
       end
     end


### PR DESCRIPTION
In my language, 1 and 11 share the same plural rule, so I can't deal with the variable switcheroo while translating.

I was unable to find out how to switch on the e-mail subscription feature for an account (I gave it the role permission but couldn't find any UI to activate the option), so this is untested.

I could not find any references to `email_subscription_mailer.notification.title` in the source code  anywhere - looks like a duplicate anyway. The i18n checks force me to keep it in though.