### PR TITLE
fix: restore default color scheme and contrast in admin appearance

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -16,6 +16,8 @@ class Form::AdminSettings
     closed_registrations_message
     bootstrap_timeline_accounts
     theme
+    default_color_scheme
+    default_contrast
     activity_api_enabled
     peers_api_enabled
     preview_sensitive_media

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -38,8 +38,8 @@ class UserSettings
     setting :display_media, default: 'default', in: %w(hide_all default show_all)
     setting :auto_play, default: false
     setting :emoji_style, default: 'auto', in: %w(auto native twemoji)
-    setting :color_scheme, default: 'auto', in: %w(auto light dark)
-    setting :contrast, default: 'auto', in: %w(auto high)
+    setting :color_scheme, default: -> { ::Setting.default_color_scheme || 'auto' }, in: %w(auto light dark)
+    setting :contrast, default: -> { ::Setting.default_contrast || 'auto' }, in: %w(auto high)
   end
 
   namespace :notification_emails do

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -38,8 +38,8 @@ class UserSettings
     setting :display_media, default: 'default', in: %w(hide_all default show_all)
     setting :auto_play, default: false
     setting :emoji_style, default: 'auto', in: %w(auto native twemoji)
-    setting :color_scheme, default: -> { ::Setting.default_color_scheme || 'auto' }, in: %w(auto light dark)
-    setting :contrast, default: -> { ::Setting.default_contrast || 'auto' }, in: %w(auto high)
+    setting :color_scheme, default: -> { ::Setting.default_color_scheme }, in: %w(auto light dark)
+    setting :contrast, default: -> { ::Setting.default_contrast }, in: %w(auto high)
   end
 
   namespace :notification_emails do

--- a/app/views/admin/settings/appearance/show.html.haml
+++ b/app/views/admin/settings/appearance/show.html.haml
@@ -21,7 +21,7 @@
   .fields-group
     = f.input :default_color_scheme,
               as: :radio_buttons,
-              collection: %w(auto light dark),
+              collection: UserSettings.definition_for('color_scheme')&.in,
               include_blank: false,
               label_method: ->(color_scheme) { I18n.t("color_scheme.#{color_scheme}", default: color_scheme) },
               wrapper: :with_label
@@ -29,7 +29,7 @@
   .fields-group
     = f.input :default_contrast,
               as: :radio_buttons,
-              collection: %w(auto high),
+              collection: UserSettings.definition_for('contrast')&.in,
               include_blank: false,
               label_method: ->(contrast) { I18n.t("contrast.#{contrast}", default: contrast) },
               wrapper: :with_label

--- a/app/views/admin/settings/appearance/show.html.haml
+++ b/app/views/admin/settings/appearance/show.html.haml
@@ -10,11 +10,28 @@
 
   %p.lead= t('admin.settings.appearance.preamble')
 
+  - if Themes.instance.names.size > 1
+    .fields-group
+      = f.input :theme,
+                collection: Themes.instance.names,
+                include_blank: false,
+                label_method: ->(theme) { I18n.t("themes.#{theme}", default: theme) },
+                wrapper: :with_label
+
   .fields-group
-    = f.input :theme,
-              collection: Themes.instance.names,
+    = f.input :default_color_scheme,
+              as: :radio_buttons,
+              collection: %w(auto light dark),
               include_blank: false,
-              label_method: ->(theme) { I18n.t("themes.#{theme}", default: theme) },
+              label_method: ->(color_scheme) { I18n.t("color_scheme.#{color_scheme}", default: color_scheme) },
+              wrapper: :with_label
+
+  .fields-group
+    = f.input :default_contrast,
+              as: :radio_buttons,
+              collection: %w(auto high),
+              include_blank: false,
+              label_method: ->(contrast) { I18n.t("contrast.#{contrast}", default: contrast) },
               wrapper: :with_label
 
   .fields-group

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -109,6 +109,8 @@ en:
         site_title: How people may refer to your server besides its domain name.
         status_page_url: URL of a page where people can see the status of this server during an outage
         theme: Theme that logged out visitors and new users see.
+        default_color_scheme: Default color scheme for users who have not set a custom preference.
+        default_contrast: Default contrast level for users who have not set a custom preference.
         thumbnail: A roughly 2:1 image displayed alongside your server information.
         thumbnail_description: A description of the image to help people with visual impairments understand its content.
         trendable_by_default: Skip manual review of trending content. Individual items can still be removed from trends after the fact.
@@ -319,6 +321,8 @@ en:
         site_title: Server name
         status_page_url: Status page URL
         theme: Default theme
+        default_color_scheme: Default color scheme
+        default_contrast: Default contrast
         thumbnail: Server thumbnail
         thumbnail_description: Thumbnail alt text
         trendable_by_default: Allow trends without prior review

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,6 +20,8 @@ defaults: &defaults
   preview_sensitive_media: false
   noindex: false
   theme: 'default'
+  default_color_scheme: 'auto'
+  default_contrast: 'auto'
   thumbnail_description: ''
   trends: true
   trendable_by_default: false


### PR DESCRIPTION
## Problem

After PR #37612 migrated the theming infrastructure from a theme-based system (mastodon-light, contrast, system) to a color-scheme + contrast system, the admin appearance settings page (/admin/settings/appearance) was not updated. It only showed the default theme selector but was missing the default color scheme and contrast selectors that admins need to configure instance-wide defaults.

## Solution

This PR adds the missing default color scheme and contrast settings to the admin appearance page:

1. **Added new instance-wide settings** (`default_color_scheme`, `default_contrast`) to `config/settings.yml` with defaults of `"auto"`
2. **Added these keys to `Form::AdminSettings::KEYS`** so they can be saved through the admin form
3. **Added color scheme and contrast selectors** to the admin appearance view (`app/views/admin/settings/appearance/show.html.haml`) as radio buttons, matching the same options available in user preferences (auto/light/dark for color scheme, auto/high for contrast)
4. **Updated `UserSettings`** to reference the instance-level settings as defaults for `color_scheme` and `contrast`, instead of hardcoded `"auto"` values — consistent with how `theme` already works
5. **Added locale labels and hints** in `simple_form.en.yml` for the new admin form fields
6. **Made the theme selector conditional** (only shown when `Themes.instance.names.size > 1`), consistent with user preferences

## Before

The admin appearance page only showed:
- Default theme (even though only one theme exists now)

## After

The admin appearance page now shows:
- Default theme (only if multiple themes exist)
- Default color scheme (Auto / Light / Dark)
- Default contrast (Auto / High)

Fixes #38979