### PR TITLE
Exercise more of `tags/show.rss` view

### DIFF
--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe 'Tags' do
   describe 'GET /tags/:id' do
     context 'when tag exists' do
       let(:tag) { Fabricate :tag }
+      let(:status) { Fabricate :status }
+
+      before { status.tags << tag }
 
       context 'with HTML format' do
         before { get tag_path(tag) }
@@ -51,6 +54,8 @@ RSpec.describe 'Tags' do
             .and have_cacheable_headers.with_vary('Accept, Accept-Language, Cookie')
           expect(response.content_type)
             .to start_with('application/rss+xml')
+          expect(response.body)
+            .to include(status.text)
         end
       end
     end


### PR DESCRIPTION
Using the view coverage reports from https://github.com/mastodon/mastodon/pull/39112 -- there is some low hanging fruit of views/partials where we have a big coverage gap, but can close that gap with pretty minimal additions to specs. Going to do a pass at some of these. Will start with only a few and wait on feedback.

In this case the tag being viewed did not have any statuses, so the bulk of the rss view was not being processed.