### PR TITLE
Use collection partial for "software updates" list in admin area

### DIFF
--- a/app/views/admin/software_updates/_software_update.html.haml
+++ b/app/views/admin/software_updates/_software_update.html.haml
@@ -1,0 +1,11 @@
+%tr{ id: dom_id(software_update) }
+  %td= software_update.version
+  %td= t("admin.software_updates.types.#{software_update.type}")
+  %td{ class: class_names(critical: software_update.urgent?) }
+    - if software_update.urgent?
+      = t('admin.software_updates.critical_update')
+  %td.release-notes
+    - if software_update.release_notes?
+      = table_link_to 'link',
+                      t('admin.software_updates.release_notes'),
+                      software_update.release_notes

--- a/app/views/admin/software_updates/_software_update.html.haml
+++ b/app/views/admin/software_updates/_software_update.html.haml
@@ -5,7 +5,6 @@
     - if software_update.urgent?
       = t('admin.software_updates.critical_update')
   %td.release-notes
-    - if software_update.release_notes?
-      = table_link_to 'link',
-                      t('admin.software_updates.release_notes'),
-                      software_update.release_notes
+    = table_link_to 'link',
+                    t('admin.software_updates.release_notes'),
+                    software_update.release_notes

--- a/app/views/admin/software_updates/index.html.haml
+++ b/app/views/admin/software_updates/index.html.haml
@@ -18,12 +18,4 @@
           %th
           %th
       %tbody
-        - @software_updates.each do |update|
-          %tr
-            %td= update.version
-            %td= t("admin.software_updates.types.#{update.type}")
-            - if update.urgent?
-              %td.critical= t('admin.software_updates.critical_update')
-            - else
-              %td
-            %td= table_link_to 'link', t('admin.software_updates.release_notes'), update.release_notes
+        = render collection: @software_updates, partial: 'admin/software_updates/software_update'

--- a/spec/system/admin/software_updates_spec.rb
+++ b/spec/system/admin/software_updates_spec.rb
@@ -3,23 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe 'finding software updates through the admin interface' do
-  before do
-    Fabricate(:software_update, version: '99.99.99', type: 'major', urgent: true, release_notes: 'https://github.com/mastodon/mastodon/releases/v99')
-    Fabricate(:software_update, version: '3.5.0', type: 'major', urgent: true, release_notes: 'https://github.com/mastodon/mastodon/releases/v3.5.0')
+  before { sign_in Fabricate(:owner_user) }
 
-    sign_in Fabricate(:owner_user), scope: :user
-  end
+  let!(:latest_release) { Fabricate(:software_update, version: '99.99.99', type: 'major', urgent: true, release_notes: 'https://github.com/mastodon/mastodon/releases/v99') }
+  let!(:other_release) { Fabricate(:software_update, version: '98.0.0', type: 'major', release_notes: '') }
+  let!(:outdated_release) { Fabricate(:software_update, version: '3.5.0', type: 'major', urgent: true, release_notes: 'https://github.com/mastodon/mastodon/releases/v3.5.0') }
 
   it 'shows a link to the software updates page, which links to release notes' do
     visit settings_profile_path
     click_on I18n.t('admin.critical_update_pending')
 
-    expect(page).to have_title(I18n.t('admin.software_updates.title'))
+    expect(page)
+      .to have_title(I18n.t('admin.software_updates.title'))
+      .and have_content(latest_release.version)
+      .and have_content(other_release.version)
+      .and have_no_content(outdated_release.version)
 
-    expect(page).to have_content('99.99.99')
-      .and have_no_content('3.5.0')
+    within("#software_update_#{other_release.id}") do
+      expect(find('.release-notes').value).to be_nil
+    end
 
     click_on I18n.t('admin.software_updates.release_notes')
-    expect(page).to have_current_path('https://github.com/mastodon/mastodon/releases/v99', url: true)
+    expect(page)
+      .to have_current_path('https://github.com/mastodon/mastodon/releases/v99', url: true)
   end
 end

--- a/spec/system/admin/software_updates_spec.rb
+++ b/spec/system/admin/software_updates_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'finding software updates through the admin interface' do
       .and have_no_content(outdated_release.version)
 
     within("#software_update_#{other_release.id}") do
-      expect(find('.release-notes').value).to be_nil
+      expect(find('.release-notes').value).to be_blank
     end
 
     within("#software_update_#{latest_release.id}") do

--- a/spec/system/admin/software_updates_spec.rb
+++ b/spec/system/admin/software_updates_spec.rb
@@ -19,10 +19,6 @@ RSpec.describe 'finding software updates through the admin interface' do
       .and have_content(other_release.version)
       .and have_no_content(outdated_release.version)
 
-    within("#software_update_#{other_release.id}") do
-      expect(find('.release-notes').value).to be_blank
-    end
-
     within("#software_update_#{latest_release.id}") do
       click_on I18n.t('admin.software_updates.release_notes')
     end

--- a/spec/system/admin/software_updates_spec.rb
+++ b/spec/system/admin/software_updates_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe 'finding software updates through the admin interface' do
       expect(find('.release-notes').value).to be_nil
     end
 
-    click_on I18n.t('admin.software_updates.release_notes')
+    within("#software_update_#{latest_release.id}") do
+      click_on I18n.t('admin.software_updates.release_notes')
+    end
     expect(page)
       .to have_current_path('https://github.com/mastodon/mastodon/releases/v99', url: true)
   end


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/35945 - simple collection render.

- I noticed that "release notes" cannot be null, but defaults to empty string. Changed the `td` there to only actually generate the link when release notes are present (avoids linking to nothing). In practice, I suspect this value always is present.
- Updated spec to capture that no link when missing change, and misc style updates