### PR TITLE
Use the same condition for stale refresh

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -265,8 +265,14 @@ class Account < ApplicationRecord
     last_webfingered_at.nil? || last_webfingered_at <= STALE_THRESHOLD.ago
   end
 
+  def needs_background_refresh?
+    return false if local?
+
+    last_webfingered_at.blank? || last_webfingered_at <= BACKGROUND_REFRESH_INTERVAL.ago
+  end
+
   def schedule_refresh_if_stale!
-    return unless last_webfingered_at.present? && last_webfingered_at <= BACKGROUND_REFRESH_INTERVAL.ago
+    return unless needs_background_refresh?
 
     AccountRefreshWorker.perform_in(rand(REFRESH_DEADLINE), id)
   end

--- a/app/workers/account_refresh_worker.rb
+++ b/app/workers/account_refresh_worker.rb
@@ -7,7 +7,7 @@ class AccountRefreshWorker
 
   def perform(account_id)
     account = Account.find_by(id: account_id)
-    return if account.nil? || account.last_webfingered_at > Account::BACKGROUND_REFRESH_INTERVAL.ago
+    return unless account&.needs_background_refresh?
 
     ResolveAccountService.new.call(account)
   end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -840,4 +840,36 @@ RSpec.describe Account do
       end
     end
   end
+
+  describe '#needs_background_refresh?' do
+    subject { account.needs_background_refresh? }
+
+    context 'when account is local' do
+      let(:account) { Fabricate(:account) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when account is remote' do
+      let(:account) { Fabricate(:remote_account, last_webfingered_at:) }
+
+      context 'when account has never been updated or last update is unknown' do
+        let(:last_webfingered_at) { nil }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when account has not been updated for over a week' do
+        let(:last_webfingered_at) { 8.days.ago }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when account has been updated in the last week' do
+        let(:last_webfingered_at) { 4.days.ago }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
 end

--- a/spec/workers/account_refresh_worker_spec.rb
+++ b/spec/workers/account_refresh_worker_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe AccountRefreshWorker do
 
     context 'when account exists' do
       context 'when account does not need refreshing' do
-        let(:account) { Fabricate(:account, last_webfingered_at: recent_webfinger_at) }
+        let(:account) { Fabricate(:remote_account, last_webfingered_at: recent_webfinger_at) }
 
         it 'returns immediately without processing' do
           worker.perform(account.id)
@@ -29,9 +29,9 @@ RSpec.describe AccountRefreshWorker do
       end
 
       context 'when account needs refreshing' do
-        let(:account) { Fabricate(:account, last_webfingered_at: outdated_webfinger_at) }
+        let(:account) { Fabricate(:remote_account, last_webfingered_at: outdated_webfinger_at) }
 
-        it 'schedules an account update' do
+        it 'performs an account update' do
           worker.perform(account.id)
 
           expect(service).to have_received(:call)


### PR DESCRIPTION
This is a small refactor I made as part of a different feature, that I think makes sense as a stand-alone change.

`Account#schedule_refresh_if_stale!` and `AccountRefreshWorker` both check if a refresh is necessary. This makes sense, because the account might have been updated between the initial scheduling and the point in time when the worker is run. But before this change, they would both have their own way of determining this. This change pulls the conditions into their own method so both are guaranteed to use the same ones.

This also changes the logic slightly:

1.) It now returns early for local accounts. These never need to be refreshed from a remote source. And while the old code was unlikely to schedule a job for those *and* it is checked several times down the line, this is now explicit and as early as possible.

2.) This now also allows a refresh when `last_webfingered_at` is `nil`. I do not believe this case can actually occur, but it felt strange to disallow it, especially when `#possibly_stale?` right above *does* account for it.