### PR TITLE
Hide bio & familiar followers from Followers/Following lists

### DIFF
--- a/app/javascript/mastodon/components/account_list_item/index.tsx
+++ b/app/javascript/mastodon/components/account_list_item/index.tsx
@@ -11,7 +11,6 @@ import { useRelationship } from 'mastodon/hooks/useRelationship';
 import type { Relationship } from 'mastodon/models/relationship';
 
 import { EmojiHTML } from '../emoji/html';
-import { FamiliarFollowers } from '../familiar_followers';
 import { FollowButton } from '../follow_button';
 import { FormattedDateWrapper } from '../formatted_date';
 import { NumberFields, NumberFieldsItem } from '../number_fields';
@@ -31,6 +30,7 @@ interface Props {
   accountId: string | undefined;
   stats?: Stat[];
   renderButton?: (options: RenderButtonOptions) => React.ReactNode;
+  withBio?: boolean;
   withBorder?: boolean;
 }
 
@@ -46,6 +46,7 @@ const DEFAULT_STATS: Stat[] = ['followers', 'following', 'joined'];
 export const AccountListItem: React.FC<Props> = ({
   accountId,
   stats = DEFAULT_STATS,
+  withBio = true,
   withBorder = true,
   renderButton = defaultRenderButton,
 }) => {
@@ -161,8 +162,7 @@ export const AccountListItem: React.FC<Props> = ({
           />
         )}
       </NumberFields>
-      <FamiliarFollowers accountId={accountId} />
-      {account.note.length > 0 && (
+      {withBio && account.note.length > 0 && (
         <EmojiHTML
           className={classNames(classes.bio, 'translate')}
           htmlString={account.note_emojified}

--- a/app/javascript/mastodon/components/account_list_item/index.tsx
+++ b/app/javascript/mastodon/components/account_list_item/index.tsx
@@ -34,7 +34,7 @@ interface Props {
   withBorder?: boolean;
 }
 
-const DEFAULT_STATS: Stat[] = ['followers', 'following', 'joined'];
+const DEFAULT_STATS: Stat[] = ['followers', 'posts', 'last-active'];
 
 /**
  * Extended account list item with bio, verified link badge,

--- a/app/javascript/mastodon/features/collections/detail/accounts_list.tsx
+++ b/app/javascript/mastodon/features/collections/detail/accounts_list.tsx
@@ -146,7 +146,6 @@ export const CollectionAccountsList: React.FC<{
                 <AccountListItem
                   accountId={account_id}
                   withBorder={index !== items.length - 1}
-                  stats={['followers', 'last-active']}
                   renderButton={renderAccountItemButton}
                 />
               </Article>

--- a/app/javascript/mastodon/features/followers/components/list.tsx
+++ b/app/javascript/mastodon/features/followers/components/list.tsx
@@ -53,12 +53,20 @@ export const AccountList: FC<AccountListProps> = ({
     }
     const children =
       list?.items.map((followerId) => (
-        <AccountListItem key={followerId} accountId={followerId} />
+        <AccountListItem
+          key={followerId}
+          accountId={followerId}
+          withBio={false}
+        />
       )) ?? [];
 
     if (prependAccountId) {
       children.unshift(
-        <AccountListItem key={prependAccountId} accountId={prependAccountId} />,
+        <AccountListItem
+          key={prependAccountId}
+          accountId={prependAccountId}
+          withBio={false}
+        />,
       );
     }
     return children;


### PR DESCRIPTION
### Changes proposed in this PR:
- Hides bio from Followers/Following lists to make them easier to scan
- Changes default stats shown in `AccountListItem` to followers, posts, and last active date
- Removes "familiar followers" from the new `AccountListItem` component entirely, as it triggers an API call per list item which is too expensive.

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="600" height="755" alt="image" src="https://github.com/user-attachments/assets/7ad7c10f-f27c-4c8e-b27a-3085d914fb37" /> | <img width="601" height="623" alt="image" src="https://github.com/user-attachments/assets/e877bf4b-3bf8-461d-88d2-0e47bcbb752c" /> |