### PR TITLE
Prevent logged out users from accessing collection & list creation routes

### DIFF
--- a/app/javascript/mastodon/features/account_featured/index.tsx
+++ b/app/javascript/mastodon/features/account_featured/index.tsx
@@ -29,7 +29,7 @@ import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 import AddIcon from '@/material-icons/400-24px/add.svg?react';
 
 import { CollectionListItem } from '../collections/components/collection_list_item';
-import { useCollectionsCreatedBy } from '../collections/overview/created_by_you';
+import { useCollectionsCreatedBy } from '../collections/overview/created_by_account';
 
 import { EmptyMessage } from './components/empty_message';
 import { Subheading, SubheadingLink } from './components/subheading';

--- a/app/javascript/mastodon/features/collection_adder/index.tsx
+++ b/app/javascript/mastodon/features/collection_adder/index.tsx
@@ -15,7 +15,7 @@ import { IconButton } from 'mastodon/components/icon_button';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
 import { MAX_COLLECTION_ACCOUNT_COUNT } from '../collections/editor/accounts';
-import { useCollectionsCreatedBy } from '../collections/overview/created_by_you';
+import { useCollectionsCreatedBy } from '../collections/overview/created_by_account';
 
 import { CollectionToggle } from './collection_toggle';
 

--- a/app/javascript/mastodon/features/collections/editor/index.tsx
+++ b/app/javascript/mastodon/features/collections/editor/index.tsx
@@ -26,7 +26,7 @@ import {
 } from 'mastodon/reducers/slices/collections';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
-import { useCollectionsCreatedBy } from '../overview/created_by_you';
+import { useCollectionsCreatedBy } from '../overview/created_by_account';
 
 import { CollectionAccounts } from './accounts';
 import { CollectionDetails } from './details';

--- a/app/javascript/mastodon/features/collections/editor/index.tsx
+++ b/app/javascript/mastodon/features/collections/editor/index.tsx
@@ -13,13 +13,14 @@ import {
 
 import { Helmet } from '@unhead/react/helmet';
 
-import { Callout } from '@/mastodon/components/callout';
-import { useCurrentAccountId } from '@/mastodon/hooks/useAccountId';
-import { initialState } from '@/mastodon/initial_state';
 import ListAltIcon from '@/material-icons/400-24px/list_alt.svg?react';
+import { Callout } from 'mastodon/components/callout';
 import { Column } from 'mastodon/components/column';
 import { ColumnHeader } from 'mastodon/components/column_header';
 import { LoadingIndicator } from 'mastodon/components/loading_indicator';
+import { NotSignedInIndicator } from 'mastodon/components/not_signed_in_indicator';
+import { useIdentity } from 'mastodon/identity_context';
+import { initialState } from 'mastodon/initial_state';
 import {
   collectionEditorActions,
   fetchCollection,
@@ -75,7 +76,7 @@ export const CollectionEditorPage: React.FC<{
 }> = ({ multiColumn }) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
-  const accountId = useCurrentAccountId();
+  const { accountId, signedIn } = useIdentity();
   const { id = null } = useParams<{ id?: string }>();
   const { path } = useRouteMatch();
   const collection = useAppSelector((state) =>
@@ -94,13 +95,13 @@ export const CollectionEditorPage: React.FC<{
     (!isEditMode && collectionListStatus === 'loading');
 
   const canCreateMoreCollections =
-    isEditMode || collectionList.length < userCollectionLimit;
+    signedIn && (isEditMode || collectionList.length < userCollectionLimit);
 
   useEffect(() => {
-    if (id) {
+    if (id && signedIn) {
       void dispatch(fetchCollection({ collectionId: id }));
     }
-  }, [dispatch, id]);
+  }, [dispatch, id, signedIn]);
 
   useEffect(() => {
     if (id !== editorStateId) {
@@ -129,6 +130,8 @@ export const CollectionEditorPage: React.FC<{
       <div className='scrollable'>
         {isLoading ? (
           <LoadingIndicator />
+        ) : !signedIn ? (
+          <NotSignedInIndicator />
         ) : canCreateMoreCollections ? (
           <Switch>
             <Route

--- a/app/javascript/mastodon/features/collections/index.tsx
+++ b/app/javascript/mastodon/features/collections/index.tsx
@@ -4,15 +4,15 @@ import { Route, Switch, useRouteMatch } from 'react-router-dom';
 
 import { Helmet } from '@unhead/react/helmet';
 
-import { TabLink, TabList } from '@/mastodon/components/tab_list';
 import { Column } from 'mastodon/components/column';
 import { ColumnHeader } from 'mastodon/components/column_header';
 import { DisplayNameSimple } from 'mastodon/components/display_name/simple';
 import { Scrollable } from 'mastodon/components/scrollable_list/components';
+import { TabLink, TabList } from 'mastodon/components/tab_list';
 import { useAccount } from 'mastodon/hooks/useAccount';
 import { useAccountId, useCurrentAccountId } from 'mastodon/hooks/useAccountId';
 
-import { CollectionsCreatedByYou } from './overview/created_by_you';
+import { CollectionsCreatedByAccount } from './overview/created_by_account';
 import { CollectionsFeaturingYou } from './overview/featuring_you';
 import classes from './styles.module.scss';
 
@@ -89,7 +89,7 @@ export const Collections: React.FC<{
           </TabList>
         </header>
         <Switch>
-          <Route exact path={path} component={CollectionsCreatedByYou} />
+          <Route exact path={path} component={CollectionsCreatedByAccount} />
           <Route
             exact
             path={`${path}/featuring-you`}

--- a/app/javascript/mastodon/features/collections/overview/created_by_account.tsx
+++ b/app/javascript/mastodon/features/collections/overview/created_by_account.tsx
@@ -5,10 +5,12 @@ import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 
 import AddIcon from '@/material-icons/400-24px/add.svg?react';
+import { DisplayName } from 'mastodon/components/display_name';
 import { EmptyState } from 'mastodon/components/empty_state';
 import { Icon } from 'mastodon/components/icon';
 import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 import { ItemList } from 'mastodon/components/scrollable_list/components';
+import { useAccount } from 'mastodon/hooks/useAccount';
 import { useAccountId, useCurrentAccountId } from 'mastodon/hooks/useAccountId';
 import {
   fetchCollectionsCreatedByAccount,
@@ -61,6 +63,7 @@ export function useCollectionsCreatedBy(accountId: string | null | undefined) {
 export const CollectionsCreatedByAccount: React.FC = () => {
   const me = useCurrentAccountId();
   const accountId = useAccountId();
+  const account = useAccount(accountId);
 
   const { collections, status } = useCollectionsCreatedBy(accountId);
 
@@ -78,24 +81,40 @@ export const CollectionsCreatedByAccount: React.FC = () => {
   }
 
   if (collections.length === 0) {
-    return (
-      <EmptyState
-        title={
-          <FormattedMessage
-            id='empty_column.account_featured_self.showcase_accounts'
-            defaultMessage='Showcase your favorite accounts'
-          />
-        }
-        message={
-          <FormattedMessage
-            id='empty_column.account_featured_self.showcase_accounts_desc'
-            defaultMessage='Collections are curated lists of accounts to help others discover more of the Fediverse.'
-          />
-        }
-      >
-        <CreateButton />
-      </EmptyState>
-    );
+    if (isOwnCollectionPage) {
+      return (
+        <EmptyState
+          title={
+            <FormattedMessage
+              id='empty_column.account_featured_self.showcase_accounts'
+              defaultMessage='Showcase your favorite accounts'
+            />
+          }
+          message={
+            <FormattedMessage
+              id='empty_column.account_featured_self.showcase_accounts_desc'
+              defaultMessage='Collections are curated lists of accounts to help others discover more of the Fediverse.'
+            />
+          }
+        >
+          <CreateButton />
+        </EmptyState>
+      );
+    } else {
+      return (
+        <EmptyState
+          title={
+            <FormattedMessage
+              id='empty_column.collections'
+              defaultMessage='{acct} has not created any collections yet.'
+              values={{
+                acct: <DisplayName variant='simple' account={account} />,
+              }}
+            />
+          }
+        />
+      );
+    }
   }
 
   return (

--- a/app/javascript/mastodon/features/collections/overview/created_by_account.tsx
+++ b/app/javascript/mastodon/features/collections/overview/created_by_account.tsx
@@ -113,7 +113,7 @@ export const CollectionsCreatedByAccount: React.FC = () => {
         {showCreateButton && <CreateButton />}
       </div>
       <ItemList>
-        {!canCreateMoreCollections && (
+        {isOwnCollectionPage && !canCreateMoreCollections && (
           <MaxCollectionsCallout className={classes.maxCollectionsError} />
         )}
         {collections.map((item, index) => (

--- a/app/javascript/mastodon/features/collections/overview/created_by_account.tsx
+++ b/app/javascript/mastodon/features/collections/overview/created_by_account.tsx
@@ -58,7 +58,7 @@ export function useCollectionsCreatedBy(accountId: string | null | undefined) {
   );
 }
 
-export const CollectionsCreatedByYou: React.FC = () => {
+export const CollectionsCreatedByAccount: React.FC = () => {
   const me = useCurrentAccountId();
   const accountId = useAccountId();
 

--- a/app/javascript/mastodon/features/collections/overview/featuring_you.tsx
+++ b/app/javascript/mastodon/features/collections/overview/featuring_you.tsx
@@ -16,7 +16,7 @@ import { useAppSelector, useAppDispatch } from 'mastodon/store';
 import { CollectionListItem } from '../components/collection_list_item';
 import classes from '../styles.module.scss';
 
-import { CollectionListError } from './created_by_you';
+import { CollectionListError } from './created_by_account';
 
 function useCollectionsFeaturing(accountId: string | null | undefined) {
   const dispatch = useAppDispatch();

--- a/app/javascript/mastodon/features/lists/index.tsx
+++ b/app/javascript/mastodon/features/lists/index.tsx
@@ -6,6 +6,8 @@ import { Link } from 'react-router-dom';
 
 import { Helmet } from '@unhead/react/helmet';
 
+import { NotSignedInIndicator } from '@/mastodon/components/not_signed_in_indicator';
+import { useIdentity } from '@/mastodon/identity_context';
 import AddIcon from '@/material-icons/400-24px/add.svg?react';
 import ListAltIcon from '@/material-icons/400-24px/list_alt.svg?react';
 import MoreHorizIcon from '@/material-icons/400-24px/more_horiz.svg?react';
@@ -78,10 +80,13 @@ const Lists: React.FC<{
   const dispatch = useAppDispatch();
   const intl = useIntl();
   const lists = useAppSelector((state) => getOrderedLists(state));
+  const { signedIn } = useIdentity();
 
   useEffect(() => {
-    void dispatch(fetchLists());
-  }, [dispatch]);
+    if (signedIn) {
+      void dispatch(fetchLists());
+    }
+  }, [signedIn, dispatch]);
 
   const emptyMessage = (
     <>
@@ -112,14 +117,16 @@ const Lists: React.FC<{
         iconComponent={ListAltIcon}
         multiColumn={multiColumn}
         extraButton={
-          <Link
-            to='/lists/new'
-            className='column-header__button'
-            title={intl.formatMessage(messages.create)}
-            aria-label={intl.formatMessage(messages.create)}
-          >
-            <Icon id='plus' icon={AddIcon} />
-          </Link>
+          signedIn && (
+            <Link
+              to='/lists/new'
+              className='column-header__button'
+              title={intl.formatMessage(messages.create)}
+              aria-label={intl.formatMessage(messages.create)}
+            >
+              <Icon id='plus' icon={AddIcon} />
+            </Link>
+          )
         }
       />
 
@@ -128,9 +135,13 @@ const Lists: React.FC<{
         emptyMessage={emptyMessage}
         bindToDocument={!multiColumn}
       >
-        {lists.map((list) => (
-          <ListItem key={list.id} id={list.id} title={list.title} />
-        ))}
+        {signedIn ? (
+          lists.map((list) => (
+            <ListItem key={list.id} id={list.id} title={list.title} />
+          ))
+        ) : (
+          <NotSignedInIndicator />
+        )}
       </ScrollableList>
 
       <Helmet>

--- a/app/javascript/mastodon/features/lists/new.tsx
+++ b/app/javascript/mastodon/features/lists/new.tsx
@@ -8,6 +8,8 @@ import { isFulfilled } from '@reduxjs/toolkit';
 
 import { Helmet } from '@unhead/react/helmet';
 
+import { NotSignedInIndicator } from '@/mastodon/components/not_signed_in_indicator';
+import { useIdentity } from '@/mastodon/identity_context';
 import ChevronRightIcon from '@/material-icons/400-24px/chevron_right.svg?react';
 import ListAltIcon from '@/material-icons/400-24px/list_alt.svg?react';
 import { fetchList } from 'mastodon/actions/lists';
@@ -250,16 +252,17 @@ const NewListWrapper: React.FC<{
 }> = ({ multiColumn }) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
+  const { signedIn } = useIdentity();
   const { id } = useParams<{ id?: string }>();
   const list = useAppSelector((state) =>
     id ? state.lists.get(id) : undefined,
   );
 
   useEffect(() => {
-    if (id) {
+    if (signedIn && id) {
       dispatch(fetchList(id));
     }
-  }, [dispatch, id]);
+  }, [dispatch, signedIn, id]);
 
   const isLoading = id && !list;
 
@@ -277,7 +280,13 @@ const NewListWrapper: React.FC<{
       />
 
       <div className='scrollable'>
-        {isLoading ? <LoadingIndicator /> : <NewList list={list} />}
+        {!signedIn ? (
+          <NotSignedInIndicator />
+        ) : isLoading ? (
+          <LoadingIndicator />
+        ) : (
+          <NewList list={list} />
+        )}
       </div>
 
       <Helmet>

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -646,6 +646,7 @@
   "empty_column.account_unavailable": "Profile unavailable",
   "empty_column.blocks": "You haven't blocked any users yet.",
   "empty_column.bookmarked_statuses": "You don't have any bookmarked posts yet. When you bookmark one, it will show up here.",
+  "empty_column.collections": "{acct} has not created any collections yet.",
   "empty_column.collections.featured_in": "You have not been added to any collections yet.",
   "empty_column.collections.featured_in_undiscoverable": "In order for people to add you to collections, you need to allow featuring in discovery experiences from <link>Preferences > Privacy and reach</link>",
   "empty_column.community": "The local timeline is empty. Write something publicly to get the ball rolling!",


### PR DESCRIPTION
### Changes proposed in this PR:
- Shows the standard "You need to sign in to access this resource" message when opening the following pages while not signed in:
   - `/collections/new`
   - `/lists`
   - `/lists/new`
- Hides the "maximum collection count reached" message when viewing the `/@username/collections` page of another account
- Updates the copy of the same collections page empty state when viewing another account's page
- Renames the `CreatedByYou` component to `CreatedByAccount` for accuracy

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="626" height="510" alt="image" src="https://github.com/user-attachments/assets/b65fba0e-2b1d-49fa-8097-ff4915eca4f1" /> | <img width="631" height="556" alt="image" src="https://github.com/user-attachments/assets/a0b6fdb0-7f9d-4581-ae21-b3bfdb859a0e" /> |
| <img width="599" height="548" alt="image" src="https://github.com/user-attachments/assets/9682c4a1-aa79-4662-a7af-889bde729d05" /> | <img width="600" height="471" alt="image" src="https://github.com/user-attachments/assets/52d0fc02-c1e9-4d48-a9ca-6770b9adad22" /> |
| <img width="616" height="607" alt="image" src="https://github.com/user-attachments/assets/b8500ecc-3224-4e86-83ef-f30401b3b804" /> | <img width="623" height="429" alt="image" src="https://github.com/user-attachments/assets/8e6e42b0-788a-4bd5-9ba6-491900eca21f" /> |
| <img width="627" height="470" alt="image" src="https://github.com/user-attachments/assets/3e20fcc4-be20-4b8c-8b94-f95873063f90" /> | <img width="630" height="450" alt="image" src="https://github.com/user-attachments/assets/a9bd4d88-5306-4f5b-bc9f-1966058e17df" /> |