### PR TITLE
Drop support for EOL node version 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Mastodon is a **free, open-source social network server** based on [ActivityPub]
 - **Ruby** 3.3+
 - **PostgreSQL** 14+
 - **Redis** 7.0+
-- **Node.js** 20+
+- **Node.js** 22+
 - **FFmpeg** 5.1+
 
 This repository includes deployment configurations for **Docker and docker-compose**, as well as for other environments like Heroku and Scalingo. For Helm charts, reference the [mastodon/chart repository](https://github.com/mastodon/chart). A [**standalone** installation guide](https://docs.joinmastodon.org/admin/install/) is available in the main documentation.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "AGPL-3.0-or-later",
   "packageManager": "yarn@4.14.1",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "workspaces": [
     ".",

--- a/streaming/package.json
+++ b/streaming/package.json
@@ -3,7 +3,7 @@
   "license": "AGPL-3.0-or-later",
   "packageManager": "yarn@4.14.1",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "description": "Mastodon's Streaming Server",
   "private": true,


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/38917#issuecomment-4389094379

Based changes on drop of version 18 support - https://github.com/mastodon/mastodon/pull/34390

Pre-requisite for that `lint-staged` PR (and maybe other near future PRs as other packages drop support)