### PR TITLE
Fix emoji picker not rendering when no custom emojis

### DIFF
--- a/app/javascript/mastodon/features/emoji/picker.ts
+++ b/app/javascript/mastodon/features/emoji/picker.ts
@@ -29,7 +29,8 @@ export async function fetchCustomEmojiData() {
   const { loadAllCustomEmoji } = await import('./database');
   const emojisRaw = await loadAllCustomEmoji();
   if (emojisRaw.length === 0) {
-    return [];
+    customEmojis = [];
+    return customEmojis;
   }
 
   const categories = new Set(['custom']);


### PR DESCRIPTION
Fix a bug introduced by #38825 ("Remove custom emojis from Redux") where the emoji picker fails to render entirely.

`fetchCustomEmojiData()` in `picker.ts` returned `[]` when IndexedDB had no custom emoji data, but did not update the module-level `customEmojis` variable, leaving it as `null`.
The `Picker` component checks `if (!customEmojis) return null;`, so the entire picker was hidden.
This fix assigns `customEmojis = []` before returning, allowing standard emoji categories to render normally.