### PR TITLE
Add `devcontainer-lock.json` with Renovate update support

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/sshd@sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee",
+      "integrity": "sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee"
+    }
+  }
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,13 @@
   // to `null` after any other rule set it to something.
   dependencyDashboardHeader: 'This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more. Before approving any upgrade: read the description and comments in the [`renovate.json5` file](https://github.com/mastodon/mastodon/blob/main/.github/renovate.json5).',
   postUpdateOptions: ['yarnDedupeHighest'],
+  devcontainer: {
+    managerFilePatterns: [
+      '/^\.devcontainer\/devcontainer\.json$/',
+      '/^\.devcontainer\.json$/',
+      '/^\.devcontainer\/devcontainer-lock\.json$/',
+    ],
+  },
   // The types are now included in recent versions,we ignore them here until we upgrade and remove the dependency
   ignoreDeps: ['@types/emoji-mart'],
   packageRules: [


### PR DESCRIPTION
Proposing we commit this new `devcoontainer-lock.json` which was automatically created while rebuilding my devcontainer. It appears such lockfiles are now automatically created as of vscode v1.118, i.e. as of about last week or so as the current version is ~v1.119~ v1.120.

https://code.visualstudio.com/updates/v1_118#_dev-container-lockfile-for-features-enabled-by-default

<img width="2880" height="1856" alt="Screenshot From 2026-05-18 20-35-23" src="https://github.com/user-attachments/assets/dad08af8-b936-4d3b-849f-77609019c80f" />

Additionally I've tried to set up Renovate support for such via its config file.

Inspired by my other effort: https://github.com/rubygems/rubygems.org/pull/6471