### PR TITLE
Add constants to track media player height/width

### DIFF
--- a/app/helpers/media_player_helper.rb
+++ b/app/helpers/media_player_helper.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module MediaPlayerHelper
+  PLAYER_HEIGHT = 380
+  PLAYER_WIDTH = 670
+end

--- a/app/views/media/player.html.haml
+++ b/app/views/media/player.html.haml
@@ -14,7 +14,7 @@
                     detailed: true,
                     editable: true,
                     frameRate: meta.dig('original', 'frame_rate'),
-                    height: 380,
+                    height: MediaPlayerHelper::PLAYER_HEIGHT,
                     inline: true,
                     media: [ActiveModelSerializers::SerializableResource.new(@media_attachment, serializer: REST::MediaAttachmentSerializer)].as_json,
                     preview: @media_attachment.thumbnail.present? ? @media_attachment.thumbnail.url : @media_attachment.file.url(:small),
@@ -25,7 +25,7 @@
 - elsif @media_attachment.gifv?
   = react_component :media_gallery,
                     autoplay: true,
-                    height: 380,
+                    height: MediaPlayerHelper::PLAYER_HEIGHT,
                     media: [ActiveModelSerializers::SerializableResource.new(@media_attachment, serializer: REST::MediaAttachmentSerializer).as_json],
                     standalone: true do
     %video{ autoplay: 'autoplay', muted: 'muted', loop: 'loop' }
@@ -38,9 +38,9 @@
                     duration: meta.dig(:original, :duration),
                     foregroundColor: meta.dig('colors', 'foreground'),
                     fullscreen: true,
-                    height: 380,
+                    height: MediaPlayerHelper::PLAYER_HEIGHT,
                     poster: @media_attachment.thumbnail.present? ? @media_attachment.thumbnail.url : @media_attachment.account.avatar_static_url,
                     src: @media_attachment.file.url(:original),
-                    width: 670 do
+                    width: MediaPlayerHelper::PLAYER_WIDTH do
     %audio{ controls: 'controls' }
       %source{ src: @media_attachment.file.url(:original) }

--- a/app/views/statuses/_og_image.html.haml
+++ b/app/views/statuses/_og_image.html.haml
@@ -38,8 +38,8 @@
       = opengraph 'twitter:player', player_medium_url(media)
       = opengraph 'twitter:player:stream', full_asset_url(media.file.url(:original))
       = opengraph 'twitter:player:stream:content_type', media.file_content_type
-      = opengraph 'twitter:player:width', '670'
-      = opengraph 'twitter:player:height', '380'
+      = opengraph 'twitter:player:width', MediaPlayerHelper::PLAYER_WIDTH
+      = opengraph 'twitter:player:height', MediaPlayerHelper::PLAYER_HEIGHT
   - if player_card
     = opengraph 'twitter:card', 'player'
   - else


### PR DESCRIPTION
Intention here is to do a followup which also pulls out some of the mildly complex in-view ruby to this helper module as well.