### PR TITLE
Add sign? methods to the Quote and CollectionItem models

### DIFF
--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -64,6 +64,10 @@ class CollectionItem < ApplicationRecord
     :featured_item
   end
 
+  def sign?
+    true
+  end
+
   private
 
   def set_position

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -79,6 +79,10 @@ class Quote < ApplicationRecord
     ActivityPub::QuoteRefreshWorker.perform_in(rand(REFRESH_DEADLINE), id)
   end
 
+  def sign?
+    true
+  end
+
   private
 
   def reset_parent_cache!


### PR DESCRIPTION
I believe this is missing by mistake and PR aligns with other models (accounts, FeaturedTag etc) passing sign? to serialize_payload to sign LD via RevokeQuoteService.

If this is the case, I'd imagine you'd need some tests.