### PR TITLE
Fallback to `default` theme when admin-selected theme does not exist

### DIFF
--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -47,9 +47,15 @@ module ThemeHelper
   end
 
   def current_theme
-    return Setting.theme unless Themes.instance.names.include? current_user&.setting_theme
+    available_themes = Themes.instance.names
 
-    current_user.setting_theme
+    user_theme = current_user&.setting_theme
+    return user_theme if user_theme && available_themes.include?(user_theme)
+
+    site_theme = Setting.theme
+    return site_theme if available_themes.include?(site_theme)
+
+    'default'  # Fallback
   end
 
   def color_scheme

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -55,7 +55,7 @@ module ThemeHelper
     site_theme = Setting.theme
     return site_theme if available_themes.include?(site_theme)
 
-    'default'  # Fallback
+    'default' # Fallback
   end
 
   def color_scheme

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -112,7 +112,6 @@ class Form::AdminSettings
   validates :status_page_url, url: true, allow_blank: true
   validate :validate_site_uploads
   validates :landing_page, inclusion: { in: LANDING_PAGE }, if: -> { defined?(@landing_page) }
-  validates :theme, inclusion: { in: Themes.instance.names }, if: -> { defined?(@theme) }
 
   KEYS.each do |key|
     define_method(key) do

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -112,6 +112,7 @@ class Form::AdminSettings
   validates :status_page_url, url: true, allow_blank: true
   validate :validate_site_uploads
   validates :landing_page, inclusion: { in: LANDING_PAGE }, if: -> { defined?(@landing_page) }
+  validates :theme, inclusion: { in: Themes.instance.names }, if: -> { defined?(@theme) }
 
   KEYS.each do |key|
     define_method(key) do

--- a/spec/helpers/theme_helper_spec.rb
+++ b/spec/helpers/theme_helper_spec.rb
@@ -107,6 +107,12 @@ RSpec.describe ThemeHelper do
       context 'when theme was not changed in settings' do
         it { is_expected.to eq('default') }
       end
+
+      context 'when theme is changed in settings' do
+        before { Setting.theme = 'contrast' }
+
+        it { is_expected.to eq('contrast') }
+      end
     end
 
     context 'when user is signed in' do

--- a/spec/helpers/theme_helper_spec.rb
+++ b/spec/helpers/theme_helper_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe ThemeHelper do
       end
 
       context 'when theme is changed in settings' do
-        before { Setting.theme = 'contrast' }
+        before { allow(Themes.instance).to receive(:names).and_return(%w(default contrast)) }
 
         it { is_expected.to eq('contrast') }
       end

--- a/spec/helpers/theme_helper_spec.rb
+++ b/spec/helpers/theme_helper_spec.rb
@@ -109,9 +109,18 @@ RSpec.describe ThemeHelper do
       end
 
       context 'when theme is changed in settings' do
-        before { allow(Setting.theme).to receive(:names).and_return(%w(default contrast)) }
+        before do
+          allow(Themes.instance).to receive(:names).and_return(%w(default contrast))
+          Setting.theme = 'contrast'
+        end
 
         it { is_expected.to eq('contrast') }
+      end
+
+      context 'when theme is changed to invalid value' do
+        before { Setting.theme = 'fakethemename' }
+
+        it { is_expected.to eq('default') }
       end
     end
 

--- a/spec/helpers/theme_helper_spec.rb
+++ b/spec/helpers/theme_helper_spec.rb
@@ -107,12 +107,6 @@ RSpec.describe ThemeHelper do
       context 'when theme was not changed in settings' do
         it { is_expected.to eq('default') }
       end
-
-      context 'when theme is changed in settings' do
-        before { Setting.theme = 'contrast' }
-
-        it { is_expected.to eq('contrast') }
-      end
     end
 
     context 'when user is signed in' do

--- a/spec/helpers/theme_helper_spec.rb
+++ b/spec/helpers/theme_helper_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe ThemeHelper do
       end
 
       context 'when theme is changed in settings' do
-        before { allow(Themes.instance).to receive(:names).and_return(%w(default contrast)) }
+        before { allow(Setting.theme).to receive(:names).and_return(%w(default contrast)) }
 
         it { is_expected.to eq('contrast') }
       end


### PR DESCRIPTION
Low hanging fruit. I've been having problems with themes causing 500 errors when trying to move themes around.

This should catch my mistakes with theme naming.