### PR TITLE
Fix hero image radius, bring into repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a style="text-decoration:none" href="https://www.youtube.com/watch?v=IPSbNdBmWKE">
-    <img alt="Mastodon hero image" src="https://github.com/user-attachments/assets/ef53f5e9-c0d8-484d-9f53-00efdebb92c3" />
+    <img alt="Mastodon hero image" src="https://github.com/user-attachments/assets/7f171473-dc7a-4610-8489-d4abc42dad9d" />
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a style="text-decoration:none" href="https://www.youtube.com/watch?v=IPSbNdBmWKE">
-    <img alt="Mastodon hero image" src="https://github.com/user-attachments/assets/7f171473-dc7a-4610-8489-d4abc42dad9d" />
+    <img alt="Mastodon hero image" src="./docs/hero-nodes.gif" />
   </a>
 </p>
 


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/35744 which may be blocked (?!) on not-being-local-asset?

That PR fixed an issue where this hero image has one frame in its animation with a weird corner.

This PR starts with that change, rebases, then brings that updated image (pulled from original PR) into the actual repo so that we're not reliant on an uploaded GH asset.