### PR TITLE
Fix inconsistent badges height in follow suggestion carousel

### DIFF
--- a/app/javascript/mastodon/components/badge/index.tsx
+++ b/app/javascript/mastodon/components/badge/index.tsx
@@ -18,10 +18,9 @@ import { Icon } from '../icon';
 
 import classes from './styles.module.scss';
 
-interface BadgeProps {
+interface BadgeProps extends React.ComponentPropsWithoutRef<'div'> {
   label: ReactNode;
   icon?: ReactNode;
-  className?: string;
   domain?: ReactNode;
   roleId?: string;
   variant?:
@@ -40,8 +39,10 @@ export const Badge: FC<BadgeProps> = ({
   className,
   domain,
   roleId,
+  ...otherProps
 }) => (
   <div
+    {...otherProps}
     className={classNames(
       classes.badge,
       !icon && classes.badgeWithoutIcon,

--- a/app/javascript/mastodon/features/home_timeline/components/inline_follow_suggestions.tsx
+++ b/app/javascript/mastodon/features/home_timeline/components/inline_follow_suggestions.tsx
@@ -16,7 +16,7 @@ import {
 } from 'mastodon/actions/suggestions';
 import type { ApiSuggestionSourceJSON } from 'mastodon/api_types/suggestions';
 import { Avatar } from 'mastodon/components/avatar';
-import { VerifiedBadge } from 'mastodon/components/badge';
+import { Badge, VerifiedBadge } from 'mastodon/components/badge';
 import { DisplayName } from 'mastodon/components/display_name';
 import { FollowButton } from 'mastodon/components/follow_button';
 import { Icon } from 'mastodon/components/icon';
@@ -110,13 +110,12 @@ const Source: React.FC<{ id: ApiSuggestionSourceJSON }> = ({ id }) => {
   }
 
   return (
-    <div
+    <Badge
       className='inline-follow-suggestions__body__scrollable__card__text-stack__source'
       title={hint}
-    >
-      <Icon id='' icon={InfoIcon} />
-      <span>{label}</span>
-    </div>
+      label={label}
+      icon={<InfoIcon />}
+    />
   );
 };
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10666,11 +10666,6 @@ noscript {
           }
 
           &__source {
-            display: inline-flex;
-            align-items: center;
-            max-width: 100%;
-            color: var(--color-text-tertiary);
-            gap: 4px;
             overflow: hidden;
             white-space: nowrap;
             cursor: help;
@@ -10678,11 +10673,6 @@ noscript {
             > span {
               overflow: hidden;
               text-overflow: ellipsis;
-            }
-
-            .icon {
-              width: 16px;
-              height: 16px;
             }
           }
         }


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes inconsistent height between new and old badges in the inline follow suggestions carousel

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="602" height="289" alt="image" src="https://github.com/user-attachments/assets/74f8c0ed-b47e-47cc-b86b-876a77622f83" /> | <img width="601" height="289" alt="image" src="https://github.com/user-attachments/assets/d0caab33-68e9-4082-9d23-c1d9cc8c7197" /> |