### PR TITLE
Handle non-trending records in `new_trends` mailer queue

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -34,9 +34,9 @@ class AdminMailer < ApplicationMailer
   end
 
   def new_trends(links, tags, statuses)
-    @links                  = links
-    @tags                   = tags
-    @statuses               = statuses
+    @links = PreviewCard.where.associated(:trend).includes(:trend).where(id: links)
+    @statuses = Status.where.associated(:trend).includes(:account, :trend).where(id: statuses)
+    @tags = Tag.where.associated(:trend).includes(:trend).where(id: tags)
 
     mail subject: default_i18n_subject(instance: @instance)
   end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -71,10 +71,13 @@ RSpec.describe AdminMailer do
 
   describe '.new_trends' do
     let(:recipient) { Fabricate(:account, username: 'Snurf') }
+    let(:link_extra) { Fabricate(:preview_card, trendable: true, language: 'en') }
     let(:link) { Fabricate(:preview_card, trendable: true, language: 'en') }
+    let(:status_extra) { Fabricate(:status) }
     let(:status) { Fabricate(:status) }
+    let(:tag_extra) { Fabricate(:tag) }
     let(:tag) { Fabricate(:tag) }
-    let(:mail) { described_class.with(recipient: recipient).new_trends([link], [tag], [status]) }
+    let(:mail) { described_class.with(recipient: recipient).new_trends([link, link_extra], [tag, tag_extra], [status, status_extra]) }
 
     before do
       PreviewCardTrend.create!(preview_card: link)


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/39081

The scenario here is one where a tag/link/status has been trending, was queueud to send mail, wound up requeued, and then was not trending anymore during resend attempts (and then raises an error and keeps getting requeueued).

The partials here already check whether any records are present, so the path where all previously trending things are now not trending and the variable was an empty array is already handled.

Alternate idea here would be to do something in the view to `select` only the records with a trend, or update the view to handle a "previously trending but now not trending" pathway (some additional copy to call that out?, just show the item but w/out the trend/score info?)

Further improvement could be to handle the (probably exceedingly rare?) scenario where ALL the records (tags, links, statuses) are no longer trending, and just bail on sending the email entirely? Considering that out of scope here, but could be followup.