### PR TITLE
Fix inconsistent `keyboard_shortcuts.translate` string

### DIFF
--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -846,7 +846,7 @@
   "keyboard_shortcuts.toggle_sensitivity": "Show/hide media",
   "keyboard_shortcuts.toot": "Start a new post",
   "keyboard_shortcuts.top": "Move to top of list",
-  "keyboard_shortcuts.translate": "to translate a post",
+  "keyboard_shortcuts.translate": "Translate a post",
   "keyboard_shortcuts.unfocus": "Unfocus compose textarea/search",
   "keyboard_shortcuts.up": "Move up in the list",
   "learn_more_link.got_it": "Got it",


### PR DESCRIPTION
Update English string for `keyboard_shortcuts.translate` to match the imperative mood of the other `keyboard_shortcuts` strings surrounding it.

Here's a screenshot showing how the `translate` string stands out from the rest in the keyboard shortcut reference view:

<img width="962" height="426" alt="b: Boost post; q: Quote post; enter, o: Open post; t: to translate a post; e: Open media; x: Show/hide text behind CW" src="https://github.com/user-attachments/assets/dc5ddd57-c90c-40fb-8b5d-53002fe8865a" />
