### PR TITLE
Fix updating collection items when position is unknown

### DIFF
--- a/app/services/activitypub/process_featured_item_service.rb
+++ b/app/services/activitypub/process_featured_item_service.rb
@@ -16,10 +16,10 @@ class ActivityPub::ProcessFeaturedItemService
     with_redis_lock("collection_item:#{@item_json['id']}") do
       @collection_item = existing_item || pre_approved_item || new_item
 
+      @collection_item.position = position unless position.nil?
       @collection_item.update!(
         uri: @item_json['id'],
-        object_uri: value_or_id(@item_json['featuredObject']),
-        position:
+        object_uri: value_or_id(@item_json['featuredObject'])
       )
 
       @approval_uri = @item_json['featureAuthorization']

--- a/spec/services/activitypub/process_featured_item_service_spec.rb
+++ b/spec/services/activitypub/process_featured_item_service_spec.rb
@@ -72,15 +72,25 @@ RSpec.describe ActivityPub::ProcessFeaturedItemService do
       end
     end
 
-    context 'when item exists at a different position' do
+    context 'when item exists' do
       let!(:collection_item) do
         Fabricate(:collection_item, collection:, uri: featured_item_json['id'], position: 2)
       end
 
-      it 'updates the position' do
-        expect { subject.call(collection, object, position:) }.to_not change(collection.collection_items, :count)
+      context 'when no position is given' do
+        it 'does not change the position' do
+          expect { subject.call(collection, object) }.to_not change(collection.collection_items, :count)
 
-        expect(collection_item.reload.position).to eq 3
+          expect(collection_item.reload.position).to eq 2
+        end
+      end
+
+      context 'when a different position is given' do
+        it 'updates the position' do
+          expect { subject.call(collection, object, position:) }.to_not change(collection.collection_items, :count)
+
+          expect(collection_item.reload.position).to eq 3
+        end
       end
     end
 


### PR DESCRIPTION
When we receive an `Add` activity for a single collection item, we do not know the position of the item in the list. If it is an unknown item, it will just be appended, but the case when the item is already known was not handled properly and raised an exception.