### PR TITLE
Align German quiet_post_quote_info message with English semantics

### DIFF
--- a/app/javascript/mastodon/locales/de.json
+++ b/app/javascript/mastodon/locales/de.json
@@ -552,7 +552,7 @@
   "confirmations.private_quote_notify.title": "Mit Followern und erwähnten Profilen teilen?",
   "confirmations.quiet_post_quote_info.dismiss": "Nicht erneut erinnern",
   "confirmations.quiet_post_quote_info.got_it": "Verstanden",
-  "confirmations.quiet_post_quote_info.message": "Beim Zitieren eines Beitrags, dessen Sichtbarkeit „Öffentlich (still)“ ist, wird auch dein Beitrag, der das Zitat enthält, aus den Trends und öffentlichen Timelines ausgeblendet.",
+  "confirmations.quiet_post_quote_info.message": "Beim Zitieren eines Beitrags, dessen Sichtbarkeit „Öffentlich (still)“ ist, wird auch dein Beitrag, der das Zitat enthält, aus den Trends ausgeblendet.",
   "confirmations.quiet_post_quote_info.title": "Zitieren eines Beitrags mit der Sichtbarkeit „Öffentlich (still)“",
   "confirmations.redraft.confirm": "Löschen und neu erstellen",
   "confirmations.redraft.message": "Möchtest du diesen Beitrag wirklich löschen und neu verfassen? Alle Favoriten sowie die bisher geteilten Beiträge werden verloren gehen und Antworten auf den ursprünglichen Beitrag verlieren den Zusammenhang.",


### PR DESCRIPTION
The German translation incorrectly mentioned both trends and public timelines, while the English source only refers to trending timelines.