### PR TITLE
Makes RelativeTimestamp default to not showing the future

### DIFF
--- a/app/javascript/mastodon/components/account/index.tsx
+++ b/app/javascript/mastodon/components/account/index.tsx
@@ -277,7 +277,7 @@ export const Account: React.FC<AccountProps> = ({
   if (account?.mute_expires_at) {
     muteTimeRemaining = (
       <>
-        · <RelativeTimestamp timestamp={account.mute_expires_at} />
+        · <RelativeTimestamp hasFuture timestamp={account.mute_expires_at} />
       </>
     );
   }

--- a/app/javascript/mastodon/components/account_list_item/index.tsx
+++ b/app/javascript/mastodon/components/account_list_item/index.tsx
@@ -149,11 +149,7 @@ export const AccountListItem: React.FC<Props> = ({
             }
           >
             {account.last_status_at ? (
-              <RelativeTimestamp
-                long
-                timestamp={account.last_status_at}
-                noFuture
-              />
+              <RelativeTimestamp long timestamp={account.last_status_at} />
             ) : (
               '-'
             )}

--- a/app/javascript/mastodon/components/poll.tsx
+++ b/app/javascript/mastodon/components/poll.tsx
@@ -70,7 +70,7 @@ export const Poll: React.FC<PollProps> = ({ pollId, disabled, status }) => {
     if (expired) {
       return intl.formatMessage(messages.closed);
     }
-    return <RelativeTimestamp timestamp={poll.expires_at} />;
+    return <RelativeTimestamp hasFuture timestamp={poll.expires_at} />;
   }, [expired, intl, poll]);
   const votesCount = useMemo(() => {
     if (!poll) {

--- a/app/javascript/mastodon/components/relative_timestamp/index.tsx
+++ b/app/javascript/mastodon/components/relative_timestamp/index.tsx
@@ -23,16 +23,16 @@ export const RelativeTimestamp: FC<{
   timestamp: string;
   long?: boolean;
   noTime?: boolean;
-  noFuture?: boolean;
-}> = ({ timestamp, long = false, noTime = false, noFuture = false }) => {
+  hasFuture?: boolean;
+}> = ({ timestamp, long = false, noTime = false, hasFuture = false }) => {
   const intl = useIntl();
 
   const [now, setNow] = useState(() => Date.now());
 
   const date = useMemo(() => {
     const date = new Date(timestamp);
-    return noFuture ? new Date(Math.min(date.getTime(), now)) : date;
-  }, [noFuture, now, timestamp]);
+    return !hasFuture ? new Date(Math.min(date.getTime(), now)) : date;
+  }, [hasFuture, now, timestamp]);
   const ts = date.getTime();
 
   useEffect(() => {

--- a/app/javascript/mastodon/components/relative_timestamp/relative_timestamp.stories.tsx
+++ b/app/javascript/mastodon/components/relative_timestamp/relative_timestamp.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
     timestamp: new Date(Date.now() - DAY * 3).toISOString(),
     long: false,
     noTime: false,
-    noFuture: false,
+    hasFuture: false,
   },
   argTypes: {
     timestamp: {
@@ -44,10 +44,10 @@ export const DateOnly: Story = {
   },
 };
 
-export const NoFuture: Story = {
+export const HasFuture: Story = {
   args: {
     timestamp: new Date(Date.now() + DAY * 3).toISOString(),
-    noFuture: true,
+    hasFuture: true,
   },
 };
 

--- a/app/javascript/mastodon/components/status/header.tsx
+++ b/app/javascript/mastodon/components/status/header.tsx
@@ -56,10 +56,7 @@ export const StatusHeader: FC<StatusHeaderProps> = ({
         className='status__relative-time'
       >
         <StatusVisibility visibility={status.get('visibility')} />
-        <RelativeTimestamp
-          timestamp={status.get('created_at') as string}
-          noFuture
-        />
+        <RelativeTimestamp timestamp={status.get('created_at') as string} />
         {editedAt && <StatusEditedAt editedAt={editedAt} />}
       </Link>
 

--- a/app/javascript/mastodon/features/account_timeline/v2/status_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/v2/status_header.tsx
@@ -36,10 +36,7 @@ export const AccountStatusHeader: FC<StatusHeaderProps> = ({
         className='status__relative-time'
       >
         <StatusVisibility visibility={status.get('visibility')} />
-        <RelativeTimestamp
-          timestamp={status.get('created_at') as string}
-          noFuture
-        />
+        <RelativeTimestamp timestamp={status.get('created_at') as string} />
         {editedAt && <StatusEditedAt editedAt={editedAt} />}
       </Link>
 


### PR DESCRIPTION
Fixes #38675.

Converts `noFuture` to `hasFuture` and defaults to disabling showing the future with the RelativeTimestamp component. The main areas this timestamp shows the future is for polls and mute expiration, but if there are other places that expect a future date they should be updated too.

I tested via checking both past dates and a new poll showing the expected string.