### PR TITLE
Update to copy and order for media display options

### DIFF
--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -35,7 +35,7 @@ class UserSettings
     setting :missing_alt_text_modal, default: true
     setting :reduce_motion, default: false
     setting :expand_content_warnings, default: false
-    setting :display_media, default: 'default', in: %w(default show_all hide_all)
+    setting :display_media, default: 'default', in: %w(hide_all default show_all)
     setting :auto_play, default: false
     setting :emoji_style, default: 'auto', in: %w(auto native twemoji)
     setting :color_scheme, default: 'auto', in: %w(auto light dark)

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -61,9 +61,9 @@ en:
         setting_default_quote_policy_private: Followers-only posts authored on Mastodon can't be quoted by others.
         setting_default_quote_policy_unlisted: When people quote you, their post will also be hidden from trending timelines.
         setting_default_sensitive: Sensitive media is hidden by default and can be revealed with a click
-        setting_display_media_default: Hide media marked as sensitive
-        setting_display_media_hide_all: Always hide media
-        setting_display_media_show_all: Always show media
+        setting_display_media_default: Warn before showing media marked as sensitive
+        setting_display_media_hide_all: Warn before showing all media
+        setting_display_media_show_all: Show all media without warning, including media marked as sensitive
         setting_emoji_style: How to display emojis. "Auto" will try using native emoji, but falls back to Twemoji for legacy browsers.
         setting_quick_boosting_html: When enabled, clicking on the %{boost_icon} Boost icon will immediately boost instead of opening the boost/quote dropdown menu. Relocates the quoting action to the %{options_icon} (Options) menu.
         setting_system_scrollbars_ui: Applies only to desktop browsers based on Safari and Chrome


### PR DESCRIPTION
Rebased/updated version of https://github.com/mastodon/mastodon/pull/26552#issuecomment-4266904704 based on latest feedback.

After change:

<img width="823" height="315" alt="Screenshot 2026-04-17 at 08 18 11" src="https://github.com/user-attachments/assets/eca680e7-0313-44b1-89b1-90941ffc8d70" />

(Opening this on assumption original author may have abandoned ... attempted to preserve commit history here, but I believe it was edited/merged via GH ui a few times or something...)