### PR TITLE
Remove legacy edge case handling in fan out on write service

### DIFF
--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -27,14 +27,7 @@ class FanOutOnWriteService < BaseService
   private
 
   def check_race_condition!
-    # I don't know why but at some point we had an issue where
-    # this service was being executed with status objects
-    # that had a null visibility - which should not be possible
-    # since the column in the database is not nullable.
-    #
-    # This check re-queues the service to be run at a later time
-    # with the full object, if something like it occurs
-
+    # Handle invalid data by re-queueing for later run
     raise Mastodon::RaceConditionError if @status.visibility.nil?
   end
 

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -16,7 +16,6 @@ class FanOutOnWriteService < BaseService
 
     return if @status.proper.account.suspended?
 
-    check_race_condition!
     warm_payload_cache!
 
     fan_out_to_local_recipients!
@@ -25,11 +24,6 @@ class FanOutOnWriteService < BaseService
   end
 
   private
-
-  def check_race_condition!
-    # Handle invalid data by re-queueing for later run
-    raise Mastodon::RaceConditionError if @status.visibility.nil?
-  end
 
   def fan_out_to_local_recipients!
     deliver_to_self!

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe FanOutOnWriteService do
     end
   end
 
+  context 'when status visibility is nil' do
+    let(:status) { Fabricate.build :status }
+
+    before { status.visibility = nil }
+
+    it 'handles edge case by raising for future re-queue run' do
+      expect { subject.call(status) }.to raise_error(Mastodon::RaceConditionError)
+    end
+  end
+
   context 'when status is public' do
     let(:visibility) { 'public' }
 

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -41,16 +41,6 @@ RSpec.describe FanOutOnWriteService do
     end
   end
 
-  context 'when status visibility is nil' do
-    let(:status) { Fabricate.build :status }
-
-    before { status.visibility = nil }
-
-    it 'handles edge case by raising for future re-queue run' do
-      expect { subject.call(status) }.to raise_error(Mastodon::RaceConditionError)
-    end
-  end
-
   context 'when status is public' do
     let(:visibility) { 'public' }
 


### PR DESCRIPTION
Recreate this seemingly impossible situation in spec, delete extraneous inline comments.