### PR TITLE
Extract partial for common session detail data in user mailer

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -190,11 +190,8 @@ class UserMailer < Devise::Mailer
   end
 
   def suspicious_sign_in(user, remote_ip, user_agent, timestamp)
-    @resource   = user
-    @remote_ip  = remote_ip
-    @user_agent = user_agent
-    @detection  = Browser.new(user_agent)
-    @timestamp  = timestamp.to_time.utc
+    @resource = user
+    @session_detail = SessionDetailPresenter.new(user, remote_ip, user_agent, timestamp)
 
     I18n.with_locale(locale) do
       mail subject: default_i18n_subject
@@ -202,11 +199,8 @@ class UserMailer < Devise::Mailer
   end
 
   def failed_2fa(user, remote_ip, user_agent, timestamp)
-    @resource   = user
-    @remote_ip  = remote_ip
-    @user_agent = user_agent
-    @detection  = Browser.new(user_agent)
-    @timestamp  = timestamp.to_time.utc
+    @resource = user
+    @session_detail = SessionDetailPresenter.new(user, remote_ip, user_agent, timestamp)
 
     I18n.with_locale(locale) do
       mail subject: default_i18n_subject

--- a/app/presenters/session_detail_presenter.rb
+++ b/app/presenters/session_detail_presenter.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class SessionDetailPresenter
+  attr_reader :remote_ip, :user_agent
+
+  def initialize(user, remote_ip, user_agent, timestamp)
+    @user = user
+    @remote_ip = remote_ip
+    @user_agent = user_agent
+    @timestamp = timestamp
+  end
+
+  def to_partial_path
+    'user_mailer/session_detail'
+  end
+
+  def browser
+    I18n.t("sessions.browsers.#{browser_id}", default: browser_id)
+  end
+
+  def platform
+    I18n.t("sessions.platforms.#{platform_id}", default: platform_id)
+  end
+
+  def access_time
+    @timestamp.in_time_zone(@user.time_zone.presence)
+  end
+
+  private
+
+  def browser_id
+    detection.id.to_s
+  end
+
+  def platform_id
+    detection.platform.id.to_s
+  end
+
+  def detection
+    @detection ||= Browser.new(@user_agent)
+  end
+end

--- a/app/views/user_mailer/_session_detail.html.haml
+++ b/app/views/user_mailer/_session_detail.html.haml
@@ -1,0 +1,12 @@
+%p
+  %strong #{t('sessions.ip')}:
+  = session_detail.remote_ip
+  %br/
+  %strong #{t('sessions.browser')}:
+  %span{ title: session_detail.user_agent }
+    = t 'sessions.description',
+        browser: session_detail.browser,
+        platform: session_detail.platform
+  %br/
+  %strong #{t('sessions.date')}:
+  = l(session_detail.access_time, format: :with_time_zone)

--- a/app/views/user_mailer/_session_detail.text.erb
+++ b/app/views/user_mailer/_session_detail.text.erb
@@ -1,0 +1,3 @@
+<%= t('sessions.ip') %>: <%= session_detail.remote_ip %>
+<%= t('sessions.browser') %>: <%= t('sessions.description', browser: session_detail.browser, platform: session_detail.platform ) %>
+<%= l(session_detail.access_time, format: :with_time_zone) %>

--- a/app/views/user_mailer/failed_2fa.html.haml
+++ b/app/views/user_mailer/failed_2fa.html.haml
@@ -10,18 +10,7 @@
         %tr
           %td.email-inner-card-td.email-prose
             %p= t 'user_mailer.failed_2fa.details'
-            %p
-              %strong #{t('sessions.ip')}:
-              = @remote_ip
-              %br/
-              %strong #{t('sessions.browser')}:
-              %span{ title: @user_agent }
-                = t 'sessions.description',
-                    browser: t("sessions.browsers.#{@detection.id}", default: @detection.id.to_s),
-                    platform: t("sessions.platforms.#{@detection.platform.id}", default: @detection.platform.id.to_s)
-              %br/
-              %strong #{t('sessions.date')}:
-              = l(@timestamp.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
+            = render @session_detail
             = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
       %p= t 'user_mailer.failed_2fa.further_actions_html',
             action: link_to(t('user_mailer.suspicious_sign_in.change_password'), edit_user_registration_url)

--- a/app/views/user_mailer/failed_2fa.text.erb
+++ b/app/views/user_mailer/failed_2fa.text.erb
@@ -6,9 +6,7 @@
 
 <%= t 'user_mailer.failed_2fa.details' %>
 
-<%= t('sessions.ip') %>: <%= @remote_ip %>
-<%= t('sessions.browser') %>: <%= t('sessions.description', browser: t("sessions.browsers.#{@detection.id}", default: "#{@detection.id}"), platform: t("sessions.platforms.#{@detection.platform.id}", default: "#{@detection.platform.id}")) %>
-<%= l(@timestamp.in_time_zone(@resource.time_zone.presence), format: :with_time_zone) %>
+<%= render @session_detail %>
 
 <%= t 'user_mailer.failed_2fa.further_actions_html', action: t('user_mailer.suspicious_sign_in.change_password') %>
 

--- a/app/views/user_mailer/suspicious_sign_in.html.haml
+++ b/app/views/user_mailer/suspicious_sign_in.html.haml
@@ -10,18 +10,7 @@
         %tr
           %td.email-inner-card-td.email-prose
             %p= t 'user_mailer.suspicious_sign_in.details'
-            %p
-              %strong #{t('sessions.ip')}:
-              = @remote_ip
-              %br/
-              %strong #{t('sessions.browser')}:
-              %span{ title: @user_agent }
-                = t 'sessions.description',
-                    browser: t("sessions.browsers.#{@detection.id}", default: @detection.id.to_s),
-                    platform: t("sessions.platforms.#{@detection.platform.id}", default: @detection.platform.id.to_s)
-              %br/
-              %strong #{t('sessions.date')}:
-              = l(@timestamp.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
+            = render @session_detail
             = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
       %p= t 'user_mailer.suspicious_sign_in.further_actions_html',
             action: link_to(t('user_mailer.suspicious_sign_in.change_password'), edit_user_registration_url)

--- a/app/views/user_mailer/suspicious_sign_in.text.erb
+++ b/app/views/user_mailer/suspicious_sign_in.text.erb
@@ -6,9 +6,7 @@
 
 <%= t 'user_mailer.suspicious_sign_in.details' %>
 
-<%= t('sessions.ip') %>: <%= @remote_ip %>
-<%= t('sessions.browser') %>: <%= t('sessions.description', browser: t("sessions.browsers.#{@detection.id}", default: "#{@detection.id}"), platform: t("sessions.platforms.#{@detection.platform.id}", default: "#{@detection.platform.id}")) %>
-<%= l(@timestamp.in_time_zone(@resource.time_zone.presence), format: :with_time_zone) %>
+<%= render @session_detail %>
 
 <%= t 'user_mailer.suspicious_sign_in.further_actions_html', action: t('user_mailer.suspicious_sign_in.change_password') %>
 


### PR DESCRIPTION
The `failed_2fa` and `suspicious_sign_in` views have the same text and html blocks to handle the session IP, browser, timestamp output. The initial change here was just to extract text and html partials to pull out that overlapping snippet.

That was an improvement to the views, but sort of weird passing in ~5 i-vars to a partial. Followup change was to wrap up the session detail into a presenter class, simplifying the mailer actions and the render call in the view.

