### PR TITLE
Use `with_domain` scope in ReportService

### DIFF
--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -96,7 +96,7 @@ class ReportService < BaseService
   def domain_mentions(domain)
     Mention
       .joins(:account)
-      .where(Account.arel_table[:domain].lower.eq domain)
+      .merge(Account.with_domain(domain))
       .select(1).arel.exists
   end
 


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/38300 - I didn't notice this section matched an existing scope while doing that. Also an extraction from https://github.com/mastodon/mastodon/pull/37649