### PR TITLE
Auto-focus mobile composer

### DIFF
--- a/app/javascript/mastodon/features/compose/index.tsx
+++ b/app/javascript/mastodon/features/compose/index.tsx
@@ -193,7 +193,11 @@ const Compose: React.FC<{ multiColumn: boolean }> = ({ multiColumn }) => {
       />
 
       <div className='scrollable'>
-        <ComposeFormContainer />
+        <ComposeFormContainer
+          // This is fine on this single-purpose view
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus
+        />
       </div>
 
       <Helmet>

--- a/app/javascript/mastodon/features/navigation_panel/index.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/index.tsx
@@ -263,7 +263,7 @@ export const NavigationPanel: React.FC<{ multiColumn?: boolean }> = ({
             {!multiColumn && (
               <li>
                 <ColumnLink
-                  to='/publish'
+                  to={{ pathname: '/publish', state: { focusTarget: false } }}
                   icon='plus'
                   iconComponent={AddIcon}
                   activeIconComponent={AddIcon}

--- a/app/javascript/mastodon/features/ui/components/column_link.tsx
+++ b/app/javascript/mastodon/features/ui/components/column_link.tsx
@@ -3,6 +3,7 @@ import { useRouteMatch, NavLink } from 'react-router-dom';
 
 import { Icon } from 'mastodon/components/icon';
 import type { IconProp } from 'mastodon/components/icon';
+import type { MastodonLocationDescriptor } from 'mastodon/components/router';
 
 export const ColumnLink: React.FC<{
   icon: React.ReactNode;
@@ -11,7 +12,7 @@ export const ColumnLink: React.FC<{
   activeIconComponent?: IconProp;
   isActive?: (match: unknown, location: { pathname: string }) => boolean;
   text: string;
-  to?: string;
+  to?: MastodonLocationDescriptor;
   href?: string;
   method?: string;
   badge?: React.ReactNode;
@@ -31,7 +32,9 @@ export const ColumnLink: React.FC<{
   transparent,
   ...other
 }) => {
-  const match = useRouteMatch(to ?? '');
+  const match = useRouteMatch(
+    (typeof to === 'string' ? to : to?.pathname) ?? '',
+  );
   const className = classNames('column-link', {
     'column-link--transparent': transparent,
   });

--- a/app/javascript/mastodon/features/ui/components/navigation_bar.tsx
+++ b/app/javascript/mastodon/features/ui/components/navigation_bar.tsx
@@ -17,6 +17,7 @@ import { toggleNavigation } from 'mastodon/actions/navigation';
 import { fetchServer } from 'mastodon/actions/server';
 import { Icon } from 'mastodon/components/icon';
 import { IconWithBadge } from 'mastodon/components/icon_with_badge';
+import type { MastodonLocationDescriptor } from 'mastodon/components/router';
 import { useIdentity } from 'mastodon/identity_context';
 import { registrationsOpen, sso_redirect } from 'mastodon/initial_state';
 import { selectUnreadNotificationGroupsCount } from 'mastodon/selectors/notifications';
@@ -38,12 +39,14 @@ export const messages = defineMessages({
 });
 
 const IconLabelButton: React.FC<{
-  to: string;
+  to: MastodonLocationDescriptor;
   icon?: React.ReactNode;
   activeIcon?: React.ReactNode;
   title: string;
 }> = ({ to, icon, activeIcon, title }) => {
-  const match = useRouteMatch(to);
+  const match = useRouteMatch(
+    typeof to === 'string' ? to : (to.pathname ?? ''),
+  );
 
   return (
     <NavLink
@@ -189,7 +192,7 @@ export const NavigationBar: React.FC = () => {
             />
             <IconLabelButton
               title={intl.formatMessage(messages.publish)}
-              to='/publish'
+              to={{ pathname: '/publish', state: { focusTarget: false } }}
               icon={<Icon id='' icon={AddIcon} />}
             />
             <NotificationsButton />


### PR DESCRIPTION
### Changes proposed in this PR:
- Sets focus to the composer on mobile, matching the behaviour of our Android app. (Where supported – I believe mobile Safari doesn't support using autofocus in this way, or at least won't bring up the keyboard, but this might be outdated information.)

### Screencap

https://github.com/user-attachments/assets/468f92bc-339a-4dc2-b813-d112d66773b3

