### PR TITLE
Indent collection preview cards when displayed in notifications

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10759,6 +10759,7 @@ noscript {
   .picture-in-picture-placeholder,
   .more-from-author,
   .status-card,
+  .collection-preview,
   .hashtag-bar,
   .content-warning,
   .filter-warning {


### PR DESCRIPTION
### Changes proposed in this PR:
- Indents collection preview cards when displayed in notifications

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="586" height="323" alt="image" src="https://github.com/user-attachments/assets/78b2fadd-a542-4112-a6c8-5bf383f25836" /> | <img width="587" height="320" alt="image" src="https://github.com/user-attachments/assets/28c06bc5-8d01-46eb-abab-58d6f7a384e0" /> |