### PR TITLE
Honor configuration.statuses.max_characters from /api/v2/instance

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/compose_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/compose_form_container.js
@@ -58,7 +58,7 @@ const mapStateToProps = state => ({
     && !state.getIn(['settings', 'dismissed_banners', PRIVATE_QUOTE_MODAL_ID]),
   isInReply: state.getIn(['compose', 'in_reply_to']) !== null,
   lang: state.getIn(['compose', 'language']),
-  maxChars: state.getIn(['server', 'server', 'configuration', 'statuses', 'max_characters'], 500),
+  maxChars: state.getIn(['server', 'server', 'item', 'configuration', 'statuses', 'max_characters'], 500),
 });
 
 const mapDispatchToProps = (dispatch, props) => ({


### PR DESCRIPTION
I recently noticed that `StatusLengthValidator::MAX_CHARS` in `app/validators/status_length_validator.rb` is no longer honored on the Web UI. This looks to be from the `item` property inserted in #39089. This change is for the Web UI to follow the change.