### PR TITLE
Featured tab: Check if collections are enabled for loading status

### DIFF
--- a/app/javascript/mastodon/features/account_featured/index.tsx
+++ b/app/javascript/mastodon/features/account_featured/index.tsx
@@ -88,7 +88,8 @@ const AccountFeatured: React.FC<{ multiColumn: boolean }> = ({
 
   const hasFeaturedAccounts = !featuredAccountIds.isEmpty();
 
-  const isLoading = !accountId || collectionsLoadStatus !== 'idle';
+  const isLoading =
+    !accountId || (collectionsEnabled && collectionsLoadStatus !== 'idle');
 
   if (accountId === null) {
     return <BundleColumnError multiColumn={multiColumn} errorType='routing' />;


### PR DESCRIPTION
This fixes an issue where we don't check if collections are enabled before looking at status when loading the featured tab.