### PR TITLE
Fix invalid arguments being passed to Redis in custom Chewy strategy

### DIFF
--- a/lib/chewy/strategy/mastodon.rb
+++ b/lib/chewy/strategy/mastodon.rb
@@ -17,6 +17,9 @@ module Chewy
         RedisConnection.with do |redis|
           redis.pipelined do |pipeline|
             @stash.each do |type, ids|
+              ids = ids&.compact
+              next if ids.blank?
+
               pipeline.sadd("chewy:queue:#{type.name}", ids)
             end
           end


### PR DESCRIPTION
It appears it is sometimes given a blank `ids` or a list containing `nil` values?

We are seeing those errors occasionally:
```
Redis::CommandError: ERR wrong number of arguments for 'sadd' command
```

```
TypeError: Unsupported command argument type: NilClass
```