### PR TITLE
Allow HTML `lang` attribute in remote posts

### DIFF
--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -107,6 +107,7 @@ class Sanitize
       elements: %w(p br span a del s pre blockquote code b strong u i em ul ol li ruby rt rp),
 
       attributes: {
+        :all => %w(lang),
         'a' => %w(href rel class translate),
         'span' => %w(class translate),
         'ol' => %w(start reversed),


### PR DESCRIPTION
The `lang` attribute allows setting the rendering language of a block of text, and is important to ensure proper rendering of CJK characters.

Mastodon already supported setting the language for an entire post, but would strip lang attributes from federated posts that attempted to use `<span lang="...">` tags to use multiple languages in a single post.