### PR TITLE
Accessibility: Add visible focus outlines to emoji/language search fields

### DIFF
--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -114,10 +114,9 @@
       border: 0;
     }
 
-    &:active,
     &:focus {
-      outline: none !important;
-      border-width: 1px !important;
+      outline: var(--outline-focus-default);
+      outline-offset: -1px;
     }
 
     &::-webkit-search-cancel-button {
@@ -141,10 +140,12 @@
   &:disabled {
     cursor: default;
     pointer-events: none;
+    color: var(--color-text-secondary);
   }
 
   svg {
     fill: currentColor;
+    opacity: 1 !important;
   }
 }
 


### PR DESCRIPTION
Fixes WEB-1019
Related to #19931 and #19928

### Changes proposed in this PR:
- Building on #39111, this also adds our standard outlines to the search field in our emoji and language dropdown menus

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="319" height="230" alt="image" src="https://github.com/user-attachments/assets/4a063cd6-85ea-4467-b3d0-9873277a2cfb" /> | <img width="321" height="245" alt="image" src="https://github.com/user-attachments/assets/a1525669-6110-49d0-a2c2-2c2b4db49d78" /> |
| <img width="392" height="264" alt="image" src="https://github.com/user-attachments/assets/a2afdc5c-d15b-4394-a428-93450f14df3a" /> | <img width="392" height="256" alt="image" src="https://github.com/user-attachments/assets/affd9e78-7d31-4762-9c2c-7238ac802a7c" /> |