### PR TITLE
Handle IPv6 scenario in custom `Request::Socket`

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -303,7 +303,7 @@ class Request
         addresses.each do |address|
           check_private_address(address, host)
 
-          sock     = ::Socket.new(address.is_a?(Resolv::IPv6) ? ::Socket::AF_INET6 : ::Socket::AF_INET, ::Socket::SOCK_STREAM, 0)
+          sock     = ::Socket.new(address.match?(Resolv::IPv6::Regex) ? ::Socket::AF_INET6 : ::Socket::AF_INET, ::Socket::SOCK_STREAM, 0)
           sockaddr = ::Socket.pack_sockaddr_in(port, address.to_s)
 
           sock.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)

--- a/spec/lib/request/socket_spec.rb
+++ b/spec/lib/request/socket_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Request::Socket do
+  describe '.open' do
+    context 'when an IPv6 only host lookup' do
+      let(:resolv_service) { instance_double(Resolv) }
+      let(:socket_service) { instance_double(Socket).as_null_object }
+
+      before do
+        allow(Resolv).to receive(:new).and_return(resolv_service)
+        allow(Socket).to receive(:new).and_return(socket_service)
+        allow(resolv_service).to receive(:getaddresses).with('example.com').and_return(%w(2001:4860:4860::8844))
+      end
+
+      it 'returns a valid socket' do
+        described_class.open('example.com')
+
+        expect(Socket)
+          .to have_received(:new)
+          .with(Socket::AF_INET6, Socket::SOCK_STREAM, 0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Background here: https://github.com/mastodon/mastodon/pull/38699/changes/BASE..8c1a33f25eb08fc26875fdbd5eec41da74a51094#r3134582986

In the previous change we updated this class to allow `/etc/hosts` entries to be included in DNS lookups. During that change, a return type of the lookup changed from IPAddr classes to strings. In the actual change we handled this correctly in the addresses lookup, but this area slightly further down was overlooked.

I suspect that since that change, in cases where an IPv6 address was available, it was not being used. I also suspect that the population of people who are a) running nightlies, b) somehow have a working IPv6 setup but not a working IPv4 setup, c) are encountering hosts which are only on IPv6 address space ... is very small?!

All that said, the change here is to convert this comparison to regex match instead of class check, like the prior changes.

Future ideas here:

- This entire class (both Socket and Request) have pretty sparse spec coverage ... could round that out more
- It may be worth reviewing whether the original motivation behind this class is now handled properly by the HTTP libs we're using, and/or other gems which may have a more robust approach to this stuff?
- This class is doing like 5 sort of related but slightly disparate things ... may want to review that and chop it a bit at some point