### PR TITLE
Show "Follow" button next to accounts in a collection when logged out

### DIFF
--- a/app/javascript/mastodon/features/collections/detail/accounts_list.tsx
+++ b/app/javascript/mastodon/features/collections/detail/accounts_list.tsx
@@ -138,12 +138,16 @@ export const CollectionAccountsList: React.FC<{
 
   const renderAccountItemButton = useCallback(
     ({ relationship, accountId }: RenderButtonOptions) => {
+      if (!me || !relationship) {
+        // Show follow button when logged out (it will trigger the remote interaction modal)
+        return <AccountListItemFollowButton accountId={accountId} />;
+      }
+
       // When viewing your own collection, only show the Follow button
       // for accounts you're not following anymore.
       const withoutButton =
-        !relationship ||
-        (collectionOwnerId === me &&
-          (relationship.following || relationship.requested));
+        collectionOwnerId === me &&
+        (relationship.following || relationship.requested);
 
       if (withoutButton) return null;
 

--- a/app/javascript/mastodon/features/interaction_modal/index.tsx
+++ b/app/javascript/mastodon/features/interaction_modal/index.tsx
@@ -483,11 +483,19 @@ const InteractionModal: React.FC<{
           />
         </h3>
         <p>
-          <FormattedMessage
-            id='interaction_modal.action'
-            defaultMessage="To interact with {name}'s post, you need to sign into your account on whatever Mastodon server you use."
-            values={{ name }}
-          />
+          {intent === 'follow' ? (
+            <FormattedMessage
+              id='interaction_modal.action_follow'
+              defaultMessage='To follow {name}, you need to sign into your account on whatever Mastodon server you use.'
+              values={{ name }}
+            />
+          ) : (
+            <FormattedMessage
+              id='interaction_modal.action'
+              defaultMessage="To interact with {name}'s post, you need to sign into your account on whatever Mastodon server you use."
+              values={{ name }}
+            />
+          )}
         </p>
       </div>
 

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -796,6 +796,7 @@
   "info_button.label": "Help",
   "info_button.what_is_alt_text": "<h1>What is alt text?</h1> <p>Alt text provides image descriptions for people with vision impairments, low-bandwidth connections, or those seeking extra context.</p> <p>You can improve accessibility and understanding for everyone by writing clear, concise, and objective alt text.</p> <ul> <li>Capture important elements</li> <li>Summarize text in images</li> <li>Use regular sentence structure</li> <li>Avoid redundant information</li> <li>Focus on trends and key findings in complex visuals (like diagrams or maps)</li> </ul>",
   "interaction_modal.action": "To interact with {name}'s post, you need to sign into your account on whatever Mastodon server you use.",
+  "interaction_modal.action_follow": "To follow {name}, you need to sign into your account on whatever Mastodon server you use.",
   "interaction_modal.go": "Go",
   "interaction_modal.no_account_yet": "Don't have an account yet?",
   "interaction_modal.on_another_server": "On a different server",


### PR DESCRIPTION
### Changes proposed in this PR:
- Supersedes #38898
- Displays the regular "Follow" button on collection pages when logged out. Clicking this button opens the remote interaction dialog that prompts the user to type in their home server to complete the interaction
- Adds new copy to the remote interaction dialog to properly handle the "Follow" intent – previously the copy only said "To interact with {name}'s post, you need to sign in…", whereas now it says "To follow {name}, you need to sign in…"

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="593" height="439" alt="image" src="https://github.com/user-attachments/assets/8c726c74-abbc-4da6-9331-5e643de2a585" /> | <img width="590" height="443" alt="image" src="https://github.com/user-attachments/assets/cf0d4ec2-9903-4063-99b7-6f722c67e9dd" /> |
| <img width="622" height="281" alt="image" src="https://github.com/user-attachments/assets/bd088ffd-255f-4237-aa49-412a01c36914" /> | <img width="621" height="276" alt="image" src="https://github.com/user-attachments/assets/111d8943-9791-4a64-82df-9a1f49878a72" /> |