### PR TITLE
Add "Must follow" section to account suggestion dropdown menu

### DIFF
--- a/app/javascript/mastodon/features/collections/editor/accounts.tsx
+++ b/app/javascript/mastodon/features/collections/editor/accounts.tsx
@@ -4,6 +4,8 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useHistory } from 'react-router-dom';
 
+import type { Map as ImmutableMap } from 'immutable';
+
 import type { ApiMutedAccountJSON } from 'mastodon/api_types/accounts';
 import type { ApiCollectionJSON } from 'mastodon/api_types/collections';
 import { AccountListItem } from 'mastodon/components/account_list_item';
@@ -88,7 +90,7 @@ type GroupKey = 'available' | 'mustFollow' | 'disabled';
 
 function groupSuggestions(
   accounts: ApiMutedAccountJSON[],
-  relationships: Immutable.Map<string, Relationship>,
+  relationships: ImmutableMap<string, Relationship>,
 ) {
   const { available, mustFollow, disabled } = Object.groupBy(
     accounts,
@@ -207,6 +209,7 @@ export const CollectionAccounts: React.FC<{
   });
 
   const relationships = useAppSelector((state) => state.relationships);
+
   const groupedItems = groupSuggestions(suggestedAccounts, relationships);
 
   const handleSearchValueChange = useCallback(

--- a/app/javascript/mastodon/features/collections/editor/accounts.tsx
+++ b/app/javascript/mastodon/features/collections/editor/accounts.tsx
@@ -25,6 +25,7 @@ import {
 import { useAccount } from 'mastodon/hooks/useAccount';
 import { useSearchAccounts } from 'mastodon/hooks/useSearchAccounts';
 import { domain } from 'mastodon/initial_state';
+import type { Relationship } from 'mastodon/models/relationship';
 import {
   addCollectionItem,
   getCollectionItemIds,
@@ -85,19 +86,35 @@ const renderAccountItem = (account: ApiMutedAccountJSON) => (
 
 type GroupKey = 'available' | 'mustFollow' | 'disabled';
 
-function groupSuggestions(accounts: ApiMutedAccountJSON[]) {
-  const { available, disabled } = Object.groupBy(accounts, (account) => {
-    if (getIsItemDisabled(account)) {
-      return 'disabled';
-    }
-    // if (account.locked && !relationship?.following) {
-    //   return 'mustFollow';
-    // }
-    return 'available';
-  });
+function groupSuggestions(
+  accounts: ApiMutedAccountJSON[],
+  relationships: Immutable.Map<string, Relationship>,
+) {
+  const { available, mustFollow, disabled } = Object.groupBy(
+    accounts,
+    (account) => {
+      const relationship = relationships.get(account.id);
+
+      if (getIsItemDisabled(account)) {
+        const canAccountBeAddedByFollowers =
+          account.feature_approval.automatic.includes('followers') ||
+          account.feature_approval.manual.includes('followers');
+
+        if (
+          account.locked &&
+          canAccountBeAddedByFollowers &&
+          !relationship?.following
+        ) {
+          return 'mustFollow';
+        }
+        return 'disabled';
+      }
+      return 'available';
+    },
+  );
 
   // Returning a new object ensures a fixed property order
-  return { available, disabled };
+  return { available, mustFollow, disabled };
 }
 
 const renderGroupTitle = (groupKey: GroupKey, titleId: string) => {
@@ -188,6 +205,9 @@ export const CollectionAccounts: React.FC<{
     // Don't suggest accounts that were already added
     filterResults: (account) => !accountIds.includes(account.id),
   });
+
+  const relationships = useAppSelector((state) => state.relationships);
+  const groupedItems = groupSuggestions(suggestedAccounts, relationships);
 
   const handleSearchValueChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -330,7 +350,7 @@ export const CollectionAccounts: React.FC<{
             onKeyDown={handleSearchKeyDown}
             disabled={hasMaxAccounts}
             isLoading={isLoadingSuggestions}
-            items={groupSuggestions(suggestedAccounts)}
+            items={groupedItems}
             getItemId={getItemId}
             getIsItemDisabled={getIsItemDisabled}
             renderItem={renderAccountItem}

--- a/app/javascript/mastodon/features/collections/editor/accounts.tsx
+++ b/app/javascript/mastodon/features/collections/editor/accounts.tsx
@@ -88,30 +88,33 @@ const renderAccountItem = (account: ApiMutedAccountJSON) => (
 
 type GroupKey = 'available' | 'mustFollow' | 'disabled';
 
+const canAccountBeAdded = (account: ApiMutedAccountJSON) =>
+  ['automatic', 'manual'].includes(account.feature_approval.current_user);
+
 function groupSuggestions(
   accounts: ApiMutedAccountJSON[],
   relationships: ImmutableMap<string, Relationship>,
 ) {
   const { available, mustFollow, disabled } = Object.groupBy(
     accounts,
-    (account) => {
-      const relationship = relationships.get(account.id);
-
-      if (getIsItemDisabled(account)) {
-        const canAccountBeAddedByFollowers =
-          account.feature_approval.automatic.includes('followers') ||
-          account.feature_approval.manual.includes('followers');
-
-        if (
-          account.locked &&
-          canAccountBeAddedByFollowers &&
-          !relationship?.following
-        ) {
-          return 'mustFollow';
-        }
-        return 'disabled';
+    (account): GroupKey => {
+      if (canAccountBeAdded(account)) {
+        return 'available';
       }
-      return 'available';
+
+      const canAccountBeAddedByFollowers =
+        account.locked &&
+        (account.feature_approval.automatic.includes('followers') ||
+          account.feature_approval.manual.includes('followers'));
+
+      if (
+        canAccountBeAddedByFollowers &&
+        !relationships.get(account.id)?.following
+      ) {
+        return 'mustFollow';
+      }
+
+      return 'disabled';
     },
   );
 
@@ -165,10 +168,8 @@ const renderGroupTitle = (groupKey: GroupKey, titleId: string) => {
 };
 
 const getItemId = (account: ApiMutedAccountJSON) => account.id;
-
-// Disable accounts who can't be added to a collection
 const getIsItemDisabled = (account: ApiMutedAccountJSON) =>
-  !['automatic', 'manual'].includes(account.feature_approval.current_user);
+  !canAccountBeAdded(account);
 
 export const CollectionAccounts: React.FC<{
   collection?: ApiCollectionJSON | null;

--- a/app/javascript/mastodon/features/collections/editor/accounts.tsx
+++ b/app/javascript/mastodon/features/collections/editor/accounts.tsx
@@ -103,9 +103,8 @@ function groupSuggestions(
       }
 
       const canAccountBeAddedByFollowers =
-        account.locked &&
-        (account.feature_approval.automatic.includes('followers') ||
-          account.feature_approval.manual.includes('followers'));
+        account.feature_approval.automatic.includes('followers') ||
+        account.feature_approval.manual.includes('followers');
 
       if (
         canAccountBeAddedByFollowers &&


### PR DESCRIPTION
Fixes WEB-954

### Changes proposed in this PR:
- Properly implements the "Must follow first" section in the accounts suggestion dropdown menu of the Collection editor (following on from #38739)
- Note that this PR depends on the fix from #38751 to be merged for proper functionality
