### PR TITLE
Only preload accounts in Collections when needed

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -66,11 +66,14 @@ class Collection < ApplicationRecord
   end
 
   def items_for(account = nil, include_accounts: false)
-    result = collection_items
-    result = result.with_accounts if include_accounts
-    result = account == self.account ? result.pending_or_accepted : result.accepted
-    result = result.not_blocked_by(account) unless account.nil?
-    result
+    @items_for ||= {}
+    @items_for[account] ||= begin
+      result = collection_items
+      result = result.with_accounts if include_accounts
+      result = account == self.account ? result.pending_or_accepted : result.accepted
+      result = result.not_blocked_by(account) unless account.nil?
+      result
+    end
   end
 
   def tag_name

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -65,8 +65,9 @@ class Collection < ApplicationRecord
     !local?
   end
 
-  def items_for(account = nil)
-    result = collection_items.with_accounts
+  def items_for(account = nil, include_accounts: false)
+    result = collection_items
+    result = result.with_accounts if include_accounts
     result = account == self.account ? result.pending_or_accepted : result.accepted
     result = result.not_blocked_by(account) unless account.nil?
     result

--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -43,7 +43,7 @@ class CollectionItem < ApplicationRecord
 
   scope :ordered, -> { order(position: :asc) }
   scope :with_accounts, -> { includes(account: [:account_stat, :user]) }
-  scope :not_blocked_by, ->(account) { where.not(accounts: { id: account.blocking }) }
+  scope :not_blocked_by, ->(account) { joins(:account).where.not(accounts: { id: account.blocking }) }
   scope :local, -> { joins(:collection).merge(Collection.local) }
   scope :accepted_partial, ->(account) { joins(:account).merge(Account.local).accepted.where(uri: nil, account_id: account.id) }
   scope :pending_or_accepted, -> { where(state: [:pending, :accepted]) }

--- a/app/serializers/rest/collection_with_accounts_serializer.rb
+++ b/app/serializers/rest/collection_with_accounts_serializer.rb
@@ -10,6 +10,6 @@ class REST::CollectionWithAccountsSerializer < ActiveModel::Serializer
   end
 
   def accounts
-    [object.account] + object.collection_items.filter_map(&:account)
+    [object.account] + object.items_for(current_user&.account, include_accounts: true).map(&:account)
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -132,6 +132,20 @@ RSpec.describe Collection do
         expect { items.first.account }.to_not execute_queries
       end
     end
+
+    context 'when called multiple times' do
+      let(:account) { subject.account }
+
+      it 'memoizes results' do
+        subject.items_for.to_a
+
+        expect { subject.items_for.to_a }.to_not execute_queries
+
+        expect { subject.items_for(account).to_a }.to execute_queries
+
+        expect { subject.items_for(account).to_a }.to_not execute_queries
+      end
+    end
   end
 
   describe '#tag_name=' do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -124,6 +124,14 @@ RSpec.describe Collection do
         expect(subject.items_for(account)).to match_array(accepted_items + [pending_item])
       end
     end
+
+    context 'when `include_accounts` is set to `true`' do
+      it 'preloads accounts' do
+        items = subject.items_for(include_accounts: true).to_a
+
+        expect { items.first.account }.to_not execute_queries
+      end
+    end
   end
 
   describe '#tag_name=' do


### PR DESCRIPTION
`Collection#items_for` used to always preload accounts (+ associated records necessary to render the full JSON representation). This was introduced initially when Collections always included full account JSON.

This is no longer the case. The preloading still makes sense for the endpoint to get a single collection, because this one returns full account data, but not for most other use cases where it is just unnecessary overhead.

This change makes the preloading optional and makes sure it is actually used where it makes sense (it was not before, potentially returning too many accounts).

For this to work efficiently, the results of `Collection#items_for` need to be cached, so this also introduces simple memoization.