### PR TITLE
Use `approvable` concern for repeated API approve/reject routes

### DIFF
--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -300,32 +300,20 @@ namespace :api, format: false do
       resources :ip_blocks, only: [:index, :show, :update, :create, :destroy]
 
       namespace :trends do
-        resources :tags, only: [:index] do
+        concern :approvable do
           member do
             post :approve
             post :reject
           end
         end
-        resources :links, only: [:index] do
-          member do
-            post :approve
-            post :reject
-          end
-        end
-        resources :statuses, only: [:index] do
-          member do
-            post :approve
-            post :reject
-          end
+        with_options only: [:index], concerns: :approvable do
+          resources :tags
+          resources :links
+          resources :statuses
         end
 
         namespace :links do
-          resources :preview_card_providers, only: [:index], path: :publishers do
-            member do
-              post :approve
-              post :reject
-            end
-          end
+          resources :preview_card_providers, only: [:index], path: :publishers, concerns: :approvable
         end
       end
 


### PR DESCRIPTION
Wraps up repetitive route creation for these four spots.