### PR TITLE
Fix misleading copy in "Remove me from collection" confirmation dialog

### DIFF
--- a/app/javascript/mastodon/features/collections/detail/revoke_collection_inclusion_modal.tsx
+++ b/app/javascript/mastodon/features/collections/detail/revoke_collection_inclusion_modal.tsx
@@ -19,7 +19,7 @@ const messages = defineMessages({
   revokeCollectionInclusionMessage: {
     id: 'confirmations.revoke_collection_inclusion.message',
     defaultMessage:
-      "This action is permanent, and the curator won't be able to re-add you to the collection later on.",
+      "The curator won't be able to re-add you to this collection for 24 hours. To prevent them from adding you to collections permanently, you can block them.",
   },
   revokeCollectionInclusionConfirm: {
     id: 'confirmations.revoke_collection_inclusion.confirm',

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -561,7 +561,7 @@
   "confirmations.remove_from_followers.message": "{name} will stop following you. Are you sure you want to proceed?",
   "confirmations.remove_from_followers.title": "Remove follower?",
   "confirmations.revoke_collection_inclusion.confirm": "Remove me",
-  "confirmations.revoke_collection_inclusion.message": "This action is permanent, and the curator won't be able to re-add you to the collection later on.",
+  "confirmations.revoke_collection_inclusion.message": "The curator won't be able to re-add you to this collection for 24 hours. To prevent them from adding you to collections permanently, you can block them.",
   "confirmations.revoke_collection_inclusion.title": "Remove yourself from this collection?",
   "confirmations.revoke_quote.confirm": "Remove post",
   "confirmations.revoke_quote.message": "This action cannot be undone.",


### PR DESCRIPTION
Fixes #39389

### Changes proposed in this PR:
- Fixes the copy of the "Remove me from collection" confirmation dialog to clarify how permanent the inclusion revocation will be

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="639" height="225" alt="image" src="https://github.com/user-attachments/assets/70567caa-2958-44d6-91fc-c54a9df84370" /> | <img width="641" height="233" alt="image" src="https://github.com/user-attachments/assets/0d9336b7-26d5-4fe1-b515-8cd1427fa1e6" /> |