### PR TITLE
Fix "New collection" link appearing on other accounts' profiles

### DIFF
--- a/app/javascript/mastodon/features/account_featured/index.tsx
+++ b/app/javascript/mastodon/features/account_featured/index.tsx
@@ -24,6 +24,7 @@ import Column from '@/mastodon/features/ui/components/column';
 import { useAccount } from '@/mastodon/hooks/useAccount';
 import { useAccountId } from '@/mastodon/hooks/useAccountId';
 import { useAccountVisibility } from '@/mastodon/hooks/useAccountVisibility';
+import { me } from '@/mastodon/initial_state';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 import AddIcon from '@/material-icons/400-24px/add.svg?react';
 
@@ -173,12 +174,14 @@ const AccountFeatured: React.FC<{ multiColumn: boolean }> = ({
                   defaultMessage='Collections'
                 />
               </h2>
-              <SubheadingLink to='/collections/new' icon={AddIcon}>
-                <FormattedMessage
-                  id='account.featured.new_collection'
-                  defaultMessage='New collection'
-                />
-              </SubheadingLink>
+              {accountId === me && (
+                <SubheadingLink to='/collections/new' icon={AddIcon}>
+                  <FormattedMessage
+                    id='account.featured.new_collection'
+                    defaultMessage='New collection'
+                  />
+                </SubheadingLink>
+              )}
             </Subheading>
             {hasCollections ? (
               <ItemList>


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes "New collection" link appearing on other accounts' profiles

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="616" height="156" alt="image" src="https://github.com/user-attachments/assets/4cef3f69-0080-4d87-9a11-499efa73573f" /> | <img width="618" height="162" alt="image" src="https://github.com/user-attachments/assets/6cec1814-31da-48b6-91ed-02ef62de4a3a" /> |