### PR TITLE
Allow "Follows you" badge to wrap along with profile heading

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -21,7 +21,6 @@ import { useAppSelector, useAppDispatch } from '@/mastodon/store';
 
 import { AccountName } from './account_name';
 import { AccountSubscriptionForm } from './account_subscription_form';
-import { AccountBadges } from './badges';
 import { AccountButtons } from './buttons';
 import { FamiliarFollowers } from './familiar_followers';
 import { AccountHeaderFields } from './fields';
@@ -157,8 +156,6 @@ export const AccountHeader: React.FC<{
               forceMenu={'share' in navigator}
             />
           </div>
-
-          <AccountBadges accountId={accountId} />
 
           <AccountNumberFields accountId={accountId} />
 

--- a/app/javascript/mastodon/features/account_timeline/components/account_name.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_name.tsx
@@ -21,6 +21,7 @@ import ContentCopyIcon from '@/material-icons/400-24px/content_copy.svg?react';
 import HelpIcon from '@/material-icons/400-24px/help.svg?react';
 import DomainIcon from '@/material-icons/400-24px/language.svg?react';
 
+import { AccountBadges } from './badges';
 import classes from './styles.module.scss';
 
 const messages = defineMessages({
@@ -77,6 +78,8 @@ export const AccountName: FC<{ accountId: string }> = ({ accountId }) => {
         domain={domain}
         isSelf={account.id === me}
       />
+
+      <AccountBadges accountId={accountId} />
     </div>
   );
 };

--- a/app/javascript/mastodon/features/account_timeline/components/account_subscription_form.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_subscription_form.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback, useId } from 'react';
 import { FormattedMessage, useIntl, defineMessages } from 'react-intl';
 import type { IntlShape } from 'react-intl';
 
+import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 
 import { AxiosError } from 'axios';
@@ -127,7 +128,9 @@ export const AccountSubscriptionForm: React.FC<{ accountId: string }> = ({
 
   if (submitted) {
     return (
-      <div className={classes.bannerBaseCentered}>
+      <div
+        className={classNames(classes.bannerBase, classes.bannerBaseCentered)}
+      >
         <div className={classes.bannerTextAndActions}>
           <h2>
             <FormattedMessage

--- a/app/javascript/mastodon/features/account_timeline/components/badges.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/badges.tsx
@@ -16,6 +16,8 @@ import { useAccount } from '@/mastodon/hooks/useAccount';
 import type { AccountRole } from '@/mastodon/models/account';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 
+import classes from './styles.module.scss';
+
 export const AccountBadges: FC<{ accountId: string }> = ({ accountId }) => {
   const account = useAccount(accountId);
   const localDomain = useAppSelector(
@@ -101,7 +103,7 @@ export const AccountBadges: FC<{ accountId: string }> = ({ accountId }) => {
     return null;
   }
 
-  return <div className={'account__header__badges'}>{badges}</div>;
+  return <div className={classes.badges}>{badges}</div>;
 };
 
 function isAdminBadge(role: AccountRole) {

--- a/app/javascript/mastodon/features/account_timeline/components/styles.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/styles.module.scss
@@ -28,19 +28,21 @@
 }
 
 .name {
-  display: flex;
-  gap: 2px;
-  align-items: baseline;
-
   > h1 {
+    display: inline;
     font-size: 22px;
     line-height: normal;
     white-space: initial;
+    margin-inline-end: 4px;
   }
 }
 
 .followerBadgeIcon {
   color: var(--color-text-secondary);
+}
+
+.badges {
+  margin-top: 8px;
 }
 
 .handleHelpButton {
@@ -189,6 +191,10 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
 
 .bio {
   font-size: 15px;
+}
+
+.familiarFollowers {
+  margin-top: 16px;
 }
 
 .note {

--- a/app/javascript/mastodon/features/account_timeline/components/styles.module.scss
+++ b/app/javascript/mastodon/features/account_timeline/components/styles.module.scss
@@ -406,6 +406,15 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
   margin: 16px 0;
 }
 
+.bannerBaseCentered {
+  min-height: 146px;
+  align-items: center;
+
+  .bannerTextAndActions {
+    text-align: center;
+  }
+}
+
 .bannerTextAndActions {
   display: flex;
   flex-direction: column;
@@ -423,16 +432,6 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
 .bannerDisclaimer {
   a {
     color: inherit;
-  }
-}
-
-.bannerBaseCentered {
-  composes: bannerBase;
-  min-height: 146px;
-  align-items: center;
-
-  .bannerTextAndActions {
-    text-align: center;
   }
 }
 


### PR DESCRIPTION
Fixes WEB-955

### Changes proposed in this PR:
- Places the "Follows you" badge inline with the heading when it wraps
- Improves spacing around other account badges to match current design specs
- Removes CSS Modules `composes` keyword in favour of simple class name composition

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="617" height="294" alt="image" src="https://github.com/user-attachments/assets/c111a55c-6c55-4c3e-b8df-67b725f026aa" /> | <img width="617" height="279" alt="image" src="https://github.com/user-attachments/assets/f8047f76-3345-47af-b566-f85e9a8e12d7" /> |