### PR TITLE
.2059806565729300:3d512160b457a5d03afa79404adcde0e_69e630efb13256d09ece8873.69e70322b13256d09ece89f3.69e70322c51cac5d7d00c542:Trae CN.T(2026/4/21 12:54:58)

### DIFF
--- a/app/controllers/concerns/api/error_handling.rb
+++ b/app/controllers/concerns/api/error_handling.rb
@@ -33,8 +33,18 @@ module Api::ErrorHandling
     end
 
     rescue_from Seahorse::Client::NetworkingError do |e|
-      Rails.logger.warn "Storage server error: #{e}"
+      Rails.logger.warn "Storage server error: #{e.class}"
       render json: { error: 'There was a temporary problem serving your request, please try again' }, status: 503
+    end
+
+    rescue_from JSON::GeneratorError do |e|
+      Rails.logger.warn "API serialization error: #{e.class}"
+      render json: { error: 'Invalid data format' }, status: 422
+    end
+
+    rescue_from ArgumentError, TypeError do |e|
+      Rails.logger.warn "API parameter error: #{e.class}"
+      render json: { error: 'Invalid parameter' }, status: 422
     end
 
     rescue_from Mastodon::RaceConditionError, Stoplight::Error::RedLight do

--- a/app/serializers/rest/media_attachment_serializer.rb
+++ b/app/serializers/rest/media_attachment_serializer.rb
@@ -46,6 +46,9 @@ class REST::MediaAttachmentSerializer < ActiveModel::Serializer
   end
 
   def meta
-    object.file.meta
+    meta = object.file.meta
+    return {} unless meta.is_a?(Hash)
+
+    meta.with_indifferent_access.slice(*MediaAttachment::META_KEYS).presence || {}
   end
 end

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -459,6 +459,80 @@ RSpec.describe '/api/v1/statuses' do
         end
       end
 
+      context 'with media attachments' do
+        let!(:media_attachment) { Fabricate(:media_attachment, account: user.account) }
+        let(:params) { { status: 'Hello world with media', media_ids: [media_attachment.id] } }
+
+        it 'creates a status with media attachment', :aggregate_failures do
+          expect { subject }.to change(user.account.statuses, :count).by(1)
+
+          expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
+          expect(response.parsed_body[:media_attachments].size).to eq 1
+          expect(response.parsed_body[:media_attachments].first[:id]).to eq media_attachment.id.to_s
+        end
+
+        it 'serializes media metadata safely', :aggregate_failures do
+          subject
+
+          expect(response).to have_http_status(200)
+          media = response.parsed_body[:media_attachments].first
+          expect(media).to include(:meta)
+          expect(media[:meta]).to be_a(Hash)
+        end
+
+        context 'with media containing invalid metadata' do
+          before do
+            media_attachment.file.instance_write(:meta, 'invalid string metadata')
+            media_attachment.save!(validate: false)
+          end
+
+          it 'handles invalid metadata gracefully without 500', :aggregate_failures do
+            subject
+
+            expect(response).to have_http_status(200)
+            media = response.parsed_body[:media_attachments].first
+            expect(media[:meta]).to eq({})
+          end
+        end
+
+        context 'with media containing nil metadata' do
+          before do
+            media_attachment.file.instance_write(:meta, nil)
+            media_attachment.save!(validate: false)
+          end
+
+          it 'handles nil metadata gracefully', :aggregate_failures do
+            subject
+
+            expect(response).to have_http_status(200)
+            media = response.parsed_body[:media_attachments].first
+            expect(media[:meta]).to eq({})
+          end
+        end
+
+        context 'with media containing extra keys in metadata' do
+          before do
+            media_attachment.file.instance_write(:meta, {
+              original: { width: 600, height: 400 },
+              extra_key: 'should be filtered',
+              sensitive_data: { internal_path: '/secret/path' }
+            })
+            media_attachment.save!(validate: false)
+          end
+
+          it 'filters out non-allowed keys from metadata', :aggregate_failures do
+            subject
+
+            expect(response).to have_http_status(200)
+            media = response.parsed_body[:media_attachments].first
+            expect(media[:meta]).to include('original' => include('width' => 600, 'height' => 400))
+            expect(media[:meta]).not_to include('extra_key', 'sensitive_data')
+          end
+        end
+      end
+
       context 'with missing thread' do
         let(:params) { { status: 'Hello world', in_reply_to_id: 0 } }
 

--- a/spec/serializers/rest/media_attachment_serializer_spec.rb
+++ b/spec/serializers/rest/media_attachment_serializer_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe REST::MediaAttachmentSerializer do
+  let(:serializer) { described_class.new(media_attachment) }
+  let(:media_attachment) { Fabricate(:media_attachment, account: account) }
+  let(:account) { Fabricate(:account) }
+
+  describe '#meta' do
+    context 'when file.meta is a valid hash with allowed keys' do
+      before do
+        media_attachment.file.instance_write(:meta, {
+          original: { width: 600, height: 400, aspect: 1.5 },
+          small: { width: 300, height: 200, aspect: 1.5 },
+          focus: { x: 0.5, y: 0.5 },
+          colors: { primary: '#ffffff' }
+        })
+      end
+
+      it 'returns only allowed keys' do
+        expect(serializer.meta).to include(
+          'original' => include('width' => 600, 'height' => 400),
+          'small' => include('width' => 300, 'height' => 200),
+          'focus' => include('x' => 0.5, 'y' => 0.5),
+          'colors' => include('primary' => '#ffffff')
+        )
+      end
+
+      it 'does not include extra keys' do
+        media_attachment.file.instance_write(:meta, {
+          original: { width: 600 },
+          extra_key: 'should not be included'
+        })
+        expect(serializer.meta).not_to include('extra_key')
+      end
+    end
+
+    context 'when file.meta is nil' do
+      before do
+        media_attachment.file.instance_write(:meta, nil)
+      end
+
+      it 'returns an empty hash' do
+        expect(serializer.meta).to eq({})
+      end
+    end
+
+    context 'when file.meta is not a hash' do
+      it 'returns an empty hash for string' do
+        media_attachment.file.instance_write(:meta, 'invalid string')
+        expect(serializer.meta).to eq({})
+      end
+
+      it 'returns an empty hash for array' do
+        media_attachment.file.instance_write(:meta, ['invalid', 'array'])
+        expect(serializer.meta).to eq({})
+      end
+
+      it 'returns an empty hash for number' do
+        media_attachment.file.instance_write(:meta, 123)
+        expect(serializer.meta).to eq({})
+      end
+
+      it 'returns an empty hash for boolean' do
+        media_attachment.file.instance_write(:meta, true)
+        expect(serializer.meta).to eq({})
+      end
+    end
+
+    context 'when file.meta is an empty hash' do
+      before do
+        media_attachment.file.instance_write(:meta, {})
+      end
+
+      it 'returns an empty hash' do
+        expect(serializer.meta).to eq({})
+      end
+    end
+
+    context 'when file.meta contains only non-allowed keys' do
+      before do
+        media_attachment.file.instance_write(:meta, {
+          invalid_key1: 'value1',
+          invalid_key2: 'value2'
+        })
+      end
+
+      it 'returns an empty hash' do
+        expect(serializer.meta).to eq({})
+      end
+    end
+
+    context 'with symbolized keys' do
+      before do
+        media_attachment.file.instance_write(:meta, {
+          original: { width: 600, height: 400 },
+          focus: { x: 0.5, y: 0.5 }
+        })
+      end
+
+      it 'accesses values correctly with indifferent access' do
+        expect(serializer.meta['original']).to include('width' => 600, 'height' => 400)
+        expect(serializer.meta['focus']).to include('x' => 0.5, 'y' => 0.5)
+      end
+    end
+
+    context 'with string keys' do
+      before do
+        media_attachment.file.instance_write(:meta, {
+          'original' => { 'width' => 600, 'height' => 400 },
+          'focus' => { 'x' => 0.5, 'y' => 0.5 }
+        })
+      end
+
+      it 'accesses values correctly' do
+        expect(serializer.meta['original']).to include('width' => 600, 'height' => 400)
+        expect(serializer.meta['focus']).to include('x' => 0.5, 'y' => 0.5)
+      end
+    end
+  end
+
+  describe 'full serialization' do
+    before do
+      media_attachment.file.instance_write(:meta, {
+        original: { width: 600, height: 400, aspect: 1.5 },
+        small: { width: 300, height: 200, aspect: 1.5 },
+        focus: { x: 0.5, y: 0.5 }
+      })
+    end
+
+    it 'serializes successfully without errors' do
+      expect { serializer.as_json }.not_to raise_error
+    end
+
+    it 'includes meta in the serialized output' do
+      json = serializer.as_json
+      expect(json).to include(:meta)
+      expect(json[:meta]).to include(
+        'original' => include('width' => 600, 'height' => 400),
+        'small' => include('width' => 300, 'height' => 200),
+        'focus' => include('x' => 0.5, 'y' => 0.5)
+      )
+    end
+
+    it 'converts to JSON string without errors' do
+      json = serializer.as_json
+      expect { json.to_json }.not_to raise_error
+    end
+
+    context 'with invalid metadata types' do
+      before do
+        media_attachment.file.instance_write(:meta, 'invalid string metadata')
+      end
+
+      it 'serializes successfully with empty meta' do
+        json = serializer.as_json
+        expect(json[:meta]).to eq({})
+      end
+
+      it 'does not raise errors during JSON serialization' do
+        json = serializer.as_json
+        expect { json.to_json }.not_to raise_error
+      end
+    end
+
+    context 'with nil metadata' do
+      before do
+        media_attachment.file.instance_write(:meta, nil)
+      end
+
+      it 'serializes successfully with empty meta' do
+        json = serializer.as_json
+        expect(json[:meta]).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
确保媒体附件序列化时正确处理各种元数据类型
添加错误处理以捕获JSON序列化和参数错误
增加测试覆盖所有元数据场景