### PR TITLE
Update vite to version 8.0.5

### DIFF
--- a/app/javascript/mastodon/polyfills/index.ts
+++ b/app/javascript/mastodon/polyfills/index.ts
@@ -32,7 +32,6 @@ async function loadEmojiPolyfills() {
 // Loads Vite's module preload polyfill for older browsers, but not in a Worker context.
 function loadVitePreloadPolyfill() {
   if (typeof document === 'undefined') return;
-  // @ts-expect-error -- This is a virtual module provided by Vite.
   // eslint-disable-next-line import/extensions
   return import('vite/modulepreload-polyfill');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14741,8 +14741,8 @@ __metadata:
   linkType: hard
 
 "vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0-0, vite@npm:^8.0.0":
-  version: 8.0.3
-  resolution: "vite@npm:8.0.3"
+  version: 8.0.5
+  resolution: "vite@npm:8.0.5"
   dependencies:
     fsevents: "npm:~2.3.3"
     lightningcss: "npm:^1.32.0"
@@ -14753,7 +14753,7 @@ __metadata:
   peerDependencies:
     "@types/node": ^20.19.0 || >=22.12.0
     "@vitejs/devtools": ^0.1.0
-    esbuild: ^0.27.0
+    esbuild: ^0.27.0 || ^0.28.0
     jiti: ">=1.21.0"
     less: ^4.0.0
     sass: ^1.70.0
@@ -14793,7 +14793,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/bed9520358080393a02fe22565b3309b4b3b8f916afe4c97577528f3efb05c1bf4b29f7b552179bc5b3938629e50fbd316231727457411dbc96648fa5c9d14bf
+  checksum: 10c0/bfc22896b2661753c01c398a058f1859bdbd3ebe55f3d8505ab629b39e5f68790c0a6f55f8644b6692b0b9b8e210f698082ef9f4fd0d76509f4a46762fbfbba2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/38573

8.0.5 fixes a CVE, but 8.0.4 fails a lint.

This is the version bump from there plus a removal of no longer needed line (8.0.4 added types to preload polyfill...) which should pass the lint.