### PR TITLE
Fix ValidationError when loading many collections at once

### DIFF
--- a/app/javascript/mastodon/reducers/slices/collections.ts
+++ b/app/javascript/mastodon/reducers/slices/collections.ts
@@ -27,6 +27,7 @@ import {
   createAppSelector,
   createDataLoadingThunk,
 } from '@/mastodon/store/typed_functions';
+import { batchArray } from '@/mastodon/utils/batch_array';
 import { inputToHashtag } from '@/mastodon/utils/hashtags';
 
 type QueryStatus = 'idle' | 'loading' | 'error';
@@ -337,10 +338,14 @@ async function importAccountsForPreviewCard(
     )
     .filter((id): id is string => !!id);
 
-  await dispatch(
-    fetchAccounts({
-      accountIds: previewAccountIds,
-    }),
+  // fetchAccounts can only process up to 40 item ids, so we'll
+  // batch the list of ids
+  const batchedAccountIdLists = batchArray(previewAccountIds, 40);
+
+  await Promise.allSettled(
+    batchedAccountIdLists.map((accountIds) =>
+      dispatch(fetchAccounts({ accountIds })),
+    ),
   );
 }
 

--- a/app/javascript/mastodon/utils/batch_array.ts
+++ b/app/javascript/mastodon/utils/batch_array.ts
@@ -1,0 +1,15 @@
+/**
+ * Splits a long array so that the resulting nested arrays
+ * never exceed the `maxLength` provided.
+ * Useful when dealing with endpoints that accept a limited number
+ * of parameters
+ */
+export function batchArray<T>(array: T[], maxLength: number) {
+  const result: T[][] = [];
+
+  for (let i = 0; i < array.length; i += maxLength) {
+    result.push(array.slice(i, i + maxLength));
+  }
+
+  return result;
+}


### PR DESCRIPTION
Fixes #39280

### Changes proposed in this PR:
- Fixes a `ValidationError` when loading many collections at once; this was caused by the prefetching of the accounts needed to display avatars next to each collection item. The endpoint can only process up to 40 parameters which can quickly be reached once there's more than 10 collections.
- Adds a new `batchArray` utility to facilitate this