### PR TITLE
Use `ubuntu-26.04` instead of `ubuntu-latest` as `runs-on` target in `github-actions`

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   # Build each (amd64 and arm64) image separately
   build-image:
-    runs-on: ${{ startsWith(matrix.platform, 'linux/arm') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ startsWith(matrix.platform, 'linux/arm') && 'ubuntu-26.04-arm' || 'ubuntu-26.04' }}
     strategy:
       fail-fast: false
       matrix:
@@ -111,7 +111,7 @@ jobs:
   # Then merge the docker images into a single one
   merge-images:
     if: ${{ inputs.push_to_images != '' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs:
       - build-image
 

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   compute-suffix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     if: github.repository == 'mastodon/mastodon'
     steps:
       - id: version_vars

--- a/.github/workflows/build-push-pr.yml
+++ b/.github/workflows/build-push-pr.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   compute-suffix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     # This is only allowed to run if:
     # - the PR branch is in the `mastodon/mastodon` repository
     # - the PR is not a draft

--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   check-latest-stable:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     outputs:
       latest: ${{ steps.check.outputs.is_latest_stable }}
     steps:

--- a/.github/workflows/build-security.yml
+++ b/.github/workflows/build-security.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   compute-suffix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - id: version_vars
         env:

--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   security:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     env:
       BUNDLE_ONLY: development

--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   check-i18n:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   pathcheck:
     name: Check for relevant changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     outputs:
       changed: ${{ steps.filter.outputs.src }}
     steps:
@@ -37,7 +37,7 @@ jobs:
 
   chromatic:
     name: Run Chromatic
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     needs: pathcheck
     if: github.repository == 'mastodon/mastodon' && needs.pathcheck.outputs.changed == 'true'
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/crowdin-download-stable.yml
+++ b/.github/workflows/crowdin-download-stable.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   download-translations-stable:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     if: github.repository == 'mastodon/mastodon'
 
     steps:

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   download-translations:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     if: github.repository == 'mastodon/mastodon'
 
     steps:

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   upload-translations:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     if: github.repository == 'mastodon/mastodon'
 
     steps:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
       - name: Clone repository

--- a/.github/workflows/lint-css.yml
+++ b/.github/workflows/lint-css.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
       - name: Clone repository

--- a/.github/workflows/lint-haml.yml
+++ b/.github/workflows/lint-haml.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     env:
       BUNDLE_ONLY: development

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
       - name: Clone repository

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     env:
       BUNDLE_ONLY: development

--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   label-rebase-needed:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     if: github.repository == 'mastodon/mastodon'
 
     concurrency:

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
       - name: Clone repository

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     strategy:
       fail-fast: true
@@ -74,7 +74,7 @@ jobs:
           retention-days: 0
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     needs:
       - build
@@ -175,7 +175,7 @@ jobs:
 
   test-e2e:
     name: End to End testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     needs:
       - build
@@ -278,7 +278,7 @@ jobs:
 
   test-search:
     name: Elastic Search integration testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     needs:
       - build


### PR DESCRIPTION
This is to avoid unexpected breakage, especially in older branches, when `ubuntu-latest` is updated.