### PR TITLE
Temporary tweak to account background refresh

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -268,7 +268,19 @@ class Account < ApplicationRecord
   def needs_background_refresh?
     return false if local?
 
-    last_webfingered_at.blank? || last_webfingered_at <= BACKGROUND_REFRESH_INTERVAL.ago
+    return true if last_webfingered_at.blank? || last_webfingered_at <= BACKGROUND_REFRESH_INTERVAL.ago
+
+    # TODO: Remove some time after 4.6
+    # This is temporary workaround to speed up account refreshs after
+    # collections have been enabled / deployed.
+    # Accounts will be refreshed when they lack a feature_approval_policy
+    # but we know from other account's on the same server that they should
+    # have.
+    return false unless feature_approval_policy.zero?
+
+    Rails.cache.fetch("feature_approval_policy_availability:#{domain}", expires_in: 30.minutes) do
+      Account.where(domain:).where.not(feature_approval_policy: 0).exists?
+    end
   end
 
   def schedule_refresh_if_stale!

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -868,7 +868,17 @@ RSpec.describe Account do
       context 'when account has been updated in the last week' do
         let(:last_webfingered_at) { 4.days.ago }
 
-        it { is_expected.to be false }
+        context 'when there is no other account from the same domain with an feature approval policy' do
+          it { is_expected.to be false }
+        end
+
+        context 'when there is another account from the same domain with a feature approval policy' do
+          before do
+            Fabricate(:remote_account, domain: account.domain, feature_approval_policy: 1)
+          end
+
+          it { is_expected.to be true }
+        end
       end
     end
   end


### PR DESCRIPTION
To help kickstart the rollout of Collections: This change allows for earlier account refreshes in case an account does not yet have a `feature_approval_policy` but we know from other accounts on the same server that it should have.

This can be reverted someway down the line.

Fixes WEB-1006