### PR TITLE
Change i18n unused strings check to only check English strings

### DIFF
--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -39,7 +39,7 @@ jobs:
         run: bin/i18n-tasks check-normalized
 
       - name: Check for unused strings
-        run: bin/i18n-tasks unused
+        run: bin/i18n-tasks unused -l en
 
       - name: Check for missing strings in English YML
         run: |


### PR DESCRIPTION
Similar to #37801, only check the English (source) strings, this is quicker and less noisy. Unused strings that are not in the English strings will get removed on the next Crowdin merge anyway.