### PR TITLE
Fix intermittent failure with order dependent RankedTrend `locales` pluck

### DIFF
--- a/spec/support/examples/models/concerns/ranked_trend.rb
+++ b/spec/support/examples/models/concerns/ranked_trend.rb
@@ -34,7 +34,7 @@ RSpec.shared_examples 'RankedTrend' do
 
     it 'returns unique set of languages' do
       expect(described_class.locales)
-        .to eq(['en', 'es'])
+        .to contain_exactly('en', 'es')
     end
   end
 


### PR DESCRIPTION
There's no guaranteed order from this method.

I'm not sure I've seen this on CI, but just saw this (intermitten/order-based) failure locally.