### PR TITLE
Move by_domain/local interaction check to filter

### DIFF
--- a/app/controllers/admin/custom_emojis_controller.rb
+++ b/app/controllers/admin/custom_emojis_controller.rb
@@ -5,9 +5,6 @@ module Admin
     def index
       authorize :custom_emoji, :index?
 
-      # If filtering by local emojis, remove by_domain filter.
-      params.delete(:by_domain) if params[:local].present?
-
       # If filtering by domain, ensure remote filter is set.
       if params[:by_domain].present?
         params.delete(:local)

--- a/app/models/custom_emoji_filter.rb
+++ b/app/models/custom_emoji_filter.rb
@@ -19,7 +19,7 @@ class CustomEmojiFilter
   def results
     scope = CustomEmoji.alphabetic
 
-    params.each do |key, value|
+    relevant_params.each do |key, value|
       next if IGNORED_PARAMS.include?(key.to_s)
 
       scope.merge!(scope_for(key, value)) if value.present?
@@ -29,6 +29,12 @@ class CustomEmojiFilter
   end
 
   private
+
+  def relevant_params
+    params.tap do |args|
+      args.delete(:by_domain) if args[:local].present?
+    end
+  end
 
   def scope_for(key, value)
     case key.to_s

--- a/spec/models/custom_emoji_filter_spec.rb
+++ b/spec/models/custom_emoji_filter_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe CustomEmojiFilter do
 
     context 'when params have values' do
       context 'when local' do
-        let(:params) { { local: true } }
+        let(:params) { { local: true, by_domain: 'a' } }
 
-        it 'returns ActiveRecord::Relation' do
+        it 'ignores domain and returns ActiveRecord::Relation' do
           expect(subject).to be_a(ActiveRecord::Relation)
           expect(subject).to contain_exactly(custom_emoji_domain_nil)
         end


### PR DESCRIPTION
This is more consistent with how other of the "filter" classes handle this sort of scenario where interactions between params need to impact the chosen scope.

I was going to also move the lines immediately under this (more by_domain/local/remote stuff) ... but for those there's sort of a dual-use of the params both for creating the filter and for informing the html page how to build links based on params presence. Needs more consideration.

Separately, I think there might be a bug here where setting the remote param and having by_domain both at the same time trips up how the scopes are combined. Will attempt to reproduce that and do followup if confirmed.