### PR TITLE
Fix preview for local collection links

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -31,6 +31,7 @@ import { getHashtagBarForStatus } from './hashtag_bar';
 import StatusActionBar from './status_action_bar';
 import StatusContent from './status_content';
 import { StatusThreadLabel } from './status_thread_label';
+import { CollectionPreviewCard } from '../features/collections/components/collection_preview_card';
 
 const domParser = new DOMParser();
 
@@ -562,6 +563,13 @@ class Status extends ImmutablePureComponent {
             card={status.get('card')}
             sensitive={status.get('sensitive')}
           />
+        );
+      }
+    } else if (status.get('tagged_collections').size) {
+      const firstLinkedCollection = status.get('tagged_collections').first();
+      if (firstLinkedCollection) {
+        media = (
+          <CollectionPreviewCard collection={firstLinkedCollection.toJS()} />
         );
       }
     }

--- a/app/javascript/mastodon/features/collections/components/collection_preview_card.tsx
+++ b/app/javascript/mastodon/features/collections/components/collection_preview_card.tsx
@@ -1,3 +1,5 @@
+import classNames from 'classnames';
+
 import type { CollectionLockupProps } from 'mastodon/features/collections/components/collection_lockup';
 import { CollectionLockup } from 'mastodon/features/collections/components/collection_lockup';
 
@@ -13,7 +15,7 @@ export const CollectionPreviewCard: React.FC<CollectionPreviewCardProps> = ({
   ...otherProps
 }) => {
   return (
-    <div className={classes.wrapper}>
+    <div className={classNames(classes.wrapper, 'collection-preview')}>
       <CollectionLockup collection={collection} {...otherProps} />
     </div>
   );

--- a/app/javascript/mastodon/features/status/components/detailed_status.tsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.tsx
@@ -282,6 +282,13 @@ export const DetailedStatus: React.FC<{
         />
       );
     }
+  } else if (status.get('tagged_collections').size) {
+    const firstLinkedCollection = status.get('tagged_collections').first();
+    if (firstLinkedCollection) {
+      media = (
+        <CollectionPreviewCard collection={firstLinkedCollection.toJS()} />
+      );
+    }
   }
 
   if (status.get('application')) {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1499,8 +1499,9 @@ body > [data-popper-placement] {
   .media-gallery,
   .video-player,
   .audio-player,
-  .attachment-list {
-    margin-top: 16px;
+  .attachment-list,
+  .collection-preview {
+    margin-top: 14px;
   }
 
   &--in-thread {
@@ -1517,6 +1518,7 @@ body > [data-popper-placement] {
     & > .picture-in-picture-placeholder,
     & > .more-from-author,
     & > .status-card,
+    & > .collection-preview,
     & > .hashtag-bar,
     & > .content-warning,
     & > .filter-warning,
@@ -1787,7 +1789,8 @@ body > [data-popper-placement] {
 
   .media-gallery,
   .video-player,
-  .audio-player {
+  .audio-player,
+  .collection-preview {
     margin-top: 16px;
   }
 


### PR DESCRIPTION
Fixes PRO-431

### Changes proposed in this PR:
- Fixes preview card for links to local collections; those weren't covered in #38643 as no `card` property is generated for their posts
- Unifies spacing above nested cards in posts to 14px (previously it was 16px for audio/video, 14px for link cards)

### Screenshots

Post in feed:
<img width="612" height="265" alt="image" src="https://github.com/user-attachments/assets/e105d2fb-6574-4e6c-9411-5e1ff1856205" />

Post detail view:
<img width="608" height="360" alt="image" src="https://github.com/user-attachments/assets/238e9800-6a9e-4507-8b0d-e40c5cebb8fb" />

Post in thread:
<img width="611" height="256" alt="image" src="https://github.com/user-attachments/assets/7052ff10-b47b-4c85-b556-322a39457b5c" />
