### PR TITLE
fix naming of custom filter export param

### DIFF
--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -62,7 +62,7 @@ class Export
 
       data_collection[:custom_filters] << {
         title: filter.title,
-        expire_at: filter.expires_at,
+        expires_at: filter.expires_at,
         context: filter.context,
         action: filter.action,
         keywords_attributes: keywords_attributes,

--- a/spec/requests/settings/exports/custom_filters_spec.rb
+++ b/spec/requests/settings/exports/custom_filters_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Settings / Exports / CustomFilters' do
         { 'custom_filters' => [
           {
             'title' => other_filter.phrase,
-            'expire_at' => nil,
+            'expires_at' => nil,
             'context' => other_filter.context,
             'action' => other_filter.action,
             'keywords_attributes' => [{
@@ -31,7 +31,7 @@ RSpec.describe 'Settings / Exports / CustomFilters' do
           },
           {
             'title' => filter.phrase,
-            'expire_at' => nil,
+            'expires_at' => nil,
             'context' => filter.context,
             'action' => filter.action,
             'keywords_attributes' => [{


### PR DESCRIPTION
the naming should be consistent throughout the app, this was discovered when imports failed