### PR TITLE
[proposal] Add OpenAPI specification with committee-based response assertion

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,4 +1,8 @@
 name: OpenAPI
+
+permissions:
+  contents: read
+
 on:
   merge_group:
   push:

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,45 @@
+name: OpenAPI
+on:
+  merge_group:
+  push:
+    branches:
+      - 'main'
+      - 'stable-*'
+    paths:
+      - 'openapi/**'
+      - 'redocly.yaml'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.nvmrc'
+      - '.github/workflows/openapi.yml'
+
+  pull_request:
+    paths:
+      - 'openapi/**'
+      - 'redocly.yaml'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.nvmrc'
+      - '.github/workflows/openapi.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Javascript environment
+        uses: ./.github/actions/setup-javascript
+
+      - name: Lint OpenAPI specification
+        run: yarn openapi:lint
+
+      - name: Verify bundled OpenAPI artifact is up to date
+        run: |
+          yarn openapi:bundle
+          if ! git diff --exit-code openapi/openapi.json; then
+            echo "::error::openapi/openapi.json is out of date. Run 'yarn openapi:bundle' and commit the result." >&2
+            exit 1
+          fi

--- a/Gemfile
+++ b/Gemfile
@@ -147,6 +147,10 @@ group :test do
   # Validate schemas in specs
   gem 'json-schema', '~> 6.0'
 
+  # Validate API responses against the OpenAPI specification in specs
+  gem 'committee', '~> 5.0'
+  gem 'committee-rails', '~> 0.10'
+
   # Test harness fo rack components
   gem 'rack-test', '~> 2.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,15 @@ GEM
     climate_control (1.2.0)
     cocoon (1.2.15)
     color_diff (0.2)
+    committee (5.6.3)
+      json_schema (~> 0.14, >= 0.14.3)
+      openapi_parser (~> 2.0)
+      rack (>= 1.5)
+    committee-rails (0.10.0)
+      actionpack (>= 6.0)
+      activesupport (>= 6.0)
+      committee (>= 5.1.0)
+      railties (>= 6.0)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     cose (1.3.1)
@@ -377,6 +386,7 @@ GEM
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
+    json_schema (0.21.0)
     jsonapi-renderer (0.2.2)
     jwt (2.10.3)
       base64
@@ -491,6 +501,7 @@ GEM
     omniauth_openid_connect (0.8.0)
       omniauth (>= 1.9, < 3)
       openid_connect (~> 2.2)
+    openapi_parser (2.3.1)
     openid_connect (2.5.0)
       activemodel
       attr_required (>= 1.0.0)
@@ -967,6 +978,8 @@ DEPENDENCIES
   climate_control
   cocoon (~> 1.2)
   color_diff (~> 0.1)
+  committee (~> 5.0)
+  committee-rails (~> 0.10)
   concurrent-ruby
   connection_pool
   csv (~> 3.2)

--- a/openapi/components/schemas/V2Instance.yaml
+++ b/openapi/components/schemas/V2Instance.yaml
@@ -1,0 +1,272 @@
+type: object
+description: Information about the server.
+required:
+  - domain
+  - title
+  - version
+  - source_url
+  - description
+  - usage
+  - thumbnail
+  - icon
+  - languages
+  - configuration
+  - registrations
+  - api_versions
+  - contact
+  - rules
+  - wrapstodon
+properties:
+  domain:
+    type: string
+    description: The domain name of the instance.
+  title:
+    type: string
+    description: The title of the website.
+  version:
+    type: string
+    description: The version of Mastodon installed on the instance.
+  source_url:
+    type: string
+    format: uri
+    description: The URL for the source code of the software running on this instance.
+  description:
+    type: string
+    description: A short, plain-text description of the website.
+  usage:
+    type: object
+    required: [users]
+    properties:
+      users:
+        type: object
+        required: [active_month]
+        properties:
+          active_month:
+            type: integer
+  thumbnail:
+    type: object
+    required: [url]
+    properties:
+      url:
+        type: string
+        format: uri
+      blurhash:
+        type: string
+      versions:
+        type: object
+        properties:
+          '@1x':
+            type: string
+            format: uri
+          '@2x':
+            type: string
+            format: uri
+      description:
+        type: string
+        nullable: true
+  icon:
+    type: array
+    items:
+      type: object
+      required: [src, size]
+      properties:
+        src:
+          type: string
+          format: uri
+        size:
+          type: string
+          example: '36x36'
+  languages:
+    type: array
+    items:
+      type: string
+      description: ISO 639-1 language code.
+  configuration:
+    type: object
+    required:
+      - urls
+      - vapid
+      - accounts
+      - statuses
+      - media_attachments
+      - polls
+      - translation
+      - timelines_access
+      - limited_federation
+    properties:
+      urls:
+        type: object
+        required: [streaming, status, about, privacy_policy, terms_of_service]
+        properties:
+          streaming:
+            type: string
+            format: uri
+          status:
+            type: string
+            format: uri
+            nullable: true
+          about:
+            type: string
+            format: uri
+          privacy_policy:
+            type: string
+            format: uri
+            nullable: true
+          terms_of_service:
+            type: string
+            format: uri
+            nullable: true
+      vapid:
+        type: object
+        required: [public_key]
+        properties:
+          public_key:
+            type: string
+      accounts:
+        type: object
+        required:
+          - max_display_name_length
+          - max_note_length
+          - max_avatar_description_length
+          - max_header_description_length
+          - max_featured_tags
+          - max_pinned_statuses
+          - max_profile_fields
+          - profile_field_name_limit
+          - profile_field_value_limit
+        properties:
+          max_display_name_length: { type: integer }
+          max_note_length: { type: integer }
+          max_avatar_description_length: { type: integer }
+          max_header_description_length: { type: integer }
+          max_featured_tags: { type: integer }
+          max_pinned_statuses: { type: integer }
+          max_profile_fields: { type: integer }
+          profile_field_name_limit: { type: integer }
+          profile_field_value_limit: { type: integer }
+      statuses:
+        type: object
+        required:
+          [max_characters, max_media_attachments, characters_reserved_per_url]
+        properties:
+          max_characters: { type: integer }
+          max_media_attachments: { type: integer }
+          characters_reserved_per_url: { type: integer }
+      media_attachments:
+        type: object
+        required:
+          - description_limit
+          - image_matrix_limit
+          - image_size_limit
+          - supported_mime_types
+          - video_frame_rate_limit
+          - video_matrix_limit
+          - video_size_limit
+        properties:
+          description_limit: { type: integer }
+          image_matrix_limit: { type: integer }
+          image_size_limit: { type: integer }
+          supported_mime_types:
+            type: array
+            items:
+              type: string
+          video_frame_rate_limit: { type: integer }
+          video_matrix_limit: { type: integer }
+          video_size_limit: { type: integer }
+      polls:
+        type: object
+        required:
+          - max_options
+          - max_characters_per_option
+          - min_expiration
+          - max_expiration
+        properties:
+          max_options: { type: integer }
+          max_characters_per_option: { type: integer }
+          min_expiration: { type: integer }
+          max_expiration: { type: integer }
+      translation:
+        type: object
+        required: [enabled]
+        properties:
+          enabled: { type: boolean }
+      timelines_access:
+        type: object
+        required: [live_feeds, hashtag_feeds, trending_link_feeds]
+        properties:
+          live_feeds:
+            type: object
+            required: [local, remote]
+            properties:
+              local:
+                type: string
+                enum: [public, authenticated, disabled]
+              remote:
+                type: string
+                enum: [public, authenticated, disabled]
+          hashtag_feeds:
+            type: object
+            required: [local, remote]
+            properties:
+              local:
+                type: string
+                enum: [public, authenticated]
+              remote:
+                type: string
+                enum: [public, authenticated, disabled]
+          trending_link_feeds:
+            type: object
+            required: [local, remote]
+            properties:
+              local:
+                type: string
+                enum: [public, authenticated]
+              remote:
+                type: string
+                enum: [public, authenticated, disabled]
+      limited_federation:
+        type: boolean
+  registrations:
+    type: object
+    required:
+      [enabled, approval_required, reason_required, message, min_age, url]
+    properties:
+      enabled:
+        type: boolean
+      approval_required:
+        type: boolean
+      reason_required:
+        type: boolean
+      message:
+        type: string
+        nullable: true
+      min_age:
+        type: integer
+        nullable: true
+      url:
+        type: string
+        nullable: true
+  api_versions:
+    type: object
+    description: Per-software API version numbers (e.g. mastodon, mitra).
+    additionalProperties:
+      type: integer
+  contact:
+    type: object
+    required: [email, account]
+    properties:
+      email:
+        type: string
+      account:
+        type: object
+        nullable: true
+        description: The account that can be contacted natively.
+  rules:
+    type: array
+    items:
+      type: object
+      description: A rule that visitors should agree to.
+  wrapstodon:
+    type: integer
+    nullable: true
+    description: Year of the current Wrapstodon (annual report) campaign, if active.

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,0 +1,22 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Mastodon API",
+    "version": "4.6.0-alpha",
+    "description": "Machine-readable specification of the Mastodon REST API.\n\nThis document is a work in progress and currently covers a small subset\nof endpoints. Coverage will expand incrementally.\n",
+    "license": {
+      "name": "AGPL-3.0-or-later",
+      "url": "https://www.gnu.org/licenses/agpl-3.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://mastodon.example",
+      "description": "A Mastodon server"
+    }
+  ],
+  "paths": {},
+  "components": {
+    "schemas": {}
+  }
+}

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -15,8 +15,457 @@
       "description": "A Mastodon server"
     }
   ],
-  "paths": {},
+  "paths": {
+    "/api/v2/instance": {
+      "get": {
+        "operationId": "getInstanceV2",
+        "summary": "View server information (V2)",
+        "description": "Obtain general information about the server.\n",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Server information.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2Instance"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "components": {
-    "schemas": {}
+    "schemas": {
+      "V2Instance": {
+        "type": "object",
+        "description": "Information about the server.",
+        "required": [
+          "domain",
+          "title",
+          "version",
+          "source_url",
+          "description",
+          "usage",
+          "thumbnail",
+          "icon",
+          "languages",
+          "configuration",
+          "registrations",
+          "api_versions",
+          "contact",
+          "rules",
+          "wrapstodon"
+        ],
+        "properties": {
+          "domain": {
+            "type": "string",
+            "description": "The domain name of the instance."
+          },
+          "title": {
+            "type": "string",
+            "description": "The title of the website."
+          },
+          "version": {
+            "type": "string",
+            "description": "The version of Mastodon installed on the instance."
+          },
+          "source_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL for the source code of the software running on this instance."
+          },
+          "description": {
+            "type": "string",
+            "description": "A short, plain-text description of the website."
+          },
+          "usage": {
+            "type": "object",
+            "required": ["users"],
+            "properties": {
+              "users": {
+                "type": "object",
+                "required": ["active_month"],
+                "properties": {
+                  "active_month": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          "thumbnail": {
+            "type": "object",
+            "required": ["url"],
+            "properties": {
+              "url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "blurhash": {
+                "type": "string"
+              },
+              "versions": {
+                "type": "object",
+                "properties": {
+                  "@1x": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "@2x": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              },
+              "description": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "icon": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["src", "size"],
+              "properties": {
+                "src": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "size": {
+                  "type": "string",
+                  "example": "36x36"
+                }
+              }
+            }
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "ISO 639-1 language code."
+            }
+          },
+          "configuration": {
+            "type": "object",
+            "required": [
+              "urls",
+              "vapid",
+              "accounts",
+              "statuses",
+              "media_attachments",
+              "polls",
+              "translation",
+              "timelines_access",
+              "limited_federation"
+            ],
+            "properties": {
+              "urls": {
+                "type": "object",
+                "required": [
+                  "streaming",
+                  "status",
+                  "about",
+                  "privacy_policy",
+                  "terms_of_service"
+                ],
+                "properties": {
+                  "streaming": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "status": {
+                    "type": "string",
+                    "format": "uri",
+                    "nullable": true
+                  },
+                  "about": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "privacy_policy": {
+                    "type": "string",
+                    "format": "uri",
+                    "nullable": true
+                  },
+                  "terms_of_service": {
+                    "type": "string",
+                    "format": "uri",
+                    "nullable": true
+                  }
+                }
+              },
+              "vapid": {
+                "type": "object",
+                "required": ["public_key"],
+                "properties": {
+                  "public_key": {
+                    "type": "string"
+                  }
+                }
+              },
+              "accounts": {
+                "type": "object",
+                "required": [
+                  "max_display_name_length",
+                  "max_note_length",
+                  "max_avatar_description_length",
+                  "max_header_description_length",
+                  "max_featured_tags",
+                  "max_pinned_statuses",
+                  "max_profile_fields",
+                  "profile_field_name_limit",
+                  "profile_field_value_limit"
+                ],
+                "properties": {
+                  "max_display_name_length": {
+                    "type": "integer"
+                  },
+                  "max_note_length": {
+                    "type": "integer"
+                  },
+                  "max_avatar_description_length": {
+                    "type": "integer"
+                  },
+                  "max_header_description_length": {
+                    "type": "integer"
+                  },
+                  "max_featured_tags": {
+                    "type": "integer"
+                  },
+                  "max_pinned_statuses": {
+                    "type": "integer"
+                  },
+                  "max_profile_fields": {
+                    "type": "integer"
+                  },
+                  "profile_field_name_limit": {
+                    "type": "integer"
+                  },
+                  "profile_field_value_limit": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "statuses": {
+                "type": "object",
+                "required": [
+                  "max_characters",
+                  "max_media_attachments",
+                  "characters_reserved_per_url"
+                ],
+                "properties": {
+                  "max_characters": {
+                    "type": "integer"
+                  },
+                  "max_media_attachments": {
+                    "type": "integer"
+                  },
+                  "characters_reserved_per_url": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "media_attachments": {
+                "type": "object",
+                "required": [
+                  "description_limit",
+                  "image_matrix_limit",
+                  "image_size_limit",
+                  "supported_mime_types",
+                  "video_frame_rate_limit",
+                  "video_matrix_limit",
+                  "video_size_limit"
+                ],
+                "properties": {
+                  "description_limit": {
+                    "type": "integer"
+                  },
+                  "image_matrix_limit": {
+                    "type": "integer"
+                  },
+                  "image_size_limit": {
+                    "type": "integer"
+                  },
+                  "supported_mime_types": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "video_frame_rate_limit": {
+                    "type": "integer"
+                  },
+                  "video_matrix_limit": {
+                    "type": "integer"
+                  },
+                  "video_size_limit": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "polls": {
+                "type": "object",
+                "required": [
+                  "max_options",
+                  "max_characters_per_option",
+                  "min_expiration",
+                  "max_expiration"
+                ],
+                "properties": {
+                  "max_options": {
+                    "type": "integer"
+                  },
+                  "max_characters_per_option": {
+                    "type": "integer"
+                  },
+                  "min_expiration": {
+                    "type": "integer"
+                  },
+                  "max_expiration": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "translation": {
+                "type": "object",
+                "required": ["enabled"],
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "timelines_access": {
+                "type": "object",
+                "required": [
+                  "live_feeds",
+                  "hashtag_feeds",
+                  "trending_link_feeds"
+                ],
+                "properties": {
+                  "live_feeds": {
+                    "type": "object",
+                    "required": ["local", "remote"],
+                    "properties": {
+                      "local": {
+                        "type": "string",
+                        "enum": ["public", "authenticated", "disabled"]
+                      },
+                      "remote": {
+                        "type": "string",
+                        "enum": ["public", "authenticated", "disabled"]
+                      }
+                    }
+                  },
+                  "hashtag_feeds": {
+                    "type": "object",
+                    "required": ["local", "remote"],
+                    "properties": {
+                      "local": {
+                        "type": "string",
+                        "enum": ["public", "authenticated"]
+                      },
+                      "remote": {
+                        "type": "string",
+                        "enum": ["public", "authenticated", "disabled"]
+                      }
+                    }
+                  },
+                  "trending_link_feeds": {
+                    "type": "object",
+                    "required": ["local", "remote"],
+                    "properties": {
+                      "local": {
+                        "type": "string",
+                        "enum": ["public", "authenticated"]
+                      },
+                      "remote": {
+                        "type": "string",
+                        "enum": ["public", "authenticated", "disabled"]
+                      }
+                    }
+                  }
+                }
+              },
+              "limited_federation": {
+                "type": "boolean"
+              }
+            }
+          },
+          "registrations": {
+            "type": "object",
+            "required": [
+              "enabled",
+              "approval_required",
+              "reason_required",
+              "message",
+              "min_age",
+              "url"
+            ],
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "approval_required": {
+                "type": "boolean"
+              },
+              "reason_required": {
+                "type": "boolean"
+              },
+              "message": {
+                "type": "string",
+                "nullable": true
+              },
+              "min_age": {
+                "type": "integer",
+                "nullable": true
+              },
+              "url": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "api_versions": {
+            "type": "object",
+            "description": "Per-software API version numbers (e.g. mastodon, mitra).",
+            "additionalProperties": {
+              "type": "integer"
+            }
+          },
+          "contact": {
+            "type": "object",
+            "required": ["email", "account"],
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "account": {
+                "type": "object",
+                "nullable": true,
+                "description": "The account that can be contacted natively."
+              }
+            }
+          },
+          "rules": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "A rule that visitors should agree to."
+            }
+          },
+          "wrapstodon": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Year of the current Wrapstodon (annual report) campaign, if active."
+          }
+        }
+      }
+    }
   }
 }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: Mastodon API
+  version: 4.6.0-alpha
+  description: |
+    Machine-readable specification of the Mastodon REST API.
+
+    This document is a work in progress and currently covers a small subset
+    of endpoints. Coverage will expand incrementally.
+  license:
+    name: AGPL-3.0-or-later
+    url: https://www.gnu.org/licenses/agpl-3.0.html
+servers:
+  - url: https://mastodon.example
+    description: A Mastodon server
+paths: {}
+components:
+  schemas: {}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -13,6 +13,10 @@ info:
 servers:
   - url: https://mastodon.example
     description: A Mastodon server
-paths: {}
+paths:
+  /api/v2/instance:
+    $ref: 'paths/api/v2/instance.yaml'
 components:
-  schemas: {}
+  schemas:
+    V2Instance:
+      $ref: 'components/schemas/V2Instance.yaml'

--- a/openapi/paths/api/v2/instance.yaml
+++ b/openapi/paths/api/v2/instance.yaml
@@ -1,0 +1,13 @@
+get:
+  operationId: getInstanceV2
+  summary: View server information (V2)
+  description: |
+    Obtain general information about the server.
+  security: []
+  responses:
+    '200':
+      description: Server information.
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/V2Instance.yaml'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "lint:js": "cd $INIT_CWD && eslint --cache --report-unused-disable-directives",
     "lint:css": "stylelint \"**/*.{css,scss}\"",
     "lint": "yarn lint:js && yarn lint:css",
+    "openapi:lint": "redocly lint main",
+    "openapi:bundle": "redocly bundle main -o openapi/openapi.json && oxfmt openapi/openapi.json",
     "postversion": "git push --tags",
     "postinstall": "test -d node_modules/husky && husky || echo \"husky is not installed\"",
     "start": "node ./streaming/index.js",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@formatjs/cli": "^6.1.1",
+    "@redocly/cli": "^2.37.0",
     "@storybook/addon-a11y": "^10.3.0",
     "@storybook/addon-docs": "^10.3.0",
     "@storybook/addon-vitest": "^10.3.0",

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,6 @@
+extends:
+  - recommended
+
+apis:
+  main:
+    root: openapi/openapi.yaml

--- a/spec/requests/api/v2/instance_spec.rb
+++ b/spec/requests/api/v2/instance_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'Instances' do
           .and include(title: 'Mastodon')
           .and include_api_versions
           .and include_configuration_limits
+
+        assert_schema_conform(200)
       end
     end
 
@@ -39,6 +41,8 @@ RSpec.describe 'Instances' do
           .and include(title: 'Mastodon')
           .and include_api_versions
           .and include_configuration_limits
+
+        assert_schema_conform(200)
       end
     end
 
@@ -59,6 +63,8 @@ RSpec.describe 'Instances' do
         expect(response.parsed_body)
           .to be_present
           .and include(wrapstodon: 2025)
+
+        assert_schema_conform(200)
       end
     end
 

--- a/spec/support/committee.rb
+++ b/spec/support/committee.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'committee'
+require 'committee/rails/test/methods'
+
+RSpec.configure do |config|
+  config.include Committee::Rails::Test::Methods
+  config.add_setting :committee_options
+  config.committee_options = {
+    schema_path: Rails.root.join('openapi', 'openapi.json').to_s,
+    query_hash_key: 'rack.request.query_hash',
+    parse_response_by_content_type: true,
+    strict_reference_validation: true,
+  }
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2935,6 +2935,7 @@ __metadata:
     "@github/webauthn-json": "npm:^2.1.1"
     "@optimize-lodash/rollup-plugin": "npm:^6.0.0"
     "@react-spring/web": "npm:^10.1.1"
+    "@redocly/cli": "npm:^2.37.0"
     "@reduxjs/toolkit": "npm:^2.0.1"
     "@rolldown/plugin-babel": "npm:^0.2.2"
     "@storybook/addon-a11y": "npm:^10.3.0"
@@ -3930,6 +3931,16 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 10c0/e6f518ba53ec87fe542876e6c7662170672f4890f72d186f0aef42ade503cafd2e69fe6a50aacb8a9747b9b310b49a72da86c74cd269c2ee3955c2d4f825df8e
+  languageName: node
+  linkType: hard
+
+"@redocly/cli@npm:^2.37.0":
+  version: 2.37.0
+  resolution: "@redocly/cli@npm:2.37.0"
+  bin:
+    openapi: bin/cli.js
+    redocly: bin/cli.js
+  checksum: 10c0/b1712f0e2ec91c9efb0e5fbfc14cdd8547169395bae491d096c0fd7b79b52056411768df4e76226aa72229ce35cad904f49d9baceb0bebae1e9e5d10e9272d93
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR is a re-implementation of https://github.com/mastodon/mastodon/pull/25043 .

## Scope
- Adds an OpenAPI 3.0.3 specification at `openapi/openapi.yaml`
  (3.0.3 chosen for committee compatibility).
- Currently covers only `GET /api/v2/instance`.
- Adds the `committee` gem to assert API responses against the
  OpenAPI specification in request specs.

## diffs from #25043
- More features are next or later PRs.
  - more API specifications
  - generated TypeScript types
- Tooling: Use redocly instead of openapi-generator.
  - by this, no need java runtime.