### PR TITLE
Extract text from language tagged strings for link preview

### DIFF
--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -28,11 +28,11 @@ class LinkDetailsExtractor
     end
 
     def headline
-      json['headline']
+      text_or_language_tagged_string(json['headline'])
     end
 
     def description
-      json['description']
+      text_or_language_tagged_string(json['description'])
     end
 
     def language
@@ -94,6 +94,10 @@ class LinkDetailsExtractor
 
     def first_of_hash(arr)
       arr.is_a?(Array) ? arr.flatten.find { |item| item.is_a?(Hash) } : arr
+    end
+
+    def text_or_language_tagged_string(obj)
+      obj.is_a?(Hash) && obj['@value'] && obj['@language'] ? obj['@value'] : obj
     end
 
     def root_array(root)

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -287,6 +287,41 @@ RSpec.describe LinkDetailsExtractor do
         expect(subject.provider_name).to eq 'Pet News'
       end
     end
+
+    context 'with headline and description as language tagged strings' do
+      let(:ld_json) do
+        {
+          '@context' => 'https://schema.org',
+          '@type' => 'NewsArticle',
+          'headline' => {
+            '@value' => 'Title in English',
+            '@language' => 'en',
+          },
+          'description' => {
+            '@value' => 'Text in English.',
+            '@language' => 'en',
+          },
+        }.to_json
+      end
+      let(:html) { <<~HTML }
+        <!doctype html>
+        <html>
+        <body>
+          <script type="application/ld+json">
+            #{ld_json}
+          </script>
+        </body>
+        </html>
+      HTML
+
+      it 'gives correct title' do
+        expect(subject.title).to eq 'Title in English'
+      end
+
+      it 'gives correct description' do
+        expect(subject.description).to eq 'Text in English.'
+      end
+    end
   end
 
   context 'when Open Graph protocol data is present' do


### PR DESCRIPTION
There is a news site that provides headline and description as language tagged strings rather than literal text within structured data.

This makes the previews more useful for news articles like https://news.web.nhk/newsweb/na/na-k10015132671000

---
(Edited to add examples)

Before: https://mastodon.zunda.ninja/@zundan/116649546568517326

<img width="755" height="900" alt="Screenshot_2026-05-28_09-18-37" src="https://github.com/user-attachments/assets/b49c2bfd-7de0-4e3c-918e-1e80f95d0119" />


After: https://mastodon.zunda.ninja/@zundan/116649566848209209

<img width="755" height="900" alt="Screenshot_2026-05-28_09-18-58" src="https://github.com/user-attachments/assets/df965a51-e2eb-46fe-a79a-ac6a5ed3ba0b" />
