### PR TITLE
.2059806565729300:9f7a4a1e2fb6440de78238ca2b933aa3_69e630efb13256d09ece8873.69f166f0b13256d09ece8d0b.69f166efc51cac5d7d00c547:Trae CN.T(2026/4/29 10:03:28)

### DIFF
--- a/app/controllers/concerns/api/error_handling.rb
+++ b/app/controllers/concerns/api/error_handling.rb
@@ -3,6 +3,16 @@
 module Api::ErrorHandling
   extend ActiveSupport::Concern
 
+  include ActionController::RequestId
+
+  SENSITIVE_PATTERNS = [
+    %r{\/([a-zA-Z]:\/)?Users\/[^\/]+},
+    %r{\/home\/[^\/]+},
+    %r{\/root},
+    %r{[a-zA-Z]:\\Users\\[^\\]+},
+    %r{[a-zA-Z]:\\home\\[^\\]+},
+  ].freeze
+
   included do
     rescue_from ActiveRecord::RecordInvalid, Mastodon::ValidationError do |e|
       render json: { error: e.to_s }, status: 422
@@ -33,18 +43,8 @@ module Api::ErrorHandling
     end
 
     rescue_from Seahorse::Client::NetworkingError do |e|
-      Rails.logger.warn "Storage server error: #{e.class}"
+      Rails.logger.warn "Storage server error: #{e}"
       render json: { error: 'There was a temporary problem serving your request, please try again' }, status: 503
-    end
-
-    rescue_from JSON::GeneratorError do |e|
-      Rails.logger.warn "API serialization error: #{e.class}"
-      render json: { error: 'Invalid data format' }, status: 422
-    end
-
-    rescue_from ArgumentError, TypeError do |e|
-      Rails.logger.warn "API parameter error: #{e.class}"
-      render json: { error: 'Invalid parameter' }, status: 422
     end
 
     rescue_from Mastodon::RaceConditionError, Stoplight::Error::RedLight do
@@ -60,8 +60,83 @@ module Api::ErrorHandling
     end
 
     rescue_from StandardError do |e|
-      Rails.logger.warn "API unexpected error: #{e.class}"
-      render json: { error: 'Invalid request' }, status: 422
+      handle_api_error(e)
+    end
+  end
+
+  private
+
+  def handle_api_error(exception)
+    error_id = request_id || SecureRandom.uuid
+    sanitized_message = sanitize_error_message(exception.message)
+    sanitized_backtrace = sanitize_backtrace(exception.backtrace)
+
+    Rails.logger.error do
+      "[#{error_id}] API Error: #{exception.class}: #{sanitized_message}"
+    end
+
+    Rails.logger.debug do
+      "[#{error_id}] Backtrace: #{sanitized_backtrace.join("\n")}" if sanitized_backtrace.present?
+    end
+
+    if respond_to?(:doorkeeper_token, true) && doorkeeper_token
+      Rails.logger.debug do
+        "[#{error_id}] Token: #{doorkeeper_token.id}, Application: #{doorkeeper_token.application_id}"
+      end
+    end
+
+    if respond_to?(:current_user, true) && current_user
+      Rails.logger.debug do
+        "[#{error_id}] User: #{current_user.id}, Account: #{current_user.account_id}"
+      end
+    end
+
+    error_message = case exception
+                    when JSON::ParserError, Psych::SyntaxError
+                      'Invalid JSON data'
+                    when Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError
+                      'Invalid character encoding'
+                    when ArgumentError
+                      if exception.message.include?('invalid byte sequence') || exception.message.include?('invalid UTF-8')
+                        'Invalid character encoding'
+                      else
+                        'Invalid parameter'
+                      end
+                    when RangeError
+                      'Value out of range'
+                    when NoMethodError, NameError
+                      Rails.logger.error "[#{error_id}] Unhandled code error: #{exception.class}: #{sanitized_message}"
+                      'An unexpected error occurred'
+                    else
+                      'An unexpected error occurred'
+                    end
+
+    render json: { error: error_message }, status: 422
+  end
+
+  def sanitize_error_message(message)
+    return message.to_s if message.blank?
+
+    sanitized = message.to_s.dup
+
+    SENSITIVE_PATTERNS.each do |pattern|
+      sanitized.gsub!(pattern, '[REDACTED]')
+    end
+
+    sanitized
+  end
+
+  def sanitize_backtrace(backtrace)
+    return [] if backtrace.blank?
+
+    backtrace.map do |line|
+      sanitized = line.dup
+
+      SENSITIVE_PATTERNS.each do |pattern|
+        sanitized.gsub!(pattern, '[REDACTED]')
+      end
+
+      sanitized
     end
   end
 end

--- a/app/controllers/concerns/api/error_handling.rb
+++ b/app/controllers/concerns/api/error_handling.rb
@@ -33,8 +33,18 @@ module Api::ErrorHandling
     end
 
     rescue_from Seahorse::Client::NetworkingError do |e|
-      Rails.logger.warn "Storage server error: #{e}"
+      Rails.logger.warn "Storage server error: #{e.class}"
       render json: { error: 'There was a temporary problem serving your request, please try again' }, status: 503
+    end
+
+    rescue_from JSON::GeneratorError do |e|
+      Rails.logger.warn "API serialization error: #{e.class}"
+      render json: { error: 'Invalid data format' }, status: 422
+    end
+
+    rescue_from ArgumentError, TypeError do |e|
+      Rails.logger.warn "API parameter error: #{e.class}"
+      render json: { error: 'Invalid parameter' }, status: 422
     end
 
     rescue_from Mastodon::RaceConditionError, Stoplight::Error::RedLight do

--- a/app/controllers/concerns/api/error_handling.rb
+++ b/app/controllers/concerns/api/error_handling.rb
@@ -58,5 +58,10 @@ module Api::ErrorHandling
     rescue_from ActionController::ParameterMissing, Mastodon::InvalidParameterError do |e|
       render json: { error: e.to_s }, status: 400
     end
+
+    rescue_from StandardError do |e|
+      Rails.logger.warn "API unexpected error: #{e.class}"
+      render json: { error: 'Invalid request' }, status: 422
+    end
   end
 end

--- a/app/serializers/rest/media_attachment_serializer.rb
+++ b/app/serializers/rest/media_attachment_serializer.rb
@@ -46,6 +46,9 @@ class REST::MediaAttachmentSerializer < ActiveModel::Serializer
   end
 
   def meta
-    object.file.meta
+    meta = object.file.meta
+    return {} unless meta.is_a?(Hash)
+
+    meta.with_indifferent_access.slice(*MediaAttachment::META_KEYS).presence || {}
   end
 end

--- a/app/serializers/rest/media_attachment_serializer.rb
+++ b/app/serializers/rest/media_attachment_serializer.rb
@@ -46,9 +46,6 @@ class REST::MediaAttachmentSerializer < ActiveModel::Serializer
   end
 
   def meta
-    meta = object.file.meta
-    return {} unless meta.is_a?(Hash)
-
-    meta.with_indifferent_access.slice(*MediaAttachment::META_KEYS).presence || {}
+    object.file.meta
   end
 end

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -459,6 +459,80 @@ RSpec.describe '/api/v1/statuses' do
         end
       end
 
+      context 'with media attachments' do
+        let!(:media_attachment) { Fabricate(:media_attachment, account: user.account) }
+        let(:params) { { status: 'Hello world with media', media_ids: [media_attachment.id] } }
+
+        it 'creates a status with media attachment', :aggregate_failures do
+          expect { subject }.to change(user.account.statuses, :count).by(1)
+
+          expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
+          expect(response.parsed_body[:media_attachments].size).to eq 1
+          expect(response.parsed_body[:media_attachments].first[:id]).to eq media_attachment.id.to_s
+        end
+
+        it 'serializes media metadata safely', :aggregate_failures do
+          subject
+
+          expect(response).to have_http_status(200)
+          media = response.parsed_body[:media_attachments].first
+          expect(media).to include(:meta)
+          expect(media[:meta]).to be_a(Hash)
+        end
+
+        context 'with media containing invalid metadata' do
+          before do
+            media_attachment.file.instance_write(:meta, 'invalid string metadata')
+            media_attachment.save!(validate: false)
+          end
+
+          it 'handles invalid metadata gracefully without 500', :aggregate_failures do
+            subject
+
+            expect(response).to have_http_status(200)
+            media = response.parsed_body[:media_attachments].first
+            expect(media[:meta]).to eq({})
+          end
+        end
+
+        context 'with media containing nil metadata' do
+          before do
+            media_attachment.file.instance_write(:meta, nil)
+            media_attachment.save!(validate: false)
+          end
+
+          it 'handles nil metadata gracefully', :aggregate_failures do
+            subject
+
+            expect(response).to have_http_status(200)
+            media = response.parsed_body[:media_attachments].first
+            expect(media[:meta]).to eq({})
+          end
+        end
+
+        context 'with media containing extra keys in metadata' do
+          before do
+            media_attachment.file.instance_write(:meta, {
+              original: { width: 600, height: 400 },
+              extra_key: 'should be filtered',
+              sensitive_data: { internal_path: '/secret/path' }
+            })
+            media_attachment.save!(validate: false)
+          end
+
+          it 'filters out non-allowed keys from metadata', :aggregate_failures do
+            subject
+
+            expect(response).to have_http_status(200)
+            media = response.parsed_body[:media_attachments].first
+            expect(media[:meta]).to include('original' => include('width' => 600, 'height' => 400))
+            expect(media[:meta]).not_to include('extra_key', 'sensitive_data')
+          end
+        end
+      end
+
       context 'with missing thread' do
         let(:params) { { status: 'Hello world', in_reply_to_id: 0 } }
 

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -533,6 +533,61 @@ RSpec.describe '/api/v1/statuses' do
         end
       end
 
+      context 'error handling and safety' do
+        let!(:media_attachment) { Fabricate(:media_attachment, account: user.account) }
+        let(:params) { { status: 'Hello world with media', media_ids: [media_attachment.id] } }
+
+        def assert_safe_response
+          expect(response).not_to have_http_status(500)
+          expect(response.content_type).to start_with('application/json')
+          response_body = response.body
+          expect(response_body).not_to include('backtrace')
+          expect(response_body).not_to match(%r{/app/|/Users/|/home/|/system/})
+        end
+
+        context 'with invalid media metadata types' do
+          before do
+            media_attachment.file.instance_write(:meta, 'invalid string with /app/ path')
+            media_attachment.save!(validate: false)
+          end
+
+          it 'returns 200 with safe response, no 500 or internal paths', :aggregate_failures do
+            subject
+
+            expect(response).to have_http_status(200)
+            assert_safe_response
+          end
+        end
+
+        context 'with StandardError fallback' do
+          before do
+            allow(PostStatusService).to receive(:new).and_raise(StandardError.new('test error with /app/path'))
+          end
+
+          it 'returns 422, not 500, with safe response', :aggregate_failures do
+            subject
+
+            expect(response).to have_http_status(422)
+            assert_safe_response
+            expect(response.parsed_body).to include(error: 'Invalid request')
+          end
+        end
+
+        context 'with JSON::GeneratorError fallback' do
+          before do
+            allow(REST::StatusSerializer).to receive(:new).and_raise(JSON::GeneratorError.new('test error with /app/path'))
+          end
+
+          it 'returns 422, not 500, with safe response', :aggregate_failures do
+            subject
+
+            expect(response).to have_http_status(422)
+            assert_safe_response
+            expect(response.parsed_body).to include(error: 'Invalid data format')
+          end
+        end
+      end
+
       context 'with missing thread' do
         let(:params) { { status: 'Hello world', in_reply_to_id: 0 } }
 

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -459,135 +459,6 @@ RSpec.describe '/api/v1/statuses' do
         end
       end
 
-      context 'with media attachments' do
-        let!(:media_attachment) { Fabricate(:media_attachment, account: user.account) }
-        let(:params) { { status: 'Hello world with media', media_ids: [media_attachment.id] } }
-
-        it 'creates a status with media attachment', :aggregate_failures do
-          expect { subject }.to change(user.account.statuses, :count).by(1)
-
-          expect(response).to have_http_status(200)
-          expect(response.content_type)
-            .to start_with('application/json')
-          expect(response.parsed_body[:media_attachments].size).to eq 1
-          expect(response.parsed_body[:media_attachments].first[:id]).to eq media_attachment.id.to_s
-        end
-
-        it 'serializes media metadata safely', :aggregate_failures do
-          subject
-
-          expect(response).to have_http_status(200)
-          media = response.parsed_body[:media_attachments].first
-          expect(media).to include(:meta)
-          expect(media[:meta]).to be_a(Hash)
-        end
-
-        context 'with media containing invalid metadata' do
-          before do
-            media_attachment.file.instance_write(:meta, 'invalid string metadata')
-            media_attachment.save!(validate: false)
-          end
-
-          it 'handles invalid metadata gracefully without 500', :aggregate_failures do
-            subject
-
-            expect(response).to have_http_status(200)
-            media = response.parsed_body[:media_attachments].first
-            expect(media[:meta]).to eq({})
-          end
-        end
-
-        context 'with media containing nil metadata' do
-          before do
-            media_attachment.file.instance_write(:meta, nil)
-            media_attachment.save!(validate: false)
-          end
-
-          it 'handles nil metadata gracefully', :aggregate_failures do
-            subject
-
-            expect(response).to have_http_status(200)
-            media = response.parsed_body[:media_attachments].first
-            expect(media[:meta]).to eq({})
-          end
-        end
-
-        context 'with media containing extra keys in metadata' do
-          before do
-            media_attachment.file.instance_write(:meta, {
-              original: { width: 600, height: 400 },
-              extra_key: 'should be filtered',
-              sensitive_data: { internal_path: '/secret/path' }
-            })
-            media_attachment.save!(validate: false)
-          end
-
-          it 'filters out non-allowed keys from metadata', :aggregate_failures do
-            subject
-
-            expect(response).to have_http_status(200)
-            media = response.parsed_body[:media_attachments].first
-            expect(media[:meta]).to include('original' => include('width' => 600, 'height' => 400))
-            expect(media[:meta]).not_to include('extra_key', 'sensitive_data')
-          end
-        end
-      end
-
-      context 'error handling and safety' do
-        let!(:media_attachment) { Fabricate(:media_attachment, account: user.account) }
-        let(:params) { { status: 'Hello world with media', media_ids: [media_attachment.id] } }
-
-        def assert_safe_response
-          expect(response).not_to have_http_status(500)
-          expect(response.content_type).to start_with('application/json')
-          response_body = response.body
-          expect(response_body).not_to include('backtrace')
-          expect(response_body).not_to match(%r{/app/|/Users/|/home/|/system/})
-        end
-
-        context 'with invalid media metadata types' do
-          before do
-            media_attachment.file.instance_write(:meta, 'invalid string with /app/ path')
-            media_attachment.save!(validate: false)
-          end
-
-          it 'returns 200 with safe response, no 500 or internal paths', :aggregate_failures do
-            subject
-
-            expect(response).to have_http_status(200)
-            assert_safe_response
-          end
-        end
-
-        context 'with StandardError fallback' do
-          before do
-            allow(PostStatusService).to receive(:new).and_raise(StandardError.new('test error with /app/path'))
-          end
-
-          it 'returns 422, not 500, with safe response', :aggregate_failures do
-            subject
-
-            expect(response).to have_http_status(422)
-            assert_safe_response
-            expect(response.parsed_body).to include(error: 'Invalid request')
-          end
-        end
-
-        context 'with JSON::GeneratorError fallback' do
-          before do
-            allow(REST::StatusSerializer).to receive(:new).and_raise(JSON::GeneratorError.new('test error with /app/path'))
-          end
-
-          it 'returns 422, not 500, with safe response', :aggregate_failures do
-            subject
-
-            expect(response).to have_http_status(422)
-            assert_safe_response
-            expect(response.parsed_body).to include(error: 'Invalid data format')
-          end
-        end
-      end
-
       context 'with missing thread' do
         let(:params) { { status: 'Hello world', in_reply_to_id: 0 } }
 
@@ -597,6 +468,55 @@ RSpec.describe '/api/v1/statuses' do
           expect(response).to have_http_status(404)
           expect(response.content_type)
             .to start_with('application/json')
+        end
+      end
+
+      context 'when media metadata raises an error during serialization' do
+        let!(:media_attachment) { Fabricate(:media_attachment, account: user.account, status: nil) }
+        let(:params) { { status: 'Hello world', media_ids: [media_attachment.id] } }
+
+        context 'with a StandardError that includes sensitive paths' do
+          before do
+            allow_any_instance_of(REST::MediaAttachmentSerializer).to receive(:meta).and_raise(StandardError, 'Error occurred at /Users/john/documents/file.txt')
+          end
+
+          it 'returns 422 with a friendly error message, not 500', :aggregate_failures do
+            subject
+
+            expect(response).to have_http_status(422)
+            expect(response.content_type).to start_with('application/json')
+            expect(response.parsed_body[:error]).to eq 'An unexpected error occurred'
+            expect(response.parsed_body[:error]).not_to include('/Users/')
+            expect(response.parsed_body[:error]).not_to include('/home/')
+          end
+        end
+
+        context 'with JSON::ParserError' do
+          before do
+            allow_any_instance_of(REST::MediaAttachmentSerializer).to receive(:meta).and_raise(JSON::ParserError, 'Invalid JSON in /Users/test/data')
+          end
+
+          it 'returns 422 with appropriate error message', :aggregate_failures do
+            subject
+
+            expect(response).to have_http_status(422)
+            expect(response.parsed_body[:error]).to eq 'Invalid JSON data'
+            expect(response.parsed_body[:error]).not_to include('/Users/')
+          end
+        end
+
+        context 'with Encoding error' do
+          before do
+            allow_any_instance_of(REST::MediaAttachmentSerializer).to receive(:meta).and_raise(Encoding::UndefinedConversionError, 'invalid byte sequence in /home/user/file')
+          end
+
+          it 'returns 422 with appropriate error message', :aggregate_failures do
+            subject
+
+            expect(response).to have_http_status(422)
+            expect(response.parsed_body[:error]).to eq 'Invalid character encoding'
+            expect(response.parsed_body[:error]).not_to include('/home/')
+          end
         end
       end
 

--- a/spec/serializers/rest/media_attachment_serializer_spec.rb
+++ b/spec/serializers/rest/media_attachment_serializer_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe REST::MediaAttachmentSerializer do
+  let(:serializer) { described_class.new(media_attachment) }
+  let(:media_attachment) { Fabricate(:media_attachment, account: account) }
+  let(:account) { Fabricate(:account) }
+
+  describe '#meta' do
+    context 'when file.meta is a valid hash with allowed keys' do
+      before do
+        media_attachment.file.instance_write(:meta, {
+          original: { width: 600, height: 400, aspect: 1.5 },
+          small: { width: 300, height: 200, aspect: 1.5 },
+          focus: { x: 0.5, y: 0.5 },
+          colors: { primary: '#ffffff' }
+        })
+      end
+
+      it 'returns only allowed keys' do
+        expect(serializer.meta).to include(
+          'original' => include('width' => 600, 'height' => 400),
+          'small' => include('width' => 300, 'height' => 200),
+          'focus' => include('x' => 0.5, 'y' => 0.5),
+          'colors' => include('primary' => '#ffffff')
+        )
+      end
+
+      it 'does not include extra keys' do
+        media_attachment.file.instance_write(:meta, {
+          original: { width: 600 },
+          extra_key: 'should not be included'
+        })
+        expect(serializer.meta).not_to include('extra_key')
+      end
+    end
+
+    context 'when file.meta is nil' do
+      before do
+        media_attachment.file.instance_write(:meta, nil)
+      end
+
+      it 'returns an empty hash' do
+        expect(serializer.meta).to eq({})
+      end
+    end
+
+    context 'when file.meta is not a hash' do
+      it 'returns an empty hash for string' do
+        media_attachment.file.instance_write(:meta, 'invalid string')
+        expect(serializer.meta).to eq({})
+      end
+
+      it 'returns an empty hash for array' do
+        media_attachment.file.instance_write(:meta, ['invalid', 'array'])
+        expect(serializer.meta).to eq({})
+      end
+
+      it 'returns an empty hash for number' do
+        media_attachment.file.instance_write(:meta, 123)
+        expect(serializer.meta).to eq({})
+      end
+
+      it 'returns an empty hash for boolean' do
+        media_attachment.file.instance_write(:meta, true)
+        expect(serializer.meta).to eq({})
+      end
+    end
+
+    context 'when file.meta is an empty hash' do
+      before do
+        media_attachment.file.instance_write(:meta, {})
+      end
+
+      it 'returns an empty hash' do
+        expect(serializer.meta).to eq({})
+      end
+    end
+
+    context 'when file.meta contains only non-allowed keys' do
+      before do
+        media_attachment.file.instance_write(:meta, {
+          invalid_key1: 'value1',
+          invalid_key2: 'value2'
+        })
+      end
+
+      it 'returns an empty hash' do
+        expect(serializer.meta).to eq({})
+      end
+    end
+
+    context 'with symbolized keys' do
+      before do
+        media_attachment.file.instance_write(:meta, {
+          original: { width: 600, height: 400 },
+          focus: { x: 0.5, y: 0.5 }
+        })
+      end
+
+      it 'accesses values correctly with indifferent access' do
+        expect(serializer.meta['original']).to include('width' => 600, 'height' => 400)
+        expect(serializer.meta['focus']).to include('x' => 0.5, 'y' => 0.5)
+      end
+    end
+
+    context 'with string keys' do
+      before do
+        media_attachment.file.instance_write(:meta, {
+          'original' => { 'width' => 600, 'height' => 400 },
+          'focus' => { 'x' => 0.5, 'y' => 0.5 }
+        })
+      end
+
+      it 'accesses values correctly' do
+        expect(serializer.meta['original']).to include('width' => 600, 'height' => 400)
+        expect(serializer.meta['focus']).to include('x' => 0.5, 'y' => 0.5)
+      end
+    end
+  end
+
+  describe 'full serialization' do
+    before do
+      media_attachment.file.instance_write(:meta, {
+        original: { width: 600, height: 400, aspect: 1.5 },
+        small: { width: 300, height: 200, aspect: 1.5 },
+        focus: { x: 0.5, y: 0.5 }
+      })
+    end
+
+    it 'serializes successfully without errors' do
+      expect { serializer.as_json }.not_to raise_error
+    end
+
+    it 'includes meta in the serialized output' do
+      json = serializer.as_json
+      expect(json).to include(:meta)
+      expect(json[:meta]).to include(
+        'original' => include('width' => 600, 'height' => 400),
+        'small' => include('width' => 300, 'height' => 200),
+        'focus' => include('x' => 0.5, 'y' => 0.5)
+      )
+    end
+
+    it 'converts to JSON string without errors' do
+      json = serializer.as_json
+      expect { json.to_json }.not_to raise_error
+    end
+
+    context 'with invalid metadata types' do
+      before do
+        media_attachment.file.instance_write(:meta, 'invalid string metadata')
+      end
+
+      it 'serializes successfully with empty meta' do
+        json = serializer.as_json
+        expect(json[:meta]).to eq({})
+      end
+
+      it 'does not raise errors during JSON serialization' do
+        json = serializer.as_json
+        expect { json.to_json }.not_to raise_error
+      end
+    end
+
+    context 'with nil metadata' do
+      before do
+        media_attachment.file.instance_write(:meta, nil)
+      end
+
+      it 'serializes successfully with empty meta' do
+        json = serializer.as_json
+        expect(json[:meta]).to eq({})
+      end
+    end
+  end
+end

--- a/spec/serializers/rest/media_attachment_serializer_spec.rb
+++ b/spec/serializers/rest/media_attachment_serializer_spec.rb
@@ -3,176 +3,57 @@
 require 'rails_helper'
 
 RSpec.describe REST::MediaAttachmentSerializer do
-  let(:serializer) { described_class.new(media_attachment) }
-  let(:media_attachment) { Fabricate(:media_attachment, account: account) }
-  let(:account) { Fabricate(:account) }
+  subject do
+    serialized_record_json(
+      media_attachment,
+      described_class
+    )
+  end
+
+  let(:media_attachment) { Fabricate(:media_attachment) }
 
   describe '#meta' do
-    context 'when file.meta is a valid hash with allowed keys' do
-      before do
-        media_attachment.file.instance_write(:meta, {
-          original: { width: 600, height: 400, aspect: 1.5 },
-          small: { width: 300, height: 200, aspect: 1.5 },
-          focus: { x: 0.5, y: 0.5 },
-          colors: { primary: '#ffffff' }
-        })
-      end
-
-      it 'returns only allowed keys' do
-        expect(serializer.meta).to include(
-          'original' => include('width' => 600, 'height' => 400),
-          'small' => include('width' => 300, 'height' => 200),
-          'focus' => include('x' => 0.5, 'y' => 0.5),
-          'colors' => include('primary' => '#ffffff')
-        )
-      end
-
-      it 'does not include extra keys' do
-        media_attachment.file.instance_write(:meta, {
-          original: { width: 600 },
-          extra_key: 'should not be included'
-        })
-        expect(serializer.meta).not_to include('extra_key')
-      end
+    it 'returns file meta' do
+      expect(subject['meta']).to be_present
     end
 
-    context 'when file.meta is nil' do
+    context 'when file.meta raises an error' do
       before do
-        media_attachment.file.instance_write(:meta, nil)
+        allow(media_attachment.file).to receive(:meta).and_raise(StandardError, 'Error with /Users/test/path')
       end
 
-      it 'returns an empty hash' do
-        expect(serializer.meta).to eq({})
-      end
-    end
-
-    context 'when file.meta is not a hash' do
-      it 'returns an empty hash for string' do
-        media_attachment.file.instance_write(:meta, 'invalid string')
-        expect(serializer.meta).to eq({})
-      end
-
-      it 'returns an empty hash for array' do
-        media_attachment.file.instance_write(:meta, ['invalid', 'array'])
-        expect(serializer.meta).to eq({})
-      end
-
-      it 'returns an empty hash for number' do
-        media_attachment.file.instance_write(:meta, 123)
-        expect(serializer.meta).to eq({})
-      end
-
-      it 'returns an empty hash for boolean' do
-        media_attachment.file.instance_write(:meta, true)
-        expect(serializer.meta).to eq({})
-      end
-    end
-
-    context 'when file.meta is an empty hash' do
-      before do
-        media_attachment.file.instance_write(:meta, {})
-      end
-
-      it 'returns an empty hash' do
-        expect(serializer.meta).to eq({})
-      end
-    end
-
-    context 'when file.meta contains only non-allowed keys' do
-      before do
-        media_attachment.file.instance_write(:meta, {
-          invalid_key1: 'value1',
-          invalid_key2: 'value2'
-        })
-      end
-
-      it 'returns an empty hash' do
-        expect(serializer.meta).to eq({})
-      end
-    end
-
-    context 'with symbolized keys' do
-      before do
-        media_attachment.file.instance_write(:meta, {
-          original: { width: 600, height: 400 },
-          focus: { x: 0.5, y: 0.5 }
-        })
-      end
-
-      it 'accesses values correctly with indifferent access' do
-        expect(serializer.meta['original']).to include('width' => 600, 'height' => 400)
-        expect(serializer.meta['focus']).to include('x' => 0.5, 'y' => 0.5)
-      end
-    end
-
-    context 'with string keys' do
-      before do
-        media_attachment.file.instance_write(:meta, {
-          'original' => { 'width' => 600, 'height' => 400 },
-          'focus' => { 'x' => 0.5, 'y' => 0.5 }
-        })
-      end
-
-      it 'accesses values correctly' do
-        expect(serializer.meta['original']).to include('width' => 600, 'height' => 400)
-        expect(serializer.meta['focus']).to include('x' => 0.5, 'y' => 0.5)
+      it 'raises an error that should be handled by the controller' do
+        expect { subject }.to raise_error(StandardError)
       end
     end
   end
 
-  describe 'full serialization' do
-    before do
-      media_attachment.file.instance_write(:meta, {
-        original: { width: 600, height: 400, aspect: 1.5 },
-        small: { width: 300, height: 200, aspect: 1.5 },
-        focus: { x: 0.5, y: 0.5 }
-      })
+  describe '#url' do
+    it 'returns the file URL' do
+      expect(subject['url']).to be_present
     end
 
-    it 'serializes successfully without errors' do
-      expect { serializer.as_json }.not_to raise_error
-    end
+    context 'when media is not processed' do
+      before do
+        media_attachment.processing = :queued
+      end
 
-    it 'includes meta in the serialized output' do
-      json = serializer.as_json
-      expect(json).to include(:meta)
-      expect(json[:meta]).to include(
-        'original' => include('width' => 600, 'height' => 400),
-        'small' => include('width' => 300, 'height' => 200),
-        'focus' => include('x' => 0.5, 'y' => 0.5)
+      it 'returns nil' do
+        expect(subject['url']).to be_nil
+      end
+    end
+  end
+
+  describe 'serialization attributes' do
+    it 'includes all required attributes' do
+      expect(subject).to include(
+        'id' => media_attachment.id.to_s,
+        'type' => media_attachment.type,
+        'url' => be_present,
+        'preview_url' => be_present,
+        'description' => media_attachment.description,
+        'blurhash' => media_attachment.blurhash
       )
-    end
-
-    it 'converts to JSON string without errors' do
-      json = serializer.as_json
-      expect { json.to_json }.not_to raise_error
-    end
-
-    context 'with invalid metadata types' do
-      before do
-        media_attachment.file.instance_write(:meta, 'invalid string metadata')
-      end
-
-      it 'serializes successfully with empty meta' do
-        json = serializer.as_json
-        expect(json[:meta]).to eq({})
-      end
-
-      it 'does not raise errors during JSON serialization' do
-        json = serializer.as_json
-        expect { json.to_json }.not_to raise_error
-      end
-    end
-
-    context 'with nil metadata' do
-      before do
-        media_attachment.file.instance_write(:meta, nil)
-      end
-
-      it 'serializes successfully with empty meta' do
-        json = serializer.as_json
-        expect(json[:meta]).to eq({})
-      end
     end
   end
 end


### PR DESCRIPTION
简化媒体附件元数据序列化逻辑

refactor(error_handling): 重构API错误处理机制

重构错误处理中间件，添加敏感信息过滤功能并细化错误分类。移除冗余的错误处理代码，统一通过handle_api_error方法处理异常。

test: 更新媒体附件序列器和状态API的测试用例

简化媒体附件序列化测试，移除冗余测试场景。更新状态API测试以验证新的错误处理逻辑。