### PR TITLE
Move `PartialAccountSerializer` to the top-level

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,6 +5,7 @@
 # Table name: collections
 #
 #  id                       :bigint(8)        not null, primary key
+#  deleted_at               :datetime
 #  description              :text
 #  description_html         :text
 #  discoverable             :boolean          not null

--- a/app/serializers/rest/dedup_notification_group_serializer.rb
+++ b/app/serializers/rest/dedup_notification_group_serializer.rb
@@ -1,18 +1,8 @@
 # frozen_string_literal: true
 
 class REST::DedupNotificationGroupSerializer < ActiveModel::Serializer
-  class PartialAccountSerializer < REST::AccountSerializer
-    # This is a hack to reset ActiveModel::Serializer internals and only expose the attributes
-    # we care about.
-    self._attributes_data = {}
-    self._reflections = []
-    self._links = []
-
-    attributes :id, :acct, :locked, :bot, :url, :avatar, :avatar_static
-  end
-
   has_many :accounts, serializer: REST::AccountSerializer
-  has_many :partial_accounts, serializer: PartialAccountSerializer, if: :return_partial_accounts?
+  has_many :partial_accounts, serializer: REST::PartialAccountSerializer, if: :return_partial_accounts?
   has_many :statuses, serializer: REST::StatusSerializer
   has_many :notification_groups, serializer: REST::NotificationGroupSerializer
 

--- a/app/serializers/rest/partial_account_serializer.rb
+++ b/app/serializers/rest/partial_account_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class REST::PartialAccountSerializer < REST::AccountSerializer
+  # This is a hack to reset ActiveModel::Serializer internals and only expose the attributes
+  # we care about.
+  self._attributes_data = {}
+  self._reflections = []
+  self._links = []
+
+  attributes :id, :acct, :locked, :bot, :url, :avatar, :avatar_static, :avatar_description
+end

--- a/spec/requests/api/v2/notifications_spec.rb
+++ b/spec/requests/api/v2/notifications_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe 'Notifications' do
         expect(response.content_type)
           .to start_with('application/json')
         expect(response.parsed_body[:partial_accounts].size).to be > 0
-        expect(response.parsed_body[:partial_accounts][0].keys.map(&:to_sym)).to contain_exactly(:acct, :avatar, :avatar_static, :bot, :id, :locked, :url)
+        expect(response.parsed_body[:partial_accounts][0].keys.map(&:to_sym)).to contain_exactly(:acct, :avatar, :avatar_static, :avatar_description, :bot, :id, :locked, :url)
         expect(response.parsed_body[:partial_accounts].pluck(:id)).to_not include(recent_account.id.to_s)
         expect(response.parsed_body[:accounts].pluck(:id)).to include(recent_account.id.to_s)
       end

--- a/spec/serializers/rest/partial_account_serializer_spec.rb
+++ b/spec/serializers/rest/partial_account_serializer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe REST::PartialAccountSerializer do
+  subject do
+    serialized_record_json(account, described_class, options: {
+      scope: nil,
+      scope_name: :current_user,
+    })
+  end
+
+  let(:account) { Fabricate(:account, avatar_description: 'image') }
+
+  it 'includes the expected attributes' do
+    expect(subject).to include({
+      'id' => account.id.to_s,
+      'acct' => account.pretty_acct,
+      'locked' => false,
+      'bot' => false,
+      'url' => ActivityPub::TagManager.instance.url_for(account),
+      'avatar' => include(account.avatar_original_url),
+      'avatar_static' => include(account.avatar_static_url),
+      'avatar_description' => 'image',
+    })
+  end
+end


### PR DESCRIPTION
This is in preparation of using it in other places (e.g. for previewing accounts in collections).

While I was at it I took the liberty to also include the new attribute `avatar_description`. I think it makes sense to have that here as including avatar information is one of the most important aspects of these "partial accounts".