### PR TITLE
Accessibility: Add landmark elements to login/sign-up pages

### DIFF
--- a/app/views/layouts/auth.html.haml
+++ b/app/views/layouts/auth.html.haml
@@ -3,14 +3,14 @@
 
 - content_for :content do
   .container-alt
-    .logo-container
+    %header.logo-container
       - if within_authorization_flow?
         = logo_as_symbol(:wordmark)
       - else
         = link_to root_path do
           = logo_as_symbol(:wordmark)
 
-    .form-container
+    %main.form-container
       = render 'flashes'
 
       = yield


### PR DESCRIPTION
### Changes proposed in this PR:
- Wraps the contents of our auth pages (login, sign-up, etc) in `<header>` and `<main>` elements to improve their navigability (WCAG Guideline [1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG22/#info-and-relationships))