### PR TITLE
Remove "View other collections from this user" from collection menu

### DIFF
--- a/app/javascript/mastodon/features/collections/components/collection_menu.tsx
+++ b/app/javascript/mastodon/features/collections/components/collection_menu.tsx
@@ -2,8 +2,6 @@ import { useCallback, useMemo } from 'react';
 
 import { defineMessages, useIntl } from 'react-intl';
 
-import { matchPath } from 'react-router';
-
 import { showAlert } from '@/mastodon/actions/alerts';
 import { initBlockModal } from '@/mastodon/actions/blocks';
 import { useAccount } from '@/mastodon/hooks/useAccount';
@@ -34,10 +32,6 @@ const messages = defineMessages({
   copyLinkConfirmation: {
     id: 'collections.copy_link_confirmation',
     defaultMessage: 'Copied collection link to clipboard',
-  },
-  viewOtherCollections: {
-    id: 'collections.view_other_collections_by_user',
-    defaultMessage: 'View other collections by this user',
   },
   delete: {
     id: 'collections.delete_collection',
@@ -168,25 +162,11 @@ export const CollectionMenu: React.FC<{
         return ownerItems;
       }
     } else {
-      const nonOwnerItems: MenuItem[] = [viewCollectionItem, ...shareItems];
-
-      if (context !== 'notifications' && ownerAccount) {
-        const featuredCollectionsPath = `/@${ownerAccount.acct}/featured`;
-        // Don't show menu link to featured collections while on that very page
-        if (
-          !matchPath(location.pathname, {
-            path: featuredCollectionsPath,
-            exact: true,
-          })
-        ) {
-          nonOwnerItems.push({
-            text: intl.formatMessage(messages.viewOtherCollections),
-            to: featuredCollectionsPath,
-          });
-        }
-      }
-
-      nonOwnerItems.push(null);
+      const nonOwnerItems: MenuItem[] = [
+        viewCollectionItem,
+        ...shareItems,
+        null,
+      ];
 
       // Collection notifications already have a prominent 'Remove me' button
       if (currentAccountInCollection && context !== 'notifications') {
@@ -218,7 +198,6 @@ export const CollectionMenu: React.FC<{
     dispatch,
     openDeleteConfirmation,
     context,
-    ownerAccount,
     currentAccountInCollection,
     openReportModal,
     openBlockModal,

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -415,7 +415,6 @@
   "collections.unlisted_collections_description": "These don’t appear on your profile to others. Anyone with the link can discover them.",
   "collections.unlisted_collections_with_count": "Unlisted collections ({count})",
   "collections.view_collection": "View collection",
-  "collections.view_other_collections_by_user": "View other collections by this user",
   "collections.visibility_public": "Public",
   "collections.visibility_public_hint": "Discoverable in search results and other areas where recommendations appear.",
   "collections.visibility_title": "Visibility",


### PR DESCRIPTION
### Changes proposed in this PR:
- Removes the "View other collections from this user" option from the collection context menu

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="662" height="402" alt="image" src="https://github.com/user-attachments/assets/da18f641-b0ec-4b8a-97a0-cc714f412b35" /> | <img width="666" height="365" alt="image" src="https://github.com/user-attachments/assets/0f4bf98e-28cd-4215-8ddd-fdd56ec8b90a" /> |