### PR TITLE
Collections: Handle URLs in search

### DIFF
--- a/app/javascript/mastodon/api_types/search.ts
+++ b/app/javascript/mastodon/api_types/search.ts
@@ -1,4 +1,5 @@
 import type { ApiAccountJSON } from './accounts';
+import type { ApiCollectionJSON } from './collections';
 import type { ApiStatusJSON } from './statuses';
 import type { ApiHashtagJSON } from './tags';
 
@@ -8,4 +9,5 @@ export interface ApiSearchResultsJSON {
   accounts: ApiAccountJSON[];
   statuses: ApiStatusJSON[];
   hashtags: ApiHashtagJSON[];
+  collections: ApiCollectionJSON[];
 }

--- a/app/javascript/mastodon/features/compose/components/search.tsx
+++ b/app/javascript/mastodon/features/compose/components/search.tsx
@@ -19,6 +19,7 @@ import { useHistory } from 'react-router-dom';
 
 import { isFulfilled } from '@reduxjs/toolkit';
 
+import { getCollectionPath } from '@/mastodon/features/collections/utils';
 import CancelIcon from '@/material-icons/400-24px/cancel-fill.svg?react';
 import CloseIcon from '@/material-icons/400-24px/close.svg?react';
 import SearchIcon from '@/material-icons/400-24px/search.svg?react';
@@ -339,7 +340,7 @@ export const Search: React.FC<{
                   );
                 } else if (result.payload.collections[0]) {
                   history.push(
-                    `/collections/${result.payload.collections[0].id}`,
+                    getCollectionPath(result.payload.collections[0].id),
                   );
                 }
               }

--- a/app/javascript/mastodon/features/compose/components/search.tsx
+++ b/app/javascript/mastodon/features/compose/components/search.tsx
@@ -337,6 +337,10 @@ export const Search: React.FC<{
                   history.push(
                     `/@${result.payload.statuses[0].account.acct}/${result.payload.statuses[0].id}`,
                   );
+                } else if (result.payload.collections[0]) {
+                  history.push(
+                    `/collections/${result.payload.collections[0].id}`,
+                  );
                 }
               }
 


### PR DESCRIPTION
Fixes WEB-1009.

Allows opening Collections via pasting a URL in the search bar and clicking "Open URL in Mastodon"