### PR TITLE
Make fields build spec resilient to changed size constant

### DIFF
--- a/spec/models/account/fields_spec.rb
+++ b/spec/models/account/fields_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Account, '#fields' do
       it { is_expected.to_not allow_values(fields_over_limit, fields_empty_name).for(:fields) }
 
       def fields_empty_name_value
-        Array.new(4) { { 'name' => '', 'value' => '' } }
+        Array.new(described_class::DEFAULT_FIELDS_SIZE) { %w(name value).index_with('') }
       end
 
       def fields_over_limit
@@ -150,6 +150,8 @@ RSpec.describe Account, '#fields' do
 
   describe '#build_fields' do
     let(:account) { Fabricate.build :account }
+
+    before { stub_const('Account::DEFAULT_FIELDS_SIZE', 4) }
 
     context 'when fields already full' do
       before { account.fields = Array.new(Account::DEFAULT_FIELDS_SIZE) { |i| { name: "Name#{i}", value: 'Test' } } }


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/38434 which seems abandoned.

Same motivation as there, though -- allow this spec to pass on forks which have modified this constant.

Because we override the getter (as part of this feature) its a little challenging to use `stub_const` on the entire file because of how the validation matchers work. However, these two changes should make this function correctly on what I suspect are most reasonable values that might be set here (I tried 1,2,3,4,10)