### PR TITLE
Move "skip mx check" to rails config

### DIFF
--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -20,7 +20,7 @@ class EmailSubscription < ApplicationRecord
   normalizes :email, with: ->(str) { str.squish.downcase }
 
   validates :email, presence: true, email_address: true, length: { maximum: 320 }, uniqueness: { scope: :account_id }
-  validates :email, email_mx: true, if: -> { email_changed? && !Rails.env.local? }
+  validates :email, email_mx: true, if: -> { email_changed? && Rails.configuration.x.email.perform_mx_checks }
 
   scope :confirmed, -> { where.not(confirmed_at: nil) }
   scope :unconfirmed, -> { where(confirmed_at: nil) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,10 +148,6 @@ class User < ApplicationRecord
     end
   end
 
-  def self.skip_mx_check?
-    Rails.env.local?
-  end
-
   def role
     if role_id.nil?
       UserRole.everyone
@@ -473,7 +469,7 @@ class User < ApplicationRecord
 
     # Doing this conditionally is not very satisfying, but this is consistent
     # with the MX records validations we do and keeps the specs tractable.
-    records = DomainResource.new(email_domain).mx unless self.class.skip_mx_check?
+    records = DomainResource.new(email_domain).mx if Rails.configuration.x.email.perform_mx_checks
 
     EmailDomainBlock.requires_approval?(records + [email_domain], attempt_ip: sign_up_ip)
   end
@@ -522,7 +518,7 @@ class User < ApplicationRecord
   end
 
   def validate_email_dns?
-    email_changed? && !external? && !self.class.skip_mx_check?
+    email_changed? && !external? && Rails.configuration.x.email.perform_mx_checks
   end
 
   def validate_role_elevation

--- a/config/email.yml
+++ b/config/email.yml
@@ -1,8 +1,11 @@
 # Note that these settings only apply in `production` even when other
 # keys are added here.
+shared:
+  perform_mx_checks: false
 production:
   delivery_method: <%= ENV.fetch('SMTP_DELIVERY_METHOD', 'smtp') %>
   from_address: <%= ENV.fetch('SMTP_FROM_ADDRESS', 'notifications@localhost')&.to_json %>
+  perform_mx_checks: true
   reply_to: <%= ENV.fetch('SMTP_REPLY_TO', nil)&.to_json %>
   return_path: <%= ENV.fetch('SMTP_RETURN_PATH', nil)&.to_json %>
   smtp_settings:

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe Auth::RegistrationsController do
       end
     end
 
-    context 'when user has an email address requiring approval through a MX record' do
+    context 'when user has an email address requiring approval through a MX record', :enable_mx_checks do
       subject do
         request.headers['Accept-Language'] = accept_language
         post :create, params: { user: { account_attributes: { username: 'test' }, email: 'test@example.com', password: '12345678', password_confirmation: '12345678', agreement: 'true' } }
@@ -237,7 +237,6 @@ RSpec.describe Auth::RegistrationsController do
       before do
         Setting.registrations_mode = 'open'
         Fabricate(:email_domain_block, allow_with_approval: true, domain: 'mail.example.com')
-        allow(User).to receive(:skip_mx_check?).and_return(false)
         configure_mx(domain: 'example.com', exchange: 'mail.example.com')
       end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe UserMailer do
   end
 
   shared_examples 'optional bulk mailer settings' do
+    before { Rails.configuration.x.email = Rails.application.config_for(:email) }
+
     context 'when no optional bulk mailer settings are present' do
       it 'does not include delivery method options' do
         expect(mail.message.delivery_method.settings).to be_empty
@@ -22,6 +24,10 @@ RSpec.describe UserMailer do
     end
 
     context 'when optional bulk mailer settings are present' do
+      before do
+        Rails.configuration.x.email.update({ bulk_mail: { smtp_settings: } })
+      end
+
       let(:smtp_settings) do
         {
           address: 'localhost',
@@ -29,15 +35,6 @@ RSpec.describe UserMailer do
           authentication: 'none',
           enable_starttls_auto: true,
         }
-      end
-
-      before do
-        Rails.configuration.x.email ||= ActiveSupport::OrderedOptions.new
-        Rails.configuration.x.email.update({ bulk_mail: { smtp_settings: } })
-      end
-
-      after do
-        Rails.configuration.x.email = nil
       end
 
       it 'uses the bulk mailer settings' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -138,6 +138,12 @@ RSpec.configure do |config|
     example.run
   end
 
+  config.around(:each, :enable_mx_checks) do |example|
+    Rails.configuration.x.email.perform_mx_checks = true
+    example.run
+    Rails.configuration.x.email.perform_mx_checks = false
+  end
+
   config.before :each, type: :cli do
     stub_reset_connection_pools
   end

--- a/spec/services/app_sign_up_service_spec.rb
+++ b/spec/services/app_sign_up_service_spec.rb
@@ -48,11 +48,10 @@ RSpec.describe AppSignUpService do
       end
     end
 
-    context 'when the email address requires approval through MX records' do
+    context 'when the email address requires approval through MX records', :enable_mx_checks do
       before do
         Setting.registrations_mode = 'open'
         Fabricate(:email_domain_block, allow_with_approval: true, domain: 'smtp.email.com')
-        allow(User).to receive(:skip_mx_check?).and_return(false)
         configure_mx(domain: 'email.com', exchange: 'smtp.email.com')
       end
 


### PR DESCRIPTION
This setting was previously only used in `User`, via a class accessor style method, to control which envs we actually do MX lookups during domain/mx validation.

This PR https://github.com/mastodon/mastodon/pull/38502 adds another check for what is essentially the same concept/value, but from another model.

The change here is to pull it out of User, into a `config_for`, and use that same setting from both spots. The changes to user mailer spec are needed because the previously safe `after` (setting to nil) now causes order-dependent failures since `shared` was added.

Possible followups here would be to...

- Move the check entirely into the validator itself to simplify the call sites?
- And/or update the validator to use `DomainResource` for the mx lookup, and then update that to check this config value and return empty array when not enabled?

Related https://github.com/mastodon/mastodon/pull/35839