### PR TITLE
[Accessibility] Patch over a11y issues caused by "simple" ruby gems

### DIFF
--- a/app/javascript/entrypoints/public.tsx
+++ b/app/javascript/entrypoints/public.tsx
@@ -570,7 +570,6 @@ function applyRailsA11yPatches() {
    * Add fieldset-like group labels ("legends") to the date-of-birth selector
    * and groups of radio buttons
    */
-
   const groups = document.querySelectorAll<HTMLDivElement>(
     '.simple_form .date_of_birth, .simple_form .input.with_label.radio_buttons',
   );
@@ -594,7 +593,9 @@ function applyRailsA11yPatches() {
 
     groupWrapper.setAttribute('role', 'group');
     groupWrapper.setAttribute('aria-labelledby', labelId);
-    groupWrapper.setAttribute('aria-describedby', hintId);
+    if (groupHint) {
+      groupWrapper.setAttribute('aria-describedby', hintId);
+    }
   });
 }
 

--- a/app/javascript/entrypoints/public.tsx
+++ b/app/javascript/entrypoints/public.tsx
@@ -181,6 +181,12 @@ async function loaded() {
 
   truncateRuleHints();
 
+  document
+    .querySelectorAll<HTMLElement>('.simple_form label.required abbr')
+    .forEach((element) => {
+      element.setAttribute('aria-hidden', 'true');
+    });
+
   const reactComponents = document.querySelectorAll('[data-component]');
 
   if (reactComponents.length > 0) {

--- a/app/javascript/entrypoints/public.tsx
+++ b/app/javascript/entrypoints/public.tsx
@@ -181,12 +181,6 @@ async function loaded() {
 
   truncateRuleHints();
 
-  document
-    .querySelectorAll<HTMLElement>('.simple_form label.required abbr')
-    .forEach((element) => {
-      element.setAttribute('aria-hidden', 'true');
-    });
-
   applyRailsA11yPatches();
 
   const reactComponents = document.querySelectorAll('[data-component]');
@@ -535,6 +529,16 @@ function applyRailsA11yPatches() {
     '.simple-navigation-active-leaf a.selected',
   );
   activeNavLink?.setAttribute('aria-current', 'page');
+
+  /**
+   * Hides the asterisk added to labels of required form fields
+   * from assistive tech. (Those fields already have the `required` attribute)
+   */
+  document
+    .querySelectorAll<HTMLElement>('.simple_form label.required abbr')
+    .forEach((element) => {
+      element.setAttribute('aria-hidden', 'true');
+    });
 
   /**
    * Associate form field hints with their inputs via aria-describedby

--- a/app/javascript/entrypoints/public.tsx
+++ b/app/javascript/entrypoints/public.tsx
@@ -187,6 +187,8 @@ async function loaded() {
       element.setAttribute('aria-hidden', 'true');
     });
 
+  applyRailsA11yPatches();
+
   const reactComponents = document.querySelectorAll('[data-component]');
 
   if (reactComponents.length > 0) {
@@ -520,6 +522,77 @@ on('click', '.rules-list button', ({ target }) => {
     toggleRuleHint(listItem);
   }
 });
+
+/**
+ * Patch accessibility issues caused by Ruby Gems that
+ * don't produce accessible markup (simple-forms & simple-navigation)
+ */
+function applyRailsA11yPatches() {
+  /**
+   * Mark current navigation item with aria-current
+   */
+  const activeNavLink = document.querySelector(
+    '.simple-navigation-active-leaf a.selected',
+  );
+  activeNavLink?.setAttribute('aria-current', 'page');
+
+  /**
+   * Associate form field hints with their inputs via aria-describedby
+   */
+  document
+    .querySelectorAll<HTMLDivElement>('.simple_form .field_with_hint')
+    .forEach((field) => {
+      const inputs = field.querySelectorAll<
+        HTMLInputElement | HTMLTextAreaElement
+      >("input[type='text'], input[type='checkbox'], textarea");
+
+      const hint = field.querySelector<HTMLDivElement>('.hint');
+
+      // Bail out if there are more than one input as
+      // the association can't be safely made.
+      if (inputs.length !== 1 || !inputs[0] || !hint) {
+        return;
+      }
+
+      const input = inputs[0];
+      const inputId = input.getAttribute('id');
+      const hintId = `${inputId}_hint`;
+
+      input.setAttribute('aria-describedby', hintId);
+      hint.setAttribute('id', hintId);
+    });
+
+  /**
+   * Add fieldset-like group labels ("legends") to the date-of-birth selector
+   * and groups of radio buttons
+   */
+
+  const groups = document.querySelectorAll<HTMLDivElement>(
+    '.simple_form .date_of_birth, .simple_form .input.with_label.radio_buttons',
+  );
+  groups.forEach((groupWrapper) => {
+    // This is the element serving as the label of the group.
+    const groupLabel = groupWrapper.querySelector<HTMLLabelElement>('label');
+    const labelWithId =
+      groupWrapper.querySelector<HTMLLabelElement>('label[for]');
+    const groupHint = groupWrapper.querySelector<HTMLDivElement>('.hint');
+
+    // We need a unique ID to generate the aria associations. If `groupLabel`
+    // doesn't have one, we just take the first label with a `for` attribute
+    // that we can find, which is fine because we'll modify it before use.
+    const inputId =
+      groupLabel?.getAttribute('for') ?? labelWithId?.getAttribute('for');
+    const labelId = `${inputId}_label`;
+    const hintId = `${inputId}_hint`;
+
+    groupLabel?.setAttribute('id', labelId);
+    groupHint?.setAttribute('id', hintId);
+
+    groupWrapper.setAttribute('role', 'group');
+    groupWrapper.setAttribute('aria-labelledby', labelId);
+    groupWrapper.setAttribute('aria-describedby', hintId);
+  });
+}
 
 function main() {
   ready(loaded).catch((error: unknown) => {

--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -21,17 +21,17 @@
     = f.simple_fields_for :account do |ff|
       = ff.input :username,
                  append: "@#{site_hostname}",
-                 input_html: { autocomplete: 'off', pattern: '[a-zA-Z0-9_]+', maxlength: Account::USERNAME_LENGTH_LIMIT, placeholder: ' ' },
+                 input_html: { autocomplete: 'off', pattern: '[a-zA-Z0-9_]+', maxlength: Account::USERNAME_LENGTH_LIMIT },
                  required: true,
                  wrapper: :with_label
     = f.input :email,
               hint: false,
-              input_html: { autocomplete: 'username', placeholder: ' ' },
+              input_html: { autocomplete: 'username' },
               required: true,
               wrapper: :with_label
     = f.input :password,
               hint: false,
-              input_html: { autocomplete: 'new-password', minlength: User.password_length.first, maxlength: User.password_length.last, placeholder: ' ' },
+              input_html: { autocomplete: 'new-password', minlength: User.password_length.first, maxlength: User.password_length.last },
               required: true,
               wrapper: :with_label
     = f.input :password_confirmation,


### PR DESCRIPTION
Related to WEB-881
Fixes WEB-1021

### Changes proposed in this PR:
- Fixes accessibility issues caused by the ruby gems [`simple-navigation`](https://github.com/codeplant/simple-navigation) and [`simple_form`](https://github.com/heartcombo/simple_form) using JS patches. It would be better to fix these server-side (or at the source), but the libraries don't offer such customisability out of the box, so this is the most pragmatic solution for now.
   - Marks current page as active in the settings navigation by adding the `aria-current='page'` attribute where needed
   - Hides the asterisks in form labels from screenreaders (required fields are already marked up accordingly)
   - Associates hints in `simple_form` fields with the relevant inputs, causing them to be read out when focusing the field
   - Creates `<fieldset>` + `<legend>`-type aria associations for groups of radio buttons and the date-of-birth selector on the sign-up page, ensuring that the group label and hint are read out when focusing a nested input
