### PR TITLE
Relax uniqueness constraint to allow `nil`

### DIFF
--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -30,7 +30,7 @@ class CollectionItem < ApplicationRecord
 
   delegate :local?, :remote?, to: :collection
 
-  validates :account_id, uniqueness: { scope: :collection_id }
+  validates :account_id, uniqueness: { scope: :collection_id, allow_nil: true }
   validates :position, numericality: { only_integer: true, greater_than: 0 }
   validates :activity_uri, presence: true, if: :local_item_with_remote_account?
   validates :approval_uri, presence: true, unless: -> { local? || account&.local? || !accepted? }

--- a/spec/models/collection_item_spec.rb
+++ b/spec/models/collection_item_spec.rb
@@ -41,6 +41,19 @@ RSpec.describe CollectionItem do
       subject { Fabricate.build(:unverified_remote_collection_item) }
 
       it { is_expected.to validate_presence_of(:object_uri) }
+
+      context 'when another item without account exists' do
+        subject { Fabricate.build(:unverified_remote_collection_item, collection:) }
+
+        let(:collection) { Fabricate(:remote_collection) }
+
+        before do
+          Fabricate(:unverified_remote_collection_item, collection:)
+          collection.reload
+        end
+
+        it { is_expected.to be_valid }
+      end
     end
   end
 


### PR DESCRIPTION
For unverified remote collection items, there can be more than one without an account.