### PR TITLE
Prepare Dockerfile for Node 26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -340,6 +340,9 @@ COPY --from=node /usr/local/bin /usr/local/bin
 COPY --from=node /usr/local/lib /usr/local/lib
 
 RUN \
+  # Mount local Corepack and Yarn caches from Docker buildx caches
+  --mount=type=cache,id=corepack-cache-${TARGETPLATFORM},target=/usr/local/share/.cache/corepack,sharing=locked \
+  --mount=type=cache,id=yarn-cache-${TARGETPLATFORM},target=/usr/local/share/.cache/yarn,sharing=locked \
   # Remove pre-installed Yarn binaries (only present on Node <26)
   rm -f /usr/local/bin/yarn*; \
   # Install Corepack

--- a/Dockerfile
+++ b/Dockerfile
@@ -340,10 +340,8 @@ COPY --from=node /usr/local/bin /usr/local/bin
 COPY --from=node /usr/local/lib /usr/local/lib
 
 RUN \
-  # Cleanup Yarn install on Node.js <26
-  if [ "${NODE_MAJOR_VERSION}" -lt 26 ]; then \
-    rm /usr/local/bin/yarn*; \
-  fi; \
+  # Remove pre-installed Yarn binaries (only present on Node <26)
+  rm -f /usr/local/bin/yarn*; \
   # Install Corepack
   npm i -g corepack;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -340,10 +340,12 @@ COPY --from=node /usr/local/bin /usr/local/bin
 COPY --from=node /usr/local/lib /usr/local/lib
 
 RUN \
-  # Configure Corepack
-  rm /usr/local/bin/yarn*; \
-  npm i -g corepack; \
-  corepack prepare --activate;
+  # Cleanup Yarn install on Node.js <26
+  if [ "${NODE_MAJOR_VERSION}" -lt 26 ]; then \
+    rm /usr/local/bin/yarn*; \
+  fi; \
+  # Install Corepack
+  npm i -g corepack;
 
 # hadolint ignore=DL3008
 RUN \

--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -32,20 +32,18 @@ ARG GID="991"
 
 # Apply Mastodon build options based on options above
 ENV \
-  # Apply Mastodon version information
   MASTODON_VERSION_PRERELEASE="${MASTODON_VERSION_PRERELEASE}" \
   MASTODON_VERSION_METADATA="${MASTODON_VERSION_METADATA}" \
-  # Apply timezone
   TZ=${TZ}
 
+# Configure the IP to bind Mastodon to when serving traffic
+# Explicitly set PORT to match the exposed port
+# Use production settings for Yarn, Node and related nodejs based tools
+# Add Ruby and Mastodon installation to the PATH
 ENV \
-  # Configure the IP to bind Mastodon to when serving traffic
   BIND="0.0.0.0" \
-  # Explicitly set PORT to match the exposed port
   PORT=4000 \
-  # Use production settings for Yarn, Node and related nodejs based tools
   NODE_ENV="production" \
-  # Add Ruby and Mastodon installation to the PATH
   DEBIAN_FRONTEND="noninteractive"
 
 # Set default shell used for running commands
@@ -90,13 +88,12 @@ COPY package.json yarn.lock .yarnrc.yml /opt/mastodon/
 COPY ./streaming /opt/mastodon/streaming
 
 RUN \
-  # Mount local Corepack and Yarn caches from Docker buildx caches
-  --mount=type=cache,id=corepack-cache-${TARGETPLATFORM},target=/usr/local/share/.cache/corepack,sharing=locked \
-  --mount=type=cache,id=yarn-cache-${TARGETPLATFORM},target=/usr/local/share/.cache/yarn,sharing=locked \
-  # Configure Corepack
-  rm /usr/local/bin/yarn*; \
-  npm i -g corepack; \
-  corepack prepare --activate;
+  # Cleanup Yarn install on Node.js <26
+  if [ "${NODE_MAJOR_VERSION}" -lt 26 ]; then \
+    rm /usr/local/bin/yarn*; \
+  fi; \
+  # Install Corepack
+  npm i -g corepack;
 
 RUN \
   # Mount Corepack and Yarn caches from Docker buildx caches

--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -88,6 +88,9 @@ COPY package.json yarn.lock .yarnrc.yml /opt/mastodon/
 COPY ./streaming /opt/mastodon/streaming
 
 RUN \
+  # Mount local Corepack and Yarn caches from Docker buildx caches
+  --mount=type=cache,id=corepack-cache-${TARGETPLATFORM},target=/usr/local/share/.cache/corepack,sharing=locked \
+  --mount=type=cache,id=yarn-cache-${TARGETPLATFORM},target=/usr/local/share/.cache/yarn,sharing=locked \
   # Remove pre-installed Yarn binaries (only present on Node <26)
   rm -f /usr/local/bin/yarn*; \
   # Install Corepack

--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -88,10 +88,8 @@ COPY package.json yarn.lock .yarnrc.yml /opt/mastodon/
 COPY ./streaming /opt/mastodon/streaming
 
 RUN \
-  # Cleanup Yarn install on Node.js <26
-  if [ "${NODE_MAJOR_VERSION}" -lt 26 ]; then \
-    rm /usr/local/bin/yarn*; \
-  fi; \
+  # Remove pre-installed Yarn binaries (only present on Node <26)
+  rm -f /usr/local/bin/yarn*; \
   # Install Corepack
   npm i -g corepack;
 


### PR DESCRIPTION
The team managing the Node Dockerfile has removed yarn from the image starting in 26. See https://github.com/nodejs/docker-node#yarn-v1-classic-bundling

This fixes the classic yarn cleanup necessary on previous images. Yarn 4 is then installed by corepack, which is also not included as part of Node starting in 25 (Dockerfile adapted in https://github.com/mastodon/mastodon/pull/34406)

Additionally there are linting fixes for comments in the Streaming file, and cleanup of activation commands in both files.