### PR TITLE
[Accessibility] Make post/feed navigation by hotkey more robust

### DIFF
--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -86,7 +86,7 @@ import {
   Quotes,
 } from './util/async-components';
 import { ColumnsContextProvider } from './util/columns_context';
-import { focusColumn, getFocusedItemIndex, focusItemSibling, focusFirstItem } from './util/focusUtils';
+import { focusColumn, getFocusedItemIndex, focusItemSibling, focusFirstItem, getFocusedColumnIndex } from './util/focusUtils';
 import { WrappedSwitch, WrappedRoute } from './util/react_router_helpers';
 import { CustomHomepage } from 'mastodon/features/custom_homepage';
 
@@ -506,20 +506,18 @@ class UI extends PureComponent {
   handleMoveUp = () => {
     const currentItemIndex = getFocusedItemIndex();
     if (currentItemIndex === -1) {
-      focusColumn(1);
+      return focusColumn(getFocusedColumnIndex());
     } else {
-      const wasHandled = focusItemSibling(currentItemIndex, -1);
-      return wasHandled;
+      return focusItemSibling(currentItemIndex, -1);
     }
   };
 
   handleMoveDown = () => {
     const currentItemIndex = getFocusedItemIndex();
     if (currentItemIndex === -1) {
-      focusColumn(1);
+      return focusColumn(getFocusedColumnIndex());
     } else {
-      const wasHandled = focusItemSibling(currentItemIndex, 1);
-      return wasHandled;
+      return focusItemSibling(currentItemIndex, 1);
     }
   };
 

--- a/app/javascript/mastodon/features/ui/util/focusUtils.ts
+++ b/app/javascript/mastodon/features/ui/util/focusUtils.ts
@@ -62,18 +62,17 @@ export function focusColumn(index = 1) {
 
   function fallback() {
     focusColumnTitle(index + indexOffset, isMultiColumnLayout);
+    return false;
   }
 
   if (!column) {
-    fallback();
-    return;
+    return fallback();
   }
 
   const container = column.querySelector('.scrollable');
 
   if (!container) {
-    fallback();
-    return;
+    return fallback();
   }
 
   const focusableItems = Array.from(
@@ -86,8 +85,7 @@ export function focusColumn(index = 1) {
   const itemToFocus = findFirstVisibleWithRect(focusableItems);
 
   if (!itemToFocus) {
-    fallback();
-    return;
+    return fallback();
   }
 
   const viewportWidth =
@@ -110,6 +108,7 @@ export function focusColumn(index = 1) {
     itemToFocus.item.scrollIntoView(true);
   }
   itemToFocus.item.focus();
+  return true;
 }
 
 /**
@@ -124,6 +123,18 @@ export function getFocusedItemIndex() {
 
   const items = Array.from(parentElement.children);
   return items.indexOf(focusedItem);
+}
+
+/**
+ * Get the index of the column that contains the user's focus
+ */
+export function getFocusedColumnIndex() {
+  const columnWithFocus = document.activeElement?.closest('.column');
+
+  if (!columnWithFocus) return 1;
+
+  const allColumns = Array.from(document.querySelectorAll('.column'));
+  return allColumns.indexOf(columnWithFocus) + 1;
 }
 
 /**

--- a/app/javascript/mastodon/features/ui/util/focusUtils.ts
+++ b/app/javascript/mastodon/features/ui/util/focusUtils.ts
@@ -159,12 +159,7 @@ export function focusItemSibling(index: number, direction: 1 | -1) {
   );
 
   if (!siblingItem) {
-    return false;
-  }
-
-  // If sibling element is empty, we skip it
-  if (siblingItem.matches(':empty')) {
-    return focusItemSibling(index + direction, direction);
+    return focusListSibling(direction);
   }
 
   // Check if the sibling is a post or a 'follow suggestions' widget
@@ -175,6 +170,52 @@ export function focusItemSibling(index: number, direction: 1 | -1) {
   // Otherwise, check if the item is a 'load more' button.
   if (!targetElement && siblingItem.matches('.load-more')) {
     targetElement = siblingItem;
+  }
+
+  // If sibling element is empty, we skip it
+  if (!targetElement || siblingItem.matches(':empty')) {
+    return focusItemSibling(index + direction, direction);
+  }
+
+  targetElement.scrollIntoView({
+    block: 'start',
+  });
+
+  targetElement.focus();
+
+  return true;
+}
+
+/**
+ * Finds the next or previous .item-list on the page or in the column,
+ * and focuses its first or last item.
+ */
+function focusListSibling(direction: 1 | -1) {
+  const container = document.activeElement?.closest('.item-list');
+
+  if (!container) {
+    return false;
+  }
+
+  // Get all item lists in the current column or page
+  const currentColumn = container.closest('.column') ?? document;
+
+  const columnItemLists = Array.from(
+    currentColumn.querySelectorAll('.item-list'),
+  );
+  const currentListIndex = columnItemLists.indexOf(container);
+
+  // Find the next or previous item-list
+  const listSibling = columnItemLists[currentListIndex + direction];
+
+  // Depending on the direction, find the first or last focusable in the list
+  let targetElement: HTMLElement | null | undefined;
+  if (direction > 0) {
+    targetElement = listSibling?.querySelector<HTMLElement>('.focusable');
+  } else {
+    const allFocusables =
+      listSibling?.querySelectorAll<HTMLElement>('.focusable');
+    targetElement = allFocusables?.[allFocusables.length - 1];
   }
 
   if (targetElement) {


### PR DESCRIPTION
### Changes proposed in this PR:
- Following on from #39252, this makes navigating posts or feeds via hotkey more robust:
   - Feed items without a `focusable` element will now be skipped, preventing getting stuck in filtered lists that contain empty list item wrappers (which ideally shouldn't be rendered in the first place, but this would require larger refactoring)
   - If a column contains multiple item lists (e.g. the "Featured" tab on the profile), the navigation hotkeys now allow jumping between them
   - Improves the behaviour of the <kbd>PageDown</kbd> and <kbd>PageUp</kbd> keys when focus is not yet within an item list and no item list is in the viewport. Previously, the column title would be focused and the native page scrolling behaviour cancelled. Now, native page scrolling will not be cancelled anymore, allowing to easily scroll down to an item list and continue navigation from there.

### Screencap

**Before:** Navigation gets stuck above the "Mention" notification (because there's a filtered notification before it)

https://github.com/user-attachments/assets/f34159bf-ec1b-44d6-9fb6-f39852f2aa27

**After:** Navigation continues past the "Mention" notification

https://github.com/user-attachments/assets/dd3b66ec-9646-44a6-a10f-d34d63d0a687

**Before:** Navigation can't continue into the second item list (Collections)

https://github.com/user-attachments/assets/844039c6-92da-47fe-9fac-80eaca4c4440

**After:** Navigation works across lists

https://github.com/user-attachments/assets/d3bef203-cccc-43b8-8747-75fc9dae6c0e

