### PR TITLE
Fix Elasticsearch connection cleanup in Sidekiq middleware

### DIFF
--- a/lib/mastodon/sidekiq_middleware.rb
+++ b/lib/mastodon/sidekiq_middleware.rb
@@ -34,7 +34,7 @@ class Mastodon::SidekiqMiddleware
   # and each such client manages its long-lasting connection to
   # Elasticsearch.
   #
-  # As far as I know, neither `chewy`,  `elasticsearch-transport` or even
+  # As far as I know, neither `chewy`, `elastic-transport` or even
   # `faraday` provide a reliable way to immediately close a connection, and
   # rely on the underlying object to be garbage-collected instead.
   #
@@ -44,7 +44,7 @@ class Mastodon::SidekiqMiddleware
   def clean_up_elasticsearch_connections!
     return unless Chewy.enabled? && Chewy.current[:chewy_client].present?
 
-    Chewy.client.transport.transport.connections.each do |connection|
+    Chewy.client.transport.connections.each do |connection|
       # NOTE: This bit of code is tailored for the HTTPClient Faraday adapter
       connection.connection.app.instance_variable_get(:@client)&.reset_all
     end


### PR DESCRIPTION
Chewy has moved from `elasticsearch-transport` to `elastic-transport` and a few things have changed.

It also added `Chewy::ElasticClient#close` which seems to be intended to handle the same problem, but as far as I can tell, my analysis in https://github.com/mastodon/mastodon/pull/30450 remains and the `Faraday::Adapter::HTTPClient` adapter does not implement the `close` method, which causes it to fall back to the parent's class `Faraday::Adapter#close` method, which is a no-op.