### PR TITLE
Accessibility: Mark pseudo element content in link footer as decorative

### DIFF
--- a/app/javascript/mastodon/features/ui/components/link_footer.module.scss
+++ b/app/javascript/mastodon/features/ui/components/link_footer.module.scss
@@ -41,6 +41,10 @@
 
     &:not(:last-child)::after {
       content: ' · ';
+
+      @supports (content: 'x' / 'y') {
+        content: ' · ' / '';
+      }
     }
   }
 


### PR DESCRIPTION
### Changes proposed in this PR:
- A follow-up to #39144.
   This change ensures that the · separator character added as pseudo element for each footer link is not exposed as normal content to assistive tech (similar to an image with an empty alt attribute).
