### PR TITLE
Clarify notification mechanism on account action moderation

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -20,7 +20,7 @@ en:
         title: Optional. Not visible to the recipient
       admin_account_action:
         include_statuses: The user will see which posts have caused the moderation action or warning
-        send_email_notification: The user will receive an explanation of what happened with their account
+        send_email_notification: The user will receive an explanation (via email and in-app notification) of what happened with their account
         text_html: Optional. You can use post syntax. You can <a href="%{path}">add warning presets</a> to save time
         type_html: Choose what to do with <strong>%{acct}</strong>
         types:
@@ -193,7 +193,7 @@ en:
         title: Title
       admin_account_action:
         include_statuses: Include reported posts in the e-mail
-        send_email_notification: Notify the user per e-mail
+        send_email_notification: Notify the user about this action
         text: Custom warning
         type: Action
         types:


### PR DESCRIPTION
Resolves a portion of https://github.com/mastodon/mastodon/issues/32752

Related to https://github.com/mastodon/mastodon/pull/33481

<img width="514" height="121" alt="Screenshot 2026-04-14 at 12 02 28" src="https://github.com/user-attachments/assets/3db60270-6407-4f1c-8a5d-87471f4fb646" />

<img width="743" height="133" alt="Screenshot 2026-04-14 at 12 03 46" src="https://github.com/user-attachments/assets/0650a824-5509-46d0-b019-ad9e4db29ba8" />

This improves the "I dont know what happens here" aspect of the linked issue, but does not fully accomplish the "let me control what happens" aspect. There are open questions on linked PR about that portion.