### PR TITLE
Remove invalid options from recovery codes controller

### DIFF
--- a/app/controllers/settings/two_factor_authentication/recovery_codes_controller.rb
+++ b/app/controllers/settings/two_factor_authentication/recovery_codes_controller.rb
@@ -7,7 +7,7 @@ module Settings
 
       skip_before_action :require_functional!
 
-      before_action :require_challenge!, on: :create
+      before_action :require_challenge!
 
       def create
         @recovery_codes = current_user.generate_otp_backup_codes!


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/38704 - this presumably should have been `only`.

In this case the wrong option meant the callback was declared for the whole controller .. which is only this one action, so just remove. A setting to enable strict option setting on these would be useful.