### PR TITLE
Add ability to search email blocks by domain

### DIFF
--- a/app/controllers/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/admin/email_domain_blocks_controller.rb
@@ -5,7 +5,7 @@ module Admin
     def index
       authorize :email_domain_block, :index?
 
-      @email_domain_blocks = EmailDomainBlock.parents.includes(:children).order(id: :desc).page(params[:page])
+      @email_domain_blocks = filter_by_domain.page(params[:page])
       @form                = Form::EmailDomainBlockBatch.new
     end
 
@@ -56,6 +56,12 @@ module Admin
     end
 
     private
+
+    def filter_by_domain
+      scope = EmailDomainBlock.parents.includes(:children).order(id: :desc)
+      scope.merge!(EmailDomainBlock.matches_domain(params[:domain])) if params[:domain].present?
+      @filter_by_domain = scope
+    end
 
     def set_resolved_records
       @resolved_records = DomainResource.new(@email_domain_block.domain).mx

--- a/app/controllers/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/admin/email_domain_blocks_controller.rb
@@ -60,7 +60,7 @@ module Admin
     def filter_by_domain
       scope = EmailDomainBlock.parents.includes(:children).order(id: :desc)
       scope.merge!(EmailDomainBlock.matches_domain(params[:domain])) if params[:domain].present?
-      @filter_by_domain = scope
+      scope
     end
 
     def set_resolved_records

--- a/app/models/email_domain_block.rb
+++ b/app/models/email_domain_block.rb
@@ -29,6 +29,7 @@ class EmailDomainBlock < ApplicationRecord
   validates :domain, presence: true, uniqueness: true, domain: true
 
   scope :parents, -> { where(parent_id: nil) }
+  scope :matches_domain, ->(value) { where(arel_table[:domain].matches("%#{value}%")) }
 
   # Used for adding multiple blocks at once
   attr_accessor :other_domains

--- a/app/views/admin/email_domain_blocks/index.html.haml
+++ b/app/views/admin/email_domain_blocks/index.html.haml
@@ -4,8 +4,23 @@
 - content_for :heading_actions do
   = link_to t('admin.email_domain_blocks.add_new'), new_admin_email_domain_block_path, class: 'button'
 
+= form_with url: admin_email_domain_blocks_path, method: :get, class: :simple_form do |f|
+  .fields-group
+    .input.string.optional
+      = f.text_field :domain,
+                     value: params[:domain],
+                     class: 'string optional',
+                     placeholder: t('admin.email_domain_blocks.domain')
+
+  .actions
+    %button.button= t('admin.email_domain_blocks.search')
+    = link_to t('admin.email_domain_blocks.reset'), admin_email_domain_blocks_path, class: 'button button--dangerous'
+
+%hr.spacer/
+
 = form_with model: @form, url: batch_admin_email_domain_blocks_path do |f|
   = hidden_field_tag :page, params[:page] || 1
+  = hidden_field_tag :domain, params[:domain] if params[:domain].present?
 
   .batch-table
     .batch-table__toolbar

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -484,8 +484,10 @@ en:
         title: Block new email domain
       no_email_domain_block_selected: No email domain blocks were changed as none were selected
       not_permitted: Not permitted
+      reset: Reset
       resolved_dns_records_hint_html: The domain name resolves to the following MX domains, which are ultimately responsible for accepting email. Blocking an MX domain will block sign-ups from any email address which uses the same MX domain, even if the visible domain name is different. <strong>Be careful not to block major email providers.</strong>
       resolved_through_html: Resolved through %{domain}
+      search: Search
       title: Blocked email domains
     email_subscriptions:
       accounts:

--- a/spec/system/admin/email_domain_blocks_spec.rb
+++ b/spec/system/admin/email_domain_blocks_spec.rb
@@ -86,4 +86,41 @@ RSpec.describe 'Admin::EmailDomainBlocks' do
       I18n.t('admin.email_domain_blocks.no_email_domain_block_selected')
     end
   end
+
+  describe 'Searching for email domain blocks' do
+    let(:email_domain_block) { Fabricate :email_domain_block, domain: 'something.com' }
+    let(:email_domain_block2) { Fabricate :email_domain_block, domain: 'example.com' }
+
+    before do
+      visit admin_email_domain_blocks_path
+      email_domain_block
+      email_domain_block2
+    end
+
+    it 'filters by domain' do
+      fill_in 'domain', with: 'example.com'
+      click_on I18n.t('admin.email_domain_blocks.search')
+
+      expect(page).to have_text('example.com')
+      expect(page).to have_no_text('something.com')
+    end
+
+    it 'shows empty page when no such domains are blocked' do
+      fill_in 'domain', with: 'mydomain.com'
+      click_on I18n.t('admin.email_domain_blocks.search')
+
+      expect(page).to have_no_text('mydomain.com')
+      expect(page).to have_text('There is nothing here!')
+    end
+
+    it 'returns to the list when resetting the search' do
+      fill_in 'domain', with: 'example.com'
+      click_on I18n.t('admin.email_domain_blocks.search')
+      click_on I18n.t('admin.email_domain_blocks.reset')
+
+      expect(page).to have_text('example.com')
+      expect(page).to have_text('something.com')
+      expect(page).to have_no_text('There is nothing here!')
+    end
+  end
 end


### PR DESCRIPTION
Adds a search field to the block email domains.
I decided to not add a fullblown filter class but add the respective method to the controller, since it's just one filter param for now.