### PR TITLE
Hide "Follows you" badge when viewing your own list of followers

### DIFF
--- a/app/javascript/mastodon/components/hover_card_account.tsx
+++ b/app/javascript/mastodon/components/hover_card_account.tsx
@@ -154,17 +154,19 @@ export const HoverCardAccount = forwardRef<
                 {(isMutual || isFollower) && (
                   <>
                     &middot;
-                    {isMutual ? (
-                      <FormattedMessage
-                        id='account.mutual'
-                        defaultMessage='You follow each other'
-                      />
-                    ) : (
-                      <FormattedMessage
-                        id='account.follows_you'
-                        defaultMessage='Follows you'
-                      />
-                    )}
+                    <span>
+                      {isMutual ? (
+                        <FormattedMessage
+                          id='account.mutual'
+                          defaultMessage='You follow each other'
+                        />
+                      ) : (
+                        <FormattedMessage
+                          id='account.follows_you'
+                          defaultMessage='Follows you'
+                        />
+                      )}
+                    </span>
                   </>
                 )}
               </div>

--- a/app/javascript/mastodon/features/followers/components/list.tsx
+++ b/app/javascript/mastodon/features/followers/components/list.tsx
@@ -28,6 +28,7 @@ interface AccountListProps {
   list?: AccountList | null;
   loadMore: () => void;
   prependAccountId?: string | null;
+  withoutFollowsYouBadge?: boolean;
   scrollKey: string;
 }
 
@@ -40,6 +41,7 @@ export const AccountList: FC<AccountListProps> = ({
   list,
   loadMore,
   prependAccountId,
+  withoutFollowsYouBadge,
   scrollKey,
 }) => {
   const account = useAccount(accountId);
@@ -57,6 +59,7 @@ export const AccountList: FC<AccountListProps> = ({
           key={followerId}
           accountId={followerId}
           withBio={false}
+          badge={withoutFollowsYouBadge ? false : null}
         />
       )) ?? [];
 
@@ -66,11 +69,12 @@ export const AccountList: FC<AccountListProps> = ({
           key={prependAccountId}
           accountId={prependAccountId}
           withBio={false}
+          badge={withoutFollowsYouBadge ? false : null}
         />,
       );
     }
     return children;
-  }, [prependAccountId, list, forceEmptyState]);
+  }, [prependAccountId, list, forceEmptyState, withoutFollowsYouBadge]);
 
   const { multiColumn } = useLayout();
 

--- a/app/javascript/mastodon/features/followers/index.tsx
+++ b/app/javascript/mastodon/features/followers/index.tsx
@@ -9,6 +9,7 @@ import { expandFollowers, fetchFollowers } from '@/mastodon/actions/accounts';
 import { useAccount } from '@/mastodon/hooks/useAccount';
 import { useAccountId } from '@/mastodon/hooks/useAccountId';
 import { useRelationship } from '@/mastodon/hooks/useRelationship';
+import { me } from '@/mastodon/initial_state';
 import { selectUserListWithoutMe } from '@/mastodon/selectors/user_lists';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 
@@ -85,6 +86,7 @@ const Followers: FC = () => {
       list={followerList}
       loadMore={loadMore}
       prependAccountId={followerId}
+      withoutFollowsYouBadge={accountId === me}
       scrollKey='followers'
     />
   );


### PR DESCRIPTION
### Changes proposed in this PR:
- Hides the per-item "Follows you" badge when viewing your own list of followers as it's redundant and displayed for every account in the list
- Fixes missing spacing before the "Follows you" or "You follow each other" bit in the hover card

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="611" height="654" alt="image" src="https://github.com/user-attachments/assets/17e94640-0b79-4f58-be69-d18442f7687c" /> | <img width="609" height="636" alt="image" src="https://github.com/user-attachments/assets/92534ea5-1d79-4ce1-8d02-91661fc08fa8" /> |
| <img width="366" height="267" alt="image" src="https://github.com/user-attachments/assets/840ab682-2f9c-42c1-9b33-6bf7b8a64b61" /> | <img width="372" height="266" alt="image" src="https://github.com/user-attachments/assets/d0126eb4-2e33-4a14-b03b-0d35dd9dfdd1" /> |