### PR TITLE
Upgrade development Ruby from 4.0.2 to 4.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1097,7 +1097,7 @@ DEPENDENCIES
   xorcist (~> 1.1)
 
 RUBY VERSION
-  ruby 4.0.2
+  ruby 4.0.3
 
 BUNDLED WITH
   4.0.10


### PR DESCRIPTION
Proposing we upgrade our development Ruby from 4.0.2 to 4.0.3 to match CI and deployment.

https://www.ruby-lang.org/en/news/2026/04/21/ruby-4-0-3-released/

Related (used to contain the changes of)
- https://github.com/mastodon/mastodon/pull/38772
- https://github.com/mastodon/mastodon/pull/38765