### PR TITLE
Use consistent style in `*Filter` classes to skip pagination

### DIFF
--- a/app/models/account_filter.rb
+++ b/app/models/account_filter.rb
@@ -14,6 +14,8 @@ class AccountFilter
     order
   ).freeze
 
+  IGNORED_PARAMS = %w(page).freeze
+
   attr_reader :params
 
   def initialize(params)
@@ -24,7 +26,7 @@ class AccountFilter
     scope = Account.includes(:account_stat, user: [:ips, :invite_request]).without_instance_actor
 
     relevant_params.each do |key, value|
-      next if key.to_s == 'page'
+      next if IGNORED_PARAMS.include?(key.to_s)
 
       scope.merge!(scope_for(key, value)) if value.present?
     end

--- a/app/models/admin/action_log_filter.rb
+++ b/app/models/admin/action_log_filter.rb
@@ -82,6 +82,8 @@ class Admin::ActionLogFilter
     destroy_username_block: { target_type: 'UsernameBlock', action: 'destroy' }.freeze,
   }.freeze
 
+  IGNORED_PARAMS = %w(page).freeze
+
   attr_reader :params
 
   def initialize(params)
@@ -92,7 +94,7 @@ class Admin::ActionLogFilter
     scope = latest_action_logs.includes(:target, :account)
 
     params.each do |key, value|
-      next if key.to_s == 'page'
+      next if IGNORED_PARAMS.include?(key.to_s)
 
       scope.merge!(scope_for(key.to_s, value.to_s.strip)) if value.present?
     end

--- a/app/models/admin/tag_filter.rb
+++ b/app/models/admin/tag_filter.rb
@@ -7,6 +7,8 @@ class Admin::TagFilter
     order
   ).freeze
 
+  IGNORED_PARAMS = %w(page).freeze
+
   attr_reader :params
 
   def initialize(params)
@@ -17,7 +19,7 @@ class Admin::TagFilter
     scope = Tag.all
 
     params.each do |key, value|
-      next if key == :page
+      next if IGNORED_PARAMS.include?(key.to_s)
 
       scope.merge!(scope_for(key, value)) if value.present?
     end

--- a/app/models/announcement_filter.rb
+++ b/app/models/announcement_filter.rb
@@ -6,6 +6,8 @@ class AnnouncementFilter
     unpublished
   ).freeze
 
+  IGNORED_PARAMS = %w(page).freeze
+
   attr_reader :params
 
   def initialize(params)
@@ -16,7 +18,7 @@ class AnnouncementFilter
     scope = Announcement.unscoped
 
     params.each do |key, value|
-      next if key.to_s == 'page'
+      next if IGNORED_PARAMS.include?(key.to_s)
 
       scope.merge!(scope_for(key, value.to_s.strip)) if value.present?
     end

--- a/app/models/custom_emoji_filter.rb
+++ b/app/models/custom_emoji_filter.rb
@@ -8,6 +8,8 @@ class CustomEmojiFilter
     shortcode
   ).freeze
 
+  IGNORED_PARAMS = %w(page).freeze
+
   attr_reader :params
 
   def initialize(params)
@@ -18,7 +20,7 @@ class CustomEmojiFilter
     scope = CustomEmoji.alphabetic
 
     params.each do |key, value|
-      next if key.to_s == 'page'
+      next if IGNORED_PARAMS.include?(key.to_s)
 
       scope.merge!(scope_for(key, value)) if value.present?
     end

--- a/app/models/trends/preview_card_provider_filter.rb
+++ b/app/models/trends/preview_card_provider_filter.rb
@@ -5,6 +5,8 @@ class Trends::PreviewCardProviderFilter
     status
   ).freeze
 
+  IGNORED_PARAMS = %w(page).freeze
+
   attr_reader :params
 
   def initialize(params)
@@ -15,7 +17,7 @@ class Trends::PreviewCardProviderFilter
     scope = PreviewCardProvider.unscoped
 
     params.each do |key, value|
-      next if key.to_s == 'page'
+      next if IGNORED_PARAMS.include?(key.to_s)
 
       scope.merge!(scope_for(key, value.to_s.strip)) if value.present?
     end


### PR DESCRIPTION
This collection of `*Filter` classes has some which define this constant to hold a list of skippable params, and others which do an explicit check in the scope building loop. Change here is just to standardize on the constant approach. (while all changes in this diff have only `page`, some of the other classes do have others).

This is in some parts prep for another attempt at something like https://github.com/mastodon/mastodon/pull/35154 ... but also seems worthwhile on itself for consistency. Would probably have this as constant or overrideable method in hypothetical future base class re-attempt.