### PR TITLE
Unify `queue_mail` and `mail` in admin mailer new trends spec

### DIFF
--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -75,8 +75,7 @@ RSpec.describe AdminMailer do
     let!(:status) { Fabricate(:status) }
     let!(:tag) { Fabricate(:tag, display_name: 'Test Tag') }
     let!(:other_tag) { Fabricate(:tag, display_name: 'Test Tag') }
-    let!(:another_tag) { Fabricate(:tag, display_name: 'Test Tag') }
-    let(:mail) { described_class.with(recipient: recipient).new_trends([link], [tag, other_tag, another_tag], [status]) }
+    let(:mail) { described_class.with(recipient: recipient).new_trends([link], [tag, other_tag], [status]) }
     let(:other_tag_trend) { Fabricate(:tag_trend, tag: other_tag) }
 
     before do

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -77,16 +77,13 @@ RSpec.describe AdminMailer do
     let!(:other_tag) { Fabricate(:tag, display_name: 'Test Tag') }
     let!(:another_tag) { Fabricate(:tag, display_name: 'Test Tag') }
     let(:mail) { described_class.with(recipient: recipient).new_trends([link], [tag, other_tag, another_tag], [status]) }
-    let(:status_trend) { Fabricate(:status_trend, status: status, account: Fabricate(:account)) }
-    let(:tag_trend) { Fabricate(:tag_trend, tag: tag) }
     let(:other_tag_trend) { Fabricate(:tag_trend, tag: other_tag) }
-    let(:preview_card_trend) { Fabricate(:preview_card_trend, preview_card: link) }
 
     before do
       recipient.user.update(locale: :en)
-      status_trend
-      tag_trend
-      preview_card_trend
+      Fabricate(:status_trend, status: status, account: Fabricate(:account))
+      Fabricate(:tag_trend, tag: tag)
+      Fabricate(:preview_card_trend, preview_card: link)
     end
 
     it 'renders the email' do

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe AdminMailer do
     let!(:link) { Fabricate(:preview_card, trendable: true, language: 'en') }
     let!(:status) { Fabricate(:status) }
     let!(:tag) { Fabricate(:tag, display_name: 'Test Tag') }
-    let!(:other_tag) { Fabricate(:tag, display_name: 'Test Tag') }
+    let!(:other_tag) { Fabricate(:tag, display_name: 'Other Test Tag') }
     let(:mail) { described_class.with(recipient: recipient).new_trends([link], [tag, other_tag], [status]) }
     let(:other_tag_trend) { Fabricate(:tag_trend, tag: other_tag) }
 
@@ -100,37 +100,40 @@ RSpec.describe AdminMailer do
     end
 
     context 'when between queueing and sending trends gets deleted' do
-      let(:queue_mail) { described_class.with(recipient: recipient).new_trends([link], [tag, other_tag], [status]).deliver_later! }
-
       before do
         recipient.user.update(locale: :en)
       end
 
       it 'sends the email when all but one trends were deleted without the respective tag or status or link' do
         other_tag_trend
-        expect(queue_mail.successfully_enqueued?).to be(true)
+        expect(mail.deliver_later!)
+          .to be_successfully_enqueued
 
         TagTrend.delete_all
         StatusTrend.delete_all
-        expect { queue_mail.perform_now }.to send_email(
-          to: recipient.user_email,
-          from: 'notifications@localhost',
-          subject: I18n.t('admin_mailer.new_trends.subject', instance: Rails.configuration.x.local_domain)
-        )
-        expect(mail.body).to have_text(/The following items need a review before they can be displayed publicly/)
+        expect { mail.deliver }
+          .to send_email(
+            to: recipient.user_email,
+            from: 'notifications@localhost',
+            subject: I18n.t('admin_mailer.new_trends.subject', instance: Rails.configuration.x.local_domain)
+          )
+        expect(mail.body)
+          .to have_text(/The following items need a review before they can be displayed publicly/)
           .and match(link.title)
-        expect(mail.body).to_not match(ActivityPub::TagManager.instance.url_for(status))
-        expect(mail.body).to_not match(tag.display_name)
+          .and not_include(ActivityPub::TagManager.instance.url_for(status))
+          .and not_include(tag.display_name)
       end
 
       it 'returns nil when no trends are present' do
-        expect(queue_mail.successfully_enqueued?).to be(true)
+        expect(mail.deliver_later!)
+          .to be_successfully_enqueued
 
         TagTrend.delete_all
         StatusTrend.delete_all
         PreviewCardTrend.delete_all
 
-        expect { queue_mail.perform_now }.to_not send_email
+        expect { mail.deliver }
+          .to_not send_email
       end
     end
   end


### PR DESCRIPTION
I had thought I left these as comments on https://github.com/mastodon/mastodon/pull/39122 before it merged, but realize now I started a review by accident so they didn't show up.

The main change here is to fix one example which starts working on `queue_mail` and then switches to `mail` halfway down. My assumption is this should have been just one or the other (?) ... but if it was intentional I can back that part out.

Other stuff:

- Remove extra/unused tag factory record
- Move trend record creation directly into `before`, instead of in unused `let`
- Misc spec format/style/naming stuff while in there for consistency w/ project