### PR TITLE
Emoji: Add back to state

### DIFF
--- a/app/javascript/mastodon/actions/importer/emoji.ts
+++ b/app/javascript/mastodon/actions/importer/emoji.ts
@@ -22,10 +22,6 @@ export async function importCustomEmoji(emojis: ApiCustomEmojiJSON[]) {
     await clearCache('custom');
     await loadCustomEmoji();
 
-    const { reloadCustomEmojis } =
-      await import('@/mastodon/features/emoji/picker');
-    await reloadCustomEmojis();
-
     log('Custom emojis updated, reloaded cache and picker data.');
   }
 }

--- a/app/javascript/mastodon/features/account_edit/modals/fields_modals.tsx
+++ b/app/javascript/mastodon/features/account_edit/modals/fields_modals.tsx
@@ -140,7 +140,7 @@ export const EditFieldModal = forwardRef<
 
   const customEmojis = useCustomEmojis();
   const customEmojiCodes = useMemo(
-    () => Object.keys(customEmojis ?? {}),
+    () => Object.keys(customEmojis),
     [customEmojis],
   );
   const checkField = useCallback(

--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
@@ -323,10 +323,7 @@ class EmojiPickerDropdown extends PureComponent {
       EmojiPickerAsync().then(EmojiMart => {
         EmojiPicker = EmojiMart.Picker;
         Emoji = EmojiMart.Emoji;
-
-        void EmojiMart.loadCustomEmojiData().then(() => {
-          this.setState({ loading: false });
-        });
+        this.setState({ loading: false });
       }).catch(() => {
         this.setState({ loading: false, active: false });
       });

--- a/app/javascript/mastodon/features/emoji/emoji_picker.tsx
+++ b/app/javascript/mastodon/features/emoji/emoji_picker.tsx
@@ -13,8 +13,6 @@ import { usePickerEmojis } from './picker';
 
 const backgroundImageFnDefault = () => `${assetHost}/emoji/sheet_16_0.png`;
 
-export { fetchCustomEmojiData as loadCustomEmojiData } from './picker';
-
 export const Picker: FC<PickerProps> = ({
   set = 'twitter',
   sheetSize = 32,
@@ -24,17 +22,13 @@ export const Picker: FC<PickerProps> = ({
   ...props
 }) => {
   const { mode } = useEmojiAppState();
-  const { customCategories, customEmojis } = usePickerEmojis();
-
-  if (!customEmojis) {
-    return null;
-  }
+  const { categories, emojis } = usePickerEmojis();
 
   return (
     <PickerRaw
       data={EmojiData}
-      custom={customEmojis}
-      include={customCategories}
+      custom={emojis}
+      include={categories}
       set={set}
       sheetSize={sheetSize}
       sheetColumns={sheetColumns}

--- a/app/javascript/mastodon/features/emoji/index.ts
+++ b/app/javascript/mastodon/features/emoji/index.ts
@@ -38,27 +38,37 @@ export async function initializeEmoji() {
     void fallbackLoad();
   }, WORKER_TIMEOUT);
 
-  tempWorker.addEventListener('message', (event: MessageEvent<string>) => {
-    const { data: message } = event;
+  tempWorker.addEventListener(
+    'message',
+    (event: MessageEvent<EmojiWorkerMessage>) => {
+      const { data: message } = event;
 
-    worker ??= tempWorker;
-    clearTimeout(timeoutId);
+      worker ??= tempWorker;
+      clearTimeout(timeoutId);
 
-    if (message !== 'ready') {
-      workerLog(message);
-      return;
-    }
+      const { type } = message;
+      if (type === 'log') {
+        workerLog(message.message);
+      } else if (type === 'done' && message.storeName === 'custom') {
+        void loadEmojisToStore();
+      }
 
-    const debugValue = localStorage.getItem('debug');
-    if (debugValue) {
-      messageWorker({ type: 'debug', debugValue });
-    }
+      if (type !== 'ready') {
+        return; // Exit for other messages.
+      }
 
-    workerLog('loading data');
-    messageWorker(userLocale);
-    messageWorker('custom');
-    messageWorker('shortcodes');
-  });
+      const debugValue = localStorage.getItem('debug');
+      if (debugValue) {
+        messageWorker({ type: 'debug', debugValue });
+      }
+
+      workerLog('loading data');
+      messageWorker(userLocale);
+      messageWorker('custom');
+      messageWorker('shortcodes');
+      void loadEmojisToStore();
+    },
+  );
 }
 
 async function fallbackLoad() {
@@ -81,6 +91,7 @@ async function fallbackLoad() {
   if (emojis) {
     log('loaded %d emojis to locale %s', emojis.length, userLocale);
   }
+  await loadEmojisToStore();
 }
 
 export async function loadCustomEmoji() {
@@ -107,4 +118,15 @@ function messageWorker(data: EmojiWorkerMessage | string) {
   } else {
     worker.postMessage(data);
   }
+}
+
+async function loadEmojisToStore() {
+  const { store } = await import('@/mastodon/store');
+  const { loadCustomEmojis, loadLocale } =
+    await import('@/mastodon/reducers/slices/emojis');
+
+  loadLocale(userLocale);
+  await store.dispatch(loadCustomEmojis());
+
+  log('loaded emoji data into store');
 }

--- a/app/javascript/mastodon/features/emoji/index.ts
+++ b/app/javascript/mastodon/features/emoji/index.ts
@@ -1,7 +1,6 @@
 import { initialState } from '@/mastodon/initial_state';
 
 import { toSupportedLocale } from './locale';
-import { reloadCustomEmojis } from './picker';
 import type { EmojiWorkerMessage } from './types';
 import { emojiLogger } from './utils';
 
@@ -71,8 +70,8 @@ async function fallbackLoad() {
   const customEmojis = await importCustomEmojiData();
   if (customEmojis && customEmojis.length > 0) {
     log('loaded %d custom emojis', customEmojis.length);
-    await reloadCustomEmojis();
   }
+
   const shortcodes = await importLegacyShortcodes();
   if (shortcodes?.length) {
     log('loaded %d legacy shortcodes', shortcodes.length);
@@ -92,7 +91,6 @@ export async function loadCustomEmoji() {
     const emojis = await importCustomEmojiData();
     if (emojis && emojis.length > 0) {
       log('loaded %d custom emojis', emojis.length);
-      await reloadCustomEmojis();
     }
   }
 }

--- a/app/javascript/mastodon/features/emoji/index.ts
+++ b/app/javascript/mastodon/features/emoji/index.ts
@@ -104,6 +104,7 @@ export async function loadCustomEmoji() {
       log('loaded %d custom emojis', emojis.length);
     }
   }
+  await loadEmojisToStore();
 }
 
 function messageWorker(data: EmojiWorkerMessage | string) {

--- a/app/javascript/mastodon/features/emoji/mode.ts
+++ b/app/javascript/mastodon/features/emoji/mode.ts
@@ -27,7 +27,6 @@ export function useEmojiAppState(): EmojiAppState {
 
   return {
     currentLocale: locale,
-    locales: [locale],
     mode,
     darkTheme: isDarkMode(),
     assetHost,
@@ -64,7 +63,6 @@ export function getEmojiAppState(): EmojiAppState {
 
   return {
     currentLocale,
-    locales: [currentLocale],
     mode: determineEmojiMode(emojiStyle),
     darkTheme: isDarkMode(),
     assetHost,

--- a/app/javascript/mastodon/features/emoji/picker.ts
+++ b/app/javascript/mastodon/features/emoji/picker.ts
@@ -85,16 +85,6 @@ type LegacyEmoji =
       custom: true;
     };
 
-export async function reloadCustomEmojis() {
-  customEmojis = null;
-
-  const { loadEmojisIntoCache } =
-    await import('@/mastodon/hooks/useCustomEmojis');
-
-  await Promise.all([fetchCustomEmojiData(), loadEmojisIntoCache()]);
-  searchCache.clear();
-}
-
 // Replicates the old legacy search function.
 export async function emojiMartSearch(
   token: string,

--- a/app/javascript/mastodon/features/emoji/picker.ts
+++ b/app/javascript/mastodon/features/emoji/picker.ts
@@ -1,82 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import type { CategoryName, CustomEmoji } from 'emoji-mart';
 
 import { autoPlayGif } from '@/mastodon/initial_state';
+import { createAppSelector, useAppSelector } from '@/mastodon/store';
 import { createLimitedCache } from '@/mastodon/utils/cache';
 
 import { emojiLogger } from './utils';
 
 const log = emojiLogger('picker');
 
-let customEmojis: CustomEmoji[] | null = null;
-let customCategories = [
-  'recent',
-  'people',
-  'nature',
-  'foods',
-  'activity',
-  'places',
-  'objects',
-  'symbols',
-  'flags',
-] as CategoryName[];
-
 const searchCache = createLimitedCache<LegacyEmoji[]>({ maxSize: 10, log });
-
-export async function fetchCustomEmojiData() {
-  if (customEmojis !== null) {
-    return customEmojis;
-  }
-
-  const { loadAllCustomEmoji } = await import('./database');
-  const emojisRaw = await loadAllCustomEmoji();
-
-  // If it returns null then custom emojis aren't even loaded yet.
-  if (emojisRaw === null) {
-    return [];
-  }
-
-  // If it's empty, then they are loaded but there aren't any.
-  if (emojisRaw.length === 0) {
-    customEmojis = [];
-    return customEmojis;
-  }
-
-  const categories = new Set(['custom']);
-  const emojis = [];
-  for (const emoji of emojisRaw) {
-    const name = emoji.shortcode.replaceAll(':', '');
-    emojis.push({
-      name,
-      id: name,
-      custom: true,
-      short_names: [name],
-      imageUrl: autoPlayGif ? emoji.url : emoji.static_url,
-      customCategory: emoji.category,
-    });
-
-    if (emoji.category) {
-      categories.add(`custom-${emoji.category}`);
-    }
-  }
-
-  customEmojis = emojis.toSorted((a, b) => {
-    return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
-  });
-  customCategories = customCategories.toSpliced(
-    1,
-    0,
-    ...(Array.from(categories).toSorted() as CategoryName[]),
-  );
-  log(
-    'loaded %d custom emojis in %d categories',
-    customEmojis.length,
-    categories.size,
-  );
-
-  return customEmojis;
-}
 
 type LegacyEmoji =
   | { id: string; custom?: false; native: string }
@@ -117,19 +51,72 @@ export async function emojiMartSearch(
   return legacyResults;
 }
 
-export function usePickerEmojis() {
-  const [, setLoaded] = useState(customEmojis !== null);
+const defaultCategories = [
+  'people',
+  'nature',
+  'foods',
+  'activity',
+  'places',
+  'objects',
+  'symbols',
+  'flags',
+] as CategoryName[];
 
-  useEffect(() => {
-    if (customEmojis === null) {
-      void fetchCustomEmojiData().then(() => {
-        setLoaded(true);
-      });
+const selectPickerData = createAppSelector(
+  [(state) => state.emojis.custom, (state) => state.emojis.customCategories],
+  (emojis, categories) => {
+    // Create a map of shortcode to category name.
+    const categoryMap = new Map<string, string>();
+    for (const category in categories) {
+      const catEmojis = categories[category];
+      if (!catEmojis?.length) {
+        continue;
+      }
+      for (const shortcode of catEmojis) {
+        categoryMap.set(shortcode, category);
+      }
     }
-  }, []);
 
-  return {
-    customEmojis,
-    customCategories,
-  };
+    const customEmojis: CustomEmoji[] = [];
+    for (const shortcode in emojis) {
+      const emoji = emojis[shortcode];
+      if (!emoji) {
+        continue;
+      }
+
+      customEmojis.push({
+        name: shortcode,
+        id: shortcode,
+        custom: true,
+        short_names: [shortcode],
+        imageUrl: autoPlayGif ? emoji.url : emoji.static_url,
+        customCategory: categoryMap.get(shortcode),
+      } as CustomEmoji);
+    }
+
+    searchCache.clear();
+    log('Regenerated the picker data');
+
+    return {
+      customEmojis,
+      customCategories: Object.keys(categories),
+    };
+  },
+);
+
+export function usePickerEmojis() {
+  const { customCategories, customEmojis } = useAppSelector(selectPickerData);
+
+  return useMemo(
+    () => ({
+      emojis: customEmojis,
+      categories: [
+        'recent',
+        'custom',
+        ...customCategories,
+        ...defaultCategories,
+      ] as CategoryName[],
+    }),
+    [customCategories, customEmojis],
+  );
 }

--- a/app/javascript/mastodon/features/emoji/picker.ts
+++ b/app/javascript/mastodon/features/emoji/picker.ts
@@ -1,9 +1,10 @@
-import { useMemo } from 'react';
-
 import type { CategoryName, CustomEmoji } from 'emoji-mart';
 
 import { autoPlayGif } from '@/mastodon/initial_state';
-import { createAppSelector, useAppSelector } from '@/mastodon/store';
+import {
+  createAppSelector,
+  useAppSelector,
+} from '@/mastodon/store/typed_functions';
 import { createLimitedCache } from '@/mastodon/utils/cache';
 
 import { emojiLogger } from './utils';
@@ -95,28 +96,20 @@ const selectPickerData = createAppSelector(
     }
 
     searchCache.clear();
-    log('Regenerated the picker data');
+    log('regenerated the picker data');
 
     return {
-      customEmojis,
-      customCategories: Object.keys(categories),
+      emojis: customEmojis,
+      categories: [
+        'recent',
+        'custom',
+        ...Object.keys(categories).toSorted(),
+        ...defaultCategories,
+      ] as CategoryName[],
     };
   },
 );
 
 export function usePickerEmojis() {
-  const { customCategories, customEmojis } = useAppSelector(selectPickerData);
-
-  return useMemo(
-    () => ({
-      emojis: customEmojis,
-      categories: [
-        'recent',
-        'custom',
-        ...customCategories,
-        ...defaultCategories,
-      ] as CategoryName[],
-    }),
-    [customCategories, customEmojis],
-  );
+  return useAppSelector(selectPickerData);
 }

--- a/app/javascript/mastodon/features/emoji/render.ts
+++ b/app/javascript/mastodon/features/emoji/render.ts
@@ -109,7 +109,7 @@ export async function updateHtmlWithEmoji({
 }: {
   element: Element;
   locale: string;
-} & Omit<EmojiAppState, 'currentLocale' | 'locales'>) {
+} & Omit<EmojiAppState, 'currentLocale'>) {
   if (mode === EMOJI_MODE_NATIVE) {
     return;
   }

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -28,7 +28,6 @@ export type CacheKey =
   | LocaleWithShortcodes;
 
 export interface EmojiAppState {
-  locales: Locale[];
   currentLocale: Locale;
   mode: EmojiMode;
   darkTheme: boolean;

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -81,9 +81,19 @@ export type ExtraCustomEmojiMap = Record<
 >;
 
 export type EmojiWorkerMessage =
+  | { type: 'ready' }
   | {
       type: 'load';
       storeName: string;
+    }
+  | {
+      type: 'done';
+      storeName: string;
+      importCount: number;
+    }
+  | {
+      type: 'log';
+      message: string;
     }
   | {
       type: 'debug';

--- a/app/javascript/mastodon/features/emoji/worker.ts
+++ b/app/javascript/mastodon/features/emoji/worker.ts
@@ -9,13 +9,13 @@ import {
 import type { EmojiWorkerMessage } from './types';
 
 addEventListener('message', handleMessage);
-self.postMessage('ready'); // After the worker is ready, notify the main thread
+self.postMessage({ type: 'ready' } satisfies EmojiWorkerMessage); // After the worker is ready, notify the main thread
 
 function handleMessage(event: MessageEvent<EmojiWorkerMessage>) {
   const { data } = event;
   if (data.type === 'debug') {
     debug.enable(data.debugValue);
-  } else {
+  } else if (data.type === 'load') {
     void loadData(data.storeName);
   }
 }
@@ -31,6 +31,10 @@ async function loadData(storeName: string) {
   }
 
   if (importCount) {
-    self.postMessage(`loaded ${importCount} emojis into ${storeName}`);
+    self.postMessage({
+      type: 'done',
+      storeName,
+      importCount,
+    } satisfies EmojiWorkerMessage);
   }
 }

--- a/app/javascript/mastodon/hooks/useCustomEmojis.ts
+++ b/app/javascript/mastodon/hooks/useCustomEmojis.ts
@@ -1,40 +1,6 @@
-import { useEffect, useState } from 'react';
-
-import type { ExtraCustomEmojiMap } from '../features/emoji/types';
-import { emojiLogger } from '../features/emoji/utils';
-
-let emojis: ExtraCustomEmojiMap | null = null;
-
-const log = emojiLogger('useCustomEmojis');
+import { selectCustomEmojis } from '@/mastodon/reducers/slices/emojis';
+import { useAppSelector } from '@/mastodon/store';
 
 export function useCustomEmojis() {
-  const [, setLoaded] = useState(emojis !== null);
-  useEffect(() => {
-    if (!emojis) {
-      void loadEmojisIntoCache().then(() => {
-        setLoaded(true);
-      });
-    }
-  }, []);
-
-  return emojis;
-}
-
-export async function loadEmojisIntoCache() {
-  const { loadAllCustomEmoji } = await import('../features/emoji/database');
-  const emojisRaw = await loadAllCustomEmoji();
-  if (emojisRaw === null) {
-    log('Custom emojis not loaded yet');
-    return;
-  }
-
-  emojis = {};
-  for (const emoji of emojisRaw) {
-    emojis[emoji.shortcode] = {
-      url: emoji.url,
-      shortcode: emoji.shortcode,
-      static_url: emoji.static_url,
-    };
-  }
-  log('Loaded %d custom emojis into cache', Object.keys(emojis).length);
+  return useAppSelector(selectCustomEmojis);
 }

--- a/app/javascript/mastodon/hooks/useCustomEmojis.ts
+++ b/app/javascript/mastodon/hooks/useCustomEmojis.ts
@@ -1,5 +1,24 @@
-import { selectCustomEmojis } from '@/mastodon/reducers/slices/emojis';
-import { useAppSelector } from '@/mastodon/store';
+import { createAppSelector, useAppSelector } from '@/mastodon/store';
+
+import type { ExtraCustomEmojiMap } from '../features/emoji/types';
+
+const selectCustomEmojis = createAppSelector(
+  [(state) => state.emojis.custom],
+  (custom) => {
+    const emojis: ExtraCustomEmojiMap = {};
+    for (const shortcode in custom) {
+      const emoji = custom[shortcode];
+      if (!emoji) {
+        continue;
+      }
+      emojis[shortcode] = {
+        shortcode,
+        ...emoji,
+      };
+    }
+    return emojis;
+  },
+);
 
 export function useCustomEmojis() {
   return useAppSelector(selectCustomEmojis);

--- a/app/javascript/mastodon/reducers/slices/emojis.ts
+++ b/app/javascript/mastodon/reducers/slices/emojis.ts
@@ -5,11 +5,12 @@ import type { Locale } from 'emojibase';
 
 import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
 import { toSupportedLocale } from '@/mastodon/features/emoji/locale';
+import type { ExtraCustomEmojiMap } from '@/mastodon/features/emoji/types';
 import { createAsyncThunk } from '@/mastodon/store/typed_functions';
 
 interface EmojisState {
   custom: Record<string, Pick<ApiCustomEmojiJSON, 'url' | 'static_url'>>;
-  customCategories: Record<string, string[]>; // { name: emoji shortcodes[] }
+  customCategories: Record<string, string[]>; // { name: shortcodes[] }
   localesLoaded: Locale[];
 }
 
@@ -52,10 +53,27 @@ const emojisSlice = createSlice({
       },
     });
   },
+  selectors: {
+    selectCustomEmojis(state): ExtraCustomEmojiMap {
+      const emojis: ExtraCustomEmojiMap = {};
+      for (const shortcode in state.custom) {
+        const emoji = state.custom[shortcode];
+        if (!emoji) {
+          continue;
+        }
+        emojis[shortcode] = {
+          shortcode,
+          ...emoji,
+        };
+      }
+      return emojis;
+    },
+  },
 });
 
 export const emojis = emojisSlice.reducer;
 export const { loadLocale } = emojisSlice.actions;
+export const { selectCustomEmojis } = emojisSlice.selectors;
 
 export const loadCustomEmojis = createAsyncThunk(
   `${emojisSlice.name}/loadCustomEmojis`,

--- a/app/javascript/mastodon/reducers/slices/emojis.ts
+++ b/app/javascript/mastodon/reducers/slices/emojis.ts
@@ -1,0 +1,67 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+
+import type { Locale } from 'emojibase';
+
+import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
+import { toSupportedLocale } from '@/mastodon/features/emoji/locale';
+import { createAsyncThunk } from '@/mastodon/store/typed_functions';
+
+interface EmojisState {
+  custom: Record<string, Pick<ApiCustomEmojiJSON, 'url' | 'static_url'>>;
+  customCategories: Record<string, string[]>; // { name: emoji shortcodes[] }
+  localesLoaded: Locale[];
+}
+
+const emojisSlice = createSlice({
+  name: 'emojis',
+  initialState: {
+    custom: {},
+    customCategories: {},
+    localesLoaded: [],
+  } as EmojisState,
+  reducers: {
+    loadLocale(state, action: PayloadAction<string>) {
+      const locale = toSupportedLocale(action.payload);
+      if (!state.localesLoaded.includes(locale)) {
+        state.localesLoaded.push(locale);
+      }
+    },
+  },
+  extraReducers(builder) {
+    builder.addAsyncThunk(loadCustomEmojis, {
+      fulfilled(state, action) {
+        if (!action.payload?.length) {
+          return;
+        }
+
+        for (const emoji of action.payload) {
+          const { shortcode, category, url, static_url } = emoji;
+          state.custom[shortcode] = {
+            url,
+            static_url,
+          };
+
+          if (category) {
+            state.customCategories[category] ??= [];
+            if (!state.customCategories[category].includes(shortcode)) {
+              state.customCategories[category].push(shortcode);
+            }
+          }
+        }
+      },
+    });
+  },
+});
+
+export const emojis = emojisSlice.reducer;
+export const { loadLocale } = emojisSlice.actions;
+
+export const loadCustomEmojis = createAsyncThunk(
+  `${emojisSlice.name}/loadCustomEmojis`,
+  async () => {
+    const { loadAllCustomEmoji } =
+      await import('@/mastodon/features/emoji/database');
+    return loadAllCustomEmoji();
+  },
+);

--- a/app/javascript/mastodon/reducers/slices/emojis.ts
+++ b/app/javascript/mastodon/reducers/slices/emojis.ts
@@ -5,12 +5,12 @@ import type { Locale } from 'emojibase';
 
 import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
 import { toSupportedLocale } from '@/mastodon/features/emoji/locale';
-import type { ExtraCustomEmojiMap } from '@/mastodon/features/emoji/types';
 import { createAsyncThunk } from '@/mastodon/store/typed_functions';
 
 interface EmojisState {
   custom: Record<string, Pick<ApiCustomEmojiJSON, 'url' | 'static_url'>>;
   customCategories: Record<string, string[]>; // { name: shortcodes[] }
+  customLoaded: boolean;
   localesLoaded: Locale[];
 }
 
@@ -19,6 +19,7 @@ const emojisSlice = createSlice({
   initialState: {
     custom: {},
     customCategories: {},
+    customLoaded: false,
     localesLoaded: [],
   } as EmojisState,
   reducers: {
@@ -49,31 +50,16 @@ const emojisSlice = createSlice({
               state.customCategories[category].push(shortcode);
             }
           }
+
+          state.customLoaded = true;
         }
       },
     });
-  },
-  selectors: {
-    selectCustomEmojis(state): ExtraCustomEmojiMap {
-      const emojis: ExtraCustomEmojiMap = {};
-      for (const shortcode in state.custom) {
-        const emoji = state.custom[shortcode];
-        if (!emoji) {
-          continue;
-        }
-        emojis[shortcode] = {
-          shortcode,
-          ...emoji,
-        };
-      }
-      return emojis;
-    },
   },
 });
 
 export const emojis = emojisSlice.reducer;
 export const { loadLocale } = emojisSlice.actions;
-export const { selectCustomEmojis } = emojisSlice.selectors;
 
 export const loadCustomEmojis = createAsyncThunk(
   `${emojisSlice.name}/loadCustomEmojis`,

--- a/app/javascript/mastodon/reducers/slices/index.ts
+++ b/app/javascript/mastodon/reducers/slices/index.ts
@@ -1,9 +1,11 @@
 import { annualReport } from './annual_report';
 import { collections } from './collections';
+import { emojis } from './emojis';
 import { profileEdit } from './profile_edit';
 
 export const sliceReducers = {
   annualReport,
   collections,
+  emojis,
   profileEdit,
 };


### PR DESCRIPTION
This resolves a few issues with async loading by going back to using the Redux state. The previous solutions had some sync issues, so this removes all that in favor of storing a subset of the data in a modern RTK slice. This means that all React components that rely on the custom emoji state (autocomplete, picker) will immediately update if state data is updated, but everything is still memoized.