### PR TITLE
Minor refactor foldToASCII in streaming/utils.js

### DIFF
--- a/streaming/utils.js
+++ b/streaming/utils.js
@@ -30,17 +30,15 @@ export function isTruthy(value) {
  */
 const NON_ASCII_CHARS        = 'ÀÁÂÃÄÅàáâãäåĀāĂăĄąÇçĆćĈĉĊċČčÐðĎďĐđÈÉÊËèéêëĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħÌÍÎÏìíîïĨĩĪīĬĭĮįİıĴĵĶķĸĹĺĻļĽľĿŀŁłÑñŃńŅņŇňŉŊŋÒÓÔÕÖØòóôõöøŌōŎŏŐőŔŕŖŗŘřŚśŜŝŞşŠšſŢţŤťŦŧÙÚÛÜùúûüŨũŪūŬŭŮůŰűŲųŴŵÝýÿŶŷŸŹźŻżŽž';
 const EQUIVALENT_ASCII_CHARS = 'AAAAAAaaaaaaAaAaAaCcCcCcCcCcDdDdDdEEEEeeeeEeEeEeEeEeGgGgGgGgHhHhIIIIiiiiIiIiIiIiIiJjKkkLlLlLlLlLlNnNnNnNnnNnOOOOOOooooooOoOoOoRrRrRrSsSsSsSssTtTtTtUUUUuuuuUuUuUuUuUuUuWwYyyYyYZzZzZz';
-
+const FOLDTOASCII_REGEX = new RegExp(NON_ASCII_CHARS.split('').join('|'), 'g');
 /**
  * @param {string} str
  * @returns {string}
  */
 export function foldToASCII(str) {
-  const regex = new RegExp(NON_ASCII_CHARS.split('').join('|'), 'g');
-
-  return str.replace(regex, function(match) {
+  return str.replace(FOLDTOASCII_REGEX, function(match) {
     const index = NON_ASCII_CHARS.indexOf(match);
-    return EQUIVALENT_ASCII_CHARS[index];
+    return EQUIVALENT_ASCII_CHARS[index] || match;
   });
 }
 

--- a/streaming/utils.js
+++ b/streaming/utils.js
@@ -38,7 +38,7 @@ const FOLDTOASCII_REGEX = new RegExp(NON_ASCII_CHARS.split('').join('|'), 'g');
 export function foldToASCII(str) {
   return str.replace(FOLDTOASCII_REGEX, function(match) {
     const index = NON_ASCII_CHARS.indexOf(match);
-    return EQUIVALENT_ASCII_CHARS[index] || match;
+    return EQUIVALENT_ASCII_CHARS[index];
   });
 }
 


### PR DESCRIPTION
Moves the RegExp creation outside the function to avoid recompiling it on every call.