### PR TITLE
Pull user settings defaults from configuration

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -23,6 +23,10 @@ module SettingsHelper
       )
   end
 
+  def user_settings_collection(value)
+    UserSettings.definition_for(value)&.in || []
+  end
+
   def author_attribution_name(account)
     return if account.nil?
 

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -36,7 +36,7 @@
       .input.horizontal-options
         = ff.input :'web.color_scheme',
                    as: :radio_buttons,
-                   collection: %w(auto light dark),
+                   collection: user_settings_collection('web.color_scheme'),
                    include_blank: false,
                    label: I18n.t('simple_form.labels.defaults.setting_color_scheme'),
                    label_method: ->(contrast) { I18n.t("color_scheme.#{contrast}", default: contrast) },
@@ -45,7 +45,7 @@
       .input.horizontal-options
         = ff.input :'web.contrast',
                    as: :radio_buttons,
-                   collection: %w(auto high),
+                   collection: user_settings_collection('web.contrast'),
                    include_blank: false,
                    label: I18n.t('simple_form.labels.defaults.setting_contrast'),
                    label_method: ->(contrast) { I18n.t("contrast.#{contrast}", default: contrast) },
@@ -55,7 +55,7 @@
   .fields-group
     = f.simple_fields_for :settings, current_user.settings do |ff|
       = ff.input :'web.emoji_style',
-                 collection: %w(auto twemoji native),
+                 collection: user_settings_collection('web.emoji_style'),
                  include_blank: false,
                  hint: I18n.t('simple_form.hints.defaults.setting_emoji_style'),
                  label: I18n.t('simple_form.labels.defaults.setting_emoji_style'),
@@ -110,7 +110,7 @@
       = ff.input :'web.display_media',
                  as: :radio_buttons,
                  collection_wrapper_tag: 'ul',
-                 collection: %w(default show_all hide_all),
+                 collection: user_settings_collection('web.display_media'),
                  hint: false,
                  item_wrapper_tag: 'li',
                  label_method: ->(item) { t("simple_form.hints.defaults.setting_display_media_#{item}") },

--- a/app/views/settings/preferences/notifications/show.html.haml
+++ b/app/views/settings/preferences/notifications/show.html.haml
@@ -35,7 +35,7 @@
       - if SoftwareUpdate.check_enabled? && current_user.can?(:view_devops)
         .fields-group
           = ff.input :'notification_emails.software_updates',
-                     collection: %w(none critical patch all),
+                     collection: user_settings_collection('notification_emails.software_updates'),
                      hint: false,
                      include_blank: false,
                      label_method: ->(setting) { I18n.t("simple_form.labels.notification_emails.software_updates.#{setting}") },

--- a/app/views/settings/preferences/posting_defaults/show.html.haml
+++ b/app/views/settings/preferences/posting_defaults/show.html.haml
@@ -26,7 +26,7 @@
 
     .fields-group
       = ff.input :default_quote_policy,
-                 collection: %w(public followers nobody),
+                 collection: user_settings_collection('default_quote_policy'),
                  include_blank: false,
                  label_method: ->(policy) { I18n.t("statuses.quote_policies.#{policy}") },
                  label: I18n.t('simple_form.labels.defaults.setting_default_quote_policy'),

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -3,6 +3,22 @@
 require 'rails_helper'
 
 RSpec.describe SettingsHelper do
+  describe '#user_settings_collection' do
+    subject { helper.user_settings_collection(value) }
+
+    context 'with valid value' do
+      let(:value) { 'web.contrast' }
+
+      it { is_expected.to eq(%w(auto high)) }
+    end
+
+    context 'with invalid value' do
+      let(:value) { 'web.nothing_at_this_key_at_all_fake_fake_fake' }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
   describe 'session_device_icon' do
     context 'with a mobile device' do
       let(:session) { SessionActivation.new(user_agent: 'Mozilla/5.0 (iPhone)') }


### PR DESCRIPTION
In all these cases, the valid "in" values defined in the `UserSettings` DSL match the eligible collection options in the UI. Update to just refer to the DSL config.