### PR TITLE
Cache build image dependencies between CI runs

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -10,6 +10,18 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Change APT cache ownership
+      shell: bash
+      run: sudo chown -R $USER /var/cache/apt
+
+    - name: Cache APT Packages
+      uses: actions/cache@v5
+      with:
+        path: /var/cache/apt/archives
+        key: ${{ runner.os }}-apt-
+        restore-keys: |
+          ${{ runner.os }}-apt-
+
     - name: Install system dependencies
       shell: bash
       run: |

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -15,7 +15,7 @@ runs:
       run: sudo chown -R $USER /var/cache/apt
 
     - name: Cache APT Packages
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: /var/cache/apt/archives
         key: ${{ runner.os }}-apt-

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -28,11 +28,15 @@ runs:
         restore-keys: |
           ${{ runner.os }}-apt-${{ steps.date.outputs.date }}
 
-    - name: Install system dependencies
+    - name: Update system dependencies
       if: steps.cache-apt-packages.outputs.cache-hit != 'true'
       shell: bash
       run: |
         sudo apt-get update
+
+    - name: Install system dependencies
+      shell: bash
+      run: |
         sudo apt-get install --no-install-recommends -y \
           libicu-dev \
           libidn11-dev \

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -10,19 +10,26 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Change APT cache ownership
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       shell: bash
+
+    - name: Change APT cache ownership
       run: sudo chown -R $USER /var/cache/apt
+      shell: bash
 
     - name: Cache APT Packages
+      id: cache-apt-packages
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: /var/cache/apt/archives
-        key: ${{ runner.os }}-apt-
+        key: ${{ runner.os }}-apt-${{ steps.date.outputs.date }}
         restore-keys: |
-          ${{ runner.os }}-apt-
+          ${{ runner.os }}-apt-${{ steps.date.outputs.date }}
 
     - name: Install system dependencies
+      if: steps.cache-apt-packages.outputs.cache-hit != 'true'
       shell: bash
       run: |
         sudo apt-get update

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -4,8 +4,6 @@ inputs:
   ruby-version:
     description: The Ruby version to install
     default: '.ruby-version'
-  additional-system-dependencies:
-    description: 'Additional packages to install'
 
 runs:
   using: 'composite'

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -15,7 +15,7 @@ runs:
       run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Change APT cache ownership
+    - name: Change APT cache ownership before apt-get
       run: sudo chown -R $USER /var/cache/apt
       shell: bash
 
@@ -40,6 +40,10 @@ runs:
           libheif-plugin-aomdec \
           libheif-plugin-libde265 \
           ${{ inputs.additional-system-dependencies }}
+
+    - name: Change APT cache ownership after apt-get
+      run: sudo chown -R $USER /var/cache/apt
+      shell: bash
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -163,7 +163,7 @@ jobs:
             rspec-persistence-main
             rspec-persistence
 
-      - run: bin/flatware rspec
+      - run: bin/flatware rspec spec/helpers
 
       - name: Upload coverage reports to Codecov
         if: matrix.ruby-version == '.ruby-version'

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -143,7 +143,6 @@ jobs:
         uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version}}
-          additional-system-dependencies: ffmpeg libpam-dev
 
       - name: Load database schema
         run: |
@@ -237,7 +236,6 @@ jobs:
         uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version}}
-          additional-system-dependencies: ffmpeg
 
       - name: Set up Javascript environment
         uses: ./.github/actions/setup-javascript
@@ -371,7 +369,6 @@ jobs:
         uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version}}
-          additional-system-dependencies: ffmpeg
 
       - name: Set up Javascript environment
         uses: ./.github/actions/setup-javascript


### PR DESCRIPTION
Watching CI perf, no need for review.

Goal is to observe whether caching the downloaded packages (still run the install process) a) works, b) has any speed improvement over full download/install (ie, is cache restore faster than download). The historical advice has been that this is not faster than download because of how the cache works and how the azure packages are served ... but I wonder with recent azure degradation if that's still true.