### PR TITLE
Accessibility: Fix broken aria label & description in `CollectionListItem`

### DIFF
--- a/app/javascript/mastodon/features/collections/components/collection_list_item.tsx
+++ b/app/javascript/mastodon/features/collections/components/collection_list_item.tsx
@@ -27,14 +27,14 @@ export const CollectionListItem: React.FC<CollectionListItemProps> = ({
   ...otherProps
 }) => {
   const uniqueId = useId();
-  const linkId = `${uniqueId}-link`;
-  const infoId = `${uniqueId}-info`;
+  const titleId = `${uniqueId}-title`;
+  const subtitleId = `${uniqueId}-info`;
 
   return (
     <Article
       focusable
-      aria-labelledby={linkId}
-      aria-describedby={infoId}
+      aria-labelledby={titleId}
+      aria-describedby={subtitleId}
       aria-posinset={positionInList}
       aria-setsize={listSize}
     >
@@ -52,6 +52,8 @@ export const CollectionListItem: React.FC<CollectionListItemProps> = ({
             className={classes.menuButton}
           />
         }
+        titleId={titleId}
+        subtitleId={subtitleId}
         {...otherProps}
       />
     </Article>

--- a/app/javascript/mastodon/features/collections/components/collection_lockup.tsx
+++ b/app/javascript/mastodon/features/collections/components/collection_lockup.tsx
@@ -48,6 +48,8 @@ export interface CollectionLockupProps {
   sideContent?: React.ReactNode;
   className?: string;
   headingLevel?: 'h2' | 'h3' | 'h4';
+  titleId?: string;
+  subtitleId?: string;
 }
 
 export const CollectionLockup: React.FC<CollectionLockupProps> = ({
@@ -56,6 +58,8 @@ export const CollectionLockup: React.FC<CollectionLockupProps> = ({
   withTimestamp,
   sideContent,
   headingLevel = 'h3',
+  titleId,
+  subtitleId,
   className,
 }) => {
   const { id, name } = collection;
@@ -74,6 +78,7 @@ export const CollectionLockup: React.FC<CollectionLockupProps> = ({
       <ListItemLink
         as={headingLevel}
         to={getCollectionPath(id)}
+        id={titleId}
         subtitle={
           <CollectionInfo
             collection={collection}
@@ -81,6 +86,7 @@ export const CollectionLockup: React.FC<CollectionLockupProps> = ({
             withTimestamp={withTimestamp}
           />
         }
+        subtitleId={subtitleId}
       >
         {name}
       </ListItemLink>


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes missing id assignments in `CollectionListItem`, breaking the aria label & description of the wrapping article element
