### PR TITLE
Fix remote statuses with large media descriptions being rejected

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -205,7 +205,7 @@ class MediaAttachment < ApplicationRecord
   remotable_attachment :thumbnail, IMAGE_LIMIT, suppress_errors: true, download_on_assign: false
 
   validates :account, presence: true
-  validates :description, length: { maximum: MAX_DESCRIPTION_LENGTH }
+  validates :description, length: { maximum: MAX_DESCRIPTION_LENGTH }, if: :local?
   validates :file, presence: true, if: :local?
   validates :thumbnail, absence: true, if: -> { local? && !audio_or_video? }
 

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -608,19 +608,19 @@ RSpec.describe ActivityPub::Activity::Create do
                 type: 'Document',
                 mediaType: 'image/png',
                 url: 'http://example.com/attachment.png',
-                name: '*' * MediaAttachment::MAX_DESCRIPTION_LENGTH,
+                name: '*' * (MediaAttachment::MAX_DESCRIPTION_HARD_LENGTH_LIMIT + 5),
               },
             ]
           )
         end
 
-        it 'creates status' do
+        it 'creates status with truncated description' do
           expect { subject.perform }.to change(sender.statuses, :count).by(1)
 
           status = sender.statuses.first
 
           expect(status).to_not be_nil
-          expect(status.media_attachments.map(&:description)).to include('*' * MediaAttachment::MAX_DESCRIPTION_LENGTH)
+          expect(status.media_attachments.map(&:description)).to include('*' * MediaAttachment::MAX_DESCRIPTION_HARD_LENGTH_LIMIT)
         end
       end
 
@@ -632,19 +632,19 @@ RSpec.describe ActivityPub::Activity::Create do
                 type: 'Document',
                 mediaType: 'image/png',
                 url: 'http://example.com/attachment.png',
-                summary: '*' * MediaAttachment::MAX_DESCRIPTION_LENGTH,
+                summary: '*' * (MediaAttachment::MAX_DESCRIPTION_HARD_LENGTH_LIMIT + 5),
               },
             ]
           )
         end
 
-        it 'creates status' do
+        it 'creates status with truncated description' do
           expect { subject.perform }.to change(sender.statuses, :count).by(1)
 
           status = sender.statuses.first
 
           expect(status).to_not be_nil
-          expect(status.media_attachments.map(&:description)).to include('*' * MediaAttachment::MAX_DESCRIPTION_LENGTH)
+          expect(status.media_attachments.map(&:description)).to include('*' * MediaAttachment::MAX_DESCRIPTION_HARD_LENGTH_LIMIT)
         end
       end
 


### PR DESCRIPTION
Fix issue introduced by #37921