### PR TITLE
Change handle explainer to refer to the Fediverse

### DIFF
--- a/app/javascript/mastodon/components/account_header/name.tsx
+++ b/app/javascript/mastodon/components/account_header/name.tsx
@@ -179,7 +179,7 @@ const AccountNameHelp: FC<{
             </ol>
             <FormattedMessage
               id='account.name.help.footer'
-              defaultMessage='Just like you can send emails to people using different email providers, you can interact with people on other Mastodon servers, and with anyone on other Mastodon-compatible social apps.'
+              defaultMessage='Just like you can send emails to people using different email providers, you can interact with people on other Mastodon servers, and with anyone on other Fediverse apps.'
               tagName='p'
             />
 

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -113,7 +113,7 @@
   "account.name.copy": "Copy handle",
   "account.name.help.domain": "{domain} is the server that hosts the user’s profile and posts.",
   "account.name.help.domain_self": "{domain} is your server that hosts your profile and posts.",
-  "account.name.help.footer": "Just like you can send emails to people using different email providers, you can interact with people on other Mastodon servers, and with anyone on other Mastodon-compatible social apps.",
+  "account.name.help.footer": "Just like you can send emails to people using different email providers, you can interact with people on other Mastodon servers, and with anyone on other Fediverse apps.",
   "account.name.help.header": "A handle is like an email address",
   "account.name.help.username": "{username} is this account’s username on their server. Someone on another server might have the same username.",
   "account.name.help.username_self": "{username} is your username on this server. Someone on another server might have the same username.",


### PR DESCRIPTION
Changes handle explainer popup to refer to the Fediverse and not use the term "Mastodon-compatible".