### PR TITLE
Fix stale collections list after deleting a collection

### DIFF
--- a/app/javascript/mastodon/features/ui/components/confirmation_modals/delete_collection.tsx
+++ b/app/javascript/mastodon/features/ui/components/confirmation_modals/delete_collection.tsx
@@ -38,8 +38,8 @@ export const ConfirmDeleteCollectionModal: React.FC<
   const history = useHistory();
   const { acct: currentUserName } = useAccount(me) ?? {};
 
-  const onConfirm = useCallback(() => {
-    void dispatch(deleteCollection({ collectionId: id }));
+  const onConfirm = useCallback(async () => {
+    await dispatch(deleteCollection({ collectionId: id }));
     history.push(`/@${currentUserName}/collections`);
   }, [dispatch, history, id, currentUserName]);
 


### PR DESCRIPTION
Fixes WEB-917

### Changes proposed in this PR:
- Fixes a bug where the list of collections would still display a collection that was just deleted from its collection page. The issue was caused by the redirect to the list view triggering too soon.