### PR TITLE
Fix collections not being refreshed on re-discovery

### DIFF
--- a/app/services/activitypub/fetch_remote_featured_collection_service.rb
+++ b/app/services/activitypub/fetch_remote_featured_collection_service.rb
@@ -18,9 +18,6 @@ class ActivityPub::FetchRemoteFeaturedCollectionService < BaseService
     account = Account.find_by(uri: json['attributedTo'])
     return unless account
 
-    existing_collection = account.collections.find_by(uri:)
-    return existing_collection if existing_collection.present?
-
     ActivityPub::ProcessFeaturedCollectionService.new.call(account, json, request_id:)
   end
 end


### PR DESCRIPTION
Allow re-processing featured collections that are already known.

One issue is that it re-checks authorizations, which can be wasteful without any kind of rate limits.