### PR TITLE
Add `domain_variants` helper to `DomainNormalizable` concern

### DIFF
--- a/app/models/concerns/account/attribution_domains.rb
+++ b/app/models/concerns/account/attribution_domains.rb
@@ -12,8 +12,7 @@ module Account::AttributionDomains
   end
 
   def can_be_attributed_from?(domain)
-    segments = domain.split('.')
-    variants = segments.map.with_index { |_, i| segments[i..].join('.') }.to_set
+    variants = self.class.domain_variants(domain).to_set
     self[:attribution_domains].to_set.intersect?(variants)
   end
 end

--- a/app/models/concerns/domain_normalizable.rb
+++ b/app/models/concerns/domain_normalizable.rb
@@ -17,6 +17,11 @@ module DomainNormalizable
         SQL
       )
     end
+
+    def domain_variants(domain)
+      segments = domain.to_s.split('.')
+      Array.new(segments.size) { |i| segments[i..].join('.') }
+    end
   end
 
   private

--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -69,9 +69,7 @@ class DomainBlock < ApplicationRecord
       return if domain.blank?
 
       uri      = Addressable::URI.new.tap { |u| u.host = domain.strip.delete('/') }
-      segments = uri.normalized_host.split('.')
-      variants = segments.map.with_index { |_, i| segments[i..].join('.') }
-
+      variants = domain_variants(uri.normalized_host)
       where(domain: variants).by_domain_length.first
     rescue Addressable::URI::InvalidURIError, IDN::Idna::IdnaError
       nil

--- a/app/models/email_domain_block.rb
+++ b/app/models/email_domain_block.rb
@@ -67,9 +67,7 @@ class EmailDomainBlock < ApplicationRecord
       @uris.flat_map do |uri|
         next if uri.nil?
 
-        segments = uri.normalized_host.split('.')
-
-        segments.map.with_index { |_, i| segments[i..].join('.') }
+        self.class.module_parent.domain_variants(uri.normalized_host)
       end.uniq
     end
 

--- a/app/models/preview_card_provider.rb
+++ b/app/models/preview_card_provider.rb
@@ -36,7 +36,6 @@ class PreviewCardProvider < ApplicationRecord
   scope :not_trendable, -> { where(trendable: false) }
 
   def self.matching_domain(domain)
-    segments = domain.split('.')
-    where(domain: segments.map.with_index { |_, i| segments[i..].join('.') }).by_domain_length.first
+    where(domain: domain_variants(domain)).by_domain_length.first
   end
 end


### PR DESCRIPTION
In many of the models which include this concern, there is this similar "convert this domain name string into an array of all its variants" logic (ie, `'www.example.host'` -> `['www.example.host', 'example.host', 'host']`). Since they all include the concern, this pulls that repeated logic out to a method in the concern.

I believe the existing behavior is preserved in all cases, and coverage for all these areas have been added/confirmed via earlier PRs.