### PR TITLE
Exercise more of `rule_translations/_rule_translation` partial

### DIFF
--- a/spec/system/auth/registrations_spec.rb
+++ b/spec/system/auth/registrations_spec.rb
@@ -5,12 +5,14 @@ require 'rails_helper'
 RSpec.describe 'Auth Registration' do
   context 'when there are server rules' do
     let!(:rule) { Fabricate :rule, text: 'You must be seven meters tall' }
+    let!(:rule_translation) { Fabricate :rule_translation, rule:, hint: 'Rule translation hint', text: rule.text }
 
     it 'shows rules page before proceeding with sign up' do
       visit new_user_registration_path
       expect(page)
         .to have_title(I18n.t('auth.register'))
         .and have_text(rule.text)
+        .and have_text(rule_translation.hint)
     end
   end
 


### PR DESCRIPTION
Using the view coverage reports from https://github.com/mastodon/mastodon/pull/39112 -- there is some low hanging fruit of views/partials where we have a big coverage gap, but can close that gap with pretty minimal additions to specs. Going to do a pass at some of these. Will start with only a few and wait on feedback.

This one just adds a translation to the rule so that more of the partial is run.