### PR TITLE
Keep trying to load emojis if data isn't available yet

### DIFF
--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -269,6 +269,10 @@ export async function searchCustomEmojisByShortcodes(shortcodes: string[]) {
 
 export async function loadAllCustomEmoji() {
   const db = await loadDB();
+  const cacheValue = await db.get('etags', 'custom');
+  if (!cacheValue) {
+    return null;
+  }
   return db.getAll('custom');
 }
 

--- a/app/javascript/mastodon/features/emoji/picker.ts
+++ b/app/javascript/mastodon/features/emoji/picker.ts
@@ -28,6 +28,13 @@ export async function fetchCustomEmojiData() {
 
   const { loadAllCustomEmoji } = await import('./database');
   const emojisRaw = await loadAllCustomEmoji();
+
+  // If it returns null then custom emojis aren't even loaded yet.
+  if (emojisRaw === null) {
+    return [];
+  }
+
+  // If it's empty, then they are loaded but there aren't any.
   if (emojisRaw.length === 0) {
     customEmojis = [];
     return customEmojis;

--- a/app/javascript/mastodon/hooks/useCustomEmojis.ts
+++ b/app/javascript/mastodon/hooks/useCustomEmojis.ts
@@ -20,7 +20,7 @@ export function useCustomEmojis() {
 async function loadEmojisIntoCache() {
   const { loadAllCustomEmoji } = await import('../features/emoji/database');
   const emojisRaw = await loadAllCustomEmoji();
-  if (emojisRaw.length === 0) {
+  if (emojisRaw === null) {
     return;
   }
 


### PR DESCRIPTION
This has the custom emoji loading feature check first if there's an entry in the emoji load IDB table, to distinguish between emojis not being loaded yet and no custom emojis on the instance. 

Noticed during review of #38885 and #38825.
