### PR TITLE
Collections API: Set a maximum for the pagination `limit` param

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -4,6 +4,7 @@ class Api::V1::CollectionsController < Api::BaseController
   include Authorization
 
   DEFAULT_COLLECTIONS_LIMIT = 40
+  MAX_COLLECTIONS_LIMIT = 100
 
   rescue_from ActiveRecord::RecordInvalid, Mastodon::ValidationError do |e|
     render json: { error: ValidationErrorFormatter.new(e).as_json }, status: 422
@@ -73,7 +74,7 @@ class Api::V1::CollectionsController < Api::BaseController
       .with_tag
       .order(created_at: :desc)
       .offset(offset_param)
-      .limit(limit_param(DEFAULT_COLLECTIONS_LIMIT))
+      .limit(limit_param(DEFAULT_COLLECTIONS_LIMIT, MAX_COLLECTIONS_LIMIT))
     @collections = @collections.discoverable unless @account == current_account
   end
 


### PR DESCRIPTION
This should probably not be unbounded as the effort to render this grows linearly. The limit I have chosen is somewhat arbitrary, but I did some very basic benchmarks and I think this is should still be reasonable.