### PR TITLE
Narrow scope of Docker build cache in Github workflows

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -87,8 +87,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           provenance: false
           push: ${{ inputs.push_to_images != '' }}
-          cache-from: ${{ inputs.cache && 'type=gha' || '' }}
-          cache-to: ${{ inputs.cache && 'type=gha,mode=max' || '' }}
+          cache-from: ${{ inputs.cache && format('type=gha,scope=build-{0}-{1}', hashFiles(inputs.file_to_build), env.PLATFORM_PAIR) || '' }}
+          cache-to: ${{ inputs.cache && format('type=gha,mode=max,scope=build-{0}-{1}', hashFiles(inputs.file_to_build), env.PLATFORM_PAIR) || '' }}
           outputs: type=image,"name=${{ env.IMAGE_NAMES }}",push-by-digest=true,name-canonical=true,push=${{ inputs.push_to_images != '' }}
 
       - name: Export digest


### PR DESCRIPTION
The `build-container-image.yml` workflow runs the image builds for linux/amd64, linux/arm64 and is invoked twice in parallel — once for `Dockerfile`, once for `streaming/Dockerfile`. That's four jobs writing to the GitHub Actions cache simultaneously. This workflow cache configuration is then inherited by other build jobs which do not explicitly disable caching (nightly and release builds) across every commit.

Per https://docs.docker.com/build/cache/backends/gha/

> Scope is a key used to identify the cache object. By default, it is set to buildkit. If you build multiple images, each build will overwrite the cache of the previous, leaving only the final cache.
> 
> To preserve the cache for multiple builds, you can specify this scope attribute with a specific name. In the following example, the cache is set to the image name, to ensure each image gets its own cache

This PR adds `scope=` to the `cache-from` and `cache-to` parameters in `build-container-image.yml`, keyed on the Dockerfile content hash and the target platform.

The 10GB overall limit of the `gha` cache still applies.