### PR TITLE
Fix broken line clamping for bios in `AccountListItem`

### DIFF
--- a/app/javascript/mastodon/components/account_list_item/styles.module.scss
+++ b/app/javascript/mastodon/components/account_list_item/styles.module.scss
@@ -8,13 +8,6 @@
   &[data-with-border='true'] {
     border-bottom: 1px solid var(--color-border-primary);
   }
-
-  :global(.account__note) {
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 3;
-    line-clamp: 3;
-  }
 }
 
 .header {
@@ -40,6 +33,12 @@
 }
 
 .bio {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+
   :any-link {
     color: var(--color-text-status-links);
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes line clamping not working for bios in the `AccountListItem` component

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="297" height="188" alt="image" src="https://github.com/user-attachments/assets/d2e582cf-389b-40ff-b0b6-06a63c29fed2" /> | <img width="295" height="172" alt="image" src="https://github.com/user-attachments/assets/e27192a5-34bc-4548-a374-91d652efccf7" /> |