### PR TITLE
Ensure quote posts have no collection previews

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -566,7 +566,7 @@ class Status extends ImmutablePureComponent {
           />
         );
       }
-    } else if (status.get('tagged_collections').size) {
+    } else if (status.get('tagged_collections').size && !status.get('quote')) {
       const firstLinkedCollection = status.get('tagged_collections').first();
       if (firstLinkedCollection) {
         media = (


### PR DESCRIPTION
### Changes proposed in this PR:
- Ensures that quote posts that contain a collection link don't display a collection preview next to the quote, mirroring the existing logic for remote posts with a `card` property (see line `551` in the same file)
