### PR TITLE
Remove resize handles from inputs in Firefox

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -557,7 +557,6 @@ code {
     display: block;
     width: 100%;
     font-family: inherit;
-    resize: vertical;
     background: var(--color-bg-secondary);
     border: 1px solid var(--color-border-primary);
     border-radius: 4px;
@@ -582,6 +581,10 @@ code {
     @media screen and (width <= 600px) {
       font-size: 16px;
     }
+  }
+
+  textarea {
+    resize: vertical;
   }
 
   input[type='text'],


### PR DESCRIPTION
### Changes proposed in this PR:
- It looks like Firefox recently got an update that made regular `input` elements respect the CSS `resize` property, causing resize handles to appear on many single-line form fields on our server-rendered pages (sign-up, settings, admin). This change applies the `resize: vertical` rule only to textarea elements.

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="506" height="615" alt="image" src="https://github.com/user-attachments/assets/5f18b9bc-945c-4827-bf4a-d0105e0d77a6" /> | <img width="501" height="613" alt="image" src="https://github.com/user-attachments/assets/b1c9b008-545c-48ce-abc6-6556da8934b7" /> |