### PR TITLE
Don't open account hover card unless preceded by mouse movement

### DIFF
--- a/app/javascript/mastodon/components/hover_card_controller.tsx
+++ b/app/javascript/mastodon/components/hover_card_controller.tsx
@@ -144,9 +144,14 @@ export const HoverCardController: React.FC = () => {
       setScrollTimeout(handleScrollEnd, 100);
     };
 
-    const handleMouseMove = () => {
+    const handleMouseMove = (e: MouseEvent) => {
       if (isUsingTouch) {
         isUsingTouch = false;
+      }
+
+      const hasMoved = Math.max(e.movementX, e.movementY) > 0;
+      if (!hasMoved) {
+        return;
       }
 
       delayEnterTimeout(enterDelay);


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes another scenario where the previous fix from #38112 didn't stop the account hover card from appearing even though no intentional pointer move preceeded the mouseenter event

### Screenshots

**Before:**

https://github.com/user-attachments/assets/e5f10f63-8193-444a-bf16-e43a48c93efa

**After**

https://github.com/user-attachments/assets/9533ae9e-5fa6-4908-9d1d-8a942c4b58d4