### PR TITLE
Exercise more of `disputes/strikes/_card` partial

### DIFF
--- a/spec/system/disputes/strikes_spec.rb
+++ b/spec/system/disputes/strikes_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe 'Disputes Strikes' do
   before { sign_in(current_user) }
 
   describe 'viewing strike disputes' do
+    let!(:strike) { Fabricate(:account_warning, target_account: current_user.account, report:, status_ids: [status.id]) }
     let(:current_user) { Fabricate(:user) }
-    let!(:strike) { Fabricate(:account_warning, target_account: current_user.account) }
+    let(:report) { Fabricate :report, category: :violation, rule_ids: rules.map(&:id), target_account: current_user.account }
+    let(:rules) { Fabricate.times 2, :rule }
+    let(:status) { Fabricate :status, account: current_user.account, text: 'Offensive text' }
 
     it 'shows a list of strikes and details for each' do
       visit disputes_strikes_path
@@ -18,6 +21,8 @@ RSpec.describe 'Disputes Strikes' do
       expect(page)
         .to have_title(strike_page_title)
         .and have_text(strike.text)
+        .and have_text(rules.last.text)
+        .and have_text(status.text)
     end
 
     def strike_page_title


### PR DESCRIPTION
Using the view coverage reports from https://github.com/mastodon/mastodon/pull/39112 -- there is some low hanging fruit of views/partials where we have a big coverage gap, but can close that gap with pretty minimal additions to specs. Going to do a pass at some of these. Will start with only a few and wait on feedback.

This one just adds a little bit more of a surrounding universe for the "strike" being passed into this partial.