### PR TITLE
Federate featured item creation date

### DIFF
--- a/app/serializers/activitypub/featured_item_serializer.rb
+++ b/app/serializers/activitypub/featured_item_serializer.rb
@@ -4,7 +4,7 @@ class ActivityPub::FeaturedItemSerializer < ActivityPub::Serializer
   include RoutingHelper
 
   attributes :id, :type, :featured_object, :featured_object_type,
-             :feature_authorization
+             :feature_authorization, :published
 
   def id
     ActivityPub::TagManager.instance.uri_for(object)
@@ -28,5 +28,9 @@ class ActivityPub::FeaturedItemSerializer < ActivityPub::Serializer
     else
       object.approval_uri
     end
+  end
+
+  def published
+    object.created_at.iso8601
   end
 end

--- a/app/serializers/rest/collection_item_serializer.rb
+++ b/app/serializers/rest/collection_item_serializer.rb
@@ -3,7 +3,7 @@
 class REST::CollectionItemSerializer < ActiveModel::Serializer
   delegate :accepted?, to: :object
 
-  attributes :id, :state
+  attributes :id, :state, :created_at
 
   attribute :account_id, if: :accepted?
 

--- a/app/services/activitypub/process_featured_item_service.rb
+++ b/app/services/activitypub/process_featured_item_service.rb
@@ -43,7 +43,9 @@ class ActivityPub::ProcessFeaturedItemService
   end
 
   def new_item
-    @collection.collection_items.new
+    @collection.collection_items.new(
+      created_at: @item_json['published']
+    )
   end
 
   def verify_authorization!

--- a/spec/serializers/activitypub/featured_collection_serializer_spec.rb
+++ b/spec/serializers/activitypub/featured_collection_serializer_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe ActivityPub::FeaturedCollectionSerializer do
           'featuredObject' => ActivityPub::TagManager.instance.uri_for(collection_items.first.account),
           'featuredObjectType' => 'Person',
           'featureAuthorization' => ap_account_feature_authorization_url(collection_items.first.account_id, collection_items.first),
+          'published' => match_api_datetime_format,
         },
         {
           'id' => ActivityPub::TagManager.instance.uri_for(collection_items.last),
@@ -46,6 +47,7 @@ RSpec.describe ActivityPub::FeaturedCollectionSerializer do
           'featuredObject' => ActivityPub::TagManager.instance.uri_for(collection_items.last.account),
           'featuredObjectType' => 'Person',
           'featureAuthorization' => ap_account_feature_authorization_url(collection_items.last.account_id, collection_items.last),
+          'published' => match_api_datetime_format,
         },
       ],
       'published' => match_api_datetime_format,

--- a/spec/serializers/activitypub/featured_item_serializer_spec.rb
+++ b/spec/serializers/activitypub/featured_item_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ActivityPub::FeaturedItemSerializer do
 
   subject { serialized_record_json(collection_item, described_class, adapter: ActivityPub::Adapter) }
 
-  let(:collection_item) { Fabricate(:collection_item) }
+  let(:collection_item) { Fabricate(:collection_item, created_at: Time.utc(2026, 4, 16, 1)) }
 
   context 'when a local account is featured' do
     it 'serializes to the expected structure' do
@@ -17,6 +17,7 @@ RSpec.describe ActivityPub::FeaturedItemSerializer do
         'featuredObject' => ActivityPub::TagManager.instance.uri_for(collection_item.account),
         'featuredObjectType' => 'Person',
         'featureAuthorization' => ap_account_feature_authorization_url(collection_item.account_id, collection_item),
+        'published' => '2026-04-16T01:00:00Z',
       })
     end
   end

--- a/spec/serializers/rest/collection_item_serializer_spec.rb
+++ b/spec/serializers/rest/collection_item_serializer_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe REST::CollectionItemSerializer do
         .to include(
           'id' => '2342',
           'account_id' => collection_item.account_id.to_s,
-          'state' => 'accepted'
+          'state' => 'accepted',
+          'created_at' => match_api_datetime_format
         )
     end
   end

--- a/spec/services/activitypub/process_featured_item_service_spec.rb
+++ b/spec/services/activitypub/process_featured_item_service_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ActivityPub::ProcessFeaturedItemService do
       'featuredObject' => featured_object_uri,
       'featuredObjectType' => 'Person',
       'featureAuthorization' => feature_authorization_uri,
+      'published' => '2026-04-16T01:00:00Z',
     }
   end
   let(:stubbed_service) do
@@ -56,6 +57,7 @@ RSpec.describe ActivityPub::ProcessFeaturedItemService do
           new_item = collection.collection_items.last
           expect(new_item.object_uri).to eq 'https://example.com/actor/1'
           expect(new_item.approval_uri).to be_nil
+          expect(new_item.created_at).to eq Time.utc(2026, 4, 16, 1)
           expect(new_item.position).to eq 3
         end
       end


### PR DESCRIPTION
Ingest and use the value when receiving remote items and emit the date in the REST API as well.

Fixes PRO-441