### PR TITLE
Follow up to #38711 - support instances running on subdomains

### DIFF
--- a/app/services/process_links_service.rb
+++ b/app/services/process_links_service.rb
@@ -21,16 +21,19 @@ class ProcessLinksService < BaseService
   private
 
   def scan_text!
-    urls = @status.text.scan(FetchLinkCardService::URL_PATTERN).map { |array| Addressable::URI.parse(array[1]).normalize }
+    urls = @status.text.scan(FetchLinkCardService::URL_PATTERN).filter_map { |array| Addressable::URI.parse(array[1]).normalize }
+    rescue Addressable::URI::InvalidURIError
+      nil
+    end
 
-    domains = urls.map(&:domain).uniq
+    domains = urls.map(&:normalized_host).uniq.compact
     valid_domains = Instance.searchable.where(domain: domains).pluck(:domain)
 
     urls.each do |url|
       # We only support `FeaturedCollection` at this time
 
       object = ActivityPub::TagManager.instance.uri_to_resource(url.to_s, Collection)
-      object ||= ResolveURLService.new.call(url.to_s) if valid_domains.include?(url.domain)
+      object ||= ResolveURLService.new.call(url.to_s) if valid_domains.include?(url.normalized_host)
       next unless object.is_a?(Collection)
 
       tagged_object = @previous_objects.find { |x| x.object == object || x.uri == url }

--- a/app/services/process_links_service.rb
+++ b/app/services/process_links_service.rb
@@ -21,7 +21,7 @@ class ProcessLinksService < BaseService
   private
 
   def scan_text!
-    urls = @status.text.scan(FetchLinkCardService::URL_PATTERN).filter_map { |array| Addressable::URI.parse(array[1]).normalize }
+    urls = @status.text.scan(FetchLinkCardService::URL_PATTERN).map { |array| Addressable::URI.parse(array[1]).normalize }
 
     domains = urls.map(&:host).uniq
     valid_domains = Instance.searchable.where(domain: domains).pluck(:domain)

--- a/app/services/process_links_service.rb
+++ b/app/services/process_links_service.rb
@@ -26,7 +26,7 @@ class ProcessLinksService < BaseService
       nil
     end
 
-    domains = urls.map(&:normalized_host).uniq.compact
+    domains = urls.map(&:normalized_host).uniq
     valid_domains = Instance.searchable.where(domain: domains).pluck(:domain)
 
     urls.each do |url|

--- a/app/services/process_links_service.rb
+++ b/app/services/process_links_service.rb
@@ -22,18 +22,15 @@ class ProcessLinksService < BaseService
 
   def scan_text!
     urls = @status.text.scan(FetchLinkCardService::URL_PATTERN).filter_map { |array| Addressable::URI.parse(array[1]).normalize }
-    rescue Addressable::URI::InvalidURIError
-      nil
-    end
 
-    domains = urls.map(&:normalized_host).uniq
+    domains = urls.map(&:host).uniq
     valid_domains = Instance.searchable.where(domain: domains).pluck(:domain)
 
     urls.each do |url|
       # We only support `FeaturedCollection` at this time
 
       object = ActivityPub::TagManager.instance.uri_to_resource(url.to_s, Collection)
-      object ||= ResolveURLService.new.call(url.to_s) if valid_domains.include?(url.normalized_host)
+      object ||= ResolveURLService.new.call(url.to_s) if valid_domains.include?(url.host)
       next unless object.is_a?(Collection)
 
       tagged_object = @previous_objects.find { |x| x.object == object || x.uri == url }


### PR DESCRIPTION
Again, Claire, I think this is correct. Please confirm....

* I believe Addressable::URI domain will snip the subdomain off? `"http://www.example.co.uk").domain # => "example.co.uk"`
Ref: https://www.rubydoc.info/gems/addressable/Addressable/URI#domain-instance_method

* Rescue code borrowed 
https://github.com/mastodon/mastodon/blob/5098b8ccc9d95a866ef109e32b6cc5de069f12b9/app/lib/request.rb#L135-L140



