### PR TITLE
New profile: Fix link colors in bio and display name overflow

### DIFF
--- a/app/javascript/mastodon/components/account_header/styles.module.scss
+++ b/app/javascript/mastodon/components/account_header/styles.module.scss
@@ -266,6 +266,14 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
 .bio {
   font-size: 15px;
   color: var(--color-text-primary);
+
+  :any-link {
+    color: var(--color-text-status-links);
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
 }
 
 .familiarFollowers {

--- a/app/javascript/mastodon/components/account_header/styles.module.scss
+++ b/app/javascript/mastodon/components/account_header/styles.module.scss
@@ -78,6 +78,8 @@
 
 .nameWrapper {
   flex-grow: 1;
+  min-width: 0;
+  overflow-wrap: break-word;
 }
 
 .name {


### PR DESCRIPTION
### Changes proposed in this PR:
- Applies our standard link colors to links (hashtags and mentions) in the profile bio (previously they were using browser defaults)
- Contains super long usernames without line breaks, preventing profile buttons from being pushed out of view

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="599" height="246" alt="image" src="https://github.com/user-attachments/assets/fb5f6c95-fdf9-471d-8272-59e456d9e840" /> | <img width="602" height="245" alt="image" src="https://github.com/user-attachments/assets/c80f56c7-6ce1-4326-862a-77dac25a65ac" /> |