### PR TITLE
Use `rubocop --format github` instead of problem matcher

### DIFF
--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -42,11 +42,8 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Set-up RuboCop Problem Matcher
-        uses: r7kamura/rubocop-problem-matchers-action@59f1a0759f50cc2649849fd850b8487594bb5a81 # v1.2.2
-
       - name: Run rubocop
-        run: bin/rubocop
+        run: bin/rubocop --format github
 
       - name: Run brakeman
         if: always() # Run both checks, even if the first failed


### PR DESCRIPTION
This github action has deprecation output about node version support, and the repo suggests you not use it anymore -- https://github.com/r7kamura/rubocop-problem-matchers-action?tab=readme-ov-file#note

Including an intentional lint issue here to see the CI run find it correctly w/ the formatter. Will remove that assuming it works as expected.