### PR TITLE
Remove outdated dependency comment

### DIFF
--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-# NOTE: I initially wrote this as `EmailValidator` but it ended up clashing
-# with an indirect dependency of ours, `validate_email`, which, turns out,
-# has the same approach as we do, but with an extra check disallowing
-# single-label domains. Decided to not switch to `validate_email` because
-# we do want to allow at least `localhost`.
-
 class EmailAddressValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     value = value.strip


### PR DESCRIPTION
Follow up on https://github.com/mastodon/mastodon/pull/39288 which dropped this dependency and thus we no longer need to avoid a naming clash.