### PR TITLE
Fix alignment of icon and text in Callout component

### DIFF
--- a/app/javascript/mastodon/components/callout/callout.stories.tsx
+++ b/app/javascript/mastodon/components/callout/callout.stories.tsx
@@ -34,6 +34,15 @@ export const Default: Story = {
   },
 };
 
+export const NoTitle: Story = {
+  args: {
+    title: '',
+    primaryLabel: '',
+    secondaryLabel: '',
+    onClose: undefined,
+  },
+};
+
 export const NoIcon: Story = {
   args: {
     icon: false,
@@ -56,11 +65,11 @@ export const OnlyText: Story = {
   },
 };
 
-// export const Subtle: Story = {
-//   args: {
-//     variant: 'subtle',
-//   },
-// };
+export const Subtle: Story = {
+  args: {
+    variant: 'subtle',
+  },
+};
 
 export const Feature: Story = {
   args: {

--- a/app/javascript/mastodon/components/callout/styles.module.css
+++ b/app/javascript/mastodon/components/callout/styles.module.css
@@ -7,6 +7,7 @@
   color: var(--color-text-primary);
   border-radius: 12px;
   font-size: 15px;
+  line-height: 1.3333;
 }
 
 .icon {
@@ -14,7 +15,7 @@
   border-radius: 9999px;
   width: 1rem;
   height: 1rem;
-  margin-top: -2px;
+  margin-block: -2px;
 }
 
 .content,
@@ -46,7 +47,7 @@
 
   h3 {
     font-weight: 500;
-    margin-bottom: 5px;
+    margin-bottom: 3px;
   }
 }
 

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -457,6 +457,7 @@ $content-width: 840px;
     color: var(--color-text-primary);
     border-radius: 12px;
     font-size: 15px;
+    line-height: 1.3333;
     margin-bottom: 30px;
 
     .icon {
@@ -464,7 +465,7 @@ $content-width: 840px;
       border-radius: 9999px;
       width: 1rem;
       height: 1rem;
-      margin-top: -2px;
+      margin-block: -2px;
       background-color: var(--color-bg-brand-soft);
     }
 
@@ -502,7 +503,7 @@ $content-width: 840px;
 
     .title {
       font-weight: 600;
-      margin-bottom: 8px;
+      margin-bottom: 6px;
       font-size: inherit;
       line-height: inherit;
     }


### PR DESCRIPTION
Fixes WEB-1037

### Changes proposed in this PR:
- Improves the alignment of icon and text in the Callout component, especially when there's no title

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="428" height="93" alt="image" src="https://github.com/user-attachments/assets/f5bb9cb1-9140-49b5-a3c8-d9b144e03c9f" /> | <img width="427" height="93" alt="image" src="https://github.com/user-attachments/assets/5a22b68a-d8dc-4851-81b0-ebe04d4dbf60" /> |
| <img width="449" height="81" alt="image" src="https://github.com/user-attachments/assets/5170e8df-c32b-46ba-9c18-827ba2f3ee81" /> | <img width="429" height="75" alt="image" src="https://github.com/user-attachments/assets/6666dba6-f3f9-473a-b67b-b157ca011675" /> |
| <img width="447" height="112" alt="image" src="https://github.com/user-attachments/assets/5c07552d-1fb6-425e-b815-c523dd746c3f" /> | <img width="423" height="89" alt="image" src="https://github.com/user-attachments/assets/14dd57d3-708a-4e92-a2a3-5d0a8aa63d21" /> |