### PR TITLE
Fix error when collection is `null` in collection notification

### DIFF
--- a/app/javascript/mastodon/features/collections/detail/revoke_collection_inclusion_modal.tsx
+++ b/app/javascript/mastodon/features/collections/detail/revoke_collection_inclusion_modal.tsx
@@ -27,7 +27,7 @@ const messages = defineMessages({
   },
 });
 
-export function useConfirmRevoke(collection?: ApiCollectionJSON) {
+export function useConfirmRevoke(collection?: ApiCollectionJSON | null) {
   const dispatch = useAppDispatch();
   const { id, items = [] } = collection ?? {};
   const ownCollectionItemId = items.find((item) => item.account_id === me)?.id;

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_collection.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_collection.tsx
@@ -24,8 +24,13 @@ export const NotificationCollection: React.FC<{
   unread: boolean;
 }> = ({ notification, unread }) => {
   const { collection, type } = notification;
-  const collectionCreatorAccount = useAccount(collection.account_id);
+
+  const collectionCreatorAccount = useAccount(collection?.account_id);
   const confirmRevoke = useConfirmRevoke(collection);
+
+  if (!collection) {
+    return null;
+  }
 
   return (
     <div

--- a/app/javascript/mastodon/models/notification_group.ts
+++ b/app/javascript/mastodon/models/notification_group.ts
@@ -91,11 +91,11 @@ export interface NotificationGroupAdminReport extends BaseNotification<'admin.re
 
 type Collection = ApiCollectionJSON;
 export interface NotificationGroupAddedToCollection extends BaseNotification<'added_to_collection'> {
-  collection: Collection;
+  collection: Collection | null;
 }
 
 export interface NotificationGroupCollectionUpdate extends BaseNotification<'collection_update'> {
-  collection: Collection;
+  collection: Collection | null;
 }
 
 export type NotificationGroup =


### PR DESCRIPTION
### Changes proposed in this PR:
- Prevents the app to error out when receiving a collection notifications whose `collection` property is `null`