### PR TITLE
Fix text overflow issues in list item component

### DIFF
--- a/app/javascript/mastodon/components/account_list_item/index.tsx
+++ b/app/javascript/mastodon/components/account_list_item/index.tsx
@@ -90,7 +90,7 @@ export const AccountListItem: React.FC<Props> = ({
         <ListItemLink
           to={`/@${account.acct}`}
           data-hover-card-account={accountId}
-          subtitle={handle}
+          subtitle={<span className={classes.handle}>{handle}</span>}
         >
           <DisplayNameSimple
             account={account}

--- a/app/javascript/mastodon/components/account_list_item/styles.module.scss
+++ b/app/javascript/mastodon/components/account_list_item/styles.module.scss
@@ -24,6 +24,13 @@
   vertical-align: -4px;
 }
 
+.handle {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .button {
   align-self: start;
 }

--- a/app/javascript/mastodon/components/list_item/index.tsx
+++ b/app/javascript/mastodon/components/list_item/index.tsx
@@ -30,7 +30,7 @@ export const ListItemWrapper: React.FC<WrapperProps> = ({
   return (
     <div {...otherProps} className={classNames(classes.wrapper, className)}>
       {icon}
-      <div>{children}</div>
+      <div className={classes.main}>{children}</div>
       {sideContent && (
         <span className={classes.sideContent}>{sideContent}</span>
       )}

--- a/app/javascript/mastodon/components/list_item/styles.module.scss
+++ b/app/javascript/mastodon/components/list_item/styles.module.scss
@@ -14,6 +14,11 @@
   color: var(--color-text-primary);
 }
 
+.main {
+  min-width: 0;
+  overflow-wrap: break-word;
+}
+
 .title {
   font-weight: 500;
 


### PR DESCRIPTION
Fixes #38947

### Changes proposed in this PR:
- Fixes text overflow in components based on `ListItem`\
- Uses an ellipsis to truncate long handles in `AccountListItem`, otherwise wraps to a new line

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="351" height="87" alt="image" src="https://github.com/user-attachments/assets/ea2cfe39-645c-45eb-a7cf-954906df1609" /> | <img width="346" height="105" alt="image" src="https://github.com/user-attachments/assets/a05a1fa5-08e1-44b1-8d8a-25bb9777bd8c" /> |