### PR TITLE
Fix font size of `Callout` component actions in Safari

### DIFF
--- a/app/javascript/mastodon/components/callout/styles.module.css
+++ b/app/javascript/mastodon/components/callout/styles.module.css
@@ -62,6 +62,7 @@
   background: none;
   border: none;
   color: inherit;
+  font: inherit;
   font-weight: 500;
   padding: 0;
   text-wrap: nowrap;


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes the font size of the actions in the `Callout` component in Safari

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="581" height="79" alt="image" src="https://github.com/user-attachments/assets/7c01e795-347f-4be5-a2e8-60ac77c37046" /> | <img width="581" height="81" alt="image" src="https://github.com/user-attachments/assets/b0a6ed25-da72-425c-96a0-e9cd868a49f3" /> |