### PR TITLE
Fix incorrect value for `feature_approval.current_user` for local users

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -473,7 +473,7 @@ class Account < ApplicationRecord
   end
 
   def featureable_by?(other_account)
-    return discoverable? && (!locked? || followed_by?(other_account)) if local?
+    return discoverable? && (!locked? || followed_by?(other_account) || other_account.id == id) if local?
 
     feature_policy_for_account(other_account).in?(%i(automatic manual))
   end

--- a/app/models/concerns/account/interaction_policy_concern.rb
+++ b/app/models/concerns/account/interaction_policy_concern.rb
@@ -18,7 +18,8 @@ module Account::InteractionPolicyConcern
   # Returns `:automatic`, `:manual`, `:unknown`, ':missing` or `:denied`
   def feature_policy_for_account(other_account)
     return :denied if other_account.nil? || (local? && !discoverable?)
-    return :automatic if local?
+    return locked? && !followed_by?(other_account) && self != other_account ? :denied : :automatic if local?
+
     # Post author is always allowed to feature themselves
     return :automatic if self == other_account
     return :missing if feature_approval_policy.zero?

--- a/spec/serializers/rest/account_serializer_spec.rb
+++ b/spec/serializers/rest/account_serializer_spec.rb
@@ -97,12 +97,26 @@ RSpec.describe REST::AccountSerializer do
           context 'when account is locked' do
             let(:account) { Fabricate(:account, locked: true) }
 
-            it 'includes a policy that allows featuring for followers' do
-              expect(subject['feature_approval']).to include({
-                'automatic' => ['followers'],
-                'manual' => [],
-                'current_user' => 'automatic',
-              })
+            context 'when the current account does not follow the user' do
+              it 'includes a policy that allows featuring for followers and has "denied" for the current user' do
+                expect(subject['feature_approval']).to include({
+                  'automatic' => ['followers'],
+                  'manual' => [],
+                  'current_user' => 'denied',
+                })
+              end
+            end
+
+            context 'when the current account follows the user' do
+              before { current_user.account.follow!(account) }
+
+              it 'includes a policy that allows featuring for followers and has "automatic" for the current user' do
+                expect(subject['feature_approval']).to include({
+                  'automatic' => ['followers'],
+                  'manual' => [],
+                  'current_user' => 'automatic',
+                })
+              end
             end
           end
         end


### PR DESCRIPTION
Eventually, we might want to refactor so the source of truth for the local account policy isn't duplicated/split across multiple methods