### PR TITLE
Fix: Blocked Domains Persist in Elasticsearch InstancesIndex

### DIFF
--- a/app/workers/scheduler/instance_refresh_scheduler.rb
+++ b/app/workers/scheduler/instance_refresh_scheduler.rb
@@ -7,6 +7,6 @@ class Scheduler::InstanceRefreshScheduler
 
   def perform
     Instance.refresh
-    InstancesIndex.import if Chewy.enabled?
+    InstancesIndex.sync if Chewy.enabled?
   end
 end


### PR DESCRIPTION
chewy import only upserts. sync should delete the blocked instances from the ES index.

The InstanceIndex is a few thousand instances.... not millions of them so the sync should be fine considering you only add a domainblock every now and then.