### PR TITLE
Use `/collections/:id` as canonical URL for a collection

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -17,7 +17,10 @@ class CollectionsController < ApplicationController
 
   def show
     respond_to do |format|
-      # TODO: format.html
+      format.html do
+        expires_in expiration_duration, public: true unless user_signed_in?
+        render template: 'home/index'
+      end
 
       format.json do
         expires_in expiration_duration, public: true if public_fetch_mode?
@@ -28,8 +31,17 @@ class CollectionsController < ApplicationController
 
   private
 
+  def set_account
+    if account_id_param.present?
+      @account = Account.local.find(account_id_param)
+    else
+      @collection = Collection.find(params[:id])
+      @account = @collection.account
+    end
+  end
+
   def set_collection
-    @collection = @account.collections.find(params[:id])
+    @collection ||= @account.collections.find(params[:id])
     authorize @collection, :show?
   rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
     not_found

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -32,7 +32,7 @@ class ActivityPub::TagManager
     when :flag
       target.uri
     when :featured_collection
-      account_collection_url(target.account, target)
+      collection_url(target)
     end
   end
 

--- a/app/views/admin/collections/show.html.haml
+++ b/app/views/admin/collections/show.html.haml
@@ -2,7 +2,7 @@
   = t('admin.collections.collection_title', name: @account.pretty_acct)
 
 - content_for :heading_actions do
-  = link_to t('admin.collections.open'), account_collection_path(@account, @collection), class: 'button', target: '_blank', rel: 'noopener'
+  = link_to t('admin.collections.open'), collection_path(@collection), class: 'button', target: '_blank', rel: 'noopener'
 
 %h3= t('admin.collections.contents')
 

--- a/app/views/admin/shared/_collection.html.haml
+++ b/app/views/admin/shared/_collection.html.haml
@@ -18,5 +18,5 @@
     &nbsp;·
     = t('admin.collections.number_of_accounts', count: collection.accepted_collection_items.size)
     &nbsp;·
-    = link_to account_collection_path(collection.account, collection), class: 'detailed-status__link', target: 'blank', rel: 'noopener' do
+    = link_to collection_path(collection), class: 'detailed-status__link', target: 'blank', rel: 'noopener' do
       = t('admin.collections.view_publicly')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,7 +97,6 @@ Rails.application.routes.draw do
   get '/authorize_follow', to: redirect { |_, request| "/authorize_interaction?#{request.params.to_query}" }
 
   concern :account_resources do
-    resources :collections, only: [:show], constraints: { id: /\d+/ }
     resources :followers, only: [:index], controller: :follower_accounts
     resources :following, only: [:index], controller: :following_accounts
 
@@ -125,6 +124,7 @@ Rails.application.routes.draw do
 
   scope path: 'ap', as: 'ap' do
     resources :accounts, path: 'users', only: [:show], param: :id, concerns: :account_resources do
+      resources :collections, only: [:show], constraints: { id: /\d+/ }
       resources :collection_items, only: [:show]
       resources :feature_authorizations, only: [:show], module: :activitypub
       resources :featured_collections, only: [:index], module: :activitypub
@@ -140,6 +140,8 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  resources :collections, only: [:show]
 
   resource :inbox, only: [:create], module: :activitypub
   resources :contexts, only: [:show], module: :activitypub, constraints: { id: /[0-9]+-[0-9]+/ } do

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -3,8 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe 'Collections' do
-  describe 'GET /@:account_username/collections/:id', feature: :collections do
-    subject { get account_collection_path(account, collection, format: :json) }
+  describe 'GET /collections/:id', feature: :collections do
+    subject { get collection_path(collection) }
+
+    let(:collection) { Fabricate(:collection) }
+
+    it 'returns success' do
+      subject
+
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /ap/:account_id/collections/:id', feature: :collections do
+    subject { get ap_account_collection_path(account.id, collection, format: :json) }
 
     let(:collection) { Fabricate(:collection) }
     let(:account) { collection.account }
@@ -80,7 +92,7 @@ RSpec.describe 'Collections' do
 
     context 'with "HTTP Signature" access signed by a remote account' do
       subject do
-        get account_collection_path(account, collection, format: :json),
+        get ap_account_collection_path(account.id, collection, format: :json),
             headers: nil,
             sign_with: remote_account
       end

--- a/spec/serializers/activitypub/featured_collection_serializer_spec.rb
+++ b/spec/serializers/activitypub/featured_collection_serializer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ActivityPub::FeaturedCollectionSerializer do
       'attributedTo' => ActivityPub::TagManager.instance.uri_for(collection.account),
       'sensitive' => false,
       'discoverable' => false,
-      'url' => account_collection_url(collection.account, collection),
+      'url' => collection_url(collection),
       'topic' => {
         'href' => match(%r{/tags/people$}),
         'type' => 'Hashtag',


### PR DESCRIPTION
I also removed the `/@:username/collections/:id` variant so it does not get confused.