### PR TITLE
Update puma to version 8.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 ruby '>= 3.3.0', '< 4.1.0'
 
 gem 'propshaft'
-gem 'puma', '~> 7.0'
+gem 'puma'
 gem 'rails', '~> 8.1.0'
 gem 'thor', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -625,7 +625,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (8.0.0)
+    puma (8.0.1)
       nio4r (~> 2.0)
     pundit (2.5.2)
       activesupport (>= 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -625,7 +625,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.2.0)
+    puma (8.0.0)
       nio4r (~> 2.0)
     pundit (2.5.2)
       activesupport (>= 3.0.0)
@@ -1045,7 +1045,7 @@ DEPENDENCIES
   prometheus_exporter (~> 2.2)
   propshaft
   public_suffix (~> 7.0)
-  puma (~> 7.0)
+  puma
   pundit (~> 2.3)
   rack-attack (~> 6.6)
   rack-cors


### PR DESCRIPTION
Release notes: https://github.com/puma/puma/releases/tag/v8.0.0

Upgrade: https://github.com/puma/puma/blob/main/docs/8.0-Upgrade.md

Looks like mostly a batch of perf improvements and small feature additions (which are mostly for frameworks, not apps).

I don't think the new config options are relevant to our current config.

I think the only possible thing to contemplate here is RE: the default binding change (previously `0.0.0.0`, now `::` when IPv6 support present), and that "systems that ONLY bind to IPv6 (without IPv4 support) this may be a breaking change."