### PR TITLE
Add `application_scope_groups` helper method for form to use

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -5,6 +5,10 @@ module SettingsHelper
     LanguagesHelper.sorted_locale_keys(LanguagesHelper::SUPPORTED_LOCALES.keys)
   end
 
+  def application_scope_groups
+    Doorkeeper.configuration.scopes.group_by { |value| value.split(':').first }.values
+  end
+
   def ui_languages
     LanguagesHelper.sorted_locale_keys(I18n.available_locales)
   end

--- a/app/views/settings/applications/_form.html.haml
+++ b/app/views/settings/applications/_form.html.haml
@@ -21,11 +21,11 @@
     = form.label t('activerecord.attributes.doorkeeper/application.scopes'), required: true
     %span.hint= t('simple_form.hints.defaults.scopes')
 
-  - Doorkeeper.configuration.scopes.group_by { |s| s.split(':').first }.each_value do |value|
+  - application_scope_groups.each do |group|
     = form.input :scopes,
                  as: :check_boxes,
                  collection_wrapper_tag: 'ul',
-                 collection: value.sort,
+                 collection: group.sort,
                  hint: false,
                  include_blank: false,
                  item_wrapper_tag: 'li',

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -19,6 +19,24 @@ RSpec.describe SettingsHelper do
     end
   end
 
+  describe '#application_scope_groups' do
+    subject { helper.application_scope_groups }
+
+    before { allow(Doorkeeper.configuration).to receive(:scopes).and_return(scopes) }
+
+    context 'with configured scopes' do
+      let(:scopes) { %w(read read:accounts profile write write:accounts) }
+
+      it { is_expected.to eq [%w(read read:accounts), %w(profile), %w(write write:accounts)] }
+    end
+
+    context 'with empty scopes' do
+      let(:scopes) { [] }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
   describe 'session_device_icon' do
     context 'with a mobile device' do
       let(:session) { SessionActivation.new(user_agent: 'Mozilla/5.0 (iPhone)') }


### PR DESCRIPTION
Pulls some inline ruby logic (and constant access) out of the view.

Vaguely related to https://github.com/mastodon/mastodon/pull/35179