### PR TITLE
Prefer runnable edge case spec over inline comments within FooW service

### DIFF
--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -27,14 +27,7 @@ class FanOutOnWriteService < BaseService
   private
 
   def check_race_condition!
-    # I don't know why but at some point we had an issue where
-    # this service was being executed with status objects
-    # that had a null visibility - which should not be possible
-    # since the column in the database is not nullable.
-    #
-    # This check re-queues the service to be run at a later time
-    # with the full object, if something like it occurs
-
+    # Handle invalid data by re-queueing for later run
     raise Mastodon::RaceConditionError if @status.visibility.nil?
   end
 

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe FanOutOnWriteService do
     end
   end
 
+  context 'when status visibility is nil' do
+    let(:status) { Fabricate.build :status }
+
+    before { status.visibility = nil }
+
+    it 'handles edge case by raising for future re-queue run' do
+      expect { subject.call(status) }.to raise_error(Mastodon::RaceConditionError)
+    end
+  end
+
   context 'when status is public' do
     let(:visibility) { 'public' }
 


### PR DESCRIPTION
Add spec for previously unchecked path, and reduce inline comment noise by moving explanation to spec as well.