### PR TITLE
Fix broken column header layout after heading refactor

### DIFF
--- a/app/javascript/mastodon/components/column_header.tsx
+++ b/app/javascript/mastodon/components/column_header.tsx
@@ -276,6 +276,10 @@ export const ColumnHeader: React.FC<Props> = ({
     </>
   );
 
+  const titleClassNames = classNames('column-header__title', {
+    'column-header__title--with-back-button': !!backButton,
+  });
+
   const component = (
     <div className={wrapperClassName}>
       <div className={headingClassName}>
@@ -285,7 +289,7 @@ export const ColumnHeader: React.FC<Props> = ({
             {onClick ? (
               <button
                 onClick={handleTitleClick}
-                className='column-header__title'
+                className={titleClassNames}
                 type='button'
                 id={getColumnSkipLinkId(columnIndex)}
               >
@@ -293,7 +297,7 @@ export const ColumnHeader: React.FC<Props> = ({
               </button>
             ) : (
               <span
-                className='column-header__title'
+                className={titleClassNames}
                 tabIndex={-1}
                 id={getColumnSkipLinkId(columnIndex)}
               >

--- a/app/javascript/mastodon/components/column_header.tsx
+++ b/app/javascript/mastodon/components/column_header.tsx
@@ -279,10 +279,9 @@ export const ColumnHeader: React.FC<Props> = ({
   const component = (
     <div className={wrapperClassName}>
       <div className={headingClassName}>
+        {backButton}
         {hasTitle && (
           <h1 className='column-header__title-wrapper'>
-            {backButton}
-
             {onClick ? (
               <button
                 onClick={handleTitleClick}
@@ -303,8 +302,6 @@ export const ColumnHeader: React.FC<Props> = ({
             )}
           </h1>
         )}
-
-        {!hasTitle && backButton}
 
         <div className='column-header__buttons'>
           {extraButton}

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4639,15 +4639,15 @@ a.status-card {
   outline: 0;
 
   &__title-wrapper {
+    display: flex;
     flex-grow: 1;
   }
 
   &__title {
     display: flex;
     align-items: center;
-    width: 100%;
-    height: 100%;
     gap: 5px;
+    flex-grow: 1;
     margin: 0;
     border: 0;
     padding: 13px;
@@ -4660,6 +4660,10 @@ a.status-card {
     overflow: hidden;
     white-space: nowrap;
 
+    &--with-back-button {
+      padding-inline-start: 0;
+    }
+
     &:focus-visible {
       outline: var(--outline-focus-default);
     }
@@ -4667,10 +4671,6 @@ a.status-card {
     .logo {
       height: 24px;
     }
-  }
-
-  .column-header__back-button + &__title {
-    padding-inline-start: 0;
   }
 
   .column-header__back-button {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4646,6 +4646,7 @@ a.status-card {
     display: flex;
     align-items: center;
     width: 100%;
+    height: 100%;
     gap: 5px;
     margin: 0;
     border: 0;


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes a regression from #39305 (and also moves the back button out of the heading, which really should've been done in that earlier PR anyway)

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="603" height="158" alt="image" src="https://github.com/user-attachments/assets/9ca0a50a-f835-4870-bf40-ea7d7e4bd38f" /> | <img width="603" height="154" alt="image" src="https://github.com/user-attachments/assets/112f06f3-2749-4d7f-8ab4-d585c77f0d41" /> |