### PR TITLE
Limit compose field height to prevent column scrolling

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -614,6 +614,7 @@ body > [data-popper-placement] {
     display: block;
     box-sizing: border-box;
     width: 100%;
+    max-height: 300px;
     margin: 0;
     color: var(--color-text-primary);
     background: transparent;


### PR DESCRIPTION
### Changes proposed in this PR:
- Adds a maximum height to the auto-sizing composer text field to prevent it from growing indefinitely & causing a scrollbar on the containing column. We think that this might fix a [reported issue](https://mamot.fr/@pluralistic/116679962254247843) whereby the <kbd>PageUp</kbd>/<kbd>PageDown</kbd> keys don't correctly scroll up/down within long textareas. It also just looks a bit nicer.

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="353" height="707" alt="image" src="https://github.com/user-attachments/assets/eb01d27a-de2a-4346-bda6-5360956240a2" /> | <img width="354" height="707" alt="image" src="https://github.com/user-attachments/assets/2d2c7a3e-0642-45e8-a346-9bbac9ede6d0" /> |