### PR TITLE
Fix container builds failing on repo names with uppercase characters

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -45,7 +45,8 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
           # Transform multi-line variable into comma-separated variable
           image_names=${PUSH_TO_IMAGES//$'\n'/,}
-          echo "IMAGE_NAMES=${image_names%,}" >> $GITHUB_ENV
+          image_names_split=${image_names%,}
+          echo "IMAGE_NAMES=${image_names_split,,}" >> $GITHUB_ENV
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         id: buildx
@@ -160,11 +161,11 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
-          echo "$PUSH_TO_IMAGES" | xargs -I{} \
+          echo "${PUSH_TO_IMAGES,,}" | xargs -I{} \
             docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
               $(printf '{}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          echo "$PUSH_TO_IMAGES" | xargs -i{} \
+          echo "${PUSH_TO_IMAGES,,}" | xargs -i{} \
             docker buildx imagetools inspect {}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
When attempting to use the GitHub action to build a container image in a repo owned by a user/organization with uppercase characters in their name, the build will fail as uppercase characters are invalid in image tag names. This should normalize the tag names to lowercase to workaround the issue.