### PR TITLE
Use more neutral background color on Share page

### DIFF
--- a/app/javascript/styles/mastodon/modal.scss
+++ b/app/javascript/styles/mastodon/modal.scss
@@ -1,7 +1,7 @@
 @use 'variables' as *;
 
 .modal-layout {
-  background: var(--color-bg-brand-softest);
+  background: var(--color-bg-primary);
   display: flex;
   flex-direction: column;
   height: 100vh;
@@ -37,6 +37,8 @@
 }
 
 .with-zig-zag-decoration {
+  isolation: isolate;
+
   &::after {
     content: '';
     position: absolute;


### PR DESCRIPTION
### Changes proposed in this PR:
- Uses the default Mastodon UI background color on the `/share` page rather than a tinted one, which looks quite intense especially in dark mode
- Fixes the jagged edge along the bottom not being visible anymore

### Screenshots

| Before (4.5) | Before (4.6 alpha) | After |
|--------|--------|--------|
| <img width="999" height="744" alt="image" src="https://github.com/user-attachments/assets/578641d0-9481-4a3b-a5ad-95a874dbcfd9" /> | <img width="1000" height="742" alt="image" src="https://github.com/user-attachments/assets/a6f20d42-7f64-472b-8a55-64bc80112308" /> | <img width="1000" height="743" alt="image" src="https://github.com/user-attachments/assets/66d4d581-7264-4214-ad50-035c12e2438e" /> |
| <img width="1001" height="742" alt="image" src="https://github.com/user-attachments/assets/5e66f897-052c-48a4-be56-dec291b62591" /> | <img width="1001" height="744" alt="image" src="https://github.com/user-attachments/assets/e4d190c6-c247-497a-8d87-c87e61deb0e6" /> | <img width="999" height="743" alt="image" src="https://github.com/user-attachments/assets/27b45b66-f7f9-4e3b-a898-0d339421ecb0" /> |