### PR TITLE
Initial sketch of collection bootstrapping

### DIFF
--- a/app/lib/activitypub/activity/add.rb
+++ b/app/lib/activitypub/activity/add.rb
@@ -17,8 +17,22 @@ class ActivityPub::Activity::Add < ActivityPub::Activity
 
       add_collection
     else
+      return unless Mastodon::Feature.collections_enabled?
+
       @collection = @account.collections.find_by(uri: value_or_id(@json['target']))
-      add_collection_item if @collection && Mastodon::Feature.collections_enabled?
+      if @collection.present?
+        add_collection_item
+      else
+        # At this point we do not know and cannot handle the target.
+        # This can have any number of reasons but for a while after
+        # FeaturedCollections are introduced it might be because the
+        # account data is stale. Instead of updating the account, which
+        # is very expensive, we attempt to only detect if this is the case
+        # with the least amount of effort possible.
+        # Can be removed once Mastodon 4.6 or later has been deployed on
+        # a sufficiently large number of servers.
+        attempt_bootstrapping_collections
+      end
     end
   end
 
@@ -44,5 +58,15 @@ class ActivityPub::Activity::Add < ActivityPub::Activity
 
   def add_collection_item
     ActivityPub::ProcessFeaturedItemService.new.call(@collection, @object)
+  end
+
+  def attempt_bootstrapping_collections
+    return if @account.collections_url.present?
+
+    actor_json = fetch_resource(@account.uri, true)
+    if actor_json && actor_json['featuredCollections'].present?
+      @account.update!(collections_url: actor_json['featuredCollections'])
+      ActivityPub::SynchronizeFeaturedCollectionsCollectionWorker.perform_async(@account.id)
+    end
   end
 end

--- a/spec/lib/activitypub/activity/add_spec.rb
+++ b/spec/lib/activitypub/activity/add_spec.rb
@@ -120,6 +120,30 @@ RSpec.describe ActivityPub::Activity::Add do
 
       expect(stubbed_service).to have_received(:call).with(account, featured_collection_json)
     end
+
+    context 'when account has no collections URI' do
+      let(:account) { Fabricate(:remote_account) }
+      let(:account_json) do
+        {
+          'id' => account.uri,
+          'type' => 'Person',
+          'inbox' => 'http://example.com/actor/1/inbox',
+          'featuredCollections' => 'https://example.com/actor/1/featured_collections',
+        }
+      end
+
+      before do
+        stub_request(:get, account.uri)
+          .to_return_json(body: account_json, headers: { 'Content-Type': 'application/activity+json' })
+      end
+
+      it 're-fetches the account and triggers collection fetching' do
+        subject.perform
+
+        expect(stubbed_service).to_not have_received(:call)
+        expect(ActivityPub::SynchronizeFeaturedCollectionsCollectionWorker).to have_enqueued_sidekiq_job
+      end
+    end
   end
 
   context 'when the target is a collection', feature: :collections do


### PR DESCRIPTION
Initially, we will not know of a cached actor's `featuredCollections` URI, so we cannot handle `Add` activities to it.

This is a small crutch to try to get over this initial hump. It can probably be improved, but the idea is that when we receive an `Add` that we cannot handle, we do the least amount of work possible to see if it could be this exact situation.

So if we actually are missing the `featuredCollections` URI (and only then), we try to fetch the actor JSON again to see if it should have one. If that is the case, we do a full (expensive) refresh of the account. This does nothing with the `Add` we could not handle, but makes sure we receive *all* collections of this account.

This could later be removed, say in a version or two, but would help with the bootstrapping problem.

Fixes WEB-877