### PR TITLE
Update rubocop-rails to version 2.35.2

### DIFF
--- a/.rubocop/rails.yml
+++ b/.rubocop/rails.yml
@@ -24,3 +24,6 @@ Rails/RakeEnvironment:
 
 Rails/SkipsModelValidations:
   Enabled: false
+
+Rails/StrongParametersExpect:
+  Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -779,7 +779,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.34.3)
+    rubocop-rails (2.35.2)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/39136

Replaces a part of https://github.com/mastodon/mastodon/pull/39038