### PR TITLE
Stylelint: Allow leading underscore in CSS variable names

### DIFF
--- a/app/javascript/mastodon/components/number_fields/styles.module.scss
+++ b/app/javascript/mastodon/components/number_fields/styles.module.scss
@@ -1,11 +1,11 @@
 .list {
-  --item-gap: var(--number-fields-gap, 24px);
+  --_item-gap: var(--number-fields-gap, 24px);
 
   display: flex;
   flex-wrap: wrap;
   margin: 0;
   padding: 0;
-  gap: 4px var(--item-gap);
+  gap: 4px var(--_item-gap);
   font-size: 13px;
   color: var(--color-text-secondary);
 }

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -24,7 +24,13 @@ module.exports = {
     'selector-id-pattern': null,
     'value-keyword-case': null,
     'value-no-vendor-prefix': null,
-    'custom-property-pattern': '^_?[a-z]([a-z0-9])*(-[a-z0-9]+)*$',
+    'custom-property-pattern': [
+      '^_?[a-z]([a-z0-9])*(-[a-z0-9]+)*$',
+      {
+        message: (name) =>
+          `Expected custom property name "${name}" to be kebab-case (optional leading underscore allowed)`,
+      },
+    ],
 
     'scss/dollar-variable-empty-line-before': null,
     'scss/no-global-function-names': null,

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -24,6 +24,7 @@ module.exports = {
     'selector-id-pattern': null,
     'value-keyword-case': null,
     'value-no-vendor-prefix': null,
+    'custom-property-pattern': '^_?[a-z]([a-z0-9])*(-[a-z0-9]+)*$',
 
     'scss/dollar-variable-empty-line-before': null,
     'scss/no-global-function-names': null,


### PR DESCRIPTION
### Changes proposed in this PR:
- Updates stylelint config to allow leading underscores in CSS variable names (see [comment from an earlier PR](https://github.com/mastodon/mastodon/pull/38963#discussion_r3208776350)). The Regex is based [on the default](https://github.com/stylelint/stylelint-config-standard/blob/43f9f5d0f6f122d4c4a09f1c956515f5750f3460/index.js#L56) and seems to work, but I'm no regex-pert.
