### PR TITLE
[Profile] Make handle button text selectable

### DIFF
--- a/app/javascript/mastodon/components/account_header/styles.module.scss
+++ b/app/javascript/mastodon/components/account_header/styles.module.scss
@@ -110,6 +110,9 @@
   word-break: break-all;
   text-align: left;
 
+  /* Allow the handle text to be selected */
+  user-select: text;
+
   > svg {
     width: 16px;
     height: 16px;


### PR DESCRIPTION
Fixes #39209

### Changes proposed in this PR:
- Allows the handle on the profile page to be selected even though it's a button label – I hope this doesn't have any major accessibility side-effects. Selecting the text will often trigger the button, but since it only opens the info dialog, this should be harmless.

### Screenshots

<img width="278" height="119" alt="image" src="https://github.com/user-attachments/assets/390ec1ea-c6b7-4ba7-add8-74a0d715fb4f" />

https://github.com/user-attachments/assets/6c7c09af-603d-4635-bec0-133369d19984

