### PR TITLE
spec: Improve branch coverage for StatusPin model

### DIFF
--- a/spec/models/status_pin_spec.rb
+++ b/spec/models/status_pin_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe StatusPin do
     describe 'Invalidating status via policy' do
       subject { Fabricate :status_pin, status: Fabricate(:status, account: account), account: account }
 
-      context 'with a local account that owns the status and has a policy' do
-        let(:account) { Fabricate :account, domain: nil }
+      let(:account) { Fabricate(:account, domain: nil) }
 
+      context 'with a local account that owns the status and has a policy' do
         before do
           Fabricate :account_statuses_cleanup_policy, account: account
           account.statuses_cleanup_policy.record_last_inspected(subject.status.id + 1_024)
@@ -82,26 +82,63 @@ RSpec.describe StatusPin do
       end
 
       context 'with a local account that owns the status and does not have a policy' do
-        let(:account) { Fabricate :account, domain: nil }
-
         it 'does not call the invalidator on destroy' do
           expect { subject.destroy }
             .to_not change(account, :updated_at)
         end
       end
 
+      context 'when the status belongs to another account' do
+        subject(:status_pin) do
+          described_class.new(
+            account: account,
+            status: Fabricate(:status)
+          )
+        end
+
+        let(:policy) { instance_spy(AccountStatusesCleanupPolicy) }
+
+        before do
+          status_pin.save(validate: false)
+          allow(AccountStatusesCleanupPolicy)
+            .to receive(:new)
+            .and_return(policy)
+        end
+
+        it 'does not invalidate last inspected on destroy' do
+          expect(status_pin.status.account_id).to_not eq(account.id)
+
+          expect { status_pin.destroy }.to_not raise_error
+
+          expect(policy)
+            .to_not have_received(:invalidate_last_inspected)
+        end
+      end
+
       context 'when the status is missing during destruction' do
-        subject { Fabricate(:status_pin, account: account) }
+        subject(:status_pin) do
+          Fabricate(:status_pin, account: account, status: status)
+        end
 
-        let(:account) { Fabricate :account, domain: nil }
+        let(:status) { Fabricate(:status, account: account) }
+        let(:policy) { instance_spy(AccountStatusesCleanupPolicy) }
 
-        it 'does not call the invalidator on destroy' do
-          allow(subject).to receive(:status).and_return(nil)
+        before do
+          allow(AccountStatusesCleanupPolicy)
+            .to receive(:new)
+            .and_return(policy)
+        end
 
-          expect_any_instance_of(AccountStatusesCleanupPolicy)
-            .to_not receive(:invalidate_last_inspected)
+        it 'does not invalidate last inspected on destroy' do
+          status_pin.id
 
-          subject.destroy
+          status.destroy!
+          status_pin.association(:status).reset
+
+          expect { status_pin.destroy }.to_not raise_error
+
+          expect(policy)
+            .to_not have_received(:invalidate_last_inspected)
         end
       end
 

--- a/spec/models/status_pin_spec.rb
+++ b/spec/models/status_pin_spec.rb
@@ -100,4 +100,24 @@ RSpec.describe StatusPin do
       end
     end
   end
+
+  describe 'Private methods' do
+    describe '#account_matches_status_account?' do
+      let(:account) { Fabricate(:account) }
+
+      it 'returns false when the status belongs to a different account' do
+        other_status = Fabricate(:status, account: Fabricate(:account))
+
+        status_pin = described_class.new(account: account, status: other_status)
+
+        expect(status_pin.send(:account_matches_status_account?)).to be false
+      end
+
+      it 'returns false when status is nil' do
+        status_pin = described_class.new(account: account, status: nil)
+
+        expect(status_pin.send(:account_matches_status_account?)).to be false
+      end
+    end
+  end
 end

--- a/spec/models/status_pin_spec.rb
+++ b/spec/models/status_pin_spec.rb
@@ -90,6 +90,21 @@ RSpec.describe StatusPin do
         end
       end
 
+      context 'when the status is missing during destruction' do
+        subject { Fabricate(:status_pin, account: account) }
+
+        let(:account) { Fabricate :account, domain: nil }
+
+        it 'does not call the invalidator on destroy' do
+          allow(subject).to receive(:status).and_return(nil)
+
+          expect_any_instance_of(AccountStatusesCleanupPolicy)
+            .to_not receive(:invalidate_last_inspected)
+
+          subject.destroy
+        end
+      end
+
       context 'with a remote account' do
         let(:account) { Fabricate :account, domain: 'host.example' }
 
@@ -97,26 +112,6 @@ RSpec.describe StatusPin do
           expect { subject.destroy }
             .to_not change(account, :updated_at)
         end
-      end
-    end
-  end
-
-  describe 'Private methods' do
-    describe '#account_matches_status_account?' do
-      let(:account) { Fabricate(:account) }
-
-      it 'returns false when the status belongs to a different account' do
-        other_status = Fabricate(:status, account: Fabricate(:account))
-
-        status_pin = described_class.new(account: account, status: other_status)
-
-        expect(status_pin.send(:account_matches_status_account?)).to be false
-      end
-
-      it 'returns false when status is nil' do
-        status_pin = described_class.new(account: account, status: nil)
-
-        expect(status_pin.send(:account_matches_status_account?)).to be false
       end
     end
   end


### PR DESCRIPTION
This PR brings the StatusPin model to 100% line and branch coverage.

While the model had existing tests, they focused on valid state persistence. I have added targeted specs to exercise the failure branches within the private guard methods.