### PR TITLE
Profile redesign: Move and rearrange number fields

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -169,6 +169,8 @@ export const AccountHeader: React.FC<{
 
           <AccountBadges accountId={accountId} />
 
+          <AccountNumberFields accountId={accountId} />
+
           {!isMe && !suspendedOrHidden && (
             <FamiliarFollowers accountId={accountId} />
           )}
@@ -195,8 +197,6 @@ export const AccountHeader: React.FC<{
               {!me && account.email_subscriptions && (
                 <AccountSubscriptionForm accountId={accountId} />
               )}
-
-              <AccountNumberFields accountId={accountId} />
             </div>
           )}
 

--- a/app/javascript/mastodon/features/account_timeline/components/number_fields.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/number_fields.tsx
@@ -28,13 +28,6 @@ export const AccountNumberFields: FC<{ accountId: string }> = ({
   return (
     <NumberFields>
       <NumberFieldsItem
-        label={<FormattedMessage id='account.posts' defaultMessage='Posts' />}
-        hint={intl.formatNumber(account.statuses_count)}
-      >
-        <ShortNumber value={account.statuses_count} />
-      </NumberFieldsItem>
-
-      <NumberFieldsItem
         label={
           <FormattedMessage id='account.followers' defaultMessage='Followers' />
         }
@@ -52,6 +45,13 @@ export const AccountNumberFields: FC<{ accountId: string }> = ({
         link={`/@${account.acct}/following`}
       >
         <ShortNumber value={account.following_count} />
+      </NumberFieldsItem>
+
+      <NumberFieldsItem
+        label={<FormattedMessage id='account.posts' defaultMessage='Posts' />}
+        hint={intl.formatNumber(account.statuses_count)}
+      >
+        <ShortNumber value={account.statuses_count} />
       </NumberFieldsItem>
 
       <NumberFieldsItem


### PR DESCRIPTION
Fixes WEB-940 and WEB-941.

This moves the numeric account fields (joined, follower counts, etc) to below the name + badges, and also puts post count before join date.