### PR TITLE
Fix advanced UI column crashing in development

### DIFF
--- a/app/javascript/mastodon/components/scrollable_list/index.jsx
+++ b/app/javascript/mastodon/components/scrollable_list/index.jsx
@@ -285,7 +285,7 @@ class ScrollableList extends PureComponent {
     if (this.props.bindToDocument) {
       document.removeEventListener('scroll', this.handleScroll);
       document.removeEventListener('wheel', this.handleWheel, listenerOptions);
-    } else {
+    } else if (this.node) {
       this.node.removeEventListener('scroll', this.handleScroll);
       this.node.removeEventListener('wheel', this.handleWheel, listenerOptions);
     }


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes the `ScrollableList` component causing a crash (`Uncaught TypeError: can't access property "removeEventListener", this.node is null`) in advanced UI. I suspect React [StrictMode](https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-re-running-ref-callbacks-in-development) to be the culprit