### PR TITLE
Make description optional in collection editor

### DIFF
--- a/app/javascript/mastodon/api_types/collections.ts
+++ b/app/javascript/mastodon/api_types/collections.ts
@@ -16,7 +16,7 @@ export interface ApiCollectionJSON {
   item_count: number;
 
   name: string;
-  description: string;
+  description: string | null;
   tag: ApiTagJSON | null;
   language: string | null;
   sensitive: boolean;

--- a/app/javascript/mastodon/features/collections/editor/details.tsx
+++ b/app/javascript/mastodon/features/collections/editor/details.tsx
@@ -182,7 +182,7 @@ export const CollectionDetails: React.FC = () => {
         />
 
         <TextAreaField
-          required
+          required={false}
           label={
             <FormattedMessage
               id='collections.collection_description'


### PR DESCRIPTION
### Changes proposed in this PR:
- Makes the description optional in the collection editor, matching the related backend change #38528

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="305" height="246" alt="image" src="https://github.com/user-attachments/assets/3eb6d49c-fc07-4675-af59-0baf72027e45" /> | <img width="326" height="247" alt="image" src="https://github.com/user-attachments/assets/6a3e2e37-3020-4286-9f35-f884be2aa6d7" /> |