### PR TITLE
Fix typo in create_collection_service.rb

### DIFF
--- a/app/services/create_collection_service.rb
+++ b/app/services/create_collection_service.rb
@@ -42,7 +42,7 @@ class CreateCollectionService
 
   def notify_local_users
     @collection.collection_items.select(&:with_local_account?).each do |collection_item|
-      LocalNotificationWorker.perform_async(@account.id, collection_item.id, collection_item.class.name, 'added_to_collection')
+      LocalNotificationWorker.perform_async(collection_item.account_id, collection_item.id, collection_item.class.name, 'added_to_collection')
     end
   end
 

--- a/spec/services/create_collection_service_spec.rb
+++ b/spec/services/create_collection_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe CreateCollectionService do
 
             expect(LocalNotificationWorker)
               .to have_enqueued_sidekiq_job
-              .with(account_ids.last, anything, 'CollectionItem', 'added_to_collection')
+              .with(account_ids.last.id, anything, 'CollectionItem', 'added_to_collection')
           end
         end
 

--- a/spec/services/create_collection_service_spec.rb
+++ b/spec/services/create_collection_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe CreateCollectionService do
 
             expect(LocalNotificationWorker)
               .to have_enqueued_sidekiq_job
-              .with(author.id, anything, 'CollectionItem', 'added_to_collection')
+              .with(account_ids.last, anything, 'CollectionItem', 'added_to_collection')
           end
         end
 

--- a/spec/services/create_collection_service_spec.rb
+++ b/spec/services/create_collection_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe CreateCollectionService do
 
             expect(LocalNotificationWorker)
               .to have_enqueued_sidekiq_job
-              .with(account_ids.last.id, anything, 'CollectionItem', 'added_to_collection')
+              .with(accounts.last.id, anything, 'CollectionItem', 'added_to_collection')
           end
         end
 


### PR DESCRIPTION
I think this is a typo? wouldn't that notification be sent the same location over for every collection item?

This similar file looks better 

https://github.com/mastodon/mastodon/blob/d6f8ac97e808821180e9ae0c66879b7a2d64e690/app/services/notify_of_collection_update_service.rb#L6-L9

https://github.com/mastodon/mastodon/blob/d6f8ac97e808821180e9ae0c66879b7a2d64e690/app/lib/activitypub/activity/feature_request.rb#L56-L58