### PR TITLE
Align `AccountFilter` email case with actual usage

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,7 +114,7 @@ class User < ApplicationRecord
   scope :enabled, -> { where(disabled: false) }
   scope :disabled, -> { where(disabled: true) }
   scope :active, -> { confirmed.signed_in_recently.account_not_suspended }
-  scope :matches_email, ->(value) { where(arel_table[:email].matches("#{value}%")) }
+  scope :matches_email, ->(value) { where(arel_table[:email].matches("%#{value}%")) }
   scope :matches_ip, ->(value) { left_joins(:ips).merge(IpBlock.contained_by(value)).group(users: [:id]) }
 
   before_validation :sanitize_role

--- a/app/views/admin/accounts/_account.html.haml
+++ b/app/views/admin/accounts/_account.html.haml
@@ -26,7 +26,7 @@
           %td.accounts-table__extra
             - if account.local?
               - if account.user_email
-                = link_to account.user_email_domain, admin_accounts_path(email: "%@#{account.user_email_domain}"), title: account.user_email
+                = link_to account.user_email_domain, admin_accounts_path(email: "@#{account.user_email_domain}"), title: account.user_email
               - else
                 \-
               %br/

--- a/app/views/admin/accounts/_local_account.html.haml
+++ b/app/views/admin/accounts/_local_account.html.haml
@@ -22,7 +22,7 @@
   %td{ rowspan: can?(:create, :email_domain_block) ? 3 : 2 }= account.user_email
   %td= table_link_to 'edit', t('admin.accounts.change_email.label'), admin_account_change_email_path(account.id) if can?(:change_email, account.user)
 %tr
-  %td= table_link_to 'search', t('admin.accounts.search_same_email_domain'), admin_accounts_path(email: "%@#{account.user_email_domain}")
+  %td= table_link_to 'search', t('admin.accounts.search_same_email_domain'), admin_accounts_path(email: "@#{account.user_email_domain}")
 - if can?(:create, :email_domain_block)
   %tr
     %td= table_link_to 'hide_source', t('admin.accounts.add_email_domain_block'), new_admin_email_domain_block_path(_domain: account.user_email_domain)

--- a/app/views/admin/email_domain_blocks/_email_domain_block.html.haml
+++ b/app/views/admin/email_domain_blocks/_email_domain_block.html.haml
@@ -3,7 +3,7 @@
     = f.check_box :email_domain_block_ids, { multiple: true, include_hidden: false }, email_domain_block.id
   .batch-table__row__content.pending-account
     .pending-account__header
-      %samp= link_to email_domain_block.domain, admin_accounts_path(email: "%@#{email_domain_block.domain}")
+      %samp= link_to email_domain_block.domain, admin_accounts_path(email: "@#{email_domain_block.domain}")
 
       %br/
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -88,11 +88,18 @@ RSpec.describe User do
     end
 
     describe 'matches_email' do
-      it 'returns a relation of users whose email starts with the given string' do
-        specified = Fabricate(:user, email: 'specified@spec')
-        Fabricate(:user, email: 'unspecified@spec')
+      it 'returns users whose email includes the given string' do
+        specified = Fabricate(:user, email: 'user@host.example')
+        Fabricate(:user, email: 'user@other.example')
 
-        expect(described_class.matches_email('specified')).to contain_exactly(specified)
+        expect(described_class.matches_email('host')).to contain_exactly(specified)
+      end
+
+      it 'respects the presence of at sign for domain limit' do
+        specified = Fabricate(:user, email: 'user@host.example')
+        Fabricate(:user, email: 'host.example@other.domain')
+
+        expect(described_class.matches_email('@host.example')).to contain_exactly(specified)
       end
     end
 

--- a/spec/system/admin/accounts_spec.rb
+++ b/spec/system/admin/accounts_spec.rb
@@ -9,6 +9,19 @@ RSpec.describe 'Admin::Accounts' do
     sign_in current_user
   end
 
+  describe 'Searching for account with email' do
+    let(:user) { Fabricate :user, email: 'user@host.example' }
+
+    it 'finds the account from the user email address' do
+      visit admin_accounts_path
+
+      fill_in 'Email', with: user.email
+      click_on I18n.t('admin.accounts.search')
+      expect(page)
+        .to have_content(user.account.username)
+    end
+  end
+
   describe 'Performing batch updates' do
     let(:unapproved_user_account) { Fabricate(:account) }
     let(:approved_user_account) { Fabricate(:account) }


### PR DESCRIPTION
Background:

- In these few views, an `email` param is passed into the admin accounts listing, which gets sent into the account filter, which finds the "email" path, which filters on accounts whose email domain values match the param value
- Previously, the views themselves were including a sql-ish "%@{domain}" type of approach to creating the value
- When a search was run, that sql wildcard shows up in the view form
- These three view locations are the only spots which use this filter path, and the filter path is the only spot that uses this scope

Changes:

- Update views to just pass in the email domain (with at prefix) as the param
- Update scope and filter to move the wildcard/at prefix into the scope
- Add scenario for basic search from admin page (using the actual form, not from a link), and for domain limits in the model spec.
- Side benefit here is this will now return partial matches where the match was not from the beginning of the email address

View before/after:

<img width="955" height="600" alt="Screenshot 2026-04-21 at 09 18 34" src="https://github.com/user-attachments/assets/11997b1d-a0a7-472f-8613-a71baeb37261" />

<img width="928" height="505" alt="Screenshot 2026-04-21 at 09 46 05" src="https://github.com/user-attachments/assets/dd5dd479-d23e-438e-aba3-eb57f228f0a1" />

Motivation:

- I find it psychologically unsettling to see that SQL wildcard in the view form, and to have the knowledge that its been passed from the views into the query params. Just really sort of jarring for me.