### PR TITLE
fix: webfinger is not declared as an attribute in actor_serializer.rb

### DIFF
--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -12,7 +12,7 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
 
   context_extensions :interaction_policies if Mastodon::Feature.collections_enabled?
 
-  attributes :id, :type, :following, :followers,
+  attributes :id, :webfinger, :type, :following, :followers,
              :inbox, :outbox, :featured, :featured_tags,
              :preferred_username, :name, :summary,
              :url, :manually_approves_followers,


### PR DESCRIPTION
@ClearlyClaire I think this is correct... this was picked up using static code analysis and might be a false alarm.