### PR TITLE
Fix mobile explore search input spacing

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8887,6 +8887,7 @@ noscript {
 
   .search__input {
     padding-block: 12px;
+    padding-inline-start: 46px;
     padding-inline-end: 30px;
   }
 
@@ -8894,9 +8895,12 @@ noscript {
     border: 1px solid var(--color-border-primary);
   }
 
-  .search__icon {
+  .search__icon-wrapper {
     top: 12px;
-    inset-inline-end: 12px;
+    margin-inline-start: 12px;
+  }
+
+  .search__icon {
     color: var(--color-text-tertiary);
   }
 }


### PR DESCRIPTION
## Summary

- Fix the mobile Explore search input spacing so the search icon no longer overlaps typed text.
- Move the Explore-specific icon offset onto `.search__icon-wrapper`, which is the positioned element in the search component.
- Add matching start padding to the Explore search input for the icon space.

Fixes #29219

## Testing

- `npm_config_cache=/Users/arieleli/Documents/Codex/2026-05-24/can-you-help-me-find-an/.npm-cache YARN_ENABLE_GLOBAL_CACHE=false YARN_GLOBAL_FOLDER=/Users/arieleli/Documents/Codex/2026-05-24/can-you-help-me-find-an/.yarn-global npx @yarnpkg/cli-dist@4.14.1 lint:css app/javascript/styles/mastodon/components.scss`
