### PR TITLE
Make the hidden account message less misleading

### DIFF
--- a/app/javascript/mastodon/components/hover_card_account.tsx
+++ b/app/javascript/mastodon/components/hover_card_account.tsx
@@ -93,7 +93,7 @@ export const HoverCardAccount = forwardRef<
               ) : (
                 <FormattedMessage
                   id='limited_account_hint.title'
-                  defaultMessage='This profile has been hidden by the moderators of {domain}.'
+                  defaultMessage='This profile or server has been hidden by the moderators of {domain}.'
                   values={{ domain }}
                 />
               )}

--- a/app/javascript/mastodon/components/limited_account_hint.tsx
+++ b/app/javascript/mastodon/components/limited_account_hint.tsx
@@ -21,7 +21,7 @@ export const LimitedAccountHint: React.FC<{ accountId: string }> = ({
       <p>
         <FormattedMessage
           id='limited_account_hint.title'
-          defaultMessage='This profile has been hidden by the moderators of {domain}.'
+          defaultMessage='This profile or server has been hidden by the moderators of {domain}.'
           values={{ domain }}
         />
       </p>

--- a/app/javascript/mastodon/locales/en-GB.json
+++ b/app/javascript/mastodon/locales/en-GB.json
@@ -835,7 +835,7 @@
   "lightbox.zoom_in": "Zoom to actual size",
   "lightbox.zoom_out": "Zoom to fit",
   "limited_account_hint.action": "Show profile anyway",
-  "limited_account_hint.title": "This profile has been hidden by the moderators of {domain}.",
+  "limited_account_hint.title": "This profile or server has been hidden by the moderators of {domain}.",
   "link_preview.author": "By {name}",
   "link_preview.more_from_author": "More from {name}",
   "link_preview.shares": "{count, plural, one {{counter} post} other {{counter} posts}}",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -850,7 +850,7 @@
   "lightbox.zoom_in": "Zoom to actual size",
   "lightbox.zoom_out": "Zoom to fit",
   "limited_account_hint.action": "Show profile anyway",
-  "limited_account_hint.title": "This profile has been hidden by the moderators of {domain}.",
+  "limited_account_hint.title": "This profile or server has been hidden by the moderators of {domain}.",
   "link_preview.author": "By {name}",
   "link_preview.more_from_author": "More from {name}",
   "link_preview.shares": "{count, plural, one {{counter} post} other {{counter} posts}}",


### PR DESCRIPTION
The message used to say "This profile has been hidden by the moderators of {domain}". However, it's often not the profile itself that's hidden, but rather the instance the profile is on. The old message makes it sound like moderators have silenced the specific profile.

I have been confused by this misleading message, thinking that my instance's moderators just hide completely innocuous accounts (or worse, accounts posting political views I *agree with*, making it seem like I have deep political differences with my instance). It wasn't before I asked around [on Mastodon](https://floss.social/@mort/116670920365177521) that I realized that the profiles are not, in fact, hidden by my instance.

Ideally, I think the message should specify whether it's the profile or the instance that's hidden. But as a quick "good enough" fix, I think this slight wording tweak should do.