### PR TITLE
Enable soft-deletion for collections

### DIFF
--- a/app/controllers/activitypub/featured_collections_controller.rb
+++ b/app/controllers/activitypub/featured_collections_controller.rb
@@ -34,6 +34,7 @@ class ActivityPub::FeaturedCollectionsController < ApplicationController
   def set_collections
     authorize @account, :index_collections?
     @collections = @account.collections
+      .kept
       .includes(:accepted_collection_items)
       .page(params[:page]).per(PER_PAGE)
   rescue Mastodon::NotPermittedError
@@ -57,7 +58,7 @@ class ActivityPub::FeaturedCollectionsController < ApplicationController
       ActivityPub::CollectionPresenter.new(
         id: ap_account_featured_collections_url(@account, page: params.fetch(:page, 1)),
         type: :unordered,
-        size: @account.collections.count,
+        size: @account.collections.kept.count,
         items: @collections,
         part_of: ap_account_featured_collections_url(@account),
         next: next_page_url,
@@ -67,7 +68,7 @@ class ActivityPub::FeaturedCollectionsController < ApplicationController
       ActivityPub::CollectionPresenter.new(
         id: ap_account_featured_collections_url(@account),
         type: :unordered,
-        size: @account.collections.count,
+        size: @account.collections.kept.count,
         first: ap_account_featured_collections_url(@account, page: 1)
       )
     end

--- a/app/controllers/api/v1_alpha/collections_controller.rb
+++ b/app/controllers/api/v1_alpha/collections_controller.rb
@@ -72,15 +72,16 @@ class Api::V1Alpha::CollectionsController < Api::BaseController
 
   def set_collections
     @collections = @account.collections
+      .kept
       .with_tag
-      .order(created_at: :desc)
+      .order(id: :desc)
       .offset(offset_param)
       .limit(limit_param(DEFAULT_COLLECTIONS_LIMIT))
     @collections = @collections.discoverable unless @account == current_account
   end
 
   def set_collection
-    @collection = Collection.find(params[:id])
+    @collection = Collection.kept.find(params[:id])
   end
 
   def collection_creation_params

--- a/app/controllers/api/v1_alpha/in_collections_controller.rb
+++ b/app/controllers/api/v1_alpha/in_collections_controller.rb
@@ -32,6 +32,7 @@ class Api::V1Alpha::InCollectionsController < Api::BaseController
 
   def set_collections
     @collections = @account.featured_in_collections
+      .kept
       .with_tag
       .offset(offset_param)
       .limit(limit_param(DEFAULT_COLLECTIONS_LIMIT))

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -35,13 +35,13 @@ class CollectionsController < ApplicationController
     if account_id_param.present?
       @account = Account.local.find(account_id_param)
     else
-      @collection = Collection.find(params[:id])
+      @collection = Collection.kept.find(params[:id])
       @account = @collection.account
     end
   end
 
   def set_collection
-    @collection ||= @account.collections.find(params[:id])
+    @collection ||= @account.collections.kept.find(params[:id])
     authorize @collection, :show?
   rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
     not_found

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,6 +5,7 @@
 # Table name: collections
 #
 #  id                       :bigint(8)        not null, primary key
+#  deleted_at               :datetime
 #  description              :text
 #  description_html         :text
 #  discoverable             :boolean          not null
@@ -22,9 +23,13 @@
 #  tag_id                   :bigint(8)
 #
 class Collection < ApplicationRecord
+  include Discard::Model
+
   MAX_ITEMS = 25
   NAME_LENGTH_HARD_LIMIT = 256
   DESCRIPTION_LENGTH_HARD_LIMIT = 2048
+
+  self.discard_column = :deleted_at
 
   belongs_to :account
   belongs_to :tag, optional: true

--- a/db/migrate/20260423094907_add_deleted_at_to_collections.rb
+++ b/db/migrate/20260423094907_add_deleted_at_to_collections.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToCollections < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :collections, :deleted_at, :datetime
+    add_index :collections, :deleted_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_20_124030) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_23_094907) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -388,6 +388,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_124030) do
   create_table "collections", id: :bigint, default: -> { "timestamp_id('collections'::text)" }, force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "created_at", null: false
+    t.datetime "deleted_at"
     t.text "description"
     t.text "description_html"
     t.boolean "discoverable", null: false
@@ -402,6 +403,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_124030) do
     t.string "uri"
     t.string "url"
     t.index ["account_id"], name: "index_collections_on_account_id"
+    t.index ["deleted_at"], name: "index_collections_on_deleted_at"
     t.index ["tag_id"], name: "index_collections_on_tag_id"
     t.index ["uri"], name: "index_collections_on_uri", unique: true, where: "(uri IS NOT NULL)"
   end

--- a/spec/requests/activitypub/featured_collections_spec.rb
+++ b/spec/requests/activitypub/featured_collections_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe 'Collections' do
       end
 
       context 'when account is accessible' do
-        it 'renders ActivityPub Collection successfully', :aggregate_failures do
+        it 'renders ActivityPub Collection successfully and does not include discarded collections', :aggregate_failures do
+          Fabricate(:collection, account:, deleted_at: 1.hour.ago)
+
           subject
 
           expect(response)

--- a/spec/requests/api/v1_alpha/collections_spec.rb
+++ b/spec/requests/api/v1_alpha/collections_spec.rb
@@ -14,9 +14,12 @@ RSpec.describe 'Api::V1Alpha::Collections', feature: :collections do
 
     let(:account) { Fabricate(:account) }
 
-    before { Fabricate.times(3, :collection, account:) }
+    before do
+      Fabricate.times(3, :collection, account:)
+      Fabricate(:collection, account:, deleted_at: 1.hour.ago)
+    end
 
-    it 'returns all collections for the given account and http success' do
+    it 'returns all collections for the given account that are not discarded and http success' do
       subject
 
       expect(response).to have_http_status(200)
@@ -136,6 +139,17 @@ RSpec.describe 'Api::V1Alpha::Collections', feature: :collections do
           expect(response.parsed_body[:collection][:items].size).to eq 1
           expect(response.parsed_body[:collection][:items][0]['id']).to eq items.last.id.to_s
         end
+      end
+    end
+
+    context 'when the collection is discarded' do
+      let(:collection) { Fabricate(:collection, deleted_at: 1.hour.ago) }
+      let(:headers) { {} }
+
+      it 'returns not found' do
+        subject
+
+        expect(response).to have_http_status(404)
       end
     end
   end

--- a/spec/requests/api/v1_alpha/in_collections_spec.rb
+++ b/spec/requests/api/v1_alpha/in_collections_spec.rb
@@ -12,10 +12,14 @@ RSpec.describe 'Api::V1Alpha::InCollections', feature: :collections do
 
     let(:params) { {} }
     let(:account) { user.account }
+    let(:discarded_collection) { Fabricate(:collection, deleted_at: 1.hour.ago) }
 
-    before { Fabricate.times(3, :collection_item, account: account) }
+    before do
+      Fabricate.times(3, :collection_item, account:)
+      Fabricate(:collection_item, collection: discarded_collection, account:)
+    end
 
-    it 'returns all collections for the given account and http success' do
+    it 'returns all collections for the given account that are not discarded and http success' do
       subject
 
       expect(response).to have_http_status(200)

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe 'Collections' do
 
       expect(response).to have_http_status(200)
     end
+
+    context 'when the collection is discarded' do
+      let(:collection) { Fabricate(:collection, deleted_at: 1.hour.ago) }
+
+      it 'returns not found' do
+        subject
+
+        expect(response).to have_http_status(404)
+      end
+    end
   end
 
   describe 'GET /ap/:account_id/collections/:id', feature: :collections do
@@ -144,6 +154,16 @@ RSpec.describe 'Collections' do
               'name' => collection.name,
             })
         end
+      end
+    end
+
+    context 'when the collection is discarded' do
+      let(:collection) { Fabricate(:collection, deleted_at: 1.hour.ago) }
+
+      it 'returns not found' do
+        subject
+
+        expect(response).to have_http_status(404)
       end
     end
   end


### PR DESCRIPTION
This is in preparation of enabling the same moderation action behavior as for statuses, where there is a grace period in which the action can be appealed and the status deletion can be undone.

Part of WEB-865