### PR TITLE
Use compact buttons in collection account list

### DIFF
--- a/app/javascript/mastodon/features/collections/detail/accounts_list.tsx
+++ b/app/javascript/mastodon/features/collections/detail/accounts_list.tsx
@@ -111,9 +111,9 @@ const AccountItem: React.FC<{
           </NumberFields>
         }
       />
-      {!withoutButton && <FollowButton accountId={accountId} />}
+      {!withoutButton && <FollowButton compact accountId={accountId} />}
       {isOwnAccount && (
-        <Button secondary onClick={onRevoke}>
+        <Button secondary compact onClick={onRevoke}>
           <FormattedMessage
             id='collections.detail.revoke_inclusion'
             defaultMessage='Remove me'


### PR DESCRIPTION
### Changes proposed in this PR:
- Uses the `compact` button size for "Follow" buttons in the account list of the collection detail view, matching the latest designs

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="588" height="669" alt="image" src="https://github.com/user-attachments/assets/bd23e7ff-fbb2-4ba6-9205-de20404f3e77" /> | <img width="579" height="659" alt="image" src="https://github.com/user-attachments/assets/17cafb65-3b9b-4ff4-84ca-fd00903969e5" /> |