### PR TITLE
Update documented Elasticsearch defaults in docker compose defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   #   restart: always
   #   image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
   #   environment:
-  #     - "ELASTIC_PASSWORD=password"  # Username is elastic. Do not change the username.
+  #     - "ELASTIC_PASSWORD=password" # Username is elastic. Do not change the username.
   #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true" # Please update the memory to suit your environment or you will have wasted memory. both -Xms & -Xmx must be the same size. 1g for GB.
   #     - "xpack.license.self_generated.type=basic"
   #     - "xpack.security.enabled=false"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
   #   image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
   #   environment:
   #     - "ELASTIC_PASSWORD=password"  # Username is elastic. Do not change the username.
-  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true"  # Please update the memory to suit your environment. both -Xms & -Xmx must be the same size. 1g for GB.
+  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true"  # Please update the memory to suit your environment or you will have wasted memory. both -Xms & -Xmx must be the same size. 1g for GB.
   #     - "xpack.license.self_generated.type=basic"
   #     - "xpack.security.enabled=false"
   #     - "xpack.watcher.enabled=false"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
   #   image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
   #   environment:
   #     - "ELASTIC_PASSWORD=password"  # Username is elastic. Do not change the username.
-  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true"  # Please update the memory to suit your environment or you will have wasted memory. both -Xms & -Xmx must be the same size. 1g for GB.
+  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true" # Please update the memory to suit your environment or you will have wasted memory. both -Xms & -Xmx must be the same size. 1g for GB.
   #     - "xpack.license.self_generated.type=basic"
   #     - "xpack.security.enabled=false"
   #     - "xpack.watcher.enabled=false"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,8 @@ services:
   #   restart: always
   #   image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
   #   environment:
-  #     - "ELASTIC_PASSWORD=password"  #Username is elastic. Do not change the username.
-  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true"
+  #     - "ELASTIC_PASSWORD=password"  # Username is elastic. Do not change the username.
+  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true"  # Please update the memory to suit your environment. both -Xms & -Xmx must be the same size.
   #     - "xpack.license.self_generated.type=basic"
   #     - "xpack.security.enabled=false"
   #     - "xpack.watcher.enabled=false"
@@ -39,7 +39,6 @@ services:
   #     - "bootstrap.memory_lock=true"
   #     - "cluster.name=es-mastodon"
   #     - "discovery.type=single-node"
-  #     - "thread_pool.write.queue_size=1000"
   #   networks:
   #      - external_network
   #      - internal_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
   #   image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
   #   environment:
   #     - "ELASTIC_PASSWORD=password"  # Username is elastic. Do not change the username.
-  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true"  # Please update the memory to suit your environment. both -Xms & -Xmx must be the same size.
+  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true"  # Please update the memory to suit your environment. both -Xms & -Xmx must be the same size. 1g for GB.
   #     - "xpack.license.self_generated.type=basic"
   #     - "xpack.security.enabled=false"
   #     - "xpack.watcher.enabled=false"


### PR DESCRIPTION
* I just noticed I've been running my ES with 1/12th of the memory for the last few years because I didn't tweak that JVM correctly.
* `"thread_pool.write.queue_size=1000"` was changed to default to `max(10000, (number of processors * 750))` in ES8.

Reference: https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/thread-pool-settings