### PR TITLE
Nudge users to turn on `discoverable` when viewing the empty list of collections they are in

### DIFF
--- a/app/javascript/mastodon/components/empty_state/empty_state.module.scss
+++ b/app/javascript/mastodon/components/empty_state/empty_state.module.scss
@@ -35,6 +35,10 @@
     color: var(--color-text-secondary);
     text-wrap: pretty;
   }
+
+  a {
+    color: inherit;
+  }
 }
 
 [data-color-scheme='dark'] .defaultImage {

--- a/app/javascript/mastodon/components/empty_state/empty_state.module.scss
+++ b/app/javascript/mastodon/components/empty_state/empty_state.module.scss
@@ -37,7 +37,7 @@
   }
 
   a {
-    color: inherit;
+    color: var(--color-text-status-links);
   }
 }
 

--- a/app/javascript/mastodon/features/collections/overview/featuring_you.tsx
+++ b/app/javascript/mastodon/features/collections/overview/featuring_you.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
+import { useAccount } from '@/mastodon/hooks/useAccount';
 import { EmptyState } from 'mastodon/components/empty_state';
 import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 import { ItemList } from 'mastodon/components/scrollable_list/components';
@@ -34,6 +35,7 @@ function useCollectionsFeaturing(accountId: string | null | undefined) {
 
 export const CollectionsFeaturingYou: React.FC = () => {
   const accountId = useAccountId();
+  const account = useAccount(accountId);
 
   const { collections, status } = useCollectionsFeaturing(accountId);
 
@@ -46,16 +48,43 @@ export const CollectionsFeaturingYou: React.FC = () => {
   }
 
   if (collections.length === 0) {
-    return (
-      <EmptyState
-        message={
-          <FormattedMessage
-            id='empty_column.collections.featured_in'
-            defaultMessage='You have not been added to any collections yet.'
-          />
-        }
-      />
-    );
+    if (account?.discoverable) {
+      return (
+        <EmptyState
+          message={
+            <FormattedMessage
+              id='empty_column.collections.featured_in'
+              defaultMessage='You have not been added to any collections yet.'
+            />
+          }
+        />
+      );
+    } else {
+      return (
+        <EmptyState
+          message={
+            <>
+              <FormattedMessage
+                id='empty_column.collections.featured_in'
+                defaultMessage='You have not been added to any collections yet.'
+              />
+              <br />
+              <FormattedMessage
+                id='empty_column.collections.featured_in_undiscoverable'
+                defaultMessage='In order for people to add you to collections, you need to allow featuring in discovery experiences from <link>Preferences > Privacy and reach</link>'
+                values={{
+                  link: (chunks) => (
+                    <a href='/settings/privacy#account_discoverable'>
+                      {chunks}
+                    </a>
+                  ),
+                }}
+              />
+            </>
+          }
+        />
+      );
+    }
   }
 
   return (

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -636,6 +636,7 @@
   "empty_column.blocks": "You haven't blocked any users yet.",
   "empty_column.bookmarked_statuses": "You don't have any bookmarked posts yet. When you bookmark one, it will show up here.",
   "empty_column.collections.featured_in": "You have not been added to any collections yet.",
+  "empty_column.collections.featured_in_undiscoverable": "In order for people to add you to collections, you need to allow featuring in discovery experiences from <link>Preferences > Privacy and reach</link>",
   "empty_column.community": "The local timeline is empty. Write something publicly to get the ball rolling!",
   "empty_column.direct": "You don't have any private mentions yet. When you send or receive one, it will show up here.",
   "empty_column.disabled_feed": "This feed has been disabled by your server administrators.",


### PR DESCRIPTION
Might need a review of the copy, and some CSS for the link.
<img width="621" height="545" alt="image" src="https://github.com/user-attachments/assets/0d82933b-40aa-4a9f-bdc0-fdd48bed5b38" />