### PR TITLE
Fix tiny checkboxes and radio buttons in Safari

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -500,6 +500,8 @@ code {
 
     input[type='radio'] {
       accent-color: var(--color-text-brand);
+      width: 15px;
+      height: 15px;
     }
   }
 
@@ -533,6 +535,8 @@ code {
   label.checkbox {
     input[type='checkbox'] {
       accent-color: var(--color-text-brand);
+      width: 15px;
+      height: 15px;
     }
   }
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes checkboxes and radio buttons looking tiny and mis-aligned in Safari

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="631" height="535" alt="image" src="https://github.com/user-attachments/assets/48c0a160-2bda-4ea2-8a19-b5ff273636ec" /> | <img width="620" height="551" alt="Screenshot 2026-06-08 at 14 51 58" src="https://github.com/user-attachments/assets/bc6484ea-ca48-4f77-8aba-ab816bd6c053" /> |
| <img width="513" height="198" alt="image" src="https://github.com/user-attachments/assets/780c9e10-7cbe-4069-92a3-70881ac35c18" /> | <img width="524" height="219" alt="image" src="https://github.com/user-attachments/assets/9c02531e-2809-4aad-bc90-7ec26e838b6b" /> |