### PR TITLE
Make old migration more robust

### DIFF
--- a/db/post_migrate/20220617202502_migrate_roles.rb
+++ b/db/post_migrate/20220617202502_migrate_roles.rb
@@ -7,7 +7,7 @@ class MigrateRoles < ActiveRecord::Migration[5.2]
   class User < ApplicationRecord; end
 
   def up
-    load Rails.root.join('db', 'seeds', '03_roles.rb')
+    create_user_roles
 
     owner_role     = UserRole.find_by(name: 'Owner')
     moderator_role = UserRole.find_by(name: 'Moderator')
@@ -23,5 +23,31 @@ class MigrateRoles < ActiveRecord::Migration[5.2]
 
     User.where(role_id: [admin_role.id, owner_role.id]).in_batches.update_all(admin: true) if admin_role
     User.where(role_id: moderator_role.id).in_batches.update_all(moderator: true) if moderator_role
+  end
+
+  private
+
+  def create_user_roles
+    now = Time.zone.now.to_fs(:db)
+
+    safety_assured do
+      execute <<~SQL.squish
+        INSERT INTO user_roles ( id, permissions, created_at, updated_at )
+        VALUES ( -99, 65536, '#{now}', '#{now}' )
+        ON CONFLICT DO NOTHING
+      SQL
+
+      [
+        ['Moderator', 10, 1308],
+        ['Admin', 100, 983_036],
+        ['Owner', 1000, 1],
+      ].each do |name, position, permissions|
+        execute <<~SQL.squish
+          INSERT INTO user_roles ( name, position, highlighted, permissions, created_at, updated_at )
+          SELECT '#{name}', #{position}, true, #{permissions}, '#{now}', '#{now}'
+          WHERE NOT EXISTS ( SELECT 1 FROM user_roles WHERE name = '#{name}' )
+        SQL
+      end
+    end
   end
 end


### PR DESCRIPTION
The migration used to call out to a seed file, which breaks if the code therein relies on newer migrations being run.

This currently prevents adding new columns to `user_roles` with validations in the model (see #38769 for an example).

This tries to use raw SQL to do the necessary inserts, with data current in 4.0 when this migration was initially released.