### PR TITLE
Move simplecov `start` to config and require to `spec_helper`

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-SimpleCov.start 'rails' do
+SimpleCov.configure do
   # During parallel runs, ensure unique names for post-run merge
   command_name "job-#{ENV['TEST_ENV_NUMBER']}" if ENV['TEST_ENV_NUMBER']
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,8 +2,6 @@
 
 ENV['RAILS_ENV'] ||= 'test'
 
-require 'simplecov' if ENV.fetch('COVERAGE', false)
-
 # This needs to be defined before Rails is initialized
 STREAMING_PORT = ENV.fetch('TEST_STREAMING_PORT', '4020')
 STREAMING_HOST = ENV.fetch('TEST_STREAMING_HOST', 'localhost')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+if ENV.fetch('COVERAGE', false)
+  require 'simplecov'
+  SimpleCov.start 'rails'
+end
+
 RSpec.configure do |config|
   config.example_status_persistence_file_path = 'tmp/rspec/examples.txt'
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
I've been rebasing/updating https://github.com/mastodon/mastodon/pull/39112 as simplecov gets close to 1.0 release.

This extracts two changes which can be done in advance of the 1.0 update:

- Move the require from rails helper to spec helper -- this starts the coverage process slightly earlier in the spec run (spec helper is required before rails helper), and it cleans up the console output (we currently see the "Coverage report generated..." text N times, one for each runner -- after this change it appears just once at end of the run)
- Calling `start` from the `.simplecov` file is deprecated and emits warning in 1.0 -- the preference is to have JUST configuration in that file and call start from the test/spec helper instead. This pre-extracts that change.

The overall report data looks the same before/after this change.

Unless something else large changes this is probably the last extraction before 1.0, and that linked PR will wind up just being the update itself, some deprecation renames, removal of no longer needed patch, etc.