### PR TITLE
Add `libheif` dependencies to `setup-ruby` action to unbreak `media_attachment_spec.rb` on latest pre-release yet rolled out runner image

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -14,7 +14,13 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install --no-install-recommends -y libicu-dev libidn11-dev libvips42 ${{ inputs.additional-system-dependencies }}
+        sudo apt-get install --no-install-recommends -y \
+          libicu-dev \
+          libidn11-dev \
+          libvips42 \
+          libheif-plugin-aomdec \
+          libheif-plugin-libde265 \
+          ${{ inputs.additional-system-dependencies }}
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@94e4d89d3e6c1c7599e0210d114c5ffb23f1a866 # v1


### PR DESCRIPTION
It appears MS/GH has rolled out a pre-release runner image which breaks `spec/models/media_attachment_spec.rb` seemingly due to changes in `libheif`. Thus, proposing we add `libheif` packages to `setup-ruby` CI step.

Inspired by https://github.com/mastodon/mastodon/issues/39051#issuecomment-4471334258, thanks!

Resolves https://github.com/mastodon/mastodon/issues/39051