### PR TITLE
spec: improve Web::PushSubscription branch coverage

### DIFF
--- a/spec/models/web/push_subscription_spec.rb
+++ b/spec/models/web/push_subscription_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe Web::PushSubscription do
       let(:policy) { 'all' }
 
       it 'returns true' do
-        # Predicate matcher syntax automatically delegates to `pushable?`
         expect(subject).to be_pushable(notification)
       end
     end
@@ -50,7 +49,6 @@ RSpec.describe Web::PushSubscription do
       let(:policy) { 'none' }
 
       it 'returns false' do
-        # Predicate matcher syntax automatically delegates to `pushable?`
         expect(subject).to_not be_pushable(notification)
       end
     end
@@ -129,7 +127,6 @@ RSpec.describe Web::PushSubscription do
       let(:policy) { 'unknown' }
 
       it 'returns a falsey value' do
-        # Predicate matcher syntax automatically delegates to `pushable?`
         expect(subject).to_not be_pushable(notification)
       end
     end
@@ -142,7 +139,7 @@ RSpec.describe Web::PushSubscription do
   describe '.unsubscribe_for' do
     let(:application) { Fabricate(:application) }
     let(:user) { Fabricate(:user, account: account) }
-    let(:subscription) do
+    let!(:subscription) do
       Fabricate(
         :web_push_subscription,
         user: user,
@@ -158,14 +155,11 @@ RSpec.describe Web::PushSubscription do
       )
     end
 
-    before do
-      subscription
-    end
-
     it 'removes subscriptions for matching application and resource owner' do
       expect do
         described_class.unsubscribe_for(application.id, user)
       end.to change(described_class, :count).by(-1)
+      expect { subscription.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/models/web/push_subscription_spec.rb
+++ b/spec/models/web/push_subscription_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe Web::PushSubscription do
       let(:policy) { 'all' }
 
       it 'returns true' do
-        expect(subject.pushable?(notification)).to be true
+        # Predicate matcher syntax automatically delegates to `pushable?`
+        expect(subject).to be_pushable(notification)
       end
     end
 
@@ -49,7 +50,8 @@ RSpec.describe Web::PushSubscription do
       let(:policy) { 'none' }
 
       it 'returns false' do
-        expect(subject.pushable?(notification)).to be false
+        # Predicate matcher syntax automatically delegates to `pushable?`
+        expect(subject).to_not be_pushable(notification)
       end
     end
 
@@ -62,13 +64,13 @@ RSpec.describe Web::PushSubscription do
         end
 
         it 'returns true' do
-          expect(subject.pushable?(notification)).to be true
+          expect(subject).to be_pushable(notification)
         end
       end
 
       context 'when notification is not from someone you follow' do
         it 'returns false' do
-          expect(subject.pushable?(notification)).to be false
+          expect(subject).to_not be_pushable(notification)
         end
       end
     end
@@ -82,19 +84,88 @@ RSpec.describe Web::PushSubscription do
         end
 
         it 'returns true' do
-          expect(subject.pushable?(notification)).to be true
+          expect(subject).to be_pushable(notification)
         end
       end
 
       context 'when notification is not from someone who follows you' do
         it 'returns false' do
-          expect(subject.pushable?(notification)).to be false
+          expect(subject).to_not be_pushable(notification)
         end
+      end
+    end
+
+    context 'when alerts configuration is missing' do
+      let(:data) { nil }
+
+      it 'returns false' do
+        expect(subject).to_not be_pushable(notification)
+      end
+    end
+
+    context 'when notification type is not configured in alerts' do
+      let(:notification_type) { :poll }
+
+      it 'returns false' do
+        expect(subject).to_not be_pushable(notification)
+      end
+    end
+
+    context 'when policy is missing' do
+      let(:data) do
+        {
+          alerts: {
+            mention: true,
+          },
+        }
+      end
+
+      it 'returns true' do
+        expect(subject).to be_pushable(notification)
+      end
+    end
+
+    context 'when policy is unknown' do
+      let(:policy) { 'unknown' }
+
+      it 'returns a falsey value' do
+        # Predicate matcher syntax automatically delegates to `pushable?`
+        expect(subject).to_not be_pushable(notification)
       end
     end
   end
 
   describe 'Delegations' do
     it { is_expected.to delegate_method(:token).to(:access_token).with_prefix(:associated_access) }
+  end
+
+  describe '.unsubscribe_for' do
+    let(:application) { Fabricate(:application) }
+    let(:user) { Fabricate(:user, account: account) }
+    let(:subscription) do
+      Fabricate(
+        :web_push_subscription,
+        user: user,
+        access_token: access_token
+      )
+    end
+
+    let(:access_token) do
+      Fabricate(
+        :accessible_access_token,
+        application: application,
+        resource_owner_id: user.id
+      )
+    end
+
+    before do
+      subscription
+    end
+
+    it 'removes subscriptions for matching application and resource owner' do
+      expect do
+        described_class.unsubscribe_for(application.id, user)
+      end.to change(described_class, :count).by(-1)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Improves test coverage for `Web::PushSubscription` by adding specs for previously unexercised branches and class-level behavior.

## Changes

* Added edge case coverage for:

  * missing alerts configuration
  * unknown notification types
  * missing policy configuration
  * unknown policy values
* Added coverage for `.unsubscribe_for`
* Updated predicate expectations to use idiomatic RSpec matcher syntax (`be_pushable`)
* Improved branch coverage without changing application behavior

## Result

Brings the model closer to full line and branch coverage while keeping specs behavior-focused and aligned with RSpec style conventions.
