### PR TITLE
Update style of "Hide" & "ALT" badges on top of images

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7050,6 +7050,11 @@ a.status-card {
   display: flex;
   gap: 2px;
   z-index: 2;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity 0.1s ease,
+    visibility 0.1s ease;
 
   &__pill {
     display: block;
@@ -7072,6 +7077,11 @@ a.status-card {
   }
 }
 
+.media-gallery:hover .media-gallery__actions {
+  opacity: 1;
+  visibility: visible;
+}
+
 .media-gallery__item__badges {
   position: absolute;
   bottom: 8px;
@@ -7079,6 +7089,12 @@ a.status-card {
   display: flex;
   gap: 2px;
   pointer-events: none;
+  opacity: 0.5;
+  transition: opacity 0.1s ease;
+}
+
+.media-gallery__item:hover .media-gallery__item__badges {
+  opacity: 1;
 }
 
 .media-gallery__alt__label,

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7089,7 +7089,7 @@ a.status-card {
   display: flex;
   gap: 2px;
   pointer-events: none;
-  opacity: 0.5;
+  opacity: 0.7;
   transition: opacity 0.1s ease;
 }
 


### PR DESCRIPTION
See #39313.

I agree that their presence can be bothersome, but I know that alt texts are there for accessibility purposes. I made a simple change that hides the "Hide" badge and lowers the opacity of the "ALT" badge until the user hovers over an image.

It would be great to have some discussion on this though as this is a UX decision that should be made by the Mastodon team.

Changes:
- "Hide" is hidden (visibly and as an element) until user hovers over an image.
- "ALT" has low opacity (still visible and not hidden) until user hovers over an image.

### PoC
#### Before
<img width="588" height="725" alt="Screenshot 2026-06-06 at 7 38 27 PM" src="https://github.com/user-attachments/assets/bc6e13c8-c40d-4fbe-b7b7-bf9119aabaaf" />

#### After
<img width="587" height="729" alt="image" src="https://github.com/user-attachments/assets/9e797bed-193d-4e83-9914-ebe73fbdff5c" />