### PR TITLE
Fix importing emoji loader statically inside worker

### DIFF
--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -302,7 +302,8 @@ async function toLoadedLocale(localeString: string) {
   }
   if (!loadedLocales.has(locale)) {
     log('Locale %s not loaded, importing...', locale);
-    const { importEmojiData } = await import('./loader');
+    // Ignore the INEFFECTIVE_DYNAMIC_IMPORT Vite warning, since the static import location is inside an inlined web worker.
+    const { importEmojiData } = await import(/* @vite-ignore */ './loader');
     await importEmojiData(locale);
     return locale;
   }

--- a/app/javascript/mastodon/features/emoji/worker.ts
+++ b/app/javascript/mastodon/features/emoji/worker.ts
@@ -1,4 +1,9 @@
 import { EMOJI_DB_NAME_SHORTCODES, EMOJI_TYPE_CUSTOM } from './constants';
+import {
+  importCustomEmojiData,
+  importEmojiData,
+  importLegacyShortcodes,
+} from './loader';
 
 addEventListener('message', handleMessage);
 self.postMessage('ready'); // After the worker is ready, notify the main thread
@@ -11,8 +16,6 @@ function handleMessage(event: MessageEvent<{ locale: string }>) {
 }
 
 async function loadData(locale: string) {
-  const { importCustomEmojiData, importEmojiData, importLegacyShortcodes } =
-    await import('./loader');
   let importCount: number | undefined;
   if (locale === EMOJI_TYPE_CUSTOM) {
     importCount = (await importCustomEmojiData())?.length;


### PR DESCRIPTION
Fixes #38500.

This resolves an issue introduced in #38174 where the Vite 8 upgrade caused some warnings about static imports, but the fix to make the import inside the worker dynamic fails as it's inlined. This reverts that change and just adds an ignore comment so Vite stops complaining.