### PR TITLE
Fix `Request` error when issuing a request which host is an IP address

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -290,7 +290,7 @@ class Request
 
         addresses = []
         begin
-          addresses = [IPAddr.new(host)]
+          addresses = [IPAddr.new(host).to_s]
         rescue IPAddr::InvalidAddressError
           resolvers = [Resolv::Hosts.new, Resolv::DNS.new.tap { |dns| dns.timeouts = 5 }]
           addresses = Resolv.new(resolvers).getaddresses(host)


### PR DESCRIPTION
Fix issue introduced in #38699