### PR TITLE
Fix Followers/Following list error when they contain accounts that have never posted

### DIFF
--- a/app/javascript/mastodon/api_types/accounts.ts
+++ b/app/javascript/mastodon/api_types/accounts.ts
@@ -53,7 +53,7 @@ export interface BaseApiAccountJSON {
   header_static: string;
   header_description: string;
   id: string;
-  last_status_at: string;
+  last_status_at: string | null;
   locked: boolean;
   show_media: boolean;
   show_media_replies: boolean;

--- a/app/javascript/mastodon/components/account_list_item/index.tsx
+++ b/app/javascript/mastodon/components/account_list_item/index.tsx
@@ -148,11 +148,15 @@ export const AccountListItem: React.FC<Props> = ({
               />
             }
           >
-            <RelativeTimestamp
-              long
-              timestamp={account.last_status_at}
-              noFuture
-            />
+            {account.last_status_at ? (
+              <RelativeTimestamp
+                long
+                timestamp={account.last_status_at}
+                noFuture
+              />
+            ) : (
+              '-'
+            )}
           </NumberFieldsItem>
         )}
         {firstVerifiedField && (

--- a/app/javascript/mastodon/features/collections/editor/accounts.tsx
+++ b/app/javascript/mastodon/features/collections/editor/accounts.tsx
@@ -61,9 +61,11 @@ const AddedAccountItem: React.FC<{
     onRemove(accountId);
   }, [accountId, onRemove]);
 
+  const lastStatusAt = account?.last_status_at;
+
   const lastPostHint = useMemo(
     () =>
-      isOlderThanAWeek(account?.last_status_at) && (
+      (!lastStatusAt || isOlderThanAWeek(lastStatusAt)) && (
         <Badge
           label={
             <FormattedMessage
@@ -75,7 +77,7 @@ const AddedAccountItem: React.FC<{
           className={classes.accountBadge}
         />
       ),
-    [account?.last_status_at],
+    [lastStatusAt],
   );
 
   return (


### PR DESCRIPTION
Fixes #38634

### Changes proposed in this PR:
- Fixes error when opening Followers/Following lists that contain accounts that have never posted (They're "Last posted" date will simply be shown as `-`)
- Fixes type error that caused this issue

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="615" height="758" alt="image" src="https://github.com/user-attachments/assets/cfbb01a3-553b-4b3b-8ae9-94189724154f" /> | <img width="611" height="753" alt="image" src="https://github.com/user-attachments/assets/79a78941-f590-45c7-9b40-c98474adbfd7" /> |