### PR TITLE
Update browserslists target

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,6 +1,6 @@
 defaults
-> 0.2%
-firefox >= 78
+> 0.2% and not ios < 15.6
+firefox >= 91
 ios >= 15.6
 not dead
 not OperaMini all


### PR DESCRIPTION
- very old iOS versions are caught by the `> 0.2%` matcher, causing various issues, so explicitly rule them out
- update Firefox minimum release from 78 to 91. That's still EOL for years, but rationale is to keep compatibility with sailfishos-browser, which afaik is currently based on Firefox 91