### PR TITLE
Fix loading/errored emoji in detailed status display name causing line break

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2498,7 +2498,7 @@ a.account__display-name {
   overflow: hidden;
 
   strong,
-  span {
+  span:not(.emojione) {
     display: block;
     text-overflow: ellipsis;
     overflow: hidden;


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes a line break caused by a loading or errored emoji in the detailed status display name being targeted by an overly broad CSS rule

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="332" height="78" alt="image" src="https://github.com/user-attachments/assets/68d08a00-11b0-4c31-8e9c-8bcaf7fd5758" /> | <img width="341" height="68" alt="image" src="https://github.com/user-attachments/assets/079775d4-b8b6-469c-a25f-bb568403d379" /> |