### PR TITLE
[Accessibility] Differentiate accessible labels of About links in footer

### DIFF
--- a/app/javascript/mastodon/features/ui/components/link_footer.tsx
+++ b/app/javascript/mastodon/features/ui/components/link_footer.tsx
@@ -29,6 +29,7 @@ export const LinkFooter: React.FC<{
                 id='footer.about_this_server'
                 defaultMessage='About'
               />
+              <span className='sr-only'> {domain}</span>
             </Link>
           </li>
           {statusPageUrl && (
@@ -82,6 +83,7 @@ export const LinkFooter: React.FC<{
           <li>
             <a href='https://joinmastodon.org' target='_blank' rel='noopener'>
               <FormattedMessage id='footer.about' defaultMessage='About' />
+              <span className='sr-only'> Mastodon</span>
             </a>
           </li>
           <li>


### PR DESCRIPTION
### Changes proposed in this PR:
- Adds extra context to the accessible labels of the About links in the footer, as their visible text content is the same in most languages
   
   | **Context** | **Before** | **After** |
   |--------|--------|--------|
   | Server | "About" | "About {server hostname}" |
   | Mastodon | "About" | "About Mastodon" |