### PR TITLE
More design tweaks for empty state in Featured tab > Collections

### DIFF
--- a/app/javascript/mastodon/components/empty_state/empty_state.module.scss
+++ b/app/javascript/mastodon/components/empty_state/empty_state.module.scss
@@ -10,7 +10,7 @@
 }
 
 .content {
-  max-width: 300px;
+  max-width: 370px;
 
   svg,
   img {

--- a/app/javascript/mastodon/features/account_featured/components/empty_message.tsx
+++ b/app/javascript/mastodon/features/account_featured/components/empty_message.tsx
@@ -21,7 +21,7 @@ interface EmptyMessageProps {
   hidden: boolean;
   blockedBy: boolean;
   accountId?: string;
-  withImage?: boolean;
+  withoutAddCollectionButton?: boolean;
 }
 
 export const EmptyMessage: React.FC<EmptyMessageProps> = ({
@@ -29,7 +29,7 @@ export const EmptyMessage: React.FC<EmptyMessageProps> = ({
   suspended,
   hidden,
   blockedBy,
-  withImage = true,
+  withoutAddCollectionButton,
 }) => {
   const { acct } = useParams<{ acct?: string }>();
   const me = useCurrentAccountId();
@@ -57,7 +57,7 @@ export const EmptyMessage: React.FC<EmptyMessageProps> = ({
 
   const hasCollections = areCollectionsEnabled();
 
-  const image = withImage && <ElephantImage />;
+  const image = <ElephantImage />;
 
   if (me === accountId) {
     if (hasCollections) {
@@ -78,12 +78,14 @@ export const EmptyMessage: React.FC<EmptyMessageProps> = ({
             />
           }
         >
-          <Link to='/collections/new' className='button'>
-            <FormattedMessage
-              id='empty_column.account_featured_self.no_collections_button'
-              defaultMessage='Create a collection'
-            />
-          </Link>
+          {!withoutAddCollectionButton && (
+            <Link to='/collections/new' className='button'>
+              <FormattedMessage
+                id='empty_column.account_featured_self.no_collections_button'
+                defaultMessage='Create a collection'
+              />
+            </Link>
+          )}
           <Button secondary onClick={confirmHideFeaturedTab}>
             <FormattedMessage
               id='empty_column.account_featured_self.no_collections_hide_tab'

--- a/app/javascript/mastodon/features/account_featured/index.tsx
+++ b/app/javascript/mastodon/features/account_featured/index.tsx
@@ -179,7 +179,7 @@ const AccountFeatured: React.FC<{ multiColumn: boolean }> = ({
               </ItemList>
             ) : (
               <EmptyMessage
-                withImage={false}
+                withoutAddCollectionButton
                 blockedBy={blockedBy}
                 hidden={hidden}
                 suspended={suspended}


### PR DESCRIPTION
Related to WEB-933

### Changes proposed in this PR:
- Increases max-width for content in empty states to `370px`
- Brings back the illustration in the empty state of the Featured tab's Collection section
- Removes "Add collection" button from empty state when it is shown underneath the "Collections" section subheading that already has such a button

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="598" height="475" alt="image" src="https://github.com/user-attachments/assets/31880d2d-2d59-415a-a38a-21b333b8e61d" /> | <img width="601" height="642" alt="image" src="https://github.com/user-attachments/assets/c970100f-74f2-4909-bfc7-59b828ed8794" /> |