### PR TITLE
Trigger initial field flow recalculation

### DIFF
--- a/app/javascript/mastodon/components/account_header/fields.tsx
+++ b/app/javascript/mastodon/components/account_header/fields.tsx
@@ -317,9 +317,10 @@ function useColumnWrap() {
       if (element) {
         listRef.current = element;
         observer.observe(element);
+        handleRecalculate();
       }
     },
-    [observer],
+    [handleRecalculate, observer],
   );
 
   return { wrapperRef: wrapperRefCallback };


### PR DESCRIPTION
Fixes WEB-1007.

When calculating field sizes, there isn't an initial call to calculate so fields are sometimes stuck until the account header changes.