### PR TITLE
Accessibility: Convey selected state of filters on Follows and followers page

### DIFF
--- a/app/helpers/admin/filter_helper.rb
+++ b/app/helpers/admin/filter_helper.rb
@@ -20,8 +20,9 @@ module Admin::FilterHelper
   def filter_link_to(text, link_to_params, link_class_params = link_to_params)
     new_url   = filtered_url_for(link_to_params)
     new_class = filtered_url_for(link_class_params)
+    is_selected = selected?(link_class_params)
 
-    link_to text, new_url, class: filter_link_class(new_class)
+    link_to text, new_url, class: filter_link_class(new_class), 'aria-current': (is_selected ? 'true' : nil)
   end
 
   def table_link_to(icon, text, path, **options)


### PR DESCRIPTION
Related to #13545

### Changes proposed in this PR:
- Adds an `aria-current` attribute to the selected filters on the "Follows and followers" page to convey selection states to users of assistive tech