### PR TITLE
Profile redesign: Persist filter setting

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/v2/context.tsx
+++ b/app/javascript/mastodon/features/account_timeline/v2/context.tsx
@@ -27,8 +27,8 @@ export const AccountTimelineProvider: FC<{
   children: ReactNode;
 }> = ({ accountId, children }) => {
   const storageOptions = {
-    type: 'session',
-    prefix: `filters-${accountId}:`,
+    type: 'local',
+    prefix: 'account-filters',
   } as const;
 
   const [boosts, setBoosts] = useStorageState<boolean>(


### PR DESCRIPTION
This makes filters persist in local storage instead of session storage, and apply for _all_ account timelines.