### PR TITLE
Include hosts resolver in request socket DNS lookup

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -292,7 +292,8 @@ class Request
         begin
           addresses = [IPAddr.new(host)]
         rescue IPAddr::InvalidAddressError
-          addresses = Resolv.getaddresses(host)
+          resolvers = [Resolv::Hosts.new, Resolv::DNS.new.tap { |dns| dns.timeouts = 5 }]
+          addresses = Resolv.new(resolvers).getaddresses(host)
           addresses = addresses.grep(Resolv::IPv6::Regex).take(2) + addresses.grep_v(Resolv::IPv6::Regex).take(2)
         end
 

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -292,11 +292,8 @@ class Request
         begin
           addresses = [IPAddr.new(host)]
         rescue IPAddr::InvalidAddressError
-          Resolv::DNS.open do |dns|
-            dns.timeouts = 5
-            addresses = dns.getaddresses(host)
-            addresses = addresses.grep(Resolv::IPv6).take(2) + addresses.grep_v(Resolv::IPv6).take(2)
-          end
+          addresses = Resolv.getaddresses(host)
+          addresses = addresses.grep(Resolv::IPv6::Regex).take(2) + addresses.grep_v(Resolv::IPv6::Regex).take(2)
         end
 
         socks = []

--- a/spec/lib/fasp/request_spec.rb
+++ b/spec/lib/fasp/request_spec.rb
@@ -86,14 +86,11 @@ RSpec.describe Fasp::Request do
         WebMock.enable!
       end
 
+      before { allow(Resolv).to receive(:getaddresses).with('reqprov.example.com').and_return(%w(0.0.0.0 2001:db8::face)) }
+
       it 'raises Mastodon::ValidationError' do
-        resolver = instance_double(Resolv::DNS)
-
-        allow(resolver).to receive(:getaddresses).with('reqprov.example.com').and_return(%w(0.0.0.0 2001:db8::face))
-        allow(resolver).to receive(:timeouts=).and_return(nil)
-        allow(Resolv::DNS).to receive(:open).and_yield(resolver)
-
-        expect { subject.send(method, '/test_path') }.to raise_error(Mastodon::ValidationError)
+        expect { subject.send(method, '/test_path') }
+          .to raise_error(Mastodon::ValidationError)
       end
     end
   end

--- a/spec/lib/fasp/request_spec.rb
+++ b/spec/lib/fasp/request_spec.rb
@@ -86,7 +86,12 @@ RSpec.describe Fasp::Request do
         WebMock.enable!
       end
 
-      before { allow(Resolv).to receive(:getaddresses).with('reqprov.example.com').and_return(%w(0.0.0.0 2001:db8::face)) }
+      let(:resolv_service) { instance_double(Resolv) }
+
+      before do
+        allow(Resolv).to receive(:new).and_return(resolv_service)
+        allow(resolv_service).to receive(:getaddresses).with('reqprov.example.com').and_return(%w(0.0.0.0 2001:db8::face))
+      end
 
       it 'raises Mastodon::ValidationError' do
         expect { subject.send(method, '/test_path') }

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -66,15 +66,15 @@ RSpec.describe Request do
         expect(a_request(:get, 'http://example.com')).to have_been_made.once
       end
 
-      it 'executes a HTTP request when the first address is private' do
-        resolver = instance_double(Resolv::DNS)
+      context 'when first address is private' do
+        before { allow(Resolv).to receive(:getaddresses).with('example.com').and_return(%w(0.0.0.0 2001:4860:4860::8844)) }
 
-        allow(resolver).to receive(:getaddresses).with('example.com').and_return(%w(0.0.0.0 2001:4860:4860::8844))
-        allow(resolver).to receive(:timeouts=).and_return(nil)
-        allow(Resolv::DNS).to receive(:open).and_yield(resolver)
-
-        expect { |block| subject.perform(&block) }.to yield_control
-        expect(a_request(:get, 'http://example.com')).to have_been_made.once
+        it 'executes a HTTP request' do
+          expect { |block| subject.perform(&block) }
+            .to yield_control
+          expect(a_request(:get, 'http://example.com'))
+            .to have_been_made.once
+        end
       end
 
       it 'makes a request with expected headers, yields, and closes the underlying connection' do
@@ -123,14 +123,11 @@ RSpec.describe Request do
         WebMock.enable!
       end
 
+      before { allow(Resolv).to receive(:getaddresses).with('example.com').and_return(%w(0.0.0.0 2001:db8::face)) }
+
       it 'raises Mastodon::ValidationError' do
-        resolver = instance_double(Resolv::DNS)
-
-        allow(resolver).to receive(:getaddresses).with('example.com').and_return(%w(0.0.0.0 2001:db8::face))
-        allow(resolver).to receive(:timeouts=).and_return(nil)
-        allow(Resolv::DNS).to receive(:open).and_yield(resolver)
-
-        expect { subject.perform }.to raise_error Mastodon::ValidationError
+        expect { subject.perform }
+          .to raise_error Mastodon::ValidationError
       end
     end
 

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -67,7 +67,12 @@ RSpec.describe Request do
       end
 
       context 'when first address is private' do
-        before { allow(Resolv).to receive(:getaddresses).with('example.com').and_return(%w(0.0.0.0 2001:4860:4860::8844)) }
+        let(:resolv_service) { instance_double(Resolv) }
+
+        before do
+          allow(Resolv).to receive(:new).and_return(resolv_service)
+          allow(resolv_service).to receive(:getaddresses).with('example.com').and_return(%w(0.0.0.0 2001:4860:4860::8844))
+        end
 
         it 'executes a HTTP request' do
           expect { |block| subject.perform(&block) }
@@ -123,7 +128,12 @@ RSpec.describe Request do
         WebMock.enable!
       end
 
-      before { allow(Resolv).to receive(:getaddresses).with('example.com').and_return(%w(0.0.0.0 2001:db8::face)) }
+      let(:resolv_service) { instance_double(Resolv) }
+
+      before do
+        allow(Resolv).to receive(:new).with([be_a(Resolv::Hosts), be_a(Resolv::DNS)]).and_return(resolv_service)
+        allow(resolv_service).to receive(:getaddresses).with('example.com').and_return(%w(0.0.0.0 2001:db8::face))
+      end
 
       it 'raises Mastodon::ValidationError' do
         expect { subject.perform }


### PR DESCRIPTION
I think this accomplishes what https://github.com/mastodon/mastodon/pull/34008 was going for, in a slightly simpler way.

The default behavior of the top level `getaddresses` is to first use the hosts resolver, then use the dns resolver. The default timeout is 5 on the dns resolver. So - I think this change preserves the previous dns behavior, and adds in the etc hosts lookup first. Should also preserve stuff around private addresses.

We have some coverage here (see changes), but I'm not sure how exactly (or if) to do anything special for the hosts addition ... it caches the file on initialization so it would be awkward to prep that.

The changes were a long time ago, but the change which converted from `Addrinfo` (which hits underlying OS and would respect etc hosts) to `Resolv::DNS` - https://github.com/mastodon/mastodon/pull/9329/changes#diff-5734acf9c6158cc1cfb688dba6a64a5a630d0c3986fb7ed52ced6c7eca29b0e9R147 - does not appear to have been specifically motivated by disabling hosts, seems to be unintended side effect.

One note here - the tests did not find this but a basic console test did ... the top level `Resolv.getaddresses` returns strings (as noted in other PR), while `Resolv::DNS.getaddresses` return classes (for ipv6 and ipv4), this is why the `grep`/`grep_v` targets changed.

There was some concern in original PR about calling `close` or not - I believe the `DNS` class lookup that is wrapped by the top level getaddresses does call close internally, so we are preserving that.

If we wanted to preserve the explicitness of the timout argument and protect against possible future defaults changes in the lib, could do that as well I think.