### PR TITLE
Update handle explainer copy

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/components/account_name.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_name.tsx
@@ -189,7 +189,7 @@ const AccountNameHelp: FC<{
             </ol>
             <FormattedMessage
               id='account.name.help.footer'
-              defaultMessage='Just like you can send emails to people using different email clients, you can interact with people on other Mastodon servers – and with anyone on other social apps powered by the same set of rules as Mastodon uses (the ActivityPub protocol).'
+              defaultMessage='Just like you can send emails to people using different email providers, you can interact with people on other Mastodon servers, and with anyone on other Mastodon-compatible social apps.'
               tagName='p'
             />
 

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -106,7 +106,7 @@
   "account.name.copy": "Copy handle",
   "account.name.help.domain": "{domain} is the server that hosts the user’s profile and posts.",
   "account.name.help.domain_self": "{domain} is your server that hosts your profile and posts.",
-  "account.name.help.footer": "Just like you can send emails to people using different email clients, you can interact with people on other Mastodon servers – and with anyone on other social apps powered by the same set of rules as Mastodon uses (the ActivityPub protocol).",
+  "account.name.help.footer": "Just like you can send emails to people using different email providers, you can interact with people on other Mastodon servers, and with anyone on other Mastodon-compatible social apps.",
   "account.name.help.header": "A handle is like an email address",
   "account.name.help.username": "{username} is this account’s username on their server. Someone on another server might have the same username.",
   "account.name.help.username_self": "{username} is your username on this server. Someone on another server might have the same username.",


### PR DESCRIPTION
Fixes #38623

Note: I'd like if we could still mention ActivityPub, but the change makes sense to me.