### PR TITLE
Fix `Bundle` being used with incorrect prop types by using type-dependent `key`

### DIFF
--- a/app/javascript/mastodon/components/media_attachments.jsx
+++ b/app/javascript/mastodon/components/media_attachments.jsx
@@ -65,7 +65,7 @@ export default class MediaAttachments extends ImmutablePureComponent {
       const description = audio.getIn(['translation', 'description']) || audio.get('description');
 
       return (
-        <Bundle fetchComponent={Audio} loading={this.renderLoadingAudioPlayer} >
+        <Bundle fetchComponent={Audio} loading={this.renderLoadingAudioPlayer} key='audio'>
           {Component => (
             <Component
               src={audio.get('url')}
@@ -87,7 +87,7 @@ export default class MediaAttachments extends ImmutablePureComponent {
       const description = video.getIn(['translation', 'description']) || video.get('description');
 
       return (
-        <Bundle fetchComponent={Video} loading={this.renderLoadingVideoPlayer} >
+        <Bundle fetchComponent={Video} loading={this.renderLoadingVideoPlayer} key='video'>
           {Component => (
             <Component
               preview={video.get('preview_url')}
@@ -108,7 +108,7 @@ export default class MediaAttachments extends ImmutablePureComponent {
       );
     } else {
       return (
-        <Bundle fetchComponent={MediaGallery} loading={this.renderLoadingMediaGallery} >
+        <Bundle fetchComponent={MediaGallery} loading={this.renderLoadingMediaGallery} key='gallery'>
           {Component => (
             <Component
               media={mediaAttachments}

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -477,7 +477,7 @@ class Status extends ImmutablePureComponent {
 
       if (['image', 'gifv', 'unknown'].includes(status.getIn(['media_attachments', 0, 'type'])) || status.get('media_attachments').size > 1) {
         media = (
-          <Bundle fetchComponent={MediaGallery} loading={this.renderLoadingMediaGallery}>
+          <Bundle fetchComponent={MediaGallery} loading={this.renderLoadingMediaGallery} key='gallery'>
             {Component => (
               <Component
                 media={status.get('media_attachments')}
@@ -499,7 +499,7 @@ class Status extends ImmutablePureComponent {
         const description = attachment.getIn(['translation', 'description']) || attachment.get('description');
 
         media = (
-          <Bundle fetchComponent={Audio} loading={this.renderLoadingAudioPlayer} >
+          <Bundle fetchComponent={Audio} loading={this.renderLoadingAudioPlayer} key='audio'>
             {Component => (
               <Component
                 src={attachment.get('url')}
@@ -525,7 +525,7 @@ class Status extends ImmutablePureComponent {
         const description = attachment.getIn(['translation', 'description']) || attachment.get('description');
 
         media = (
-          <Bundle fetchComponent={Video} loading={this.renderLoadingVideoPlayer} >
+          <Bundle fetchComponent={Video} loading={this.renderLoadingVideoPlayer} key='video'>
             {Component => (
               <Component
                 preview={attachment.get('preview_url')}


### PR DESCRIPTION
Fixes #37966

While the component should still be rewritten in a safer and more modern way (as a functional component, perhaps using `React.Suspense`), this PR should fix the immediate functional issue at hand.