### PR TITLE
Change Mastodon gGmbH => Mastodon GmbH

### DIFF
--- a/app/javascript/mastodon/features/about/index.jsx
+++ b/app/javascript/mastodon/features/about/index.jsx
@@ -168,7 +168,7 @@ class About extends PureComponent {
           <LinkFooter context='about' />
 
           <div className='about__footer'>
-            <p><FormattedMessage id='about.disclaimer' defaultMessage='Mastodon is free, open-source software, and a trademark of Mastodon gGmbH.' /></p>
+            <p><FormattedMessage id='about.disclaimer' defaultMessage='Mastodon is free, open-source software, and a trademark of Mastodon GmbH.' /></p>
           </div>
         </div>
 

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -2,7 +2,7 @@
   "about.blocks": "Moderated servers",
   "about.contact": "Contact:",
   "about.default_locale": "Default",
-  "about.disclaimer": "Mastodon is free, open-source software, and a trademark of Mastodon gGmbH.",
+  "about.disclaimer": "Mastodon is free, open-source software, and a trademark of Mastodon GmbH.",
   "about.domain_blocks.no_reason_available": "Reason not available",
   "about.domain_blocks.preamble": "Mastodon generally allows you to view content from and interact with users from any other server in the fediverse. These are the exceptions that have been made on this particular server.",
   "about.domain_blocks.silenced.explanation": "You will generally not see profiles and content from this server, unless you explicitly look it up or opt into it by following.",

--- a/config/templates/terms-of-service.md
+++ b/config/templates/terms-of-service.md
@@ -4,7 +4,7 @@ These terms of service (the "Terms") cover your access and use of Server
 Operator's ("Administrator", "we", or "us") instance, located at %{domain} (the
 "Instance"). These Terms apply solely to your use of the Instance as operated
 by the Administrator. Please note that we have no affiliation with Mastodon
-gGmbH (“Mastodon”) and these Terms do not contain any representations or
+GmbH (“Mastodon”) and these Terms do not contain any representations or
 warranties or other promises from Mastodon about your use of the Instance. If
 you would like to contact us for any reason, please direct all questions,
 comments, concerns and notices to us by following the instructions provided in


### PR DESCRIPTION
Those were leftovers we forgot to change after our non-profit status was stripped in Germany (see
https://blog.joinmastodon.org/2026/02/administrative-updates/)