### PR TITLE
Remove ignored_columns for columns removed in pre-4.2.0 migrations

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -63,15 +63,7 @@
 #
 
 class Account < ApplicationRecord
-  self.ignored_columns += %w(
-    devices_url
-    hub_url
-    remote_url
-    salmon_url
-    secret
-    subscription_expires_at
-    trust_level
-  )
+  self.ignored_columns += %w(devices_url)
 
   BACKGROUND_REFRESH_INTERVAL = 1.week.freeze
   REFRESH_DEADLINE = 6.hours

--- a/app/models/account_stat.rb
+++ b/app/models/account_stat.rb
@@ -16,7 +16,6 @@
 
 class AccountStat < ApplicationRecord
   self.locking_column = nil
-  self.ignored_columns += %w(lock_version)
 
   belongs_to :account, inverse_of: :account_stat
 

--- a/app/models/admin/action_log.rb
+++ b/app/models/admin/action_log.rb
@@ -17,10 +17,6 @@
 #
 
 class Admin::ActionLog < ApplicationRecord
-  self.ignored_columns += %w(
-    recorded_changes
-  )
-
   belongs_to :account
   belongs_to :target, polymorphic: true, optional: true
 

--- a/app/models/email_domain_block.rb
+++ b/app/models/email_domain_block.rb
@@ -13,11 +13,6 @@
 #
 
 class EmailDomainBlock < ApplicationRecord
-  self.ignored_columns += %w(
-    ips
-    last_refresh_at
-  )
-
   include DomainNormalizable
   include Paginable
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -22,8 +22,6 @@
 #
 
 class Report < ApplicationRecord
-  self.ignored_columns += %w(action_taken)
-
   include Paginable
   include RateLimitable
 

--- a/app/models/status_edit.rb
+++ b/app/models/status_edit.rb
@@ -21,10 +21,6 @@
 class StatusEdit < ApplicationRecord
   include RateLimitable
 
-  self.ignored_columns += %w(
-    media_attachments_changed
-  )
-
   class PreservedMediaAttachment < ActiveModelSerializers::Model
     attributes :media_attachment, :description
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,15 +44,10 @@
 class User < ApplicationRecord
   self.ignored_columns += %w(
     admin
-    current_sign_in_ip
     encrypted_otp_secret
     encrypted_otp_secret_iv
     encrypted_otp_secret_salt
-    filtered_languages
-    last_sign_in_ip
     moderator
-    remember_created_at
-    remember_token
     skip_sign_in_token
   )
 


### PR DESCRIPTION
Also noticed that the `skip_sign_in_token` column of `users` has been ignored for quite a while but never removed from the schema.