### PR TITLE
Reduce timeout minutes for actions

### DIFF
--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   security:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     env:
       BUNDLE_ONLY: development

--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   check-i18n:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,6 +12,7 @@ jobs:
   pathcheck:
     name: Check for relevant changes
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       changed: ${{ steps.filter.outputs.src }}
     steps:
@@ -38,6 +39,7 @@ jobs:
   chromatic:
     name: Run Chromatic
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: pathcheck
     if: github.repository == 'mastodon/mastodon' && needs.pathcheck.outputs.changed == 'true'
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Clone repository

--- a/.github/workflows/lint-css.yml
+++ b/.github/workflows/lint-css.yml
@@ -27,6 +27,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Clone repository

--- a/.github/workflows/lint-haml.yml
+++ b/.github/workflows/lint-haml.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     env:
       BUNDLE_ONLY: development

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -33,6 +33,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Clone repository

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -27,6 +27,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     env:
       BUNDLE_ONLY: development

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -31,6 +31,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Clone repository

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: true
@@ -75,6 +76,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     needs:
       - build
@@ -176,6 +178,7 @@ jobs:
   test-e2e:
     name: End to End testing
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     needs:
       - build
@@ -279,6 +282,7 @@ jobs:
   test-search:
     name: Elastic Search integration testing
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     needs:
       - build


### PR DESCRIPTION
Follow up on https://github.com/mastodon/mastodon/pull/39199

The default timeout is 360 minutes. We hit a scenario earlier today where the queue was backed up waiting on hanging jobs to finally timeout before anything could happen ... which meant that the fix for this situation also had to sit in that queue.

I didn't touch the nightly tasks or image build tasks here, but did hit the bulk of the linter/test actions. I chose 15 mins for all the quick/lightweight tasks, and slightly longer for the main ruby test suite which sometimes approaches that (I am 90% sure from looking docs that each matrix run is effectively its own job, so the limit applies to each ruby versions run, not all of them together).

I think this idea in general is good, but dont feel strongly about the times here. It should be low enough that we kill hung/broken/stuck runs, but high enough that we avoid killing a just slightly slow run. Happy to increase/decrease as desired ... and we could also nudge back up if we do see what would have been valid runs getting killed.