### PR TITLE
Fixes author name spacing in trending links items

### DIFF
--- a/app/javascript/mastodon/features/explore/components/story.jsx
+++ b/app/javascript/mastodon/features/explore/components/story.jsx
@@ -58,7 +58,7 @@ export const Story = ({
         </a>
 
         <div className='story__details__shared'>
-          {author ? <FormattedMessage id='link_preview.author' className='story__details__shared__author' defaultMessage='By {name}' values={{ name: authorAccount ? <AuthorLink accountId={authorAccount} /> : <strong>{author}</strong> }} /> : <span />}
+          {author ? <FormattedMessage id='link_preview.author' className='story__details__shared__author' defaultMessage='By {name}' values={{ name: authorAccount ? <AuthorLink accountId={authorAccount} /> : <strong>{author}</strong> }} tagName='span' /> : <span />}
           {typeof sharedTimes === 'number' ? <Link className='story__details__shared__pill' to={`/links/${encodeURIComponent(url)}`}><ShortNumber value={sharedTimes} renderer={sharesCountRenderer} /></Link> : <Skeleton width='10ch' />}
         </div>
       </div>


### PR DESCRIPTION
### Changes proposed in this PR:
- Adds a wrapping span to the author name of trending link items to fix a spacing regression caused by #38398

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="599" height="165" alt="image" src="https://github.com/user-attachments/assets/095fc901-e64b-44a7-8f5a-aab7f660753a" /> | <img width="601" height="167" alt="image" src="https://github.com/user-attachments/assets/b8b9054c-609a-41ee-95a6-f89c80ade5ce" /> |