### PR TITLE
Prevent text wrapping in Badge component

### DIFF
--- a/app/javascript/mastodon/components/badge/index.tsx
+++ b/app/javascript/mastodon/components/badge/index.tsx
@@ -52,8 +52,10 @@ export const Badge: FC<BadgeProps> = ({
     data-account-role-id={roleId}
   >
     {icon}
-    <span>{label}</span>
-    {domain && <span className={classes.domain}>{domain}</span>}
+    <span className={classes.content}>
+      {label}
+      {domain && <span className={classes.domain}> {domain}</span>}
+    </span>
   </div>
 );
 

--- a/app/javascript/mastodon/components/badge/styles.module.scss
+++ b/app/javascript/mastodon/components/badge/styles.module.scss
@@ -7,9 +7,9 @@
   gap: 4px;
   border-radius: 8px;
   align-items: center;
-  overflow-wrap: anywhere;
 
   > svg {
+    flex-shrink: 0;
     width: auto;
     height: 17px;
     fill: currentColor;
@@ -24,6 +24,12 @@
   &:not(.badgeWithoutIcon) {
     padding-inline-end: 8px;
   }
+}
+
+.content {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .domain {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10657,14 +10657,7 @@ noscript {
           }
 
           &__source {
-            overflow: hidden;
-            white-space: nowrap;
             cursor: help;
-
-            > span {
-              overflow: hidden;
-              text-overflow: ellipsis;
-            }
           }
         }
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Prevents text wrapping in Badge component
- Removes now-obsolete legacy styles that should've been doing the same thing in our follower recommendation carousel, but didn't

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="210" height="245" alt="image" src="https://github.com/user-attachments/assets/4fd3779f-093b-4078-8eb5-9ef9d07abc26" /> | <img width="206" height="228" alt="image" src="https://github.com/user-attachments/assets/61962476-22fd-449a-9aec-89bbf34e1198" /> |