### PR TITLE
Fix accounts header banner grayscale

### DIFF
--- a/app/javascript/mastodon/components/account_header/styles.module.scss
+++ b/app/javascript/mastodon/components/account_header/styles.module.scss
@@ -21,7 +21,7 @@
     height: 160px;
   }
 
-  :global(.inactive) & {
+  .moved & {
     filter: grayscale(100%);
   }
 }


### PR DESCRIPTION
To be confirmed (expected results) @ChaosExAnima @diondiondion 

before
<img width="602" height="311" alt="image" src="https://github.com/user-attachments/assets/02afc8e7-43c0-4385-82c1-5c3395176d07" />

after
<img width="602" height="311" alt="image" src="https://github.com/user-attachments/assets/0616e695-13c2-4047-aafc-39aeb795c72a" />
