### PR TITLE
Only update FASP availability if it actually changed

### DIFF
--- a/app/workers/fasp/base_worker.rb
+++ b/app/workers/fasp/base_worker.rb
@@ -10,10 +10,12 @@ class Fasp::BaseWorker
   def with_provider(provider)
     return unless provider.confirmed? && provider.available?
 
-    yield
-  rescue *Mastodon::HTTP_CONNECTION_ERRORS
-    raise if provider.available?
-  ensure
-    provider.update_availability!
+    begin
+      yield
+    rescue *Mastodon::HTTP_CONNECTION_ERRORS
+      raise if provider.available?
+    ensure
+      provider.update_availability!
+    end
   end
 end

--- a/spec/support/examples/workers/fasp/delivery_failure.rb
+++ b/spec/support/examples/workers/fasp/delivery_failure.rb
@@ -2,15 +2,18 @@
 
 RSpec.shared_examples 'worker handling fasp delivery failures' do
   context 'when provider is not available' do
+    let(:delivery_last_failed_at) { 1.minute.ago.beginning_of_minute }
+
     before do
-      provider.update(delivery_last_failed_at: 1.minute.ago)
+      provider.update(delivery_last_failed_at:)
       domain = Addressable::URI.parse(provider.base_url).normalized_host
       UnavailableDomain.create!(domain:)
     end
 
-    it 'does not attempt connecting and does not fail the job' do
+    it 'does not attempt connecting, does not fail the job and does not update the provider' do
       expect { subject }.to_not raise_error
       expect(stubbed_request).to_not have_been_made
+      expect(provider.reload.delivery_last_failed_at).to eq delivery_last_failed_at
     end
   end
 


### PR DESCRIPTION
Before this fix, once a provider became unavailable `delivery_last_failed_at` was constantly being increased, so the provider never became available again.