### PR TITLE
Federate and store a collection `url`

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -15,6 +15,7 @@
 #  original_number_of_items :integer
 #  sensitive                :boolean          not null
 #  uri                      :string
+#  url                      :string
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  account_id               :bigint(8)        not null

--- a/app/serializers/activitypub/featured_collection_serializer.rb
+++ b/app/serializers/activitypub/featured_collection_serializer.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 class ActivityPub::FeaturedCollectionSerializer < ActivityPub::Serializer
-  attributes :id, :type, :total_items, :name, :attributed_to,
+  # include Rails.application.routes.url_helpers
+  include RoutingHelper
+
+  attributes :id, :type, :total_items, :name, :attributed_to, :url,
              :sensitive, :discoverable, :published, :updated
 
   attribute :summary, unless: :language_present?
   attribute :summary_map, if: :language_present?
 
-  has_one :tag, key: :topic, serializer: ActivityPub::NoteSerializer::TagSerializer
+  has_one :topic, serializer: ActivityPub::NoteSerializer::TagSerializer
 
   has_many :collection_items, key: :ordered_items, serializer: ActivityPub::FeaturedItemSerializer
 
@@ -31,6 +34,10 @@ class ActivityPub::FeaturedCollectionSerializer < ActivityPub::Serializer
     ActivityPub::TagManager.instance.uri_for(object.account)
   end
 
+  def url
+    account_collection_url(object.account, object)
+  end
+
   def total_items
     object.accepted_collection_items.size
   end
@@ -49,5 +56,9 @@ class ActivityPub::FeaturedCollectionSerializer < ActivityPub::Serializer
 
   def collection_items
     object.accepted_collection_items
+  end
+
+  def topic
+    object.tag
   end
 end

--- a/app/services/activitypub/process_featured_collection_service.rb
+++ b/app/services/activitypub/process_featured_collection_service.rb
@@ -46,6 +46,13 @@ class ActivityPub::ProcessFeaturedCollectionService
     @json['summaryMap']&.keys&.first
   end
 
+  def url
+    url = url_to_href(@json['url'], 'text/html')
+    return @json['id'] if url.blank? || unsupported_uri_scheme?(url)
+
+    url
+  end
+
   def collection_attributes
     {
       local: false,
@@ -56,6 +63,7 @@ class ActivityPub::ProcessFeaturedCollectionService
       discoverable: @json['discoverable'],
       original_number_of_items: @json['totalItems'] || 0,
       tag_name: @json.dig('topic', 'name'),
+      url:,
     }
   end
 

--- a/db/migrate/20260415133505_add_url_to_collections.rb
+++ b/db/migrate/20260415133505_add_url_to_collections.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddURLToCollections < ActiveRecord::Migration[8.1]
+  def change
+    add_column :collections, :url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_10_083500) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_15_133505) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -400,6 +400,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_083500) do
     t.bigint "tag_id"
     t.datetime "updated_at", null: false
     t.string "uri"
+    t.string "url"
     t.index ["account_id"], name: "index_collections_on_account_id"
     t.index ["tag_id"], name: "index_collections_on_tag_id"
     t.index ["uri"], name: "index_collections_on_uri", unique: true, where: "(uri IS NOT NULL)"

--- a/spec/serializers/activitypub/featured_collection_serializer_spec.rb
+++ b/spec/serializers/activitypub/featured_collection_serializer_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe ActivityPub::FeaturedCollectionSerializer do
       'attributedTo' => ActivityPub::TagManager.instance.uri_for(collection.account),
       'sensitive' => false,
       'discoverable' => false,
+      'url' => account_collection_url(collection.account, collection),
       'topic' => {
         'href' => match(%r{/tags/people$}),
         'type' => 'Hashtag',

--- a/spec/services/activitypub/process_featured_collection_service_spec.rb
+++ b/spec/services/activitypub/process_featured_collection_service_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ActivityPub::ProcessFeaturedCollectionService do
       'name' => 'Good people from other servers',
       'sensitive' => false,
       'discoverable' => true,
+      'url' => 'https://example.com/c/1',
       'topic' => {
         'type' => 'Hashtag',
         'name' => '#people',
@@ -50,6 +51,7 @@ RSpec.describe ActivityPub::ProcessFeaturedCollectionService do
       expect(new_collection.description_html).to eq '<p>A list of remote actors you should follow.</p>'
       expect(new_collection.sensitive).to be false
       expect(new_collection.discoverable).to be true
+      expect(new_collection.url).to eq 'https://example.com/c/1'
       expect(new_collection.tag.formatted_name).to eq '#people'
 
       expect(ActivityPub::ProcessFeaturedItemWorker).to have_enqueued_sidekiq_job.with(new_collection.id, 'https://example.com/featured_items/1', 1, nil)
@@ -72,6 +74,18 @@ RSpec.describe ActivityPub::ProcessFeaturedCollectionService do
       new_collection = account.collections.last
       expect(new_collection.language).to eq 'en'
       expect(new_collection.description_html).to eq '<p>A list of remote actors you should follow.</p>'
+    end
+  end
+
+  context 'when the json does not include a `url`' do
+    let(:featured_collection_json) do
+      base_json.except('url')
+    end
+
+    it 'uses the `id` instead' do
+      subject.call(account, featured_collection_json)
+
+      expect(Collection.last.url).to eq 'https://example.com/featured_collections/1'
     end
   end
 


### PR DESCRIPTION
We use an user-facing URL for collections that is different than the URI we use as `id`. We need to know both to detect when a given URL points to a collection that we know.

This adds a `url` property to the AP representation of a collection and a new db column to store this information when we receive it.