### PR TITLE
Update openid_connect to version 2.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,8 +224,6 @@ GEM
     elasticsearch-api (8.19.3)
       multi_json
     elasticsearch-dsl (0.1.10)
-    email_validator (2.2.4)
-      activemodel
     erb (6.0.4)
     erubi (1.13.1)
     et-orbi (1.4.0)
@@ -491,10 +489,9 @@ GEM
     omniauth_openid_connect (0.8.0)
       omniauth (>= 1.9, < 3)
       openid_connect (~> 2.2)
-    openid_connect (2.3.1)
+    openid_connect (2.5.0)
       activemodel
       attr_required (>= 1.0.0)
-      email_validator
       faraday (~> 2.0)
       faraday-follow_redirects
       json-jwt (>= 1.16)


### PR DESCRIPTION
I left this out of https://github.com/mastodon/mastodon/pull/39106 because I wanted to review more, but turns out it's pretty minimal.

Changes - https://github.com/nov/openid_connect/compare/v2.3.1...v2.5.0 - looks like mostly internal testing/docs changes, with also a) drop a dependency, b) support POST on userinfo method.

Side note - RE: the comment here - https://github.com/mastodon/mastodon/blob/main/app/validators/email_address_validator.rb#L3-L7 -- because of that dep drop we could rename the validator?