### PR TITLE
Profile editing: Fix regression with adding tags

### DIFF
--- a/app/javascript/mastodon/features/account_edit/components/tag_search.tsx
+++ b/app/javascript/mastodon/features/account_edit/components/tag_search.tsx
@@ -65,7 +65,7 @@ export const AccountEditTagSearch: FC = () => {
         value={query}
         onChange={handleSearchChange}
         placeholder={inputLabel}
-        items={suggestedTags as TagSearchResult[]}
+        items={suggestedTags}
         isLoading={isLoading}
         renderItem={renderItem}
         onSelectItem={handleSelect}

--- a/app/javascript/mastodon/features/account_timeline/v2/tags_suggestions.tsx
+++ b/app/javascript/mastodon/features/account_timeline/v2/tags_suggestions.tsx
@@ -14,20 +14,27 @@ import {
   fetchSuggestedTags,
   addFeaturedTags,
 } from '@/mastodon/reducers/slices/profile_edit';
-import { useAppSelector, useAppDispatch } from '@/mastodon/store';
+import {
+  useAppSelector,
+  useAppDispatch,
+  createAppSelector,
+} from '@/mastodon/store';
 
 import classes from './styles.module.scss';
 
 const MAX_SUGGESTED_TAGS = 3;
+
+const selectSuggestedTags = createAppSelector(
+  [(state) => state.profileEdit.tagSuggestions],
+  (tagSuggestions) => tagSuggestions?.slice(0, MAX_SUGGESTED_TAGS),
+);
 
 export const TagSuggestions: FC = () => {
   const { dismiss, wasDismissed } = useDismissible(
     'profile/featured_tag_suggestions',
   );
 
-  const suggestedTags = useAppSelector((state) =>
-    state.profileEdit.tagSuggestions?.slice(0, MAX_SUGGESTED_TAGS),
-  );
+  const suggestedTags = useAppSelector(selectSuggestedTags);
   const existingTagCount = useAppSelector(
     (state) => state.profileEdit.profile?.featuredTags.length,
   );

--- a/app/javascript/mastodon/hooks/useSearchTags.ts
+++ b/app/javascript/mastodon/hooks/useSearchTags.ts
@@ -91,8 +91,8 @@ export function useSearchTags({
   // Add dedicated item for adding the current query
   const tags = useMemo(() => {
     const trimmedQuery = query ? trimHashFromStart(query.trim()) : '';
-    if (!trimmedQuery || !fetchedTags.length) {
-      return fetchedTags;
+    if (!trimmedQuery) {
+      return fetchedTags as TagSearchResult[];
     }
 
     const results: TagSearchResult[] = [...fetchedTags]; // Make array mutable


### PR DESCRIPTION
This fixes a regression from #38307 where tags that don't appear in search are not allowed to be added.

This also adds a memoized selector as Redux was throwing warnings.