### PR TITLE
Simplify media attachment lookup in show/player actions

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -24,11 +24,7 @@ class MediaController < ApplicationController
   private
 
   def set_media_attachment
-    @media_attachment = MediaAttachment.local.attached.identified(relevant_identifier)
-  end
-
-  def relevant_identifier
-    params[:id] || params[:medium_id]
+    @media_attachment = MediaAttachment.local.attached.identified(params[:id])
   end
 
   def verify_permitted_status!

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -24,7 +24,7 @@ class MediaController < ApplicationController
   private
 
   def set_media_attachment
-    @media_attachment = MediaAttachment.identified(relevant_identifier)
+    @media_attachment = MediaAttachment.local.attached.identified(relevant_identifier)
   end
 
   def relevant_identifier

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -25,7 +25,6 @@ class MediaController < ApplicationController
 
   def set_media_attachment
     id = params[:id] || params[:medium_id]
-    return if id.nil?
 
     scope = MediaAttachment.local.attached
     # If id is 19 characters long, it's a shortcode, otherwise it's an identifier

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -24,8 +24,11 @@ class MediaController < ApplicationController
   private
 
   def set_media_attachment
-    identifier = params[:id] || params[:medium_id]
-    @media_attachment = MediaAttachment.identified(identifier)
+    @media_attachment = MediaAttachment.identified(relevant_identifier)
+  end
+
+  def relevant_identifier
+    params[:id] || params[:medium_id]
   end
 
   def verify_permitted_status!

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -24,11 +24,8 @@ class MediaController < ApplicationController
   private
 
   def set_media_attachment
-    id = params[:id] || params[:medium_id]
-
-    scope = MediaAttachment.local.attached
-    # If id is 19 characters long, it's a shortcode, otherwise it's an identifier
-    @media_attachment = id.size == 19 ? scope.find_by!(shortcode: id) : scope.find(id)
+    identifier = params[:id] || params[:medium_id]
+    @media_attachment = MediaAttachment.identified(identifier)
   end
 
   def verify_permitted_status!

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -38,6 +38,8 @@ class MediaAttachment < ApplicationRecord
   enum :type, { image: 0, gifv: 1, video: 2, unknown: 3, audio: 4 }
   enum :processing, { queued: 0, in_progress: 1, complete: 2, failed: 3 }, prefix: true
 
+  SHORTCODE_LENGTH = 19
+
   MAX_DESCRIPTION_LENGTH = 1_500
   MAX_DESCRIPTION_HARD_LENGTH_LIMIT = 10_000
 
@@ -301,7 +303,7 @@ class MediaAttachment < ApplicationRecord
 
   class << self
     def identified(identifier)
-      identifier.size == 19 ? find_by!(shortcode: identifier) : find(identifier)
+      identifier.size == SHORTCODE_LENGTH ? find_by!(shortcode: identifier) : find(identifier)
     end
 
     def supported_mime_types

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -300,10 +300,8 @@ class MediaAttachment < ApplicationRecord
   after_post_process :set_meta
 
   class << self
-    def identified(id)
-      MediaAttachment.local.attached.then do |scope|
-        id.size == 19 ? scope.find_by!(shortcode: id) : scope.find(id)
-      end
+    def identified(identifier)
+      identifier.size == 19 ? find_by!(shortcode: identifier) : find(identifier)
     end
 
     def supported_mime_types

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -300,6 +300,12 @@ class MediaAttachment < ApplicationRecord
   after_post_process :set_meta
 
   class << self
+    def identified(id)
+      MediaAttachment.local.attached.then do |scope|
+        id.size == 19 ? scope.find_by!(shortcode: id) : scope.find(id)
+      end
+    end
+
     def supported_mime_types
       IMAGE_MIME_TYPES + VIDEO_MIME_TYPES + AUDIO_MIME_TYPES
     end

--- a/app/serializers/seo/social_media_posting_serializer.rb
+++ b/app/serializers/seo/social_media_posting_serializer.rb
@@ -97,7 +97,7 @@ class SEO::SocialMediaPostingSerializer < ActiveModel::Serializer
         upload_date: attachment.created_at.iso8601,
         content_url: full_asset_url(attachment.file.url(:original, false)),
         thumbnail_url: attachment.thumbnail.present? ? full_asset_url(attachment.thumbnail.url(:original)) : full_asset_url(attachment.file.url(:small)),
-        embed_url: medium_player_url(attachment),
+        embed_url: player_medium_url(attachment),
         description: attachment.description,
       }
     end
@@ -112,7 +112,7 @@ class SEO::SocialMediaPostingSerializer < ActiveModel::Serializer
         upload_date: attachment.created_at.iso8601,
         content_url: full_asset_url(attachment.file.url(:original, false)),
         thumbnail_url: attachment.thumbnail.present? ? full_asset_url(attachment.thumbnail.url(:original)) : full_asset_url(attachment.file.url(:small)),
-        embed_url: medium_player_url(attachment),
+        embed_url: player_medium_url(attachment),
         description: attachment.description,
       }
     end

--- a/app/views/statuses/_og_image.html.haml
+++ b/app/views/statuses/_og_image.html.haml
@@ -19,7 +19,7 @@
       = opengraph 'og:video', full_asset_url(media.file.url(:original))
       = opengraph 'og:video:secure_url', full_asset_url(media.file.url(:original))
       = opengraph 'og:video:type', media.file_content_type
-      = opengraph 'twitter:player', medium_player_url(media)
+      = opengraph 'twitter:player', player_medium_url(media)
       = opengraph 'twitter:player:stream', full_asset_url(media.file.url(:original))
       = opengraph 'twitter:player:stream:content_type', media.file_content_type
       - unless media.file.meta.nil?
@@ -35,7 +35,7 @@
       = opengraph 'og:audio', full_asset_url(media.file.url(:original))
       = opengraph 'og:audio:secure_url', full_asset_url(media.file.url(:original))
       = opengraph 'og:audio:type', media.file_content_type
-      = opengraph 'twitter:player', medium_player_url(media)
+      = opengraph 'twitter:player', player_medium_url(media)
       = opengraph 'twitter:player:stream', full_asset_url(media.file.url(:original))
       = opengraph 'twitter:player:stream:content_type', media.file_content_type
       = opengraph 'twitter:player:width', '670'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -193,7 +193,7 @@ Rails.application.routes.draw do
   end
 
   resources :media, only: [:show] do
-    get :player
+    member { get :player }
   end
 
   resources :tags,   only: [:show]

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'Media' do
       let(:media) { Fabricate :media_attachment }
 
       it 'responds with not found' do
-        get medium_player_path(media)
+        get player_medium_path(media)
 
         expect(response)
           .to have_http_status(404)

--- a/spec/system/media_spec.rb
+++ b/spec/system/media_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Media' do
         let(:media) { Fabricate :media_attachment, type: :video }
 
         it 'visits the player page and renders media' do
-          visit medium_player_path(media)
+          visit player_medium_path(media)
 
           expect(page)
             .to have_css('body', class: 'player')
@@ -27,7 +27,7 @@ RSpec.describe 'Media' do
         let(:media) { Fabricate :media_attachment, type: :gifv }
 
         it 'visits the player page and renders media' do
-          visit medium_player_path(media)
+          visit player_medium_path(media)
 
           expect(page)
             .to have_css('body', class: 'player')
@@ -39,7 +39,7 @@ RSpec.describe 'Media' do
         let(:media) { Fabricate :media_attachment, type: :audio }
 
         it 'visits the player page and renders media' do
-          visit medium_player_path(media)
+          visit player_medium_path(media)
 
           expect(page)
             .to have_css('body', class: 'player')


### PR DESCRIPTION
There were a few awkward things about this before action...

- Because of how the nested routes are setup, the param could be either `id` or `medium_id`
- There's a check for a nil value - but nothing would be routed here w/out that value (?)
- The controller has knowledge of what defines a shortcode vs a normal ID

Changes:

- Remove the nil check since (I dont think?!) it can ever be relevant
- Add a class method and constant to the model to wrap up the "find by shortcode or id" ternary check
- Change route to a member route, which makes the param always be `id`

As a side effect of the route change the generated method names changed, but the inbound paths should be the same.

Separately, this PR was ~5 years ago https://github.com/mastodon/mastodon/pull/16730 and had talk of deprecating/removing the shortcode entirely. Does that make sense at this point?