### PR TITLE
Fix "unlisted collections" profile section can be visible to other users

### DIFF
--- a/app/javascript/mastodon/features/account_featured/index.tsx
+++ b/app/javascript/mastodon/features/account_featured/index.tsx
@@ -41,6 +41,7 @@ const AccountFeatured: React.FC<{ multiColumn: boolean }> = ({
   const account = useAccount(accountId);
   const { suspended, blockedBy, hidden } = useAccountVisibility(accountId);
   const forceEmptyState = suspended || blockedBy || hidden;
+  const isOwnProfile = accountId === me;
 
   const dispatch = useAppDispatch();
 
@@ -69,10 +70,7 @@ const AccountFeatured: React.FC<{ multiColumn: boolean }> = ({
 
   const { listedCollections = [], unlistedCollections = [] } = Object.groupBy(
     collections,
-    (item) =>
-      item.discoverable && !!item.item_count
-        ? 'listedCollections'
-        : 'unlistedCollections',
+    (item) => (item.discoverable ? 'listedCollections' : 'unlistedCollections'),
   );
 
   const renderListItem = useCallback(
@@ -166,7 +164,7 @@ const AccountFeatured: React.FC<{ multiColumn: boolean }> = ({
               defaultMessage='Collections'
             />
           </h2>
-          {accountId === me && (
+          {isOwnProfile && (
             <SubheadingLink to='/collections/new' icon={AddIcon}>
               <FormattedMessage
                 id='account.featured.new_collection'
@@ -179,7 +177,7 @@ const AccountFeatured: React.FC<{ multiColumn: boolean }> = ({
           <ItemList>
             <TruncatedListItems
               visibleItems={listedCollections}
-              truncatedItems={unlistedCollections}
+              truncatedItems={isOwnProfile ? unlistedCollections : []}
               toggleButton={{
                 title: (
                   <FormattedMessage


### PR DESCRIPTION
### Changes proposed in this PR:
- Ensure that the "unlisted collections" section is never shown on a profile except when viewing your own collection. Previously this could happen because empty collections would be treated as unlisted, this has been removed.