### PR TITLE
Wraps content in Callout component

### DIFF
--- a/app/javascript/mastodon/components/account_header/styles.module.scss
+++ b/app/javascript/mastodon/components/account_header/styles.module.scss
@@ -200,9 +200,6 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
 
 .noteContent {
   white-space-collapse: preserve-breaks;
-  overflow-wrap: break-word;
-  word-break: break-all;
-  hyphens: auto;
 }
 
 .noteEditButton {

--- a/app/javascript/mastodon/components/callout/styles.module.css
+++ b/app/javascript/mastodon/components/callout/styles.module.css
@@ -17,6 +17,11 @@
   margin-top: -2px;
 }
 
+.content,
+.body {
+  min-width: 0;
+}
+
 .content {
   display: flex;
   gap: 8px;
@@ -32,6 +37,8 @@
 
 .body {
   flex-grow: 1;
+  overflow-wrap: break-word;
+  hyphens: auto;
 
   a {
     color: inherit;


### PR DESCRIPTION
From conversation in #38870, this moves the overflow fixes to the Callout component itself and gets rid of `break-all`.