### PR TITLE
Link directly to pending user account in email notification

### DIFF
--- a/app/views/admin_mailer/new_pending_account.text.erb
+++ b/app/views/admin_mailer/new_pending_account.text.erb
@@ -7,4 +7,4 @@
 <%= quote_wrap(@account.user&.invite_request&.text) %>
 <% end %>
 
-<%= raw t('application_mailer.view')%> <%= admin_accounts_url(status: 'pending') %>
+<%= raw t('application_mailer.view')%> <%= admin_account_url(@account.id) %>


### PR DESCRIPTION
Currently pending user account activation emails link to the generic list of pending user accounts. It would be more helpful to link directly to the account to see the data specific to the request.