### PR TITLE
Guard against undefined AudioContext in useAudioContext hook

### DIFF
--- a/app/javascript/mastodon/hooks/useAudioContext.ts
+++ b/app/javascript/mastodon/hooks/useAudioContext.ts
@@ -18,7 +18,7 @@ export const useAudioContext = ({ audioElementRef }: AudioContextOptions) => {
   const gainNodeRef = useRef<GainNode>();
 
   useEffect(() => {
-    if (!audioElementRef.current) {
+    if (!audioElementRef.current || typeof AudioContext === 'undefined') {
       return;
     }
 
@@ -43,13 +43,17 @@ export const useAudioContext = ({ audioElementRef }: AudioContextOptions) => {
   }, [audioElementRef]);
 
   const playAudio = useCallback(() => {
-    void audioElementRef.current?.play();
-    void audioContextRef.current?.resume();
+    if (audioContextRef.current && audioElementRef.current) {
+      void audioElementRef.current.play();
+      void audioContextRef.current.resume();
+    }
   }, [audioElementRef]);
 
   const pauseAudio = useCallback(() => {
-    audioElementRef.current?.pause();
-    void audioContextRef.current?.suspend();
+    if (audioContextRef.current && audioElementRef.current) {
+      audioElementRef.current.pause();
+      void audioContextRef.current.suspend();
+    }
   }, [audioElementRef]);
 
   return {


### PR DESCRIPTION
Fixes #39058.

Guard against undefined AudioContext in useAudioContext hook. The error 'ReferenceError: Can't find variable: AudioContext' occurs in Safari with Lockdown Mode where AudioContext may be unavailable. The fix adds a runtime check for AudioContext existence within the useEffect and ensures playAudio/pauseAudio are no-ops when the context is missing, preventing the ReferenceError.

I ran the available lightweight check for the frontend change.