### PR TITLE
Update FFmpeg renovate datasource to github-tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -233,7 +233,7 @@ RUN ninja && ninja install
 FROM media-build AS ffmpeg
 
 # ffmpeg version to compile, change with [--build-arg FFMPEG_VERSION="7.0.x"]
-# renovate: datasource=repology depName=ffmpeg packageName=openpkg_current/ffmpeg
+# renovate: datasource=github-tags depName=FFmpeg/FFmpeg extractVersion=^n(?<version>\d+\.\d+(\.\d+)?)$
 ARG FFMPEG_VERSION=8.1
 # ffmpeg download URL, change with [--build-arg FFMPEG_URL="https://ffmpeg.org/releases"]
 ARG FFMPEG_URL=https://github.com/FFmpeg/FFmpeg/archive/refs/tags


### PR DESCRIPTION
Should fix FFmpeg updates not being picked up in the Dockerfile.