### PR TITLE
Update codecov-action to v6

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: matrix.ruby-version == '.ruby-version'
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           files: coverage/lcov/*.lcov
         env:


### PR DESCRIPTION
Noticed a node 20 deprecation warning on unrelated job - https://github.com/mastodon/mastodon/actions/runs/25749662112 - which I think is coming from an older `actions/github-script` which is upgraded by this codecov-action bump.