### PR TITLE
Add label to "Why do you want to join" field during sign-up

### DIFF
--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -68,10 +68,9 @@
         = invite_request_fields.input :text,
                                       as: :text,
                                       hint: false,
-                                      label: false,
                                       input_html: { maxlength: UserInviteRequest::TEXT_SIZE_LIMIT },
                                       required: Setting.require_invite_text,
-                                      wrapper: :with_block_label
+                                      wrapper: :with_label
 
   = hidden_field_tag :accept, params[:accept]
   = f.input :invite_code, as: :hidden

--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -61,16 +61,14 @@
                 wrapper: :with_block_label
 
   - if approved_registrations? && @invite.blank?
-    %p.lead= t('auth.sign_up.manual_review', domain: site_hostname)
-
     .fields-group
       = f.simple_fields_for :invite_request, resource.invite_request || resource.build_invite_request do |invite_request_fields|
         = invite_request_fields.input :text,
                                       as: :text,
-                                      hint: false,
+                                      hint: t('auth.sign_up.manual_review', domain: site_hostname),
                                       input_html: { maxlength: UserInviteRequest::TEXT_SIZE_LIMIT },
                                       required: Setting.require_invite_text,
-                                      wrapper: :with_label
+                                      wrapper: :with_block_label
 
   = hidden_field_tag :accept, params[:accept]
   = f.input :invite_code, as: :hidden


### PR DESCRIPTION
Related to WEB-881

### Changes proposed in this PR:
- Adds back the accessible label for the "Why do you want to join" field during sign-up, moves the description into the field hint

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="543" height="425" alt="image" src="https://github.com/user-attachments/assets/18b4b31d-04c5-4845-929c-57e809f6916e" /> | <img width="554" height="402" alt="image" src="https://github.com/user-attachments/assets/216f35aa-17d4-4774-9f7e-89f37ba02d32" /> |