### PR TITLE
Fix gap in profile fields layout

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/components/fields.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/fields.tsx
@@ -285,11 +285,14 @@ function useColumnWrap() {
         if (!item) {
           break;
         }
+
         const { ele, span } = item;
+
         if (i < row.length - 1) {
           ele.dataset.cols = span.toString();
           remainingRowSpan -= span;
         } else if (
+          row.length > 1 &&
           row.length === halfColSpan &&
           span === 1 &&
           remainingRowSpan > 1


### PR DESCRIPTION
### Changes proposed in this PR:
- Fix gap in profile fields layout, a regression introduced in #38544

### Screenshots

| Before | After |
|--------|--------|
| <img width="358" height="177" alt="image" src="https://github.com/user-attachments/assets/58284c5b-8f87-4b61-b303-471116487407" /> | <img width="357" height="184" alt="image" src="https://github.com/user-attachments/assets/31d454b3-5d78-4cef-957a-d64121a8fb57" /> | 

Also correctly maintains the evenly split layout introduced in #38544:
<img width="640" height="120" alt="image" src="https://github.com/user-attachments/assets/2942b005-d2dc-4ba2-a826-4d61fbd86d84" />