### PR TITLE
updated ssl section with correct http2 usage

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -31,8 +31,9 @@ server {
 }
 
 server {
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
   server_name example.com;
 
   ssl_protocols TLSv1.2 TLSv1.3;


### PR DESCRIPTION
usage of "http2" in listen directive is deprecated