### PR TITLE
Fix missing boolean check in Admin Reports API

### DIFF
--- a/app/models/report_filter.rb
+++ b/app/models/report_filter.rb
@@ -41,11 +41,11 @@ class ReportFilter
   def status_scope
     resolved = params[:resolved].present? && ActiveModel::Type::Boolean.new.cast(params[:resolved])
     unresolved = params[:unresolved].present? && ActiveModel::Type::Boolean.new.cast(params[:unresolved])
-  
+
     return Report.all if resolved && unresolved
     return Report.resolved if resolved
     return Report.unresolved if unresolved
-  
+
     Report.unresolved  # Default
   end
 

--- a/app/models/report_filter.rb
+++ b/app/models/report_filter.rb
@@ -39,8 +39,8 @@ class ReportFilter
   end
 
   def status_scope
-    resolved = params[:resolved].present? && ActiveModel::Type::Boolean.new.cast(params[:resolved])
-    unresolved = params[:unresolved].present? && ActiveModel::Type::Boolean.new.cast(params[:unresolved])
+    resolved = ActiveModel::Type::Boolean.new.cast(params[:resolved])
+    unresolved = ActiveModel::Type::Boolean.new.cast(params[:unresolved])
 
     return Report.all if resolved && unresolved
     return Report.resolved if resolved

--- a/app/models/report_filter.rb
+++ b/app/models/report_filter.rb
@@ -46,7 +46,7 @@ class ReportFilter
     return Report.resolved if resolved
     return Report.unresolved if unresolved
 
-    Report.unresolved # Default
+    Report.unresolved
   end
 
   def scope_for(key, value)

--- a/app/models/report_filter.rb
+++ b/app/models/report_filter.rb
@@ -44,7 +44,8 @@ class ReportFilter
 
     return Report.all if resolved && unresolved
     return Report.resolved if resolved
-    return Report.unresolved
+
+    Report.unresolved
   end
 
   def scope_for(key, value)

--- a/app/models/report_filter.rb
+++ b/app/models/report_filter.rb
@@ -39,13 +39,14 @@ class ReportFilter
   end
 
   def status_scope
-    resolved = params.key?(:resolved)
-    unresolved = params.key?(:unresolved)
-
+    resolved = params[:resolved].present? && ActiveModel::Type::Boolean.new.cast(params[:resolved])
+    unresolved = params[:unresolved].present? && ActiveModel::Type::Boolean.new.cast(params[:unresolved])
+  
     return Report.all if resolved && unresolved
     return Report.resolved if resolved
-
-    Report.unresolved
+    return Report.unresolved if unresolved
+  
+    Report.unresolved  # Default
   end
 
   def scope_for(key, value)

--- a/app/models/report_filter.rb
+++ b/app/models/report_filter.rb
@@ -46,7 +46,7 @@ class ReportFilter
     return Report.resolved if resolved
     return Report.unresolved if unresolved
 
-    Report.unresolved  # Default
+    Report.unresolved # Default
   end
 
   def scope_for(key, value)

--- a/app/models/report_filter.rb
+++ b/app/models/report_filter.rb
@@ -44,9 +44,7 @@ class ReportFilter
 
     return Report.all if resolved && unresolved
     return Report.resolved if resolved
-    return Report.unresolved if unresolved
-
-    Report.unresolved
+    return Report.unresolved
   end
 
   def scope_for(key, value)


### PR DESCRIPTION
`ActiveModel::Type::Boolean.new.cast(params[x])` is how booleans are handed in other parts of the codebase.

https://github.com/mastodon/mastodon/blob/03b20bc0a4b12940602325a52fbcd50274b1118c/app/services/report_service.rb#L72