### PR TITLE
Fix collection sharing/link copying using the local/relative collection URL

### DIFF
--- a/app/javascript/mastodon/features/collections/components/collection_menu.tsx
+++ b/app/javascript/mastodon/features/collections/components/collection_menu.tsx
@@ -131,7 +131,7 @@ export const CollectionMenu: React.FC<{
       {
         text: intl.formatMessage(messages.copyLink),
         action: () => {
-          void navigator.clipboard.writeText(getCollectionPath(id));
+          void navigator.clipboard.writeText(collection.url);
           dispatch(showAlert({ message: messages.copyLinkConfirmation }));
         },
       },
@@ -196,13 +196,14 @@ export const CollectionMenu: React.FC<{
     id,
     openShareModal,
     isOwnCollection,
+    collection.url,
     dispatch,
     openDeleteConfirmation,
     context,
     currentAccountInCollection,
     openReportModal,
-    openBlockModal,
     openRevokeConfirmation,
+    openBlockModal,
   ]);
 
   return (

--- a/app/javascript/mastodon/features/collections/components/share_modal.tsx
+++ b/app/javascript/mastodon/features/collections/components/share_modal.tsx
@@ -42,7 +42,7 @@ export const CollectionShareModal: React.FC<{
   const isNew = !!location.state?.newCollection;
   const isOwnCollection = collection.account_id === me;
 
-  const collectionLink = `${window.location.origin}/collections/${collection.id}`;
+  const collectionLink = collection.url;
 
   const handleShareOnDevice = useCallback(() => {
     void navigator.share({


### PR DESCRIPTION
### Changes proposed in this PR:
- Uses the correct collection URL (the origin) in the "Share collection" dialog and "Copy link" function