### PR TITLE
Profile redesign: Handle + tab changes

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/components/account_name.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_name.tsx
@@ -8,13 +8,16 @@ import classNames from 'classnames';
 import Overlay from 'react-overlays/esm/Overlay';
 
 import FollowerIcon from '@/images/icons/icon_follower.svg?react';
+import { showAlert } from '@/mastodon/actions/alerts';
 import { Badge } from '@/mastodon/components/badge';
+import { Button } from '@/mastodon/components/button';
 import { DisplayName } from '@/mastodon/components/display_name';
 import { Icon } from '@/mastodon/components/icon';
 import { useAccount } from '@/mastodon/hooks/useAccount';
 import { useRelationship } from '@/mastodon/hooks/useRelationship';
-import { useAppSelector } from '@/mastodon/store';
+import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 import AtIcon from '@/material-icons/400-24px/alternate_email.svg?react';
+import ContentCopyIcon from '@/material-icons/400-24px/content_copy.svg?react';
 import HelpIcon from '@/material-icons/400-24px/help.svg?react';
 import DomainIcon from '@/material-icons/400-24px/language.svg?react';
 
@@ -29,6 +32,10 @@ const messages = defineMessages({
   nameInfo: {
     id: 'account.name_info',
     defaultMessage: 'What does this mean?',
+  },
+  copied: {
+    id: 'copy_icon_button.copied',
+    defaultMessage: 'Copied to clipboard',
   },
 });
 
@@ -88,6 +95,19 @@ const AccountNameHelp: FC<{
     setOpen((prev) => !prev);
   }, []);
 
+  const handle = `@${username}@${domain}`;
+
+  const dispatch = useAppDispatch();
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard.writeText(handle);
+    setCopied(true);
+    dispatch(showAlert({ message: messages.copied }));
+    setTimeout(() => {
+      setCopied(false);
+    }, 700);
+  }, [handle, dispatch]);
+
   return (
     <>
       <button
@@ -98,7 +118,8 @@ const AccountNameHelp: FC<{
         aria-expanded={open}
         aria-controls={accessibilityId}
       >
-        @{username}@{domain}
+        {handle}
+
         <Icon
           id='help'
           icon={HelpIcon}
@@ -168,6 +189,22 @@ const AccountNameHelp: FC<{
               defaultMessage='Just like you can send emails to people using different email clients, you can interact with people on other Mastodon servers – and with anyone on other social apps powered by the same set of rules as Mastodon uses (the ActivityPub protocol).'
               tagName='p'
             />
+
+            <Button onClick={handleCopy} className={classes.handleCopy}>
+              <Icon id='copy' icon={ContentCopyIcon} />
+              {!copied && (
+                <FormattedMessage
+                  id='account.name.copy'
+                  defaultMessage='Copy handle'
+                />
+              )}
+              {copied && (
+                <FormattedMessage
+                  id='copypaste.copied'
+                  defaultMessage='Copied'
+                />
+              )}
+            </Button>
           </div>
         )}
       </Overlay>

--- a/app/javascript/mastodon/features/account_timeline/components/account_name.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_name.tsx
@@ -64,14 +64,12 @@ export const AccountName: FC<{ accountId: string }> = ({ accountId }) => {
           />
         )}
       </div>
-      <p className={classes.username}>
-        @{username}@{domain}
-        <AccountNameHelp
-          username={username}
-          domain={domain}
-          isSelf={account.id === me}
-        />
-      </p>
+
+      <AccountNameHelp
+        username={username}
+        domain={domain}
+        isSelf={account.id === me}
+      />
     </div>
   );
 };
@@ -100,6 +98,7 @@ const AccountNameHelp: FC<{
         aria-expanded={open}
         aria-controls={accessibilityId}
       >
+        @{username}@{domain}
         <Icon
           id='help'
           icon={HelpIcon}

--- a/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
@@ -76,6 +76,10 @@
   max-width: 400px;
   box-sizing: border-box;
 
+  [data-color-scheme='dark'] & {
+    border: 1px solid var(--color-border-primary);
+  }
+
   > h3 {
     font-size: 17px;
     font-weight: 600;

--- a/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
@@ -336,7 +336,7 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
 
 .tabs {
   display: flex;
-  gap: 12px;
+  gap: 16px;
   padding: 0 16px;
 
   @container (width < 500px) {
@@ -350,7 +350,7 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
     display: block;
     font-size: 15px;
     font-weight: 500;
-    padding: 18px 4px;
+    padding: 18px 0;
     text-decoration: none;
     color: var(--color-text-primary);
     border-radius: 0;

--- a/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
@@ -43,30 +43,22 @@
   color: var(--color-text-secondary);
 }
 
-.username {
-  display: flex;
-  font-size: 13px;
-  color: var(--color-text-secondary);
-  align-items: center;
-  user-select: all;
-  margin-top: 4px;
-}
-
 .handleHelpButton {
-  appearance: none;
-  border: none;
-  background: none;
+  display: flex;
+  gap: 2px;
   padding: 0;
-  color: inherit;
-  font-size: 1em;
-  margin-left: 2px;
-  width: 16px;
-  height: 16px;
+  margin-top: 4px;
+  align-items: center;
+  appearance: none;
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: 13px;
   transition: color 0.2s ease-in-out;
 
   > svg {
-    width: 100%;
-    height: 100%;
+    width: 16px;
+    height: 16px;
   }
 
   &:hover,

--- a/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/redesign.module.scss
@@ -97,15 +97,15 @@
     &:first-child {
       margin-bottom: 12px;
     }
-  }
 
-  svg {
-    background: var(--color-bg-brand-softest);
-    width: 28px;
-    height: 28px;
-    padding: 5px;
-    border-radius: 9999px;
-    box-sizing: border-box;
+    > svg {
+      background: var(--color-bg-brand-softest);
+      width: 28px;
+      height: 28px;
+      padding: 5px;
+      border-radius: 9999px;
+      box-sizing: border-box;
+    }
   }
 
   strong {
@@ -125,6 +125,26 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
     @media (max-width: #{$button-fallback-breakpoint}) {
       display: none;
     }
+  }
+}
+
+.handleCopy {
+  border: 1px solid var(--color-border-primary);
+  border-radius: 8px;
+  box-sizing: border-box;
+  padding: 4px 8px;
+  background-color: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-size: 13px;
+  transition:
+    color 0.2s ease-in-out,
+    background-color 0.2s ease-in-out;
+  margin-top: 12px;
+
+  &:active,
+  &:focus,
+  &:hover {
+    background-color: var(--color-bg-brand-softest);
   }
 }
 

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -102,6 +102,7 @@
   "account.muted": "Muted",
   "account.muting": "Muting",
   "account.mutual": "You follow each other",
+  "account.name.copy": "Copy handle",
   "account.name.help.domain": "{domain} is the server that hosts the user’s profile and posts.",
   "account.name.help.domain_self": "{domain} is your server that hosts your profile and posts.",
   "account.name.help.footer": "Just like you can send emails to people using different email clients, you can interact with people on other Mastodon servers – and with anyone on other social apps powered by the same set of rules as Mastodon uses (the ActivityPub protocol).",


### PR DESCRIPTION
Fixes WEB-943, WEB-939, and WEB-948.

- Adds a "copy handle" button to the handle explainer popup
- Makes the handle popup appear when clicking any part of the username
- Added faint border in dark mode for better readability, like we did for the filter popup
- Tweaked padding on tabs to align with edges

| Dark | Light |
| - | - |
|<img width="866" height="668" alt="Screenshot 2026-04-07 at 13 05 48" src="https://github.com/user-attachments/assets/a9d9a19b-3cd8-4614-a2da-e39031ed3b07" />|<img width="866" height="668" alt="Screenshot 2026-04-07 at 13 06 02" src="https://github.com/user-attachments/assets/55e1b1a3-1448-4de8-b4d8-7d7cf5f0c4f7" />|

Tab spacing:

<img width="952" height="436" alt="Screenshot 2026-04-07 at 13 06 56" src="https://github.com/user-attachments/assets/3f805888-2ff4-4ec2-9a1e-0b257f7dc899" />
