### PR TITLE
Add admin area spec for email subscriptions management

### DIFF
--- a/app/controllers/admin/email_subscriptions_controller.rb
+++ b/app/controllers/admin/email_subscriptions_controller.rb
@@ -6,7 +6,7 @@ class Admin::EmailSubscriptionsController < Admin::BaseController
 
     @enabled = Setting.email_subscriptions
     @roles = UserRole.where('permissions & ? != 0', UserRole::FLAGS[:manage_email_subscriptions] | UserRole::FLAGS[:administrator])
-    @accounts = Account.local.joins(:email_subscriptions).where.associated(:email_subscriptions).includes(:user)
+    @accounts = Account.local.where.associated(:email_subscriptions).includes(:user)
   end
 
   def disable

--- a/app/views/admin/email_subscriptions/_accounts.html.haml
+++ b/app/views/admin/email_subscriptions/_accounts.html.haml
@@ -39,6 +39,7 @@
             %td.valign-middle
               = account.email_subscriptions.count
             %td.valign-middle
-              = l account.last_status_at
+              - if account.last_status_at.present?
+                = l account.last_status_at
             %td.valign-middle.align-end
               = link_to material_symbol('chevron_right'), admin_account_path(account.id), class: 'table-icon-link'

--- a/spec/policies/email_subscription_policy_spec.rb
+++ b/spec/policies/email_subscription_policy_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmailSubscriptionPolicy do
+  subject { described_class }
+
+  let(:admin) { Fabricate(:admin_user).account }
+  let(:account) { Fabricate(:account) }
+
+  permissions :index?, :enable?, :disable?, :purge? do
+    context 'when admin' do
+      it { is_expected.to permit(admin, EmailSubscription) }
+    end
+
+    context 'when not admin' do
+      it { is_expected.to_not permit(account, EmailSubscription) }
+    end
+  end
+end

--- a/spec/system/admin/email_subscriptions/additional_footer_texts_spec.rb
+++ b/spec/system/admin/email_subscriptions/additional_footer_texts_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Email Subscriptions Footer Texts' do
+  let(:user) { Fabricate(:admin_user) }
+
+  before { sign_in user }
+
+  describe 'Updated the email footer additional text' do
+    it 'updates the text and redirects to subscriptions page' do
+      visit admin_email_subscriptions_additional_footer_text_path
+      expect(page)
+        .to have_title(I18n.t('admin.email_subscriptions.additional_footer_texts.show.title'))
+
+      fill_in 'form_admin_settings_email_footer_text', with: 'More text'
+
+      expect { click_on submit_button }
+        .to change(Setting, :email_footer_text).to('More text')
+      expect(page)
+        .to have_title(I18n.t('admin.email_subscriptions.index.title'))
+    end
+  end
+end

--- a/spec/system/admin/email_subscriptions/setups_spec.rb
+++ b/spec/system/admin/email_subscriptions/setups_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Email Subscriptions Setup' do
+  let(:user) { Fabricate(:admin_user) }
+
+  before { sign_in user }
+
+  describe 'Enabling the email subscription feature' do
+    it 'enables the feature and redirects to subscriptions page' do
+      visit admin_email_subscriptions_setup_path
+      expect(page)
+        .to have_title(I18n.t('admin.email_subscriptions.index.title'))
+
+      check 'form_email_subscriptions_confirmation_agreement_privacy_and_terms'
+      check 'form_email_subscriptions_confirmation_agreement_email_volume'
+
+      expect { submit_form }
+        .to change(Setting, :email_subscriptions).to(true)
+      expect(page)
+        .to have_title(I18n.t('admin.email_subscriptions.index.title'))
+    end
+
+    def submit_form
+      click_on I18n.t('admin.email_subscriptions.setups.show.enable_feature')
+    end
+  end
+end

--- a/spec/system/admin/email_subscriptions_spec.rb
+++ b/spec/system/admin/email_subscriptions_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Email Subscriptions' do
+  let(:user) { Fabricate(:admin_user) }
+
+  before { sign_in user }
+
+  describe 'Viewing the subscriptions index page' do
+    before do
+      Fabricate.create :email_subscription # Create a sub show that purge is shown
+    end
+
+    context 'when feature enabled' do
+      before { Setting.email_subscriptions = true }
+
+      it 'shows subscription related details and manages the setting', :inline_jobs do
+        visit admin_email_subscriptions_path
+        expect(page)
+          .to have_title(I18n.t('admin.email_subscriptions.index.title'))
+          .and have_text(I18n.t('admin.email_subscriptions.compliance_settings.title'))
+
+        expect { click_on I18n.t('admin.email_subscriptions.danger_zone.erase_all_data.action') }
+          .to change(EmailSubscription, :count).to(0)
+        expect(page)
+          .to have_text(I18n.t('admin.email_subscriptions.purged_msg'))
+
+        expect { click_on I18n.t('admin.email_subscriptions.danger_zone.disable_feature.action') }
+          .to change(Setting, :email_subscriptions).to(false)
+        expect(page)
+          .to have_text(I18n.t('admin.email_subscriptions.disabled_msg'))
+      end
+    end
+
+    context 'when feature disabled' do
+      before { Setting.email_subscriptions = false }
+
+      it 'shows subscription related details' do
+        visit admin_email_subscriptions_path
+        expect(page)
+          .to have_title(I18n.t('admin.email_subscriptions.index.title'))
+          .and have_text(I18n.t('admin.email_subscriptions.index.disabled.description'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related changes from feedback overlooked during review cycle on https://github.com/mastodon/mastodon/pull/38741 ...

- Add "happy path" system spec for admin area features
- Add policy spec for new policy
- Handle edge case of missing `last_status_at` value (surfaced during specs)
- Remove unneeded join (underlying query does not change, `associated` adds this)