### PR TITLE
Remove outdated hint for "Use system scrollbar" preference

### DIFF
--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -82,7 +82,7 @@
       = ff.input :'web.disable_swiping', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_disable_swiping')
       = ff.input :'web.disable_hover_cards', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_disable_hover_cards')
       = ff.input :'web.use_system_font', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_system_font_ui')
-      = ff.input :'web.use_system_scrollbars', wrapper: :with_label, hint: I18n.t('simple_form.hints.defaults.setting_system_scrollbars_ui'), label: I18n.t('simple_form.labels.defaults.setting_system_scrollbars_ui')
+      = ff.input :'web.use_system_scrollbars', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_system_scrollbars_ui')
 
     %h2= t 'appearance.discovery'
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -66,7 +66,6 @@ en:
         setting_display_media_show_all: Show all media without warning, including media marked as sensitive
         setting_emoji_style: How to display emojis. "Auto" will try using native emoji, but falls back to Twemoji for legacy browsers.
         setting_quick_boosting_html: When enabled, clicking on the %{boost_icon} Boost icon will immediately boost instead of opening the boost/quote dropdown menu. Relocates the quoting action to the %{options_icon} (Options) menu.
-        setting_system_scrollbars_ui: Applies only to desktop browsers based on Safari and Chrome
         setting_use_blurhash: Gradients are based on the colors of the hidden visuals but obfuscate any details
         setting_use_pending_items: Hide timeline updates behind a click instead of automatically scrolling the feed
         username: You can use letters, numbers, and underscores


### PR DESCRIPTION
### Changes proposed in this PR:
- Removes an outdated hint for the "Use system scrollbar" preference that stated that the setting only applies to Chrome/Safari-based browsers. The new implementation of custom scrollbars is [standards-based](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/scrollbar-color) and supported widely.
   (Apart from that, our custom scrollbars now have higher contrast than the browser's default. :) )

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="419" height="159" alt="image" src="https://github.com/user-attachments/assets/861d4500-94ab-440e-ad54-6a46949c246b" /> | <img width="378" height="127" alt="image" src="https://github.com/user-attachments/assets/f72b4425-8a5c-4816-92dc-23bc0d37287b" /> |