### PR TITLE
Minor Quote validation tweaks

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -3,6 +3,7 @@
 class ActivityPub::Activity::Create < ActivityPub::Activity
   DISTRIBUTE_DELAY = 1.minute
   PROCESSING_DELAY = (30.seconds)..(10.minutes)
+  PROCESSING_DELAY_QUOTE = (5.seconds)..(2.seconds)
 
   def perform
     @account.schedule_refresh_if_stale!
@@ -396,8 +397,9 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
     embedded_quote = safe_prefetched_embed(@account, @status_parser.quoted_object, @json['context'])
     ActivityPub::VerifyQuoteService.new.call(@quote, @quote_approval_uri, fetchable_quoted_uri: @quote_uri, prefetched_quoted_object: embedded_quote, request_id: @options[:request_id], depth: @options[:depth])
-  rescue Mastodon::RecursionLimitExceededError, Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
-    ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(PROCESSING_DELAY), @quote.id, @quote_uri, { 'request_id' => @options[:request_id], 'approval_uri' => @quote_approval_uri })
+  rescue Mastodon::RecursionLimitExceededError, Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS => e
+    Rails.logger.warn "Quote verification failed for quote #{@quote.id} (status #{@quote.status_id}, uri #{@quote_uri}): #{e.class} - #{e.message}. Scheduling retry."
+    ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(PROCESSING_DELAY_QUOTE), @quote.id, @quote_uri, { 'request_id' => @options[:request_id], 'approval_uri' => @quote_approval_uri })
   end
 
   def conversation_from_uri(uri)

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -398,7 +398,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     embedded_quote = safe_prefetched_embed(@account, @status_parser.quoted_object, @json['context'])
     ActivityPub::VerifyQuoteService.new.call(@quote, @quote_approval_uri, fetchable_quoted_uri: @quote_uri, prefetched_quoted_object: embedded_quote, request_id: @options[:request_id], depth: @options[:depth])
   rescue Mastodon::RecursionLimitExceededError, Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS => e
-    Rails.logger.warn "Quote verification failed for quote #{@quote.id} (status #{@quote.status_id}, uri #{@quote_uri}): #{e.class} - #{e.message}. Scheduling retry."
+    Rails.logger.warn "Quote verification failed: Quote ID #{@quote.id} (status ID #{@quote.status_id}, uri #{@quote_uri}): #{e.class} - #{e.message}. Scheduling retry."
     ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(PROCESSING_DELAY_QUOTE), @quote.id, @quote_uri, { 'request_id' => @options[:request_id], 'approval_uri' => @quote_approval_uri })
   end
 

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -3,7 +3,7 @@
 class ActivityPub::Activity::Create < ActivityPub::Activity
   DISTRIBUTE_DELAY = 1.minute
   PROCESSING_DELAY = (30.seconds)..(10.minutes)
-  PROCESSING_DELAY_QUOTE = (10.seconds)..(1.minute)
+  PROCESSING_DELAY_QUOTE = (10.seconds)
 
   def perform
     @account.schedule_refresh_if_stale!

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -3,7 +3,7 @@
 class ActivityPub::Activity::Create < ActivityPub::Activity
   DISTRIBUTE_DELAY = 1.minute
   PROCESSING_DELAY = (30.seconds)..(10.minutes)
-  PROCESSING_DELAY_QUOTE = (5.seconds)..(1.minutes)
+  PROCESSING_DELAY_QUOTE = (5.seconds)..(1.minute)
 
   def perform
     @account.schedule_refresh_if_stale!

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -3,7 +3,7 @@
 class ActivityPub::Activity::Create < ActivityPub::Activity
   DISTRIBUTE_DELAY = 1.minute
   PROCESSING_DELAY = (30.seconds)..(10.minutes)
-  PROCESSING_DELAY_QUOTE = (5.seconds)..(2.minutes)
+  PROCESSING_DELAY_QUOTE = (5.seconds)..(1.minutes)
 
   def perform
     @account.schedule_refresh_if_stale!

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -3,7 +3,7 @@
 class ActivityPub::Activity::Create < ActivityPub::Activity
   DISTRIBUTE_DELAY = 1.minute
   PROCESSING_DELAY = (30.seconds)..(10.minutes)
-  PROCESSING_DELAY_QUOTE = (10.seconds)
+  PROCESSING_DELAY_QUOTE = (10.seconds)..(1.minute)
 
   def perform
     @account.schedule_refresh_if_stale!

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -3,7 +3,7 @@
 class ActivityPub::Activity::Create < ActivityPub::Activity
   DISTRIBUTE_DELAY = 1.minute
   PROCESSING_DELAY = (30.seconds)..(10.minutes)
-  PROCESSING_DELAY_QUOTE = (5.seconds)..(2.seconds)
+  PROCESSING_DELAY_QUOTE = (5.seconds)..(2.minutes)
 
   def perform
     @account.schedule_refresh_if_stale!

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -3,7 +3,7 @@
 class ActivityPub::Activity::Create < ActivityPub::Activity
   DISTRIBUTE_DELAY = 1.minute
   PROCESSING_DELAY = (30.seconds)..(10.minutes)
-  PROCESSING_DELAY_QUOTE = (10.seconds)..(1.minute)
+  PROCESSING_DELAY_QUOTE = (30.seconds)..(1.minute)
 
   def perform
     @account.schedule_refresh_if_stale!

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -3,7 +3,7 @@
 class ActivityPub::Activity::Create < ActivityPub::Activity
   DISTRIBUTE_DELAY = 1.minute
   PROCESSING_DELAY = (30.seconds)..(10.minutes)
-  PROCESSING_DELAY_QUOTE = (5.seconds)..(1.minute)
+  PROCESSING_DELAY_QUOTE = (10.seconds)..(1.minute)
 
   def perform
     @account.schedule_refresh_if_stale!

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -3,7 +3,6 @@
 class ActivityPub::Activity::Create < ActivityPub::Activity
   DISTRIBUTE_DELAY = 1.minute
   PROCESSING_DELAY = (30.seconds)..(10.minutes)
-  PROCESSING_DELAY_QUOTE = (30.seconds)..(1.minute)
 
   def perform
     @account.schedule_refresh_if_stale!
@@ -399,7 +398,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     ActivityPub::VerifyQuoteService.new.call(@quote, @quote_approval_uri, fetchable_quoted_uri: @quote_uri, prefetched_quoted_object: embedded_quote, request_id: @options[:request_id], depth: @options[:depth])
   rescue Mastodon::RecursionLimitExceededError, Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS => e
     Rails.logger.warn "Quote verification failed: Quote ID #{@quote.id} (status ID #{@quote.status_id}, uri #{@quote_uri}): #{e.class} - #{e.message}. Scheduling retry."
-    ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(PROCESSING_DELAY_QUOTE), @quote.id, @quote_uri, { 'request_id' => @options[:request_id], 'approval_uri' => @quote_approval_uri })
+    ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(PROCESSING_DELAY), @quote.id, @quote_uri, { 'request_id' => @options[:request_id], 'approval_uri' => @quote_approval_uri })
   end
 
   def conversation_from_uri(uri)

--- a/app/workers/activitypub/refetch_and_verify_quote_worker.rb
+++ b/app/workers/activitypub/refetch_and_verify_quote_worker.rb
@@ -5,7 +5,7 @@ class ActivityPub::RefetchAndVerifyQuoteWorker
   include ExponentialBackoff
   include JsonLdHelper
 
-  sidekiq_options queue: 'pull', retry: 5
+  sidekiq_options queue: 'ingress', retry: 5
 
   def perform(quote_id, quoted_uri, options = {})
     quote = Quote.find(quote_id)


### PR DESCRIPTION
My experience has been that quote validation fails at a much higher amount than expected. #37599

* Moving the quote retry from sidekiq queue pull to ingress (the create action for the quote toot is an `ingress` event, but the failed is moved to `push` which has much lower sidekiq priority).
* Added additional log for the initial verification failure