### PR TITLE
Extract `BaseFilter` class to hold common setup for filters

### DIFF
--- a/app/filters/admin/action_log_filter.rb
+++ b/app/filters/admin/action_log_filter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::ActionLogFilter
+class Admin::ActionLogFilter < BaseFilter
   KEYS = %i(
     action_type
     account_id
@@ -83,12 +83,6 @@ class Admin::ActionLogFilter
   }.freeze
 
   IGNORED_PARAMS = %w(page).freeze
-
-  attr_reader :params
-
-  def initialize(params)
-    @params = params
-  end
 
   def results
     scope = latest_action_logs.includes(:target, :account)

--- a/app/filters/admin/appeal_filter.rb
+++ b/app/filters/admin/appeal_filter.rb
@@ -1,21 +1,14 @@
 # frozen_string_literal: true
 
-class Trends::TagFilter
+class Admin::AppealFilter < BaseFilter
   KEYS = %i(
-    trending
     status
   ).freeze
 
   IGNORED_PARAMS = %w(page).freeze
 
-  attr_reader :params
-
-  def initialize(params)
-    @params = params
-  end
-
   def results
-    scope = initial_scope
+    scope = Appeal.order(id: :desc)
 
     params.each do |key, value|
       next if IGNORED_PARAMS.include?(key.to_s)
@@ -28,43 +21,25 @@ class Trends::TagFilter
 
   private
 
-  def initial_scope
-    Tag.select(Tag.arel_table[Arel.star])
-      .joins(:trend)
-      .eager_load(:trend)
-      .reorder(score: :desc)
-  end
-
   def scope_for(key, value)
     case key.to_s
     when 'status'
       status_scope(value)
-    when 'trending'
-      trending_scope(value)
     else
       raise Mastodon::InvalidParameterError, "Unknown filter: #{key}"
     end
   end
 
   def status_scope(value)
-    case value.to_s
+    case value
     when 'approved'
-      Tag.trendable
+      Appeal.approved
     when 'rejected'
-      Tag.not_trendable
-    when 'pending_review'
-      Tag.pending_review
+      Appeal.rejected
+    when 'pending'
+      Appeal.pending
     else
       raise Mastodon::InvalidParameterError, "Unknown status: #{value}"
-    end
-  end
-
-  def trending_scope(value)
-    case value
-    when 'allowed'
-      TagTrend.allowed
-    else
-      TagTrend.all
     end
   end
 end

--- a/app/filters/announcement_filter.rb
+++ b/app/filters/announcement_filter.rb
@@ -1,18 +1,12 @@
 # frozen_string_literal: true
 
-class AnnouncementFilter
+class AnnouncementFilter < BaseFilter
   KEYS = %i(
     published
     unpublished
   ).freeze
 
   IGNORED_PARAMS = %w(page).freeze
-
-  attr_reader :params
-
-  def initialize(params)
-    @params = params
-  end
 
   def results
     scope = Announcement.unscoped

--- a/app/filters/base_filter.rb
+++ b/app/filters/base_filter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class BaseFilter
+  attr_reader :params
+
+  def initialize(params)
+    @params = params
+  end
+end

--- a/app/filters/custom_emoji_filter.rb
+++ b/app/filters/custom_emoji_filter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CustomEmojiFilter
+class CustomEmojiFilter < BaseFilter
   KEYS = %i(
     local
     remote
@@ -9,12 +9,6 @@ class CustomEmojiFilter
   ).freeze
 
   IGNORED_PARAMS = %w(page).freeze
-
-  attr_reader :params
-
-  def initialize(params)
-    @params = params
-  end
 
   def results
     scope = CustomEmoji.alphabetic

--- a/app/filters/instance_filter.rb
+++ b/app/filters/instance_filter.rb
@@ -1,17 +1,11 @@
 # frozen_string_literal: true
 
-class InstanceFilter
+class InstanceFilter < BaseFilter
   KEYS = %i(
     limited
     by_domain
     availability
   ).freeze
-
-  attr_reader :params
-
-  def initialize(params)
-    @params = params
-  end
 
   def results
     scope = Instance.includes(:domain_block, :domain_allow, :unavailable_domain).order(accounts_count: :desc)

--- a/app/filters/invite_filter.rb
+++ b/app/filters/invite_filter.rb
@@ -1,16 +1,10 @@
 # frozen_string_literal: true
 
-class InviteFilter
+class InviteFilter < BaseFilter
   KEYS = %i(
     available
     expired
   ).freeze
-
-  attr_reader :params
-
-  def initialize(params)
-    @params = params
-  end
 
   def results
     scope = Invite.order(created_at: :desc)

--- a/app/filters/report_filter.rb
+++ b/app/filters/report_filter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ReportFilter
+class ReportFilter < BaseFilter
   KEYS = %i(
     resolved
     account_id
@@ -8,12 +8,6 @@ class ReportFilter
     by_target_domain
     target_origin
   ).freeze
-
-  attr_reader :params
-
-  def initialize(params)
-    @params = params
-  end
 
   def results
     scope = Report.unresolved

--- a/app/filters/trends/preview_card_filter.rb
+++ b/app/filters/trends/preview_card_filter.rb
@@ -1,18 +1,12 @@
 # frozen_string_literal: true
 
-class Trends::PreviewCardFilter
+class Trends::PreviewCardFilter < BaseFilter
   KEYS = %i(
     trending
     locale
   ).freeze
 
   IGNORED_PARAMS = %w(page).freeze
-
-  attr_reader :params
-
-  def initialize(params)
-    @params = params
-  end
 
   def results
     scope = initial_scope

--- a/app/filters/trends/preview_card_provider_filter.rb
+++ b/app/filters/trends/preview_card_provider_filter.rb
@@ -1,20 +1,14 @@
 # frozen_string_literal: true
 
-class Admin::AppealFilter
+class Trends::PreviewCardProviderFilter < BaseFilter
   KEYS = %i(
     status
   ).freeze
 
   IGNORED_PARAMS = %w(page).freeze
 
-  attr_reader :params
-
-  def initialize(params)
-    @params = params
-  end
-
   def results
-    scope = Appeal.order(id: :desc)
+    scope = PreviewCardProvider.unscoped
 
     params.each do |key, value|
       next if IGNORED_PARAMS.include?(key.to_s)
@@ -22,7 +16,7 @@ class Admin::AppealFilter
       scope.merge!(scope_for(key, value.to_s.strip)) if value.present?
     end
 
-    scope
+    scope.order(domain: :asc)
   end
 
   private
@@ -37,13 +31,13 @@ class Admin::AppealFilter
   end
 
   def status_scope(value)
-    case value
+    case value.to_s
     when 'approved'
-      Appeal.approved
+      PreviewCardProvider.trendable
     when 'rejected'
-      Appeal.rejected
-    when 'pending'
-      Appeal.pending
+      PreviewCardProvider.not_trendable
+    when 'pending_review'
+      PreviewCardProvider.unreviewed
     else
       raise Mastodon::InvalidParameterError, "Unknown status: #{value}"
     end

--- a/app/filters/trends/status_filter.rb
+++ b/app/filters/trends/status_filter.rb
@@ -1,18 +1,12 @@
 # frozen_string_literal: true
 
-class Trends::StatusFilter
+class Trends::StatusFilter < BaseFilter
   KEYS = %i(
     trending
     locale
   ).freeze
 
   IGNORED_PARAMS = %w(page).freeze
-
-  attr_reader :params
-
-  def initialize(params)
-    @params = params
-  end
 
   def results
     scope = initial_scope

--- a/app/filters/trends/tag_filter.rb
+++ b/app/filters/trends/tag_filter.rb
@@ -1,20 +1,15 @@
 # frozen_string_literal: true
 
-class Trends::PreviewCardProviderFilter
+class Trends::TagFilter < BaseFilter
   KEYS = %i(
+    trending
     status
   ).freeze
 
   IGNORED_PARAMS = %w(page).freeze
 
-  attr_reader :params
-
-  def initialize(params)
-    @params = params
-  end
-
   def results
-    scope = PreviewCardProvider.unscoped
+    scope = initial_scope
 
     params.each do |key, value|
       next if IGNORED_PARAMS.include?(key.to_s)
@@ -22,15 +17,24 @@ class Trends::PreviewCardProviderFilter
       scope.merge!(scope_for(key, value.to_s.strip)) if value.present?
     end
 
-    scope.order(domain: :asc)
+    scope
   end
 
   private
+
+  def initial_scope
+    Tag.select(Tag.arel_table[Arel.star])
+      .joins(:trend)
+      .eager_load(:trend)
+      .reorder(score: :desc)
+  end
 
   def scope_for(key, value)
     case key.to_s
     when 'status'
       status_scope(value)
+    when 'trending'
+      trending_scope(value)
     else
       raise Mastodon::InvalidParameterError, "Unknown filter: #{key}"
     end
@@ -39,13 +43,22 @@ class Trends::PreviewCardProviderFilter
   def status_scope(value)
     case value.to_s
     when 'approved'
-      PreviewCardProvider.trendable
+      Tag.trendable
     when 'rejected'
-      PreviewCardProvider.not_trendable
+      Tag.not_trendable
     when 'pending_review'
-      PreviewCardProvider.unreviewed
+      Tag.pending_review
     else
       raise Mastodon::InvalidParameterError, "Unknown status: #{value}"
+    end
+  end
+
+  def trending_scope(value)
+    case value
+    when 'allowed'
+      TagTrend.allowed
+    else
+      TagTrend.all
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,6 +18,7 @@ if ENV.fetch('COVERAGE', false)
 
     add_filter 'lib/linter'
 
+    add_group 'Filters', 'app/filters'
     add_group 'Libraries', 'lib'
     add_group 'Policies', 'app/policies'
     add_group 'Presenters', 'app/presenters'


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/38559 and re-attempt something like https://github.com/mastodon/mastodon/pull/35154

This PR is merely extracting a base class for all the "filters" which have a simple `initialize`.

Planned/expected followups:

- Convert the last few which do additional things in initialize
- Further movement to base class of both "which params are relevant" and "how to build a scope" methods, with each filter providing its base scope, and its needed add-on scopes to merge in based on params
- Normalize string vs symbol hash keys across filters