### PR TITLE
Use radio buttons for emoji style preference

### DIFF
--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -51,17 +51,16 @@
                    label_method: ->(contrast) { I18n.t("contrast.#{contrast}", default: contrast) },
                    wrapper: :with_label,
                    required: false
-
-  .fields-group
-    = f.simple_fields_for :settings, current_user.settings do |ff|
-      = ff.input :'web.emoji_style',
-                 collection: user_settings_collection('web.emoji_style'),
-                 include_blank: false,
-                 hint: I18n.t('simple_form.hints.defaults.setting_emoji_style'),
-                 label: I18n.t('simple_form.labels.defaults.setting_emoji_style'),
-                 label_method: ->(emoji_style) { I18n.t("emoji_styles.#{emoji_style}", default: emoji_style) },
-                 wrapper: :with_label,
-                 required: false
+      .input.horizontal-options
+        = ff.input :'web.emoji_style',
+                   as: :radio_buttons,
+                   collection: user_settings_collection('web.emoji_style'),
+                   include_blank: false,
+                   hint: I18n.t('simple_form.hints.defaults.setting_emoji_style'),
+                   label: I18n.t('simple_form.labels.defaults.setting_emoji_style'),
+                   label_method: ->(emoji_style) { I18n.t("emoji_styles.#{emoji_style}", default: emoji_style) },
+                   wrapper: :with_label,
+                   required: false
 
   - unless I18n.locale == :en
     .flash-message.translation-prompt


### PR DESCRIPTION
### Changes proposed in this PR:
- Changes the emoji style preference to use radio buttons for consistency with the theme options above

👉 Best reviewed with [hidden white-space changes](https://github.com/mastodon/mastodon/pull/39126/changes?w=1)

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="834" height="444" alt="image" src="https://github.com/user-attachments/assets/677f038c-1437-4dfa-a648-5fbca2b1abfd" /> | <img width="836" height="436" alt="image" src="https://github.com/user-attachments/assets/ecc68331-be3f-4da9-9c74-aac794a12746" /> |