### PR TITLE
Improve layout and spacing of number fields

### DIFF
--- a/app/javascript/mastodon/components/account_header/number_fields.tsx
+++ b/app/javascript/mastodon/components/account_header/number_fields.tsx
@@ -11,6 +11,8 @@ import { FormattedDateWrapper } from '../formatted_date';
 import { NumberFields, NumberFieldsItem } from '../number_fields';
 import { ShortNumber } from '../short_number';
 
+import classes from './styles.module.scss';
+
 export const AccountNumberFields: FC<{ accountId: string }> = ({
   accountId,
 }) => {
@@ -33,7 +35,7 @@ export const AccountNumberFields: FC<{ accountId: string }> = ({
   }
 
   return (
-    <NumberFields>
+    <NumberFields className={classes.numberFields}>
       <NumberFieldsItem
         label={
           <FormattedMessage id='account.followers' defaultMessage='Followers' />

--- a/app/javascript/mastodon/components/account_header/styles.module.scss
+++ b/app/javascript/mastodon/components/account_header/styles.module.scss
@@ -263,6 +263,18 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
   }
 }
 
+.numberFields {
+  @container (width > #{$button-breakpoint}) {
+    column-gap: 40px;
+  }
+
+  & > li {
+    @container (width < #{$button-breakpoint}) {
+      flex: 1 1 0px;
+    }
+  }
+}
+
 .bio {
   font-size: 15px;
   color: var(--color-text-primary);

--- a/app/javascript/mastodon/components/account_header/styles.module.scss
+++ b/app/javascript/mastodon/components/account_header/styles.module.scss
@@ -267,12 +267,6 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
   @container (width > #{$button-breakpoint}) {
     column-gap: 40px;
   }
-
-  & > li {
-    @container (width < #{$button-breakpoint}) {
-      flex: 1 1 0px;
-    }
-  }
 }
 
 .bio {

--- a/app/javascript/mastodon/components/account_header/styles.module.scss
+++ b/app/javascript/mastodon/components/account_header/styles.module.scss
@@ -264,8 +264,8 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
 }
 
 .numberFields {
-  @container (width > #{$button-breakpoint}) {
-    column-gap: 40px;
+  @container (width >= #{$button-breakpoint}) {
+    --number-fields-gap: 40px;
   }
 }
 

--- a/app/javascript/mastodon/components/account_list_item/styles.module.scss
+++ b/app/javascript/mastodon/components/account_list_item/styles.module.scss
@@ -1,7 +1,6 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  align-items: start;
   gap: 12px;
   padding: 16px;
 

--- a/app/javascript/mastodon/components/number_fields/styles.module.scss
+++ b/app/javascript/mastodon/components/number_fields/styles.module.scss
@@ -1,9 +1,11 @@
 .list {
+  --item-gap: var(--number-fields-gap, 24px);
+
   display: flex;
   flex-wrap: wrap;
   margin: 0;
   padding: 0;
-  gap: 4px 24px;
+  gap: 4px var(--item-gap);
   font-size: 13px;
   color: var(--color-text-secondary);
 }

--- a/app/javascript/mastodon/components/number_fields/styles.module.scss
+++ b/app/javascript/mastodon/components/number_fields/styles.module.scss
@@ -9,10 +9,6 @@
 }
 
 .item {
-  @container (width < 420px) {
-    flex: 1 1 0px;
-  }
-
   a,
   button,
   strong {

--- a/app/javascript/mastodon/components/number_fields/styles.module.scss
+++ b/app/javascript/mastodon/components/number_fields/styles.module.scss
@@ -9,6 +9,10 @@
 }
 
 .item {
+  @container (width < 420px) {
+    flex: 1 1 0px;
+  }
+
   a,
   button,
   strong {


### PR DESCRIPTION
### Changes proposed in this PR:
- Improves layout and spacing of number fields:
  - Ensure that the numbers expand to fill the full width of narrow containers in `AccountListItem`, preventing unwanted line breaks and inconsistent number display across list items
  - Increases the spacing between numbers on the profile to match the spacing of the original mockups (when there's space)

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="574" height="189" alt="image" src="https://github.com/user-attachments/assets/9db71347-ead3-4cd4-bd64-3c80bb3e4045" /> | <img width="574" height="196" alt="image" src="https://github.com/user-attachments/assets/094d9e5e-805c-4c81-bc3f-58f942298f25" /> |
| <img width="340" height="422" alt="image" src="https://github.com/user-attachments/assets/2726fd71-89b2-43c5-9035-a10360af288a" /> | <img width="339" height="403" alt="image" src="https://github.com/user-attachments/assets/7a4c605a-a5ad-40bc-b9c0-45576b0a8f48" /> |