### PR TITLE
Allow defining alt text for server thumbnail

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -22,6 +22,7 @@ class Form::AdminSettings
     custom_css
     profile_directory
     thumbnail
+    thumbnail_description
     mascot
     trends
     trendable_by_default

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -110,6 +110,7 @@ class Form::AdminSettings
   validates :media_cache_retention_period, :content_cache_retention_period, :backups_retention_period, numericality: { only_integer: true }, allow_blank: true, if: -> { defined?(@media_cache_retention_period) || defined?(@content_cache_retention_period) || defined?(@backups_retention_period) }
   validates :min_age, numericality: { only_integer: true }, allow_blank: true, if: -> { defined?(@min_age) }
   validates :site_short_description, length: { maximum: DESCRIPTION_LIMIT }, if: -> { defined?(@site_short_description) }
+  validates :thumbnail_description, length: { maximum: DESCRIPTION_LIMIT }, if: -> { defined?(@thumbnail_description) }
   validates :status_page_url, url: true, allow_blank: true
   validate :validate_site_uploads
   validates :landing_page, inclusion: { in: LANDING_PAGE }, if: -> { defined?(@landing_page) }

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -26,6 +26,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
           '@1x': full_asset_url(object.thumbnail.file.url(:'@1x')),
           '@2x': full_asset_url(object.thumbnail.file.url(:'@2x')),
         },
+        description: Setting.thumbnail_description,
       }
     else
       {

--- a/app/views/admin/settings/branding/show.html.haml
+++ b/app/views/admin/settings/branding/show.html.haml
@@ -36,6 +36,7 @@
       - if @admin_settings.thumbnail.persisted?
         = f.input :thumbnail_description,
                   as: :text,
+                  input_html: { rows: 2, maxlength: Form::AdminSettings::DESCRIPTION_LIMIT },
                   wrapper: :with_block_label
     .fields-row__column.fields-row__column-6.fields-group
       - if @admin_settings.thumbnail.persisted?

--- a/app/views/admin/settings/branding/show.html.haml
+++ b/app/views/admin/settings/branding/show.html.haml
@@ -33,6 +33,10 @@
       = f.input :thumbnail,
                 as: :file,
                 wrapper: :with_block_label
+      - if @admin_settings.thumbnail.persisted?
+        = f.input :thumbnail_description,
+                  as: :text,
+                  wrapper: :with_block_label
     .fields-row__column.fields-row__column-6.fields-group
       - if @admin_settings.thumbnail.persisted?
         = image_tag @admin_settings.thumbnail.file.url(:'@1x'), class: 'fields-group__thumbnail'

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -109,6 +109,7 @@ en:
         status_page_url: URL of a page where people can see the status of this server during an outage
         theme: Theme that logged out visitors and new users see.
         thumbnail: A roughly 2:1 image displayed alongside your server information.
+        thumbnail_description: A description of the image to help people with visual impairments understand its content.
         trendable_by_default: Skip manual review of trending content. Individual items can still be removed from trends after the fact.
         trends: Trends show which posts, hashtags and news stories are gaining traction on your server.
         wrapstodon: Offer local users to generate a playful summary of their Mastodon use during the year. This feature is available between the 10th and 31st of December of each year, and is offered to users who made at least one Public or Quiet Public post and used at least one hashtag within the year.
@@ -317,6 +318,7 @@ en:
         status_page_url: Status page URL
         theme: Default theme
         thumbnail: Server thumbnail
+        thumbnail_description: Thumbnail alt text
         trendable_by_default: Allow trends without prior review
         trends: Enable trends
         wrapstodon: Enable Wrapstodon

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,6 +20,7 @@ defaults: &defaults
   preview_sensitive_media: false
   noindex: false
   theme: 'default'
+  thumbnail_description: ''
   trends: true
   trendable_by_default: false
   disallowed_hashtags: # space separated string or list of hashtags without the hash


### PR DESCRIPTION
Related to WEB-872
Related to #38068

### Changes proposed in this PR:
- Adds a new option for adding alt text for the server thumbnail (field is only shown when a thumbnail was uploaded)
- (Backend only - the alt text will be added to the frontend in a follow -up PR)

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="831" height="267" alt="image" src="https://github.com/user-attachments/assets/19ad04da-45a7-459f-8196-8d2233f64572" /> | <img width="827" height="271" alt="image" src="https://github.com/user-attachments/assets/b1388f11-7f1f-4bd4-8516-6a1e31a557e6" /> |