### PR TITLE
Add import for custom filters

### DIFF
--- a/app/controllers/settings/imports_controller.rb
+++ b/app/controllers/settings/imports_controller.rb
@@ -13,6 +13,7 @@ class Settings::ImportsController < Settings::BaseController
     domain_blocking: 'blocked_domains_failures.csv',
     bookmarks: 'bookmarks_failures.csv',
     lists: 'lists_failures.csv',
+    custom_filters: 'custom_filters_failures.json',
   }.freeze
 
   TYPE_TO_HEADERS_MAP = {
@@ -58,6 +59,21 @@ class Settings::ImportsController < Settings::BaseController
             end
           end
         end
+
+        send_data export_data, filename: filename
+      end
+
+      format.json do
+        filename = TYPE_TO_FILENAME_MAP[@bulk_import.type.to_sym]
+
+        data_collection = { custom_filters: [] }
+        @bulk_import.rows.find_each do |row|
+          case @bulk_import.type.to_sym
+          when :custom_filters
+            data_collection[:custom_filters] << row.data
+          end
+        end
+        export_data = JSON.generate(data_collection)
 
         send_data export_data, filename: filename
       end

--- a/app/models/bulk_import.rb
+++ b/app/models/bulk_import.rb
@@ -34,6 +34,7 @@ class BulkImport < ApplicationRecord
     domain_blocking: 3,
     bookmarks: 4,
     lists: 5,
+    custom_filters: 6,
   }
 
   enum :state, {

--- a/app/models/bulk_import.rb
+++ b/app/models/bulk_import.rb
@@ -8,6 +8,7 @@
 #  finished_at       :datetime
 #  imported_items    :integer          default(0), not null
 #  likely_mismatched :boolean          default(FALSE), not null
+#  missing_status    :boolean          default(FALSE), not null
 #  original_filename :string           default(""), not null
 #  overwrite         :boolean          default(FALSE), not null
 #  processed_items   :integer          default(0), not null

--- a/app/models/form/import.rb
+++ b/app/models/form/import.rb
@@ -59,7 +59,7 @@ class Form::Import
   end
 
   def guessed_type_json
-    :custom_filters if file_name_matches?('custom_filters')
+    :custom_filters if parse_json.keys.any?('custom_filters')
   end
 
   # Whether the uploaded CSV file seems to correspond to a different import type than the one selected
@@ -195,7 +195,7 @@ class Form::Import
 
   def validate_json_data
     errors.add(:data, I18n.t('imports.errors.over_rows_processing_limit', count: ROWS_PROCESSING_LIMIT)) if json_data.count > ROWS_PROCESSING_LIMIT
-    errors.add(:data, I18n.t('imports.errors.incompatible_type')) unless allowed_json_key?
+    errors.add(:data, I18n.t('imports.errors.incompatible_type')) unless allowed_type_for_json?
   end
 
   def content_type_is_json?
@@ -203,10 +203,14 @@ class Form::Import
   end
 
   def json_data
-    @json_data ||= JSON.parse(data.read)['custom_filters'].map(&:deep_symbolize_keys)
+    parse_json['custom_filters'].map(&:deep_symbolize_keys)
   end
 
-  def allowed_json_key?
+  def parse_json
+    @parse_json ||= JSON.parse(data.read)
+  end
+
+  def allowed_type_for_json?
     type.to_sym.in?(%i(custom_filters))
   end
 end

--- a/app/models/form/import.rb
+++ b/app/models/form/import.rb
@@ -55,6 +55,8 @@ class Form::Import
       :bookmarks
     elsif file_name_matches?('lists')
       :lists
+    elsif file_name_matches?('custom_filters')
+      :custom_filters
     end
   end
 
@@ -150,9 +152,34 @@ class Form::Import
     end
   end
 
+  def file_type_is_json?
+    data.content_type == 'application/json'
+  end
+
+  def data_from_json
+    @data_from_json ||= JSON.parse(data.read)['custom_filters'].map(&:deep_symbolize_keys)
+  end
+
+  def allowed_json_key?
+    type.to_sym.in?(%i(custom_filters))
+  end
+
   def validate_data
     return if data.nil?
     return errors.add(:data, I18n.t('imports.errors.too_large')) if data.size > FILE_SIZE_LIMIT
+
+    if file_type_is_json?
+      validate_json_data
+    else
+      validate_csv_data
+    end
+  rescue CSV::MalformedCSVError => e
+    errors.add(:data, I18n.t('imports.errors.invalid_csv_file', error: e.message))
+  rescue EmptyFileError
+    errors.add(:data, I18n.t('imports.errors.empty'))
+  end
+
+  def validate_csv_data
     return errors.add(:data, I18n.t('imports.errors.incompatible_type')) unless default_csv_headers.all? { |header| csv_data.headers.include?(header) }
 
     errors.add(:data, I18n.t('imports.errors.over_rows_processing_limit', count: ROWS_PROCESSING_LIMIT)) if csv_row_count > ROWS_PROCESSING_LIMIT
@@ -163,9 +190,12 @@ class Form::Import
       limit -= current_account.following_count unless overwrite
       errors.add(:data, I18n.t('users.follow_limit_reached', limit: base_limit)) if csv_row_count > limit
     end
-  rescue CSV::MalformedCSVError => e
-    errors.add(:data, I18n.t('imports.errors.invalid_csv_file', error: e.message))
-  rescue EmptyFileError
-    errors.add(:data, I18n.t('imports.errors.empty'))
+  end
+
+  def validate_json_data
+    return unless allowed_json_key?
+
+    errors.add(:data, I18n.t('imports.errors.over_rows_processing_limit', count: ROWS_PROCESSING_LIMIT)) if data_from_json.count > ROWS_PROCESSING_LIMIT
+    errors.add(:data, I18n.t('imports.errors.incompatible_type')) unless allowed_json_key?
   end
 end

--- a/app/models/form/import.rb
+++ b/app/models/form/import.rb
@@ -77,7 +77,7 @@ class Form::Import
     ApplicationRecord.transaction do
       now = Time.now.utc
       if content_type_is_json?
-        @bulk_import = current_account.bulk_imports.create(type: type, overwrite: overwrite || false, state: :unconfirmed, original_filename: data.original_filename, likely_mismatched: likely_mismatched_json?)
+        @bulk_import = current_account.bulk_imports.create(type: type, overwrite: overwrite || false, state: :unconfirmed, original_filename: data.original_filename, likely_mismatched: likely_mismatched_json?, missing_status: missing_status?)
         nb_items = BulkImportRow.insert_all(json_data.map { |row| { bulk_import_id: bulk_import.id, data: row, created_at: now, updated_at: now } }).length
       else
         @bulk_import = current_account.bulk_imports.create(type: type, overwrite: overwrite || false, state: :unconfirmed, original_filename: data.original_filename, likely_mismatched: likely_mismatched?)
@@ -93,6 +93,14 @@ class Form::Import
 
   def mode=(str)
     self.overwrite = str.to_sym == :overwrite
+  end
+
+  def missing_status?
+    return false unless content_type_is_json?
+
+    import_statuses = json_data.pluck(:statuses).flatten.uniq
+    db_statuses = Status.where(uri: import_statuses)
+    import_statuses.count != db_statuses.count
   end
 
   private

--- a/app/models/form/import.rb
+++ b/app/models/form/import.rb
@@ -55,9 +55,11 @@ class Form::Import
       :bookmarks
     elsif file_name_matches?('lists')
       :lists
-    elsif file_name_matches?('custom_filters')
-      :custom_filters
     end
+  end
+
+  def guessed_type_json
+    :custom_filters if file_name_matches?('custom_filters')
   end
 
   # Whether the uploaded CSV file seems to correspond to a different import type than the one selected
@@ -65,13 +67,22 @@ class Form::Import
     guessed_type.present? && guessed_type != type.to_sym
   end
 
+  def likely_mismatched_json?
+    guessed_type_json.present? && guessed_type_json != type.to_sym
+  end
+
   def save
     return false unless valid?
 
     ApplicationRecord.transaction do
       now = Time.now.utc
-      @bulk_import = current_account.bulk_imports.create(type: type, overwrite: overwrite || false, state: :unconfirmed, original_filename: data.original_filename, likely_mismatched: likely_mismatched?)
-      nb_items = BulkImportRow.insert_all(parsed_rows.map { |row| { bulk_import_id: bulk_import.id, data: row, created_at: now, updated_at: now } }).length
+      if content_type_is_json?
+        @bulk_import = current_account.bulk_imports.create(type: type, overwrite: overwrite || false, state: :unconfirmed, original_filename: data.original_filename, likely_mismatched: likely_mismatched_json?)
+        nb_items = BulkImportRow.insert_all(json_data.map { |row| { bulk_import_id: bulk_import.id, data: row, created_at: now, updated_at: now } }).length
+      else
+        @bulk_import = current_account.bulk_imports.create(type: type, overwrite: overwrite || false, state: :unconfirmed, original_filename: data.original_filename, likely_mismatched: likely_mismatched?)
+        nb_items = BulkImportRow.insert_all(parsed_rows.map { |row| { bulk_import_id: bulk_import.id, data: row, created_at: now, updated_at: now } }).length
+      end
       @bulk_import.update(total_items: nb_items)
     end
   end
@@ -152,29 +163,19 @@ class Form::Import
     end
   end
 
-  def file_type_is_json?
-    data.content_type == 'application/json'
-  end
-
-  def data_from_json
-    @data_from_json ||= JSON.parse(data.read)['custom_filters'].map(&:deep_symbolize_keys)
-  end
-
-  def allowed_json_key?
-    type.to_sym.in?(%i(custom_filters))
-  end
-
   def validate_data
     return if data.nil?
     return errors.add(:data, I18n.t('imports.errors.too_large')) if data.size > FILE_SIZE_LIMIT
 
-    if file_type_is_json?
+    if content_type_is_json?
       validate_json_data
     else
       validate_csv_data
     end
   rescue CSV::MalformedCSVError => e
     errors.add(:data, I18n.t('imports.errors.invalid_csv_file', error: e.message))
+  rescue JSON::ParserError => e
+    errors.add(:data, I18n.t('imports.errors.invalid_json_file', error: e.message))
   rescue EmptyFileError
     errors.add(:data, I18n.t('imports.errors.empty'))
   end
@@ -193,9 +194,19 @@ class Form::Import
   end
 
   def validate_json_data
-    return unless allowed_json_key?
-
-    errors.add(:data, I18n.t('imports.errors.over_rows_processing_limit', count: ROWS_PROCESSING_LIMIT)) if data_from_json.count > ROWS_PROCESSING_LIMIT
+    errors.add(:data, I18n.t('imports.errors.over_rows_processing_limit', count: ROWS_PROCESSING_LIMIT)) if json_data.count > ROWS_PROCESSING_LIMIT
     errors.add(:data, I18n.t('imports.errors.incompatible_type')) unless allowed_json_key?
+  end
+
+  def content_type_is_json?
+    data.content_type == 'application/json'
+  end
+
+  def json_data
+    @json_data ||= JSON.parse(data.read)['custom_filters'].map(&:deep_symbolize_keys)
+  end
+
+  def allowed_json_key?
+    type.to_sym.in?(%i(custom_filters))
   end
 end

--- a/app/services/bulk_import_row_service.rb
+++ b/app/services/bulk_import_row_service.rb
@@ -43,13 +43,12 @@ class BulkImportRowService
 
       list.accounts << @target_account
     when :custom_filters
-      filter = @account.custom_filters.find_or_initialize_by(title: @data['title'], context: @data['context'])
+      filter = @account.custom_filters.create!(title: @data['title'], context: @data['context'])
       filter.keywords = @data['keywords_attributes'].map { |keyword| CustomFilterKeyword.new(keyword: keyword['keyword'], whole_word: keyword['whole_word']) }
       filter.action = @data['action'].to_sym
       filter.expires_at = @data['expires_at']
       status_ids = Status.where(uri: @data['statuses']).ids
       filter.statuses = status_ids.map { |status| CustomFilterStatus.new(status_id: status) } if status_ids.any?
-
       filter.save!
     end
 

--- a/app/services/bulk_import_row_service.rb
+++ b/app/services/bulk_import_row_service.rb
@@ -42,6 +42,15 @@ class BulkImportRowService
       FollowService.new.call(@account, @target_account) unless @account.id == @target_account.id
 
       list.accounts << @target_account
+    when :custom_filters
+      filter = @account.custom_filters.find_or_initialize_by(title: @data['title'], context: @data['context'])
+      filter.keywords = @data['keywords_attributes'].map { |keyword| CustomFilterKeyword.new(keyword: keyword['keyword'], whole_word: keyword['whole_word']) }
+      filter.action = @data['action'].to_sym
+      filter.expires_at = @data['expires_at']
+      status_ids = Status.where(uri: @data['statuses']).ids
+      filter.statuses = status_ids.map { |status| CustomFilterStatus.new(status_id: status) } if status_ids.any?
+
+      filter.save!
     end
 
     true

--- a/app/services/bulk_import_service.rb
+++ b/app/services/bulk_import_service.rb
@@ -18,6 +18,8 @@ class BulkImportService < BaseService
       import_bookmarks!
     when :lists
       import_lists!
+    when :custom_filters
+      import_custom_filters!
     end
 
     @import.update!(state: :finished, finished_at: Time.now.utc) if @import.processing_complete?
@@ -176,6 +178,29 @@ class BulkImportService < BaseService
 
     included_lists.each do |title|
       @account.owned_lists.find_or_create_by!(title: title)
+    end
+
+    Import::RowWorker.push_bulk(rows) do |row|
+      [row.id]
+    end
+  end
+
+  def import_custom_filters!
+    rows = @import.rows.to_a
+
+    included_custom_filters = rows.map(&:data).uniq
+
+    @account.custom_filters.where.not(title: included_custom_filters).destroy_all if @import.overwrite?
+
+    included_custom_filters.each do |filter|
+      filter_object = @account.custom_filters.find_or_create_by!(title: filter['title'], context: filter['context'])
+      filter['keywords_attributes'].each do |keyword|
+        filter_object.keywords.find_or_create_by!(keyword: keyword['keyword'], whole_word: keyword['whole_word'])
+      end
+      filter['statuses'].each do |status|
+        status = @account.statuses.find_or_create_by!(text: status)
+        filter_object.statuses.find_or_create_by!(status_id: status.id)
+      end
     end
 
     Import::RowWorker.push_bulk(rows) do |row|

--- a/app/services/bulk_import_service.rb
+++ b/app/services/bulk_import_service.rb
@@ -186,25 +186,52 @@ class BulkImportService < BaseService
   end
 
   def import_custom_filters!
-    rows = @import.rows.to_a
+    rows_by_title = @import.rows.index_by { |row| row.data['title'] }.to_h
+    included_custom_filters = rows_by_title.values.pluck('data')
+    custom_filters_hash = included_custom_filters.map { |fil| fil.except('statuses', 'keywords_attributes') }
+    custom_filters_hash.map { |fil| fil['account_id'] = @account.id }
 
-    included_custom_filters = rows.map(&:data).uniq
+    @account.custom_filters.where.not(title: rows_by_title.keys).destroy_all if @import.overwrite?
+    CustomFilter.insert_all(custom_filters_hash)
+    import_custom_filter_keywords_and_statuses(rows_by_title)
 
-    @account.custom_filters.where.not(title: included_custom_filters).destroy_all if @import.overwrite?
-
-    included_custom_filters.each do |filter|
-      filter_object = @account.custom_filters.find_or_create_by!(title: filter['title'], context: filter['context'])
-      filter['keywords_attributes'].each do |keyword|
-        filter_object.keywords.find_or_create_by!(keyword: keyword['keyword'], whole_word: keyword['whole_word'])
-      end
-      filter['statuses'].each do |status|
-        status = @account.statuses.find_or_create_by!(text: status)
-        filter_object.statuses.find_or_create_by!(status_id: status.id)
-      end
-    end
-
-    Import::RowWorker.push_bulk(rows) do |row|
+    Import::RowWorker.push_bulk(rows_by_title.values) do |row|
       [row.id]
     end
+  end
+
+  def import_custom_filter_keywords_and_statuses(rows_by_title)
+    statuses_to_insert = []
+    keywords_to_insert = []
+    @account.custom_filters.find_each do |filter|
+      row = rows_by_title[filter.title]
+      next if row.nil?
+
+      keywords = row.data['keywords_attributes']
+      statuses = row.data['statuses']
+
+      keywords.each do |keyword|
+        next if keyword.blank?
+
+        keywords_to_insert << {
+          keyword: keyword['keyword'],
+          whole_word: keyword['whole_word'],
+          custom_filter_id: filter.id,
+        }
+      end
+
+      status_ids = Status.where(uri: statuses).ids
+      next if status_ids.blank?
+
+      status_ids.each do |id|
+        statuses_to_insert << {
+          custom_filter_id: filter.id,
+          status_id: id,
+        }
+      end
+    end
+
+    CustomFilterKeyword.insert_all(keywords_to_insert) if keywords_to_insert.any?
+    CustomFilterStatus.insert_all(statuses_to_insert) if statuses_to_insert.any?
   end
 end

--- a/app/services/bulk_import_service.rb
+++ b/app/services/bulk_import_service.rb
@@ -187,9 +187,6 @@ class BulkImportService < BaseService
 
   def import_custom_filters!
     rows = @import.rows.to_a
-    import_statuses = rows.map { |row| row.data['statuses'] }
-    db_statuses = Status.where(uri: import_statuses.flatten)
-    Rails.logger.warn 'importet Status not found' if import_statuses.count != db_statuses.count
 
     @account.custom_filters.destroy_all if @import.overwrite?
 

--- a/app/services/bulk_import_service.rb
+++ b/app/services/bulk_import_service.rb
@@ -186,52 +186,13 @@ class BulkImportService < BaseService
   end
 
   def import_custom_filters!
-    rows_by_title = @import.rows.index_by { |row| row.data['title'] }.to_h
-    included_custom_filters = rows_by_title.values.pluck('data')
-    custom_filters_hash = included_custom_filters.map { |fil| fil.except('statuses', 'keywords_attributes') }
-    custom_filters_hash.map { |fil| fil['account_id'] = @account.id }
+    rows = @import.rows.to_a
+    titles = rows.map { |row| row.data['title'] }
 
-    @account.custom_filters.where.not(title: rows_by_title.keys).destroy_all if @import.overwrite?
-    CustomFilter.insert_all(custom_filters_hash)
-    import_custom_filter_keywords_and_statuses(rows_by_title)
+    @account.custom_filters.where.not(title: titles).destroy_all if @import.overwrite?
 
-    Import::RowWorker.push_bulk(rows_by_title.values) do |row|
+    Import::RowWorker.push_bulk(rows) do |row|
       [row.id]
     end
-  end
-
-  def import_custom_filter_keywords_and_statuses(rows_by_title)
-    statuses_to_insert = []
-    keywords_to_insert = []
-    @account.custom_filters.find_each do |filter|
-      row = rows_by_title[filter.title]
-      next if row.nil?
-
-      keywords = row.data['keywords_attributes']
-      statuses = row.data['statuses']
-
-      keywords.each do |keyword|
-        next if keyword.blank?
-
-        keywords_to_insert << {
-          keyword: keyword['keyword'],
-          whole_word: keyword['whole_word'],
-          custom_filter_id: filter.id,
-        }
-      end
-
-      status_ids = Status.where(uri: statuses).ids
-      next if status_ids.blank?
-
-      status_ids.each do |id|
-        statuses_to_insert << {
-          custom_filter_id: filter.id,
-          status_id: id,
-        }
-      end
-    end
-
-    CustomFilterKeyword.insert_all(keywords_to_insert) if keywords_to_insert.any?
-    CustomFilterStatus.insert_all(statuses_to_insert) if statuses_to_insert.any?
   end
 end

--- a/app/services/bulk_import_service.rb
+++ b/app/services/bulk_import_service.rb
@@ -187,9 +187,9 @@ class BulkImportService < BaseService
 
   def import_custom_filters!
     rows = @import.rows.to_a
-    titles = rows.map { |row| row.data['title'] }
+    rows.map { |row| row.data['title'] }
 
-    @account.custom_filters.where.not(title: titles).destroy_all if @import.overwrite?
+    @account.custom_filters.destroy_all if @import.overwrite?
 
     Import::RowWorker.push_bulk(rows) do |row|
       [row.id]

--- a/app/services/bulk_import_service.rb
+++ b/app/services/bulk_import_service.rb
@@ -187,7 +187,9 @@ class BulkImportService < BaseService
 
   def import_custom_filters!
     rows = @import.rows.to_a
-    rows.map { |row| row.data['title'] }
+    import_statuses = rows.map { |row| row.data['statuses'] }
+    db_statuses = Status.where(uri: import_statuses.flatten)
+    Rails.logger.warn 'importet Status not found' if import_statuses.count != db_statuses.count
 
     @account.custom_filters.destroy_all if @import.overwrite?
 

--- a/app/views/settings/imports/index.html.haml
+++ b/app/views/settings/imports/index.html.haml
@@ -5,7 +5,7 @@
   .field-group
     = f.input :type,
               as: :grouped_select,
-              collection: { constructive: %i(following bookmarks lists), destructive: %i(muting blocking domain_blocking) },
+              collection: { constructive: %i(following bookmarks lists), destructive: %i(muting blocking domain_blocking custom_filters) },
               group_label_method: ->(group) { I18n.t("imports.type_groups.#{group.first}") },
               group_method: :last,
               hint: t('imports.preface'),

--- a/app/views/settings/imports/index.html.haml
+++ b/app/views/settings/imports/index.html.haml
@@ -61,5 +61,9 @@
 
             %td
               - if import.failure_count.positive?
-                = link_to_if import.state_finished?, import.failure_count, failures_settings_import_path(import, format: :csv) do
-                  = import.failure_count
+                - if import.type == 'custom_filters'
+                  = link_to_if import.state_finished?, import.failure_count, failures_settings_import_path(import, format: :json) do
+                    = import.failure_count
+                - else
+                  = link_to_if import.state_finished?, import.failure_count, failures_settings_import_path(import, format: :csv) do
+                    = import.failure_count

--- a/app/views/settings/imports/show.html.haml
+++ b/app/views/settings/imports/show.html.haml
@@ -4,7 +4,7 @@
 - if @bulk_import.likely_mismatched?
   .flash-message.warning= t('imports.mismatched_types_warning')
 
-- if Rails.logger.warn 'importet Status not found'
+- if @bulk_import&.missing_status == true
   .flash-message.warning= I18n.t('imports.errors.status_not_found_warning')
 
 - if @bulk_import.overwrite?

--- a/app/views/settings/imports/show.html.haml
+++ b/app/views/settings/imports/show.html.haml
@@ -4,6 +4,9 @@
 - if @bulk_import.likely_mismatched?
   .flash-message.warning= t('imports.mismatched_types_warning')
 
+- if Rails.logger.warn 'importet Status not found'
+  .flash-message.warning= I18n.t('imports.errors.status_not_found_warning')
+
 - if @bulk_import.overwrite?
   %p.hint= t("imports.overwrite_preambles.#{@bulk_import.type}_html", filename: @bulk_import.original_filename, count: @bulk_import.total_items)
 - else

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -67,8 +67,8 @@ ignore_unused:
   - 'user_mailer.*.subject'
   - 'email_subscription_mailer.*'
   - 'notification_mailer.*'
-  - 'imports.overwrite_preambles.{following,blocking,muting,domain_blocking,bookmarks,lists}_html.*'
-  - 'imports.preambles.{following,blocking,muting,domain_blocking,bookmarks,lists}_html.*'
+  - 'imports.overwrite_preambles.{following,blocking,muting,domain_blocking,bookmarks,lists,custom_filters}_html.*'
+  - 'imports.preambles.{following,blocking,muting,domain_blocking,bookmarks,lists,custom_filters}_html.*'
   - 'mail_subscriptions.unsubscribe.emails.*'
   - 'preferences.other' # some locales are missing other keys, therefore leading i18n-tasks to detect `preferences` as plural and not finding use
   - 'edit_profile.other' # some locales are missing other keys, therefore leading i18n-tasks to detect `preferences` as plural and not finding use

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1558,6 +1558,7 @@ en-GB:
       incompatible_type: Incompatible with the selected import type
       invalid_csv_file: 'Invalid CSV file. Error: %{error}'
       over_rows_processing_limit: contains more than %{count} rows
+      status_not_found_warning: Some of your filters hide specific posts that are not known by this server. These posts will not be automatically filtered if they are discovered later by the server.
       too_large: File is too large
     failures: Failures
     imported: Imported

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1629,6 +1629,7 @@ en-GB:
     types:
       blocking: Blocking list
       bookmarks: Bookmarks
+      custom_filters: Custom filters
       domain_blocking: Domain blocking list
       following: Following list
       lists: Lists

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1575,6 +1575,9 @@ en-GB:
       bookmarks_html:
         one: You are about to <strong>replace your bookmarks</strong> with up to <strong>%{count} post</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>replace your bookmarks</strong> with up to <strong>%{count} posts</strong> from <strong>%{filename}</strong>.
+      custom_filters_html:
+        one: You are about to <strong>replace your filters</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{count} filter</strong> will be added to new filters.
+        other: You are about to <strong>replace your filters</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{count} filters</strong> will be added to new filters.
       domain_blocking_html:
         one: You are about to <strong>replace your domain block list</strong> with up to <strong>%{count} domain</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>replace your domain block list</strong> with up to <strong>%{count} domains</strong> from <strong>%{filename}</strong>.
@@ -1587,9 +1590,6 @@ en-GB:
       muting_html:
         one: You are about to <strong>replace your list of muted account</strong> with up to <strong>%{count} account</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>replace your list of muted accounts</strong> with up to <strong>%{count} accounts</strong> from <strong>%{filename}</strong>.
-      custom_filters_html:
-        one: You are about to <strong>replace your filters</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{count} filter</strong> will be added to new filters.
-        other: You are about to <strong>replace your filters</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{count} filters</strong> will be added to new filters.
     preambles:
       blocking_html:
         one: You are about to <strong>block</strong> up to <strong>%{count} account</strong> from <strong>%{filename}</strong>.
@@ -1597,6 +1597,9 @@ en-GB:
       bookmarks_html:
         one: You are about to add up to <strong>%{count} post</strong> from <strong>%{filename}</strong> to your <strong>bookmarks</strong>.
         other: You are about to add up to <strong>%{count} posts</strong> from <strong>%{filename}</strong> to your <strong>bookmarks</strong>.
+      custom_filters_html:
+        one: You are about to add up to <strong>%{count} filter</strong> from <strong>%{filename}</strong> to your <strong>filters</strong>.
+        other: You are about to add up to <strong>%{count} filters</strong> from <strong>%{filename}</strong> to your <strong>filters</strong>.
       domain_blocking_html:
         one: You are about to <strong>block</strong> up to <strong>%{count} domain</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>block</strong> up to <strong>%{count} domains</strong> from <strong>%{filename}</strong>.
@@ -1609,9 +1612,6 @@ en-GB:
       muting_html:
         one: You are about to <strong>mute</strong> up to <strong>%{count} account</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>mute</strong> up to <strong>%{count} accounts</strong> from <strong>%{filename}</strong>.
-      custom_filters_html:
-        one: You are about to add up to <strong>%{count} filter</strong> from <strong>%{filename}</strong> to your <strong>filters</strong>.
-        other: You are about to add up to <strong>%{count} filters</strong> from <strong>%{filename}</strong> to your <strong>filters</strong>.
     preface: You can import data that you have exported from another server, such as a list of the people you are following or blocking.
     recent_imports: Recent imports
     states:

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1587,6 +1587,9 @@ en-GB:
       muting_html:
         one: You are about to <strong>replace your list of muted account</strong> with up to <strong>%{count} account</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>replace your list of muted accounts</strong> with up to <strong>%{count} accounts</strong> from <strong>%{filename}</strong>.
+      custom_filters_html:
+        one: You are about to <strong>replace your filters</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{count} filter</strong> will be added to new filters.
+        other: You are about to <strong>replace your filters</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{count} filters</strong> will be added to new filters.
     preambles:
       blocking_html:
         one: You are about to <strong>block</strong> up to <strong>%{count} account</strong> from <strong>%{filename}</strong>.
@@ -1606,6 +1609,9 @@ en-GB:
       muting_html:
         one: You are about to <strong>mute</strong> up to <strong>%{count} account</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>mute</strong> up to <strong>%{count} accounts</strong> from <strong>%{filename}</strong>.
+      custom_filters_html:
+        one: You are about to add up to <strong>%{count} filter</strong> from <strong>%{filename}</strong> to your <strong>filters</strong>.
+        other: You are about to add up to <strong>%{count} filters</strong> from <strong>%{filename}</strong> to your <strong>filters</strong>.
     preface: You can import data that you have exported from another server, such as a list of the people you are following or blocking.
     recent_imports: Recent imports
     states:

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1558,7 +1558,6 @@ en-GB:
       incompatible_type: Incompatible with the selected import type
       invalid_csv_file: 'Invalid CSV file. Error: %{error}'
       over_rows_processing_limit: contains more than %{count} rows
-      status_not_found_warning: Some of your filters hide specific posts that are not known by this server. These posts will not be automatically filtered if they are discovered later by the server.
       too_large: File is too large
     failures: Failures
     imported: Imported

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1559,6 +1559,7 @@ en-GB:
       invalid_csv_file: 'Invalid CSV file. Error: %{error}'
       over_rows_processing_limit: contains more than %{count} rows
       too_large: File is too large
+      status_not_found_warning: Some of your filters hide specific posts that are not known by this server. These posts will not be automatically filtered if they are discovered later by the server.
     failures: Failures
     imported: Imported
     mismatched_types_warning: It appears you may have selected the wrong type for this import, please double-check.

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1558,8 +1558,8 @@ en-GB:
       incompatible_type: Incompatible with the selected import type
       invalid_csv_file: 'Invalid CSV file. Error: %{error}'
       over_rows_processing_limit: contains more than %{count} rows
-      too_large: File is too large
       status_not_found_warning: Some of your filters hide specific posts that are not known by this server. These posts will not be automatically filtered if they are discovered later by the server.
+      too_large: File is too large
     failures: Failures
     imported: Imported
     mismatched_types_warning: It appears you may have selected the wrong type for this import, please double-check.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1684,6 +1684,9 @@ en:
       bookmarks_html:
         one: You are about to <strong>replace your bookmarks</strong> with up to <strong>%{count} post</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>replace your bookmarks</strong> with up to <strong>%{count} posts</strong> from <strong>%{filename}</strong>.
+      custom_filters_html:
+        one: You are about to <strong>replace your filters</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{count} filter</strong> will be added to new filters.
+        other: You are about to <strong>replace your filters</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{count} filters</strong> will be added to new filters.
       domain_blocking_html:
         one: You are about to <strong>replace your domain block list</strong> with up to <strong>%{count} domain</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>replace your domain block list</strong> with up to <strong>%{count} domains</strong> from <strong>%{filename}</strong>.
@@ -1696,9 +1699,6 @@ en:
       muting_html:
         one: You are about to <strong>replace your list of muted account</strong> with up to <strong>%{count} account</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>replace your list of muted accounts</strong> with up to <strong>%{count} accounts</strong> from <strong>%{filename}</strong>.
-      custom_filters_html:
-        one: You are about to <strong>replace your filters</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{count} filter</strong> will be added to new filters.
-        other: You are about to <strong>replace your filters</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{count} filters</strong> will be added to new filters.
     preambles:
       blocking_html:
         one: You are about to <strong>block</strong> up to <strong>%{count} account</strong> from <strong>%{filename}</strong>.
@@ -1706,6 +1706,9 @@ en:
       bookmarks_html:
         one: You are about to add up to <strong>%{count} post</strong> from <strong>%{filename}</strong> to your <strong>bookmarks</strong>.
         other: You are about to add up to <strong>%{count} posts</strong> from <strong>%{filename}</strong> to your <strong>bookmarks</strong>.
+      custom_filters_html:
+        one: You are about to add up to <strong>%{count} filter</strong> from <strong>%{filename}</strong> to your <strong>filters</strong>.
+        other: You are about to add up to <strong>%{count} filters</strong> from <strong>%{filename}</strong> to your <strong>filters</strong>.
       domain_blocking_html:
         one: You are about to <strong>block</strong> up to <strong>%{count} domain</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>block</strong> up to <strong>%{count} domains</strong> from <strong>%{filename}</strong>.
@@ -1718,9 +1721,6 @@ en:
       muting_html:
         one: You are about to <strong>mute</strong> up to <strong>%{count} account</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>mute</strong> up to <strong>%{count} accounts</strong> from <strong>%{filename}</strong>.
-      custom_filters_html:
-        one: You are about to add up to <strong>%{count} filter</strong> from <strong>%{filename}</strong> to your <strong>filters</strong>.
-        other: You are about to add up to <strong>%{count} filters</strong> from <strong>%{filename}</strong> to your <strong>filters</strong>.
     preface: You can import data that you have exported from another server, such as a list of the people you are following or blocking.
     recent_imports: Recent imports
     states:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1665,6 +1665,7 @@ en:
       empty: Empty CSV file
       incompatible_type: Incompatible with the selected import type
       invalid_csv_file: 'Invalid CSV file. Error: %{error}'
+      invalid_json_file: 'Invalid JSON file. Error: %{error}'
       over_rows_processing_limit: contains more than %{count} rows
       too_large: File is too large
     failures: Failures

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1696,6 +1696,9 @@ en:
       muting_html:
         one: You are about to <strong>replace your list of muted account</strong> with up to <strong>%{count} account</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>replace your list of muted accounts</strong> with up to <strong>%{count} accounts</strong> from <strong>%{filename}</strong>.
+      custom_filters_html:
+        one: You are about to <strong>replace your filters</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{count} filter</strong> will be added to new filters.
+        other: You are about to <strong>replace your filters</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{count} filters</strong> will be added to new filters.
     preambles:
       blocking_html:
         one: You are about to <strong>block</strong> up to <strong>%{count} account</strong> from <strong>%{filename}</strong>.
@@ -1715,6 +1718,9 @@ en:
       muting_html:
         one: You are about to <strong>mute</strong> up to <strong>%{count} account</strong> from <strong>%{filename}</strong>.
         other: You are about to <strong>mute</strong> up to <strong>%{count} accounts</strong> from <strong>%{filename}</strong>.
+      custom_filters_html:
+        one: You are about to add up to <strong>%{count} filter</strong> from <strong>%{filename}</strong> to your <strong>filters</strong>.
+        other: You are about to add up to <strong>%{count} filters</strong> from <strong>%{filename}</strong> to your <strong>filters</strong>.
     preface: You can import data that you have exported from another server, such as a list of the people you are following or blocking.
     recent_imports: Recent imports
     states:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1667,6 +1667,7 @@ en:
       invalid_csv_file: 'Invalid CSV file. Error: %{error}'
       invalid_json_file: 'Invalid JSON file. Error: %{error}'
       over_rows_processing_limit: contains more than %{count} rows
+      status_not_found_warning: Some of your filters hide specific posts that are not known by this server. These posts will not be automatically filtered if they are discovered later by the server.
       too_large: File is too large
     failures: Failures
     imported: Imported

--- a/db/migrate/20260611150940_add_missing_status_to_bulk_import.rb
+++ b/db/migrate/20260611150940_add_missing_status_to_bulk_import.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingStatusToBulkImport < ActiveRecord::Migration[8.1]
+  def change
+    add_column :bulk_imports, :missing_status, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_05_155103) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_150940) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -338,6 +338,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_155103) do
     t.datetime "finished_at", precision: nil
     t.integer "imported_items", default: 0, null: false
     t.boolean "likely_mismatched", default: false, null: false
+    t.boolean "missing_status", default: false, null: false
     t.string "original_filename", default: "", null: false
     t.boolean "overwrite", default: false, null: false
     t.integer "processed_items", default: 0, null: false

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -169,6 +169,39 @@ RSpec.describe Settings::ImportsController do
       it_behaves_like 'export failed rows', 'following_accounts_failures.csv', "Account address,Show boosts,Notify on new posts,Languages\nfoo@bar,true,false,\nuser@bar,false,true,\"fr, de\"\n"
     end
 
+    context 'with custom filters' do
+      subject { get :failures, params: { id: bulk_import.id }, format: :json }
+
+      let(:import_type) { 'custom_filters' }
+      let(:rows) do
+        [
+          {
+            'title' => 'random title',
+            'expire_at' => nil,
+            'context' => ['public', 'account'],
+            'action' => 'warn',
+            'keywords_attributes' => [{
+              'keyword' => 'all them keywords',
+              'whole_word' => true,
+            }, {
+              'keyword' => 'more keywords even',
+              'whole_word' => true,
+            }],
+            'statuses' => ['status'],
+          },
+        ]
+      end
+      let(:bulk_import) { Fabricate(:bulk_import, account: user.account, type: import_type, state: :finished) }
+
+      before do
+        rows.each { |data| Fabricate(:bulk_import_row, bulk_import: bulk_import, data: data) }
+        bulk_import.update(total_items: bulk_import.rows.count, processed_items: bulk_import.rows.count, imported_items: 0)
+      end
+
+      it_behaves_like 'export failed rows', 'custom_filters_failures.json',
+                      '{"custom_filters":[{"title":"random title","action":"warn","context":["public","account"],"statuses":["status"],"expire_at":null,"keywords_attributes":[{"keyword":"all them keywords","whole_word":true},{"keyword":"more keywords even","whole_word":true}]},{"title":"random title","action":"warn","context":["public","account"],"statuses":["status"],"expire_at":null,"keywords_attributes":[{"keyword":"all them keywords","whole_word":true},{"keyword":"more keywords even","whole_word":true}]}]}' # rubocop:disable Layout/LineLength
+    end
+
     context 'with blocks' do
       let(:import_type) { 'blocking' }
 
@@ -291,5 +324,29 @@ RSpec.describe Settings::ImportsController do
 
     it_behaves_like 'unsuccessful import', 'following', 'empty.csv', 'merge'
     it_behaves_like 'unsuccessful import', 'following', 'empty.csv', 'overwrite'
+
+    context 'with custom filter' do
+      subject { post :create, params: { form_import: { type: 'custom_filters', mode: mode, data: data } } }
+
+      describe 'successful import' do
+        let(:data) { fixture_file_upload('custom_filters.json', 'application/json') }
+        let(:mode) { 'merge' }
+
+        it 'creates an unconfirmed bulk_import with expected type and redirects', :aggregate_failures do
+          expect { subject }.to change { user.account.bulk_imports.pluck(:state, :type) }.from([]).to([['unconfirmed', 'custom_filters']])
+          expect(response).to redirect_to(settings_import_path(user.account.bulk_imports.first))
+        end
+      end
+
+      describe 'failing import' do
+        let(:mode) { 'merge' }
+        let(:data) { fixture_file_upload('empty.json', 'application/json') }
+
+        it 'does not creates an unconfirmed bulk_import', :aggregate_failures do
+          expect { subject }.to_not(change { user.account.bulk_imports.count })
+          expect(response.body).to include('field_with_errors')
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Settings::ImportsController do
         [
           {
             'title' => 'random title',
-            'expire_at' => nil,
+            'expires_at' => nil,
             'context' => ['public', 'account'],
             'action' => 'warn',
             'keywords_attributes' => [{
@@ -199,7 +199,7 @@ RSpec.describe Settings::ImportsController do
       end
 
       it_behaves_like 'export failed rows', 'custom_filters_failures.json',
-                      '{"custom_filters":[{"title":"random title","action":"warn","context":["public","account"],"statuses":["status"],"expire_at":null,"keywords_attributes":[{"keyword":"all them keywords","whole_word":true},{"keyword":"more keywords even","whole_word":true}]},{"title":"random title","action":"warn","context":["public","account"],"statuses":["status"],"expire_at":null,"keywords_attributes":[{"keyword":"all them keywords","whole_word":true},{"keyword":"more keywords even","whole_word":true}]}]}' # rubocop:disable Layout/LineLength
+                      '{"custom_filters":[{"title":"random title","action":"warn","context":["public","account"],"statuses":["status"],"expires_at":null,"keywords_attributes":[{"keyword":"all them keywords","whole_word":true},{"keyword":"more keywords even","whole_word":true}]},{"title":"random title","action":"warn","context":["public","account"],"statuses":["status"],"expires_at":null,"keywords_attributes":[{"keyword":"all them keywords","whole_word":true},{"keyword":"more keywords even","whole_word":true}]}]}' # rubocop:disable Layout/LineLength
     end
 
     context 'with blocks' do

--- a/spec/fixtures/files/custom_filters.json
+++ b/spec/fixtures/files/custom_filters.json
@@ -1,0 +1,32 @@
+{
+  "custom_filters": [
+    {
+      "title": "dfjswa",
+      "expire_at": null,
+      "context": ["home"],
+      "action": "warn",
+      "keywords_attributes": [{ "keyword": "dvshja", "whole_word": true }],
+      "statuses": []
+    },
+    {
+      "title": "filter with a phrase as title",
+      "expire_at": null,
+      "context": ["home", "notifications", "public"],
+      "action": "warn",
+      "keywords_attributes": [
+        { "keyword": "more words let's see ", "whole_word": true }
+      ],
+      "statuses": []
+    },
+    {
+      "title": "how do I add a status to a filter?",
+      "expire_at": null,
+      "context": ["public", "account"],
+      "action": "warn",
+      "keywords_attributes": [
+        { "keyword": "will this be a status?", "whole_word": true }
+      ],
+      "statuses": []
+    }
+  ]
+}

--- a/spec/fixtures/files/custom_filters.json
+++ b/spec/fixtures/files/custom_filters.json
@@ -2,7 +2,7 @@
   "custom_filters": [
     {
       "title": "dfjswa",
-      "expire_at": null,
+      "expires_at": null,
       "context": ["home"],
       "action": "warn",
       "keywords_attributes": [{ "keyword": "dvshja", "whole_word": true }],
@@ -10,7 +10,7 @@
     },
     {
       "title": "filter with a phrase as title",
-      "expire_at": null,
+      "expires_at": null,
       "context": ["home", "notifications", "public"],
       "action": "warn",
       "keywords_attributes": [
@@ -20,7 +20,7 @@
     },
     {
       "title": "how do I add a status to a filter?",
-      "expire_at": null,
+      "expires_at": null,
       "context": ["public", "account"],
       "action": "warn",
       "keywords_attributes": [

--- a/spec/fixtures/files/custom_filters.json
+++ b/spec/fixtures/files/custom_filters.json
@@ -24,7 +24,7 @@
       "context": ["public", "account"],
       "action": "warn",
       "keywords_attributes": [
-        { "keyword": "will this be a status?", "whole_word": true }
+        { "keyword": "something something", "whole_word": true }
       ],
       "statuses": []
     }

--- a/spec/models/form/import_spec.rb
+++ b/spec/models/form/import_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Form::Import do
       end
     end
 
-    context 'when the import type is custom_filters' do
+    describe 'when the import type is custom_filters' do
       let(:data)        { fixture_file_upload(import_file, content_type) }
       let(:import_file) { File.open('spec/fixtures/files/custom_filters.json') }
       let(:import_type) { 'custom_filters' }
@@ -257,6 +257,69 @@ RSpec.describe Form::Import do
               type: eq(subject.type),
               original_filename: eq(subject.data.original_filename),
               likely_mismatched?: eq(subject.likely_mismatched?),
+              overwrite?: eq(!!subject.overwrite), # rubocop:disable Style/DoubleNegation
+              processed_items: eq(0),
+              imported_items: eq(0),
+              total_items: eq(bulk_import.rows.count),
+              state_unconfirmed?: be(true)
+            )
+          expect(bulk_import.rows.pluck(:data))
+            .to match_array(expected_rows)
+        end
+      end
+    end
+
+    describe 'when importing json' do
+      let(:import_type) { 'custom_filters' }
+      let(:data) { fixture_file_upload('custom_filters.json', 'application/json') }
+      let(:import_mode) { 'merge' }
+      let(:expected_rows) do
+        [
+          {
+            'title' => 'dfjswa',
+            'expire_at' => nil,
+            'context' => ['home'],
+            'action' => 'warn',
+            'keywords_attributes' => [{ 'keyword' => 'dvshja', 'whole_word' => true }],
+            'statuses' => [],
+          },
+          {
+            'title' => 'filter with a phrase as title',
+            'expire_at' => nil,
+            'context' => %w(home notifications public),
+            'action' => 'warn',
+            'keywords_attributes' => [
+              { 'keyword' => "more words let's see ", 'whole_word' => true },
+            ],
+            'statuses' => [],
+          },
+          {
+            'title' => 'how do I add a status to a filter?',
+            'expire_at' => nil,
+            'context' => ['public', 'account'],
+            'action' => 'warn',
+            'keywords_attributes' => [
+              { 'keyword' => 'something something', 'whole_word' => true },
+            ],
+            'statuses' => [],
+          },
+        ]
+      end
+
+      before do
+        subject.save
+      end
+
+      context 'with a BulkImport' do
+        let(:bulk_import) { account.bulk_imports.first }
+
+        it 'creates a bulk import with correct values' do
+          expect(bulk_import)
+            .to be_present
+            .and have_attributes(
+              type: eq(subject.type),
+              original_filename: eq(subject.data.original_filename),
+              likely_mismatched?: eq(subject.likely_mismatched_json?),
               overwrite?: eq(!!subject.overwrite), # rubocop:disable Style/DoubleNegation
               processed_items: eq(0),
               imported_items: eq(0),

--- a/spec/models/form/import_spec.rb
+++ b/spec/models/form/import_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe Form::Import do
         [
           {
             'title' => 'dfjswa',
-            'expire_at' => nil,
+            'expires_at' => nil,
             'context' => ['home'],
             'action' => 'warn',
             'keywords_attributes' => [{ 'keyword' => 'dvshja', 'whole_word' => true }],
@@ -285,7 +285,7 @@ RSpec.describe Form::Import do
           },
           {
             'title' => 'filter with a phrase as title',
-            'expire_at' => nil,
+            'expires_at' => nil,
             'context' => %w(home notifications public),
             'action' => 'warn',
             'keywords_attributes' => [
@@ -295,7 +295,7 @@ RSpec.describe Form::Import do
           },
           {
             'title' => 'how do I add a status to a filter?',
-            'expire_at' => nil,
+            'expires_at' => nil,
             'context' => ['public', 'account'],
             'action' => 'warn',
             'keywords_attributes' => [

--- a/spec/models/form/import_spec.rb
+++ b/spec/models/form/import_spec.rb
@@ -43,6 +43,17 @@ RSpec.describe Form::Import do
       end
     end
 
+    context 'when the import type is custom_filters' do
+      let(:data)        { fixture_file_upload(import_file, content_type) }
+      let(:import_file) { File.open('spec/fixtures/files/custom_filters.json') }
+      let(:import_type) { 'custom_filters' }
+      let(:content_type) { 'application/json' }
+
+      it 'passes validation' do
+        expect(subject).to be_valid
+      end
+    end
+
     context 'when the file too large' do
       let(:import_type) { 'following' }
       let(:import_file) { 'imports.txt' }

--- a/spec/requests/settings/imports_spec.rb
+++ b/spec/requests/settings/imports_spec.rb
@@ -4,13 +4,33 @@ require 'rails_helper'
 
 RSpec.describe 'Settings Imports' do
   describe 'POST /settings/imports' do
-    before { sign_in Fabricate(:user) }
+    let(:user) { Fabricate(:user) }
+    let(:account) { user.account }
+
+    before { sign_in user }
 
     it 'gracefully handles invalid nested params' do
       post settings_imports_path(form_import: 'invalid')
 
       expect(response)
         .to have_http_status(400)
+    end
+
+    describe 'with JSON' do
+      subject { post settings_imports_path, params: { form_import: { type: 'custom_filters', mode: 'merge', data: data } } }
+
+      let!(:data) { fixture_file_upload('custom_filters.json', 'application/json') }
+      let(:confirm) { post confirm_settings_import_path(id: user.account.bulk_imports.last.id) }
+
+      it 'redirects to confirm_settings_import_path' do
+        subject
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(settings_import_path(id: user.account.bulk_imports.last.id))
+        expect(user.account.bulk_imports.last.state).to eq('unconfirmed')
+        confirm
+        expect(response).to have_http_status(302)
+        expect(user.account.bulk_imports.last.state).to eq('scheduled')
+      end
     end
   end
 end

--- a/spec/requests/settings/imports_spec.rb
+++ b/spec/requests/settings/imports_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Settings Imports' do
       it 'redirects to confirm_settings_import_path' do
         subject
         expect(response).to have_http_status(302)
-        expect(response).to redirect_to(settings_import_path(id: user.account.bulk_imports.last.id))
+          .and redirect_to(settings_import_path(id: user.account.bulk_imports.last.id))
         expect(user.account.bulk_imports.last.state).to eq('unconfirmed')
         confirm
         expect(response).to have_http_status(302)

--- a/spec/services/bulk_import_service_spec.rb
+++ b/spec/services/bulk_import_service_spec.rb
@@ -425,7 +425,7 @@ RSpec.describe BulkImportService do
         stub_fetch_remote_and_drain_workers
         expect(account.custom_filters.count).to eq(2)
         expect(account.custom_filters.order(:phrase).last.statuses.count).to eq(1)
-        expect(account.custom_filters.last.keywords.count).to eq(2)
+        expect(account.custom_filters.order(:phrase).last.keywords.count).to eq(2)
       end
     end
 

--- a/spec/services/bulk_import_service_spec.rb
+++ b/spec/services/bulk_import_service_spec.rb
@@ -292,6 +292,56 @@ RSpec.describe BulkImportService do
       end
     end
 
+    context 'when importing custom_filters' do
+      let(:import_type) { 'custom_filters' }
+      let(:overwrite)   { false }
+
+      let!(:rows) do
+        [{
+          'title' => 'foo',
+          'expire_at' => nil,
+          'context' => ['home', 'notifications'],
+          'action' => 'warn',
+          'keywords_attributes' => [{
+            'keyword' => 'discourse',
+            'whole_word' => true,
+          }, {
+            'keyword' => 'something',
+            'whole_word' => false,
+          }],
+          'statuses' => ['Lorem ipsum dolor sit amet'],
+        }, {
+          'title' => 'bar',
+          'expire_at' => nil,
+          'context' => ['notifications'],
+          'action' => 'warn',
+          'keywords_attributes' => [{
+            'keyword' => 'discourse',
+            'whole_word' => true,
+          }, {
+            'keyword' => 'something',
+            'whole_word' => false,
+          }],
+          'statuses' => ['something something'],
+        }].map { |data| import.rows.create!(data: data) }
+      end
+
+      it 'enqueues workers for the expected rows and updates bookmarks after worker run' do
+        subject.call(import)
+
+        expect(row_worker_job_args)
+          .to match_array(rows.map(&:id))
+
+        stub_fetch_remote_and_drain_workers
+        expect(account.custom_filters.map(&:title))
+          .to eq(['foo', 'bar'])
+        expect(account.custom_filters.first.statuses.count)
+          .to eq(1)
+        expect(account.custom_filters.first.keywords.count)
+          .to eq(2)
+      end
+    end
+
     context 'when importing bookmarks with overwrite' do
       let(:import_type) { 'bookmarks' }
       let(:overwrite)   { true }

--- a/spec/services/bulk_import_service_spec.rb
+++ b/spec/services/bulk_import_service_spec.rb
@@ -292,56 +292,6 @@ RSpec.describe BulkImportService do
       end
     end
 
-    context 'when importing custom_filters' do
-      let(:import_type) { 'custom_filters' }
-      let(:overwrite)   { false }
-
-      let!(:rows) do
-        [{
-          'title' => 'foo',
-          'expire_at' => nil,
-          'context' => ['home', 'notifications'],
-          'action' => 'warn',
-          'keywords_attributes' => [{
-            'keyword' => 'discourse',
-            'whole_word' => true,
-          }, {
-            'keyword' => 'something',
-            'whole_word' => false,
-          }],
-          'statuses' => ['Lorem ipsum dolor sit amet'],
-        }, {
-          'title' => 'bar',
-          'expire_at' => nil,
-          'context' => ['notifications'],
-          'action' => 'warn',
-          'keywords_attributes' => [{
-            'keyword' => 'discourse',
-            'whole_word' => true,
-          }, {
-            'keyword' => 'something',
-            'whole_word' => false,
-          }],
-          'statuses' => ['something something'],
-        }].map { |data| import.rows.create!(data: data) }
-      end
-
-      it 'enqueues workers for the expected rows and updates bookmarks after worker run' do
-        subject.call(import)
-
-        expect(row_worker_job_args)
-          .to match_array(rows.map(&:id))
-
-        stub_fetch_remote_and_drain_workers
-        expect(account.custom_filters.map(&:title))
-          .to eq(['foo', 'bar'])
-        expect(account.custom_filters.first.statuses.count)
-          .to eq(1)
-        expect(account.custom_filters.first.keywords.count)
-          .to eq(2)
-      end
-    end
-
     context 'when importing bookmarks with overwrite' do
       let(:import_type) { 'bookmarks' }
       let(:overwrite)   { true }
@@ -376,6 +326,106 @@ RSpec.describe BulkImportService do
 
         expect(account.bookmarks.map { |bookmark| bookmark.status.uri })
           .to contain_exactly(status.uri, bookmarked.uri, 'https://domain.unknown/foo')
+      end
+    end
+
+    context 'when importing custom_filters' do
+      let(:import_type) { 'custom_filters' }
+      let!(:rows) do
+        [{
+          'title' => 'baz',
+          'expires_at' => nil,
+          'context' => ['home', 'notifications'],
+          'action' => 'warn',
+          'keywords_attributes' => [{
+            'keyword' => 'discourse',
+            'whole_word' => true,
+          }, {
+            'keyword' => 'something',
+            'whole_word' => false,
+          }],
+          'statuses' => ['http://localhost:3000/ap/users/116646814515254858/statuses/116681350935935708'],
+        }, {
+          'title' => 'buzz',
+          'expires_at' => nil,
+          'context' => ['notifications'],
+          'action' => 'warn',
+          'keywords_attributes' => [{
+            'keyword' => 'discourse',
+            'whole_word' => true,
+          }, {
+            'keyword' => 'something',
+            'whole_word' => false,
+          }],
+          'statuses' => [ActivityPub::TagManager.instance.uri_for(status)],
+        }].map { |data| import.rows.create!(data: data) }
+      end
+      let(:overwrite) { false }
+      let(:status) { Fabricate(:status, account: account, text: 'something something') }
+      let(:filter) { Fabricate(:custom_filter, account: account, title: 'a mazing title') }
+      let(:status_filter) { Fabricate(:custom_filter_status, custom_filter: filter, status: status) }
+
+      before do
+        status_filter
+      end
+
+      it 'enqueues workers for the expected rows and updates filters, keywords and statuses after worker run' do
+        subject.call(import)
+        expect(row_worker_job_args).to match_array(rows.map(&:id))
+        stub_fetch_remote_and_drain_workers
+        expect(account.custom_filters.count).to eq(3)
+        expect(account.custom_filters.order(:phrase).last.statuses.count).to eq(1)
+        expect(account.custom_filters.last.keywords.count).to eq(2)
+      end
+    end
+
+    context 'when importing custom_filters with overwrite' do
+      let(:import_type) { 'custom_filters' }
+      let!(:rows) do
+        [{
+          'title' => 'baz',
+          'expires_at' => nil,
+          'context' => ['home', 'notifications'],
+          'action' => 'warn',
+          'keywords_attributes' => [{
+            'keyword' => 'discourse',
+            'whole_word' => true,
+          }, {
+            'keyword' => 'something',
+            'whole_word' => false,
+          }],
+          'statuses' => ['http://localhost:3000/ap/users/116646814515254858/statuses/116681350935935708'],
+        }, {
+          'title' => 'buzz',
+          'expires_at' => nil,
+          'context' => ['notifications'],
+          'action' => 'warn',
+          'keywords_attributes' => [{
+            'keyword' => 'discourse',
+            'whole_word' => true,
+          }, {
+            'keyword' => 'something',
+            'whole_word' => false,
+          }],
+          'statuses' => [ActivityPub::TagManager.instance.uri_for(status)],
+        }].map { |data| import.rows.create!(data: data) }
+      end
+      let(:overwrite) { true }
+      let(:status) { Fabricate(:status, text: 'something something') }
+      let(:filter) { Fabricate(:custom_filter, account: account, title: 'a mazing title') }
+      let(:status_filter) { Fabricate(:custom_filter_status, custom_filter: filter, status: status) }
+
+      before do
+        status_filter
+      end
+
+      it 'enqueues workers for the expected rows and updates filters, keywords and statuses after worker run' do
+        subject.call(import)
+        expect(row_worker_job_args).to match_array(rows.map(&:id))
+        stub_fetch_remote_and_drain_workers
+        expect(account.custom_filters.count).to eq(2)
+        expect(account.custom_filters.order(:phrase).last.statuses.count).to eq(1)
+        expect(account.custom_filters.last.keywords.count).to eq(2)
       end
     end
 


### PR DESCRIPTION
implements WEB-1014

import for custom filters
adds json handling to the form import
status filters are fetched by uri, some statuses don't have an uri, in those cases we want to indicate to the users, that the status couldn't be imported.
adds a field to bulk imports table, for missing statuses.
the prompt appears after clicking on 'upload', on the confirmation page, before returning to imports index.
<img width="1152" height="411" alt="Screenshot 2026-06-11 at 14 23 03" src="https://github.com/user-attachments/assets/52203d9f-6f53-4aeb-b45e-f304617669ad" />


