### PR TITLE
Update doorkeeper to version 5.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       activerecord (>= 4.2, < 9.0)
     docile (1.4.1)
     domain_name (0.6.20240107)
-    doorkeeper (5.9.0)
+    doorkeeper (5.9.1)
       railties (>= 5)
     dotenv (3.2.0)
     drb (2.2.3)

--- a/config/application.rb
+++ b/config/application.rb
@@ -111,9 +111,6 @@ module Mastodon
     end
 
     config.to_prepare do
-      Doorkeeper::Application.include ApplicationExtension
-      Doorkeeper::AccessGrant.include AccessGrantExtension
-      Doorkeeper::AccessToken.include AccessTokenExtension
       Devise::FailureApp.include AbstractController::Callbacks
       Devise::FailureApp.include Localized
     end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -179,3 +179,9 @@ Doorkeeper.configure do
   # WWW-Authenticate Realm (default "Doorkeeper").
   # realm "Doorkeeper"
 end
+
+Rails.application.reloader.to_prepare do
+  Doorkeeper.config.application_model.include ApplicationExtension
+  Doorkeeper.config.access_grant_model.include AccessGrantExtension
+  Doorkeeper.config.access_token_model.include AccessTokenExtension
+end


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/39090

This doorkeeper change - https://github.com/doorkeeper-gem/doorkeeper/pull/1804 - winds up causing issues because we refer to the DK constants too early in load process, ie https://github.com/mastodon/mastodon/actions/runs/26125544258/job/76838174446?pr=39090

I'm sure there are multiple ways to do this ... basically just shifting to later in process here, at which point doorkeeper (after AR loads) has already loaded itself and we can add our "extensions" safely.