### PR TITLE
Disallow crawling of registration/invite accept token URLs in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,3 +7,5 @@ User-agent: *
 Disallow: /media_proxy/
 Disallow: /interact/
 Disallow: /api/v1/instance/domain_blocks
+Disallow: /auth/sign_up?accept=
+Disallow: /invite/*?accept=


### PR DESCRIPTION
The `accept` parameter on `/auth/sign_up` and `/invite/*` generates a new unique URL on every render, so crawlers following it get trapped on an endless set of unique pages that all return 200.

Easy to see, two requests return different tokens:
```
for n in 1 2; do curl -s https://INSTANCE/auth/sign_up | grep -oE 'accept=[0-9a-f]+' | head -1; done
```

This does not fix the root cause (a non-compliant crawler might still get trapped), but it stops compliant crawlers from wasting resources on this. For scale, I am seeing hundreds of thousands of requests per day to these paths from a single bot.