### PR TITLE
Make search field and tabs sticky on search results page

### DIFF
--- a/app/javascript/mastodon/features/search/index.tsx
+++ b/app/javascript/mastodon/features/search/index.tsx
@@ -222,51 +222,61 @@ export const SearchResults: React.FC<{ multiColumn: boolean }> = ({
         title={intl.formatMessage(messages.title, { q })}
         onClick={handleHeaderClick}
         multiColumn={multiColumn}
+        appendContent={
+          <>
+            <div className='explore__search-header'>
+              <Search
+                singleColumn
+                initialValue={trimmedValue}
+                key={trimmedValue}
+              />
+            </div>
+
+            <div className='account__section-headline'>
+              <button
+                onClick={handleSelectAll}
+                className={mappedType === 'all' ? 'active' : undefined}
+                type='button'
+              >
+                <FormattedMessage
+                  id='search_results.all'
+                  defaultMessage='All'
+                />
+              </button>
+              <button
+                onClick={handleSelectAccounts}
+                className={mappedType === 'accounts' ? 'active' : undefined}
+                type='button'
+              >
+                <FormattedMessage
+                  id='search_results.accounts'
+                  defaultMessage='Profiles'
+                />
+              </button>
+              <button
+                onClick={handleSelectHashtags}
+                className={mappedType === 'hashtags' ? 'active' : undefined}
+                type='button'
+              >
+                <FormattedMessage
+                  id='search_results.hashtags'
+                  defaultMessage='Hashtags'
+                />
+              </button>
+              <button
+                onClick={handleSelectStatuses}
+                className={mappedType === 'statuses' ? 'active' : undefined}
+                type='button'
+              >
+                <FormattedMessage
+                  id='search_results.statuses'
+                  defaultMessage='Posts'
+                />
+              </button>
+            </div>
+          </>
+        }
       />
-
-      <div className='explore__search-header'>
-        <Search singleColumn initialValue={trimmedValue} key={trimmedValue} />
-      </div>
-
-      <div className='account__section-headline'>
-        <button
-          onClick={handleSelectAll}
-          className={mappedType === 'all' ? 'active' : undefined}
-          type='button'
-        >
-          <FormattedMessage id='search_results.all' defaultMessage='All' />
-        </button>
-        <button
-          onClick={handleSelectAccounts}
-          className={mappedType === 'accounts' ? 'active' : undefined}
-          type='button'
-        >
-          <FormattedMessage
-            id='search_results.accounts'
-            defaultMessage='Profiles'
-          />
-        </button>
-        <button
-          onClick={handleSelectHashtags}
-          className={mappedType === 'hashtags' ? 'active' : undefined}
-          type='button'
-        >
-          <FormattedMessage
-            id='search_results.hashtags'
-            defaultMessage='Hashtags'
-          />
-        </button>
-        <button
-          onClick={handleSelectStatuses}
-          className={mappedType === 'statuses' ? 'active' : undefined}
-          type='button'
-        >
-          <FormattedMessage
-            id='search_results.statuses'
-            defaultMessage='Posts'
-          />
-        </button>
-      </div>
 
       <div className='explore__search-results' data-nosnippet>
         <ScrollableList


### PR DESCRIPTION
Fixes WEB-935

### Changes proposed in this PR:
- Makes the search field and tab bar sticky on the search results page

Best reviewed with [white-space changes hidden](https://github.com/mastodon/mastodon/pull/38968/changes?w=1).

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="612" height="362" alt="image" src="https://github.com/user-attachments/assets/d0a9091d-5748-4d73-beea-06a6f9b795a7" /> | <img width="614" height="368" alt="image" src="https://github.com/user-attachments/assets/0c37be04-12f1-4ba1-a975-209520b3f71b" /> |
| <img width="376" height="421" alt="image" src="https://github.com/user-attachments/assets/1a40084c-a884-4077-bd62-0d588d9fda60" /> | <img width="377" height="424" alt="image" src="https://github.com/user-attachments/assets/91d1d88b-0377-47fb-992b-37081a8c7259" /> |