### PR TITLE
Use http POST on rules acceptance button during registration

### DIFF
--- a/app/controllers/auth/acceptances_controller.rb
+++ b/app/controllers/auth/acceptances_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Auth::AcceptancesController < ApplicationController
+  def create
+    redirect_to new_user_registration_path(registration_params)
+  end
+
+  private
+
+  def registration_params
+    params.permit(:accept, :invite_code).compact_blank
+  end
+end

--- a/app/views/auth/registrations/rules.html.haml
+++ b/app/views/auth/registrations/rules.html.haml
@@ -4,7 +4,7 @@
 - content_for :header_tags do
   = render partial: 'shared/og', locals: { description: description_for_sign_up(@invite) }
 
-= form_with class: :simple_form, method: :get, url: new_user_registration_path do |form|
+= form_with class: :simple_form, url: auth_acceptance_path do |form|
   = render 'auth/shared/progress', stage: 'rules'
 
   - if @invite.present? && @invite.autofollow?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
     resource :unsubscribe, only: [:show, :create], controller: :unsubscriptions
 
     namespace :auth do
+      resource :acceptance, only: [:create]
       resource :setup, only: [:show, :update], controller: :setup
       resource :challenge, only: [:create]
       post 'captcha_confirmation', to: 'confirmations#confirm_captcha', as: :captcha_confirmation


### PR DESCRIPTION
Background in https://github.com/mastodon/mastodon/pull/39310

Based on feedback there I did this in a way which does not use the session for either the accept token or the invite code, instead just passing them along in the params (when present) so the way they are handled by the registration controller does not change.

The code paths added here are covered by the previously added changes - but definitely let me know if there are scenarios we are concerned about but not exercising yet and I'll add them.

Followup:

- I considered pulling out the "list of rules" page to `auth/rules#index` or `auth/acceptances#show` or something ... but since the "new" view and the rules listing both have in-page text related to invites I didn't want to duplicate that so I left the rules handled as an in-action `render` which halts the new view. If we did extract the invite stuff to the session this might make sense.
- I think removing the accept token (but not the invite code) and putting that as a single value in the session which gets cleaned up on registration would be a nice small improvement and mostly a deletion of the accept token code. It doesn't have the same "what if a return visit uses different one" concerns of the invite code. Could do that as followup if desired, or update here.