### PR TITLE
Fix Collections editor allowing to add the same account multiple times

### DIFF
--- a/app/javascript/mastodon/features/collections/editor/accounts.tsx
+++ b/app/javascript/mastodon/features/collections/editor/accounts.tsx
@@ -208,6 +208,12 @@ export const CollectionAccounts: React.FC<{
   const hasItems = editorItems.length > 0;
   const hasMaxItems = editorItems.length === MAX_COLLECTION_ACCOUNT_COUNT;
 
+  const wasAccountAdded = useCallback(
+    (account: ApiMutedAccountJSON) =>
+      !!editorItems.find((item) => item.account_id === account.id),
+    [editorItems],
+  );
+
   const {
     accounts: suggestedAccounts,
     isLoading: isLoadingSuggestions,
@@ -217,8 +223,7 @@ export const CollectionAccounts: React.FC<{
     withRelationships: true,
     withDefaultFollows: searchValue === '',
     // Don't suggest accounts that were already added
-    filterResults: (account) =>
-      !editorItems.find((item) => item.account_id === account.id),
+    filterResults: (account) => !wasAccountAdded(account),
   });
 
   const relationships = useAppSelector((state) => state.relationships);
@@ -256,23 +261,25 @@ export const CollectionAccounts: React.FC<{
 
   const addAccountItem = useCallback(
     (item: ApiMutedAccountJSON) => {
-      dispatch(
-        updateCollectionEditorField({
-          field: 'items',
-          value: [
-            ...editorItems,
-            {
-              account_id: item.id,
-              state:
-                item.feature_approval.current_user === 'manual'
-                  ? 'pending'
-                  : 'accepted',
-            },
-          ],
-        }),
-      );
+      if (!wasAccountAdded(item)) {
+        dispatch(
+          updateCollectionEditorField({
+            field: 'items',
+            value: [
+              ...editorItems,
+              {
+                account_id: item.id,
+                state:
+                  item.feature_approval.current_user === 'manual'
+                    ? 'pending'
+                    : 'accepted',
+              },
+            ],
+          }),
+        );
+      }
     },
-    [editorItems, dispatch],
+    [editorItems, wasAccountAdded, dispatch],
   );
 
   const instantRemoveAccountItem = useCallback(
@@ -299,13 +306,13 @@ export const CollectionAccounts: React.FC<{
 
   const instantAddAccountItem = useCallback(
     (item: ApiMutedAccountJSON) => {
-      if (id) {
+      if (id && !wasAccountAdded(item)) {
         void dispatch(
           addCollectionItem({ collectionId: id, accountId: item.id }),
         );
       }
     },
-    [dispatch, id],
+    [dispatch, id, wasAccountAdded],
   );
 
   const handleRemoveAccountItem = useCallback(

--- a/app/javascript/mastodon/hooks/useSearchAccounts.ts
+++ b/app/javascript/mastodon/hooks/useSearchAccounts.ts
@@ -51,7 +51,7 @@ export function useSearchAccounts({
       searchRequestRef.current = new AbortController();
 
       try {
-        const data = await apiRequest<ApiAccountJSON[]>(
+        const accounts = await apiRequest<ApiAccountJSON[]>(
           'GET',
           'v1/accounts/search',
           {
@@ -62,7 +62,6 @@ export function useSearchAccounts({
             },
           },
         );
-        const accounts = filterResults ? data.filter(filterResults) : data;
         const accountIds = accounts.map((a) => a.id);
         dispatch(importFetchedAccounts(accounts));
         if (withRelationships) {
@@ -95,6 +94,7 @@ export function useSearchAccounts({
   const [defaultAccounts, setDefaultAccounts] = useState<
     ApiAccountJSON[] | null
   >(null);
+
   useEffect(() => {
     if (
       !currentUserId ||
@@ -108,12 +108,11 @@ export function useSearchAccounts({
     async function doRequest() {
       setLoadingState('loading');
       try {
-        const data = await apiRequest<ApiAccountJSON[]>(
+        const accounts = await apiRequest<ApiAccountJSON[]>(
           'GET',
           `v1/accounts/${currentUserId}/following`,
           { params: { limit: 40 } },
         );
-        const accounts = filterResults ? data.filter(filterResults) : data;
         const accountIds = accounts.map((a) => a.id);
         dispatch(importFetchedAccounts(accounts));
         if (withRelationships) {
@@ -137,13 +136,19 @@ export function useSearchAccounts({
     withDefaultFollows,
   ]);
 
+  const accountsToReturn =
+    accounts.length === 0 && withDefaultFollows
+      ? (defaultAccounts ?? [])
+      : accounts;
+
+  const filteredAccounts = filterResults
+    ? accountsToReturn.filter(filterResults)
+    : accountsToReturn;
+
   return {
     searchAccounts: startSearch,
     resetAccounts,
-    accounts:
-      accounts.length === 0 && withDefaultFollows
-        ? (defaultAccounts ?? [])
-        : accounts,
+    accounts: filteredAccounts,
     isLoading: loadingState === 'loading',
     isError: loadingState === 'error',
   };


### PR DESCRIPTION
Fixes PRO-440
Fixes #39294

### Changes proposed in this PR:
- Prevents adding the same account multiple times in the Collections editor as the account filtering was only applied on initial load
- Also checks whether an account is already in the collection at the selection handler level for extra protection

### Screencap

https://github.com/user-attachments/assets/a6be5c13-a450-40cb-bf45-a25430f60ce4

