### PR TITLE
Fix missing null check when importing collections from notifications

### DIFF
--- a/app/javascript/mastodon/actions/notification_groups.ts
+++ b/app/javascript/mastodon/actions/notification_groups.ts
@@ -88,7 +88,7 @@ function dispatchAssociatedRecords(
       fetchedStatuses.push(notification.status);
     }
 
-    if ('collection' in notification) {
+    if ('collection' in notification && notification.collection) {
       collections.push(notification.collection);
     }
   });

--- a/app/javascript/mastodon/api_types/notifications.ts
+++ b/app/javascript/mastodon/api_types/notifications.ts
@@ -90,22 +90,22 @@ interface ReportNotificationJSON extends BaseNotificationJSON {
 
 interface AddedToCollectionNotificationGroupJSON extends BaseNotificationGroupJSON {
   type: 'added_to_collection';
-  collection: ApiCollectionJSON;
+  collection: ApiCollectionJSON | null;
 }
 
 interface AddedToCollectionNotificationJSON extends BaseNotificationJSON {
   type: 'added_to_collection';
-  collection: ApiCollectionJSON;
+  collection: ApiCollectionJSON | null;
 }
 
 interface CollectionUpdateNotificationGroupJSON extends BaseNotificationGroupJSON {
   type: 'collection_update';
-  collection: ApiCollectionJSON;
+  collection: ApiCollectionJSON | null;
 }
 
 interface CollectionUpdateNotificationJSON extends BaseNotificationJSON {
   type: 'collection_update';
-  collection: ApiCollectionJSON;
+  collection: ApiCollectionJSON | null;
 }
 
 type SimpleNotificationTypes = 'follow' | 'follow_request' | 'admin.sign_up';


### PR DESCRIPTION
### Changes proposed in this PR:
- A follow-up fix for #39291, where a `null` check was missing for collection notifications for deleted collections, causing a TypeError. Also adapts the notification types to account for this.