### PR TITLE
Accessibility: Add skip link & landmark regions to settings

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -136,6 +136,11 @@ $content-width: 840px;
           transition: all 100ms linear;
           transition-property: color, background-color;
         }
+
+        &:focus-visible {
+          outline: var(--outline-focus-default);
+          outline-offset: -2px;
+        }
       }
 
       ul {

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1887,6 +1887,28 @@ a.sparkline {
   }
 }
 
+.navigation-skip-link {
+  position: fixed;
+  z-index: 100;
+  margin: 10px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  font-size: 15px;
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+  box-shadow: var(--dropdown-shadow);
+
+  /* Hide visually when not focused */
+  &:not(:focus-within) {
+    width: 1px;
+    height: 1px;
+    margin: 0;
+    padding: 0;
+    clip-path: inset(50%);
+    overflow: hidden;
+  }
+}
+
 .section-skip-link {
   float: right;
 

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -7,7 +7,7 @@
 
 - content_for :content do
   .admin-wrapper
-    .sidebar-wrapper
+    %nav.sidebar-wrapper
       .sidebar-wrapper__inner
         .sidebar
           = link_to root_path do
@@ -24,7 +24,7 @@
 
           = render_navigation
 
-    .content-wrapper
+    %main.content-wrapper
       .content
         .content__heading
           - if content_for?(:heading)

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -6,6 +6,7 @@
 - content_for :body_classes, 'admin'
 
 - content_for :content do
+  %a.navigation-skip-link{ href: '#content' }= t('admin.skip_to_content')
   .admin-wrapper
     %nav.sidebar-wrapper
       .sidebar-wrapper__inner
@@ -24,7 +25,7 @@
 
           = render_navigation
 
-    %main.content-wrapper
+    %main.content-wrapper#content
       .content
         .content__heading
           - if content_for?(:heading)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -979,6 +979,7 @@ en:
     site_uploads:
       delete: Delete uploaded file
       destroyed_msg: Site upload successfully deleted!
+    skip_to_content: Skip to content
     software_updates:
       critical_update: Critical — please update quickly
       description: It is recommended to keep your Mastodon installation up to date to benefit from the latest fixes and features. Moreover, it is sometimes critical to update Mastodon in a timely manner to avoid security issues. For these reasons, Mastodon checks for updates every 30 minutes, and will notify you according to your email notification preferences.


### PR DESCRIPTION
Fixes WEB-888
Related to WEB-1015
Related to WEB-697

### Changes proposed in this PR:
- Adds "Skip to content" link to the settings page template, allowing to skip over the long navigation bar
- Uses `nav` and `main` element for the main and navigation content regions in the settings
- Improves visibility of focus outlines in settings navigation

### Screenshots

<img width="685" height="309" alt="image" src="https://github.com/user-attachments/assets/fbbbf0e8-43a7-4985-a94e-6d5c57a23c9b" />

----

| **Before** | **After** |
|--------|--------|
| <img width="360" height="308" alt="image" src="https://github.com/user-attachments/assets/4d33d436-d3b9-499c-990f-ba65aec28fbd" /> | <img width="356" height="306" alt="image" src="https://github.com/user-attachments/assets/8761a41b-6481-40df-9919-616883e529c6" /> |