### PR TITLE
Adding compression to the Rack middleware

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -88,7 +88,7 @@ module Mastodon
 
     config.middleware.use Mastodon::Middleware::PublicFileServer if Rails.env.local? || ENV['RAILS_SERVE_STATIC_FILES'] == 'true'
     config.middleware.use Rack::Attack
-    config.middleware.use Rack::Deflater
+    config.middleware.use Rack::Deflater if ENV['RACK_COMPRESS'] == 'true'
     config.middleware.use Mastodon::Middleware::SocketCleanup
 
     config.before_configuration do

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,7 +88,7 @@ module Mastodon
 
     config.middleware.use Mastodon::Middleware::PublicFileServer if Rails.env.local? || ENV['RAILS_SERVE_STATIC_FILES'] == 'true'
     config.middleware.use Rack::Attack
-    config.middleware.use Rack::Deflater if ENV['RACK_COMPRESS'] == 'true'
+    config.middleware.use Rack::Deflater # if ENV['RACK_COMPRESS'] == 'true' # add the RACK_COMPRESS once the tests complete.
     config.middleware.use Mastodon::Middleware::SocketCleanup
 
     config.before_configuration do

--- a/config/application.rb
+++ b/config/application.rb
@@ -86,9 +86,9 @@ module Mastodon
     # We use our own middleware for this
     config.public_file_server.enabled = false
 
+    config.middleware.use Rack::Deflater # if ENV['RACK_COMPRESS'] == 'true' # add the RACK_COMPRESS once the tests complete.
     config.middleware.use Mastodon::Middleware::PublicFileServer if Rails.env.local? || ENV['RAILS_SERVE_STATIC_FILES'] == 'true'
     config.middleware.use Rack::Attack
-    config.middleware.use Rack::Deflater # if ENV['RACK_COMPRESS'] == 'true' # add the RACK_COMPRESS once the tests complete.
     config.middleware.use Mastodon::Middleware::SocketCleanup
 
     config.before_configuration do

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,6 +88,7 @@ module Mastodon
 
     config.middleware.use Mastodon::Middleware::PublicFileServer if Rails.env.local? || ENV['RAILS_SERVE_STATIC_FILES'] == 'true'
     config.middleware.use Rack::Attack
+    config.middleware.use Rack::Deflater
     config.middleware.use Mastodon::Middleware::SocketCleanup
 
     config.before_configuration do


### PR DESCRIPTION
I've become aware that puma isn't serving compressed data to the reverse proxy.
This will *possibly* improve the performance between the reverse proxy and the puma server. 

<img width="1655" height="108" alt="image" src="https://github.com/user-attachments/assets/6be71d47-001b-45ee-b479-ebbccfd7269b" />

The home and notification API calls are heavily compressed. (The argument is.. it takes less time to compress, send 23kb and uncompress, than it does to send the whole 123kb uncompressed AND in some/most? cases, that is true.)

Yes, the reverse proxy to puma server is generally on the same LAN.. so the traffic/bandwidth/latency between the two make it less noticeable in the worst case... but I'd love to A/B test


https://schneems.com/2017/11/08/80-smaller-rails-footprint-with-rack-deflate/
https://onlyoneaman.medium.com/how-to-make-rails-response-faster-a8cc5f1242d
https://berislavbabic.com/use-rackdeflater-to-get-faster-first-time-loads-of-your-app/
https://thoughtbot.com/blog/content-compression-with-rack-deflater