### PR TITLE
Fix confusing hover states in admin list items

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1106,21 +1106,13 @@ a.name-tag,
       text-decoration: none;
       margin-bottom: 10px;
 
-      &:hover {
+      &:where(a):where(:hover, :focus, :active) {
         color: var(--color-text-brand);
       }
     }
 
     .icon {
       vertical-align: middle;
-    }
-
-    a.announcements-list__item__title {
-      &:hover,
-      &:focus,
-      &:active {
-        color: var(--color-text-primary);
-      }
     }
 
     &__action-bar {


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes confusing hover states in admin list items (e.g. Roles page), where unclickable items are highlighted on hover, while clickable ones aren't

### Screenshots

| Context | **Before** | **After** |
|--------|--------|--------|
| Hovering Owner heading (no link) | <img width="282" height="197" alt="image" src="https://github.com/user-attachments/assets/003ecae9-05eb-46ff-b8ed-19f3f0efd1af" /> | <img width="272" height="204" alt="image" src="https://github.com/user-attachments/assets/7f2a730b-5284-4bff-b14b-8d0d6f8cdae4" /> |
| Hovering Admin heading (with link) | <img width="312" height="193" alt="image" src="https://github.com/user-attachments/assets/b2a903a3-c1a8-4467-bf3a-f51c930d1ebf" /> | <img width="284" height="199" alt="image" src="https://github.com/user-attachments/assets/dcd12226-fcf6-438c-9c17-b69019cd5fe1" /> |