### PR TITLE
Redirect with interstitial when trying to view a remote collection while logged out

### DIFF
--- a/app/controllers/redirect/collections_controller.rb
+++ b/app/controllers/redirect/collections_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Redirect::CollectionsController < Redirect::BaseController
+  private
+
+  def set_resource
+    @resource = Collection.find(params[:id])
+    not_found if @resource.local? || @resource&.account&.suspended?
+  end
+end

--- a/app/lib/permalink_redirector.rb
+++ b/app/lib/permalink_redirector.rb
@@ -21,6 +21,9 @@ class PermalinkRedirector
       elsif accounts_request? && record_integer_id_request?
         account = Account.find_by(id: second_segment)
         account if !account&.local? && !account&.suspended?
+      elsif collections_request? && record_integer_id_request?
+        collection = Collection.find_by(id: second_segment)
+        collection if !collection&.local? && !collection&.account&.suspended?
       end
     end
   end
@@ -43,6 +46,8 @@ class PermalinkRedirector
       redirect_account_path(object.id)
     when 'Status'
       redirect_status_path(object.id)
+    when 'Collection'
+      redirect_collection_path(object.id)
     else
       @path.delete_prefix('/deck') if @path.start_with?('/deck')
     end
@@ -68,6 +73,10 @@ class PermalinkRedirector
 
   def accounts_request?
     first_segment == 'accounts'
+  end
+
+  def collections_request?
+    first_segment == 'collections'
   end
 
   def record_integer_id_request?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -189,6 +189,7 @@ Rails.application.routes.draw do
   namespace :redirect do
     resources :accounts, only: :show
     resources :statuses, only: :show
+    resources :collections, only: :show
   end
 
   namespace :email_subscriptions do

--- a/spec/lib/permalink_redirector_spec.rb
+++ b/spec/lib/permalink_redirector_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe PermalinkRedirector do
         redirector = described_class.new('@alice/123?foo=bar')
         expect(redirector.redirect_path).to eq 'https://example.com/status-123'
       end
+
+      it 'returns path for collections link' do
+        collection = Fabricate(:remote_collection, account: remote_account)
+        redirector = described_class.new("collections/#{collection.id}")
+        expect(redirector.redirect_path).to eq(ActivityPub::TagManager.instance.url_for(collection) || ActivityPub::TagManager.instance.uri_for(collection))
+      end
     end
 
     context 'when account is suspended' do
@@ -79,6 +85,12 @@ RSpec.describe PermalinkRedirector do
 
       it 'returns nil for pretty status links with a query param' do
         redirector = described_class.new('@alice/123?foo=bar')
+        expect(redirector.redirect_path).to be_nil
+      end
+
+      it 'returns nil for collections link' do
+        collection = Fabricate(:remote_collection, account: remote_account)
+        redirector = described_class.new("collections/#{collection.id}")
         expect(redirector.redirect_path).to be_nil
       end
     end


### PR DESCRIPTION
This redirects in the same way as when attempting to view a remote account or status.