### PR TITLE
Add link to profile editing from “Privacy and reach”

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -487,6 +487,8 @@ $content-width: 840px;
     .title {
       font-weight: 600;
       margin-bottom: 8px;
+      font-size: inherit;
+      line-height: inherit;
     }
 
     a {

--- a/app/views/settings/privacy/show.html.haml
+++ b/app/views/settings/privacy/show.html.haml
@@ -38,6 +38,14 @@
     .fields-group
       = ff.input :show_application, wrapper: :with_label
 
+  %aside.callout
+    = material_symbol 'info'
+    .content
+      .body
+        %p.title= t('edit_profile.redesign_title')
+        %p= t('edit_profile.privacy_redesign_body')
+      = link_to t('edit_profile.redesign_button'), '/profile/edit'
+
   - if Rails.application.config.x.email_subscriptions && Setting.email_subscriptions && current_user.can?(:manage_email_subscriptions)
     %h2= t('privacy.email_subscriptions')
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1501,6 +1501,7 @@ en:
       your_appeal_rejected: Your appeal has been rejected
   edit_profile:
     other: Other
+    privacy_redesign_body: The choice to show your follows and followers is now made directly from your profile.
     redesign_body: Profile editing can now be accessed directly from the profile page.
     redesign_button: Go there
     redesign_title: There’s a new profile editing experience


### PR DESCRIPTION
Fixes #39272

Add the following callout where the setting previously was:
> The choice to show your follows and followers is now made directly from your profile.

<img width="838" height="405" alt="image" src="https://github.com/user-attachments/assets/23085411-010a-4b13-8966-6f99fe0e572e" />