### PR TITLE
Allow `authorized_interactions` endpoint to handle Collections

### DIFF
--- a/app/controllers/authorize_interactions_controller.rb
+++ b/app/controllers/authorize_interactions_controller.rb
@@ -7,11 +7,12 @@ class AuthorizeInteractionsController < ApplicationController
   before_action :set_resource
 
   def show
-    if @resource.is_a?(Account)
+    case @resource
+    when Account
       redirect_to web_url("@#{@resource.pretty_acct}")
-    elsif @resource.is_a?(Status)
+    when Status
       redirect_to web_url("@#{@resource.account.pretty_acct}/#{@resource.id}")
-    elsif @resource.is_a?(Collection)
+    when Collection
       redirect_to web_url("collections/#{resource.id}")
     else
       not_found

--- a/app/controllers/authorize_interactions_controller.rb
+++ b/app/controllers/authorize_interactions_controller.rb
@@ -11,6 +11,8 @@ class AuthorizeInteractionsController < ApplicationController
       redirect_to web_url("@#{@resource.pretty_acct}")
     elsif @resource.is_a?(Status)
       redirect_to web_url("@#{@resource.account.pretty_acct}/#{@resource.id}")
+    elsif @resource.is_a?(Collection)
+      redirect_to web_url("collections/#{resource.id}")
     else
       not_found
     end


### PR DESCRIPTION
This is a partial fix to #39281

It's incomplete because the underlying `ActivityPub::FetchRemoteFeaturedCollectionService` still skips accounts that are unknown.