### PR TITLE
Update vite_rails to version 3.11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -230,4 +230,4 @@ gem 'hcaptcha', '~> 7.1'
 
 gem 'mail', '~> 2.8'
 
-gem 'vite_rails', '~> 3.0.19'
+gem 'vite_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,7 +354,7 @@ GEM
       azure-blob (~> 0.5.2)
       hashie (~> 5.0)
     jmespath (1.6.2)
-    json (2.19.5)
+    json (2.19.7)
     json-canonicalization (1.0.0)
     json-jwt (1.17.0)
       activesupport (>= 4.2)
@@ -647,7 +647,7 @@ GEM
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
-    rack-proxy (0.7.7)
+    rack-proxy (0.8.2)
       rack
     rack-session (2.1.2)
       base64 (>= 0.1.0)
@@ -901,7 +901,7 @@ GEM
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
-    vite_rails (3.0.20)
+    vite_rails (3.11.0)
       railties (>= 5.1, < 9)
       vite_ruby (~> 3.0, >= 3.2.2)
     vite_ruby (3.10.2)
@@ -937,7 +937,7 @@ GEM
     xorcist (1.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.5)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   ruby
@@ -1089,7 +1089,7 @@ DEPENDENCIES
   tty-prompt (~> 0.23)
   twitter-text (~> 3.1.0)
   tzinfo-data (~> 1.2023)
-  vite_rails (~> 3.0.19)
+  vite_rails
   webauthn (~> 3.0)
   webmock (~> 3.18)
   webpush!

--- a/lib/vite_ruby/sri_extensions.rb
+++ b/lib/vite_ruby/sri_extensions.rb
@@ -75,7 +75,7 @@ module ViteRails::TagHelpers::IntegrityExtension
                           asset_type: :javascript,
                           skip_preload_tags: false,
                           skip_style_tags: false,
-                          crossorigin: 'anonymous',
+                          crossorigin: '',
                           media: 'screen',
                           **options)
     entries = vite_manifest.resolve_entries_with_integrity(*names, type: asset_type)


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/38272

This is the version bump from that PR, plus one change to align with upstream in our SRI patch. The relevant changes are in https://github.com/ElMassimo/vite_ruby/pull/544/changes - we already had the `crossorigin: crossorigin` change in the stylesheet helper, so this is just changing the default for crossorigin. I believe that every spot we call `vite_typescript_tag` passes in "anonymous" for this value, so this should not change output.