### PR TITLE
Disable yarn postinstall scripts

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
+enableScripts: false
 nodeLinker: node-modules


### PR DESCRIPTION
This PR disables postinstall scripts in JS dependencies to reduce the attack surface.

I'm not sure how to know exactly which dependencies have a postinstall script. A quick grep shows the following:
```
node_modules/@storybook/addon-vitest/package.json:    "./postinstall": "./dist/postinstall.js",
node_modules/@storybook/addon-a11y/package.json:    "./postinstall": "./dist/postinstall.js",
node_modules/core-js/package.json:    "postinstall": "node -e \"try{require('./postinstall')}catch(e){}\""
node_modules/eslint-plugin-react/node_modules/resolve/test/resolver/multirepo/package.json:    "postinstall": "lerna bootstrap",
node_modules/esbuild/package.json:    "postinstall": "node install.js"
node_modules/napi-postinstall/package.json:  "name": "napi-postinstall",
node_modules/napi-postinstall/package.json:  "description": "The `postinstall` script helper for handling native bindings in legacy `npm` versions",
node_modules/napi-postinstall/package.json:  "repository": "git+https://github.com/un-ts/napi-postinstall.git",
node_modules/napi-postinstall/package.json:  "funding": "https://opencollective.com/napi-postinstall",
node_modules/tesseract.js/package.json:    "postinstall": "opencollective-postinstall || true"
node_modules/tesseract.js/package.json:    "opencollective-postinstall": "^2.0.3",
node_modules/opencollective-postinstall/package.json:  "name": "opencollective-postinstall",
node_modules/opencollective-postinstall/package.json:  "description": "Lightweight npm postinstall message to invite people to donate to your collective",
node_modules/opencollective-postinstall/package.json:    "url": "git+https://github.com/opencollective/opencollective-postinstall.git"
node_modules/opencollective-postinstall/package.json:    "url": "https://github.com/opencollective/opencollective-postinstall/issues"
node_modules/opencollective-postinstall/package.json:  "homepage": "https://github.com/opencollective/opencollective-postinstall#readme",
node_modules/unrs-resolver/package.json:    "postinstall": "napi-postinstall unrs-resolver 1.11.1 check"
node_modules/unrs-resolver/package.json:    "napi-postinstall": "^0.3.0"
node_modules/resolve/test/resolver/multirepo/package.json:    "postinstall": "lerna bootstrap",
node_modules/msw/package.json:    "config/scripts/postinstall.js",
node_modules/msw/package.json:    "postinstall": "node -e \"import('./config/scripts/postinstall.js').catch(() => void 0)\"",
node_modules/twitter-text/node_modules/core-js/package.json:    "postinstall": "node -e \"try{require('./postinstall')}catch(e){}\""
```

Having a look at them:
- `core-js` is just about displaying a banner, it can be safely ignored
- `opencollective-postinstall` / `tesseract.js` are just about displaying a banner, and can be safely ignored
- `nsw` updates `.storybook/static/mockServiceWorker.js`, which needs to be considered when updating
- I am unsure about the others but checking out the repo and installing without running the postinstall scripts is not an issue

I am relatively confident we can disable all of the postinstall scripts, except for `msw`.

I considered allowing scripts for `msw`, but I'm not sure it is worth it.