### PR TITLE
Fix crash of standalone wrapstodon and embedded status pages

### DIFF
--- a/app/javascript/entrypoints/wrapstodon.tsx
+++ b/app/javascript/entrypoints/wrapstodon.tsx
@@ -5,6 +5,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { importFetchedStatuses } from '@/mastodon/actions/importer';
 import { hydrateStore } from '@/mastodon/actions/store';
 import type { ApiAnnualReportResponse } from '@/mastodon/api/annual_report';
+import { FocusTargetProvider } from '@/mastodon/components/navigation_focus_target';
 import { Router } from '@/mastodon/components/router';
 import { WrapstodonSharedPage } from '@/mastodon/features/annual_report/shared_page';
 import { IntlProvider, loadLocale } from '@/mastodon/locales';
@@ -52,7 +53,9 @@ function loaded() {
     <IntlProvider>
       <ReduxProvider store={store}>
         <Router>
-          <WrapstodonSharedPage />
+          <FocusTargetProvider>
+            <WrapstodonSharedPage />
+          </FocusTargetProvider>
         </Router>
       </ReduxProvider>
     </IntlProvider>,

--- a/app/javascript/mastodon/components/navigation_focus_target/index.tsx
+++ b/app/javascript/mastodon/components/navigation_focus_target/index.tsx
@@ -102,15 +102,9 @@ export const FocusTargetProvider: React.FC<{
 export function useFocusOnNavigation(targetName?: string) {
   const focusTargetRef = useContext(FocusTargetContext);
 
-  if (focusTargetRef === null) {
-    throw Error(
-      'useFocusTargetContext must be used inside of a FocusTargetProvider',
-    );
-  }
-
   return useCallback(
     (element: HTMLElement | null) => {
-      const focusTarget = focusTargetRef.current;
+      const focusTarget = focusTargetRef?.current;
 
       // Bail out if focusTarget was set to `false`
       if (!element || !focusTarget) {

--- a/app/javascript/mastodon/features/standalone/status/index.tsx
+++ b/app/javascript/mastodon/features/standalone/status/index.tsx
@@ -8,6 +8,7 @@ import { Provider } from 'react-redux';
 
 import { fetchStatus, toggleStatusSpoilers } from 'mastodon/actions/statuses';
 import { hydrateStore } from 'mastodon/actions/store';
+import { FocusTargetProvider } from 'mastodon/components/navigation_focus_target';
 import { Router } from 'mastodon/components/router';
 import { DetailedStatus } from 'mastodon/features/status/components/detailed_status';
 import { useRenderSignal } from 'mastodon/hooks/useRenderSignal';
@@ -79,7 +80,9 @@ export const Status: React.FC<{ id: string }> = ({ id }) => {
     <IntlProvider>
       <Provider store={store}>
         <Router>
-          <Embed id={id} />
+          <FocusTargetProvider>
+            <Embed id={id} />
+          </FocusTargetProvider>
         </Router>
       </Provider>
     </IntlProvider>


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes a crash of the standalone wrapstodon and embedded status pages
- Prevent future similar crashes by not erroring when no `FocusTargetProvider` is present