### PR TITLE
Update Dockerfile with bundle lock --normalize-platforms;

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -325,6 +325,7 @@ RUN \
   # Configure bundle to not warn about root user
   bundle config set silence_root_warning "true"; \
   # Download and install required Gems
+  bundle lock --normalize-platforms; \
   bundle install -j"$(nproc)";
 
 # Create temporary assets build layer from build layer


### PR DESCRIPTION
A number of packages offer platform builds and can be detected at build time.

```
12.38 The following platform specific gems are getting installed, yet the lockfile includes only their generic ruby version: 
12.38 * pg-1.6.3-x86_64-linux 
12.38 * nokogiri-1.19.2-x86_64-linux-gnu 
12.38 * ffi-1.17.4-x86_64-linux-gnu 
12.38 * google-protobuf-4.34.1-x86_64-linux-gnu 
12.38 Please run bundle lock --normalize-platforms and commit the resulting lockfile.
```