### PR TITLE
Remove flatware config block, re-extract simplecov config to standalone file

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+SimpleCov.start 'rails' do
+  # During parallel runs, ensure unique names for post-run merge
+  command_name "job-#{ENV['TEST_ENV_NUMBER']}" if ENV['TEST_ENV_NUMBER']
+
+  if ENV['CI']
+    require 'simplecov-lcov'
+    formatter SimpleCov::Formatter::LcovFormatter
+    formatter.config.report_with_single_file = true
+  else
+    formatter SimpleCov::Formatter::HTMLFormatter
+  end
+
+  enable_coverage :branch
+
+  add_filter 'lib/linter'
+
+  add_group 'Libraries', 'lib'
+  add_group 'Policies', 'app/policies'
+  add_group 'Presenters', 'app/presenters'
+  add_group 'Search', 'app/chewy'
+  add_group 'Serializers', 'app/serializers'
+  add_group 'Services', 'app/services'
+  add_group 'Validators', 'app/validators'
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,34 +2,7 @@
 
 ENV['RAILS_ENV'] ||= 'test'
 
-if ENV.fetch('COVERAGE', false)
-  require 'simplecov'
-
-  SimpleCov.start 'rails' do
-    # During parallel runs, ensure unique names for post-run merge
-    command_name "job-#{ENV['TEST_ENV_NUMBER']}" if ENV['TEST_ENV_NUMBER']
-
-    if ENV['CI']
-      require 'simplecov-lcov'
-      formatter SimpleCov::Formatter::LcovFormatter
-      formatter.config.report_with_single_file = true
-    else
-      formatter SimpleCov::Formatter::HTMLFormatter
-    end
-
-    enable_coverage :branch
-
-    add_filter 'lib/linter'
-
-    add_group 'Libraries', 'lib'
-    add_group 'Policies', 'app/policies'
-    add_group 'Presenters', 'app/presenters'
-    add_group 'Search', 'app/chewy'
-    add_group 'Serializers', 'app/serializers'
-    add_group 'Services', 'app/services'
-    add_group 'Validators', 'app/validators'
-  end
-end
+require 'simplecov' if ENV.fetch('COVERAGE', false)
 
 # This needs to be defined before Rails is initialized
 STREAMING_PORT = ENV.fetch('TEST_STREAMING_PORT', '4020')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,12 +29,6 @@ if ENV.fetch('COVERAGE', false)
     add_group 'Services', 'app/services'
     add_group 'Validators', 'app/validators'
   end
-
-  if defined?(Flatware)
-    Flatware.configure do |config|
-      config.after_fork { |test| SimpleCov.at_fork.call(test) } # Combines parallel coverage results
-    end
-  end
 end
 
 # This needs to be defined before Rails is initialized


### PR DESCRIPTION
Followup on https://github.com/mastodon/mastodon/pull/38944 and more prep for simplecov 1.0.

Two changes here:

- Entirely remove the inline `Flatware.configure` block here. I've confirmed that the same results are reported (as long as `command_name ...` is present) both with and without this block. I think the configuration prior to the last PR (with separate requires of simplecov and without `command_name` did require this, but with those changed now we can drop it as well.
- With that done, we can also (re-)extract the simplecov config to standalone file. We previously had this setup in place, but because of these load order issues, returned it to rails helper in https://github.com/mastodon/mastodon/pull/30302

I have a WIP/tracking branch for simplecov main, and checked that this also preserves coverage values in that branch as well, so this should survive that upgrade.

As with the last one -- this is both ready as-is, but could also sit around as simplecov 1.0 tracking branch if preferred.