### PR TITLE
Add failing service case to remote account refresh worker spec

### DIFF
--- a/app/workers/remote_account_refresh_worker.rb
+++ b/app/workers/remote_account_refresh_worker.rb
@@ -8,8 +8,8 @@ class RemoteAccountRefreshWorker
   sidekiq_options queue: 'pull', retry: 3
 
   def perform(id)
-    account = Account.find_by(id: id)
-    return if account.nil? || account.local?
+    account = Account.remote.find_by(id: id)
+    return if account.nil?
 
     ActivityPub::FetchRemoteAccountService.new.call(account.uri)
   rescue Mastodon::UnexpectedResponseError => e

--- a/spec/workers/remote_account_refresh_worker_spec.rb
+++ b/spec/workers/remote_account_refresh_worker_spec.rb
@@ -4,35 +4,50 @@ require 'rails_helper'
 
 RSpec.describe RemoteAccountRefreshWorker do
   let(:worker) { described_class.new }
-  let(:service) { instance_double(ActivityPub::FetchRemoteAccountService, call: true) }
 
   describe '#perform' do
     before { stub_service }
 
     let(:account) { Fabricate(:account, domain: 'host.example') }
 
-    it 'sends the status to the service' do
-      worker.perform(account.id)
-
-      expect(service).to have_received(:call).with(account.uri)
-    end
-
-    it 'returns nil for non-existent record' do
-      result = worker.perform(123_123_123)
-
-      expect(result).to be_nil
-    end
-
-    it 'returns nil for a local record' do
-      account = Fabricate :account, domain: nil
-      result = worker.perform(account.id)
-      expect(result).to be_nil
-    end
-
     def stub_service
       allow(ActivityPub::FetchRemoteAccountService)
         .to receive(:new)
         .and_return(service)
+    end
+
+    context 'with a working service' do
+      let(:service) { instance_double(ActivityPub::FetchRemoteAccountService, call: true) }
+
+      it 'sends the status to the service' do
+        worker.perform(account.id)
+
+        expect(service).to have_received(:call).with(account.uri)
+      end
+
+      it 'returns nil for non-existent record' do
+        result = worker.perform(123_123_123)
+
+        expect(result).to be_nil
+      end
+
+      it 'returns nil for a local record' do
+        account = Fabricate :account, domain: nil
+        result = worker.perform(account.id)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'with a failing service' do
+      let(:service) { instance_double(ActivityPub::FetchRemoteAccountService) }
+      let(:response) { instance_double(HTTP::Response, code: 500) }
+
+      before { allow(service).to receive(:call).and_raise(Mastodon::UnexpectedResponseError, response) }
+
+      it 'raises error when service fails' do
+        expect { worker.perform(account.id) }
+          .to raise_error(Mastodon::UnexpectedResponseError)
+      end
     end
   end
 end

--- a/spec/workers/remote_account_refresh_worker_spec.rb
+++ b/spec/workers/remote_account_refresh_worker_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RemoteAccountRefreshWorker do
 
     it 'returns nil for a local record' do
       account = Fabricate :account, domain: nil
-      result = worker.perform(account)
+      result = worker.perform(account.id)
       expect(result).to be_nil
     end
 

--- a/spec/workers/remote_account_refresh_worker_spec.rb
+++ b/spec/workers/remote_account_refresh_worker_spec.rb
@@ -10,12 +10,6 @@ RSpec.describe RemoteAccountRefreshWorker do
 
     let(:account) { Fabricate(:account, domain: 'host.example') }
 
-    def stub_service
-      allow(ActivityPub::FetchRemoteAccountService)
-        .to receive(:new)
-        .and_return(service)
-    end
-
     context 'with a working service' do
       let(:service) { instance_double(ActivityPub::FetchRemoteAccountService, call: true) }
 
@@ -48,6 +42,12 @@ RSpec.describe RemoteAccountRefreshWorker do
         expect { worker.perform(account.id) }
           .to raise_error(Mastodon::UnexpectedResponseError)
       end
+    end
+
+    def stub_service
+      allow(ActivityPub::FetchRemoteAccountService)
+        .to receive(:new)
+        .and_return(service)
     end
   end
 end


### PR DESCRIPTION
In the specs:

- Shuffle things to have top level contexts for working vs failing service (basically all diff noise comes from this)
- Within the added failing service context, add spec for the re-raise path

In worker, optimize the remote account check to just only get those in the first place.