### PR TITLE
add search field to admin ip blocks

### DIFF
--- a/app/controllers/admin/ip_blocks_controller.rb
+++ b/app/controllers/admin/ip_blocks_controller.rb
@@ -48,7 +48,7 @@ module Admin
 
       if params[:ip].present?
         if full_ip?(params[:ip])
-          scope.merge!(IpBlock.matches_ip(params[:ip]))
+          scope.merge!(IpBlock.contained_by(params[:ip]))
         else
           scope.merge!(IpBlock.matches_partial_ip(params[:ip]))
         end

--- a/app/controllers/admin/ip_blocks_controller.rb
+++ b/app/controllers/admin/ip_blocks_controller.rb
@@ -46,7 +46,13 @@ module Admin
     def filter_by_ip
       scope = IpBlock.order(ip: :asc).page(params[:page])
 
-      scope.merge!(IpBlock.contained_by(params[:ip])) if params[:ip].present?
+      if params[:ip].present?
+        if cidr?(params[:ip])
+          scope.merge!(IpBlock.contained_by(params[:ip]))
+        else
+          scope.merge!(IpBlock.containing(params[:ip]))
+        end
+      end
       scope
     end
 
@@ -62,6 +68,14 @@ module Admin
     def form_ip_block_batch_params
       params
         .expect(form_ip_block_batch: [ip_block_ids: []])
+    end
+
+    def cidr?(ip)
+      ip_obj = IPAddr.new(ip)
+
+      ip_obj.cidr == ip
+    rescue IPAddr::InvalidAddressError
+      false
     end
   end
 end

--- a/app/controllers/admin/ip_blocks_controller.rb
+++ b/app/controllers/admin/ip_blocks_controller.rb
@@ -5,7 +5,7 @@ module Admin
     def index
       authorize :ip_block, :index?
 
-      @ip_blocks = IpBlock.order(ip: :asc).page(params[:page])
+      @ip_blocks = filter_by_ip.page(params[:page])
       @form      = Form::IpBlockBatch.new
     end
 
@@ -43,6 +43,19 @@ module Admin
 
     private
 
+    def filter_by_ip
+      scope = IpBlock.order(ip: :asc).page(params[:page])
+
+      if params[:ip].present?
+        if full_ip?(params[:ip])
+          scope.merge!(IpBlock.matches_ip(params[:ip]))
+        else
+          scope.merge!(IpBlock.matches_partial_ip(params[:ip]))
+        end
+      end
+      scope
+    end
+
     def resource_params
       params
         .expect(ip_block: [:ip, :severity, :comment, :expires_in])
@@ -55,6 +68,13 @@ module Admin
     def form_ip_block_batch_params
       params
         .expect(form_ip_block_batch: [ip_block_ids: []])
+    end
+
+    def full_ip?(ip)
+      IPAddr.new(ip)
+      true
+    rescue IPAddr::InvalidAddressError
+      false
     end
   end
 end

--- a/app/controllers/admin/ip_blocks_controller.rb
+++ b/app/controllers/admin/ip_blocks_controller.rb
@@ -5,7 +5,7 @@ module Admin
     def index
       authorize :ip_block, :index?
 
-      @ip_blocks = filter_by_ip.page(params[:page])
+      @ip_blocks = filter_by_ip(IpBlock.order(ip: :asc).page(params[:page]))
       @form      = Form::IpBlockBatch.new
     end
 
@@ -43,9 +43,7 @@ module Admin
 
     private
 
-    def filter_by_ip
-      scope = IpBlock.order(ip: :asc).page(params[:page])
-
+    def filter_by_ip(scope)
       scope.merge!(IpBlock.overlapping_with(params[:ip])) if params[:ip].present?
       scope
     end

--- a/app/controllers/admin/ip_blocks_controller.rb
+++ b/app/controllers/admin/ip_blocks_controller.rb
@@ -46,13 +46,7 @@ module Admin
     def filter_by_ip
       scope = IpBlock.order(ip: :asc).page(params[:page])
 
-      if params[:ip].present?
-        if full_ip?(params[:ip])
-          scope.merge!(IpBlock.contained_by(params[:ip]))
-        else
-          scope.merge!(IpBlock.matches_partial_ip(params[:ip]))
-        end
-      end
+      scope.merge!(IpBlock.contained_by(params[:ip])) if params[:ip].present?
       scope
     end
 
@@ -68,13 +62,6 @@ module Admin
     def form_ip_block_batch_params
       params
         .expect(form_ip_block_batch: [ip_block_ids: []])
-    end
-
-    def full_ip?(ip)
-      IPAddr.new(ip)
-      true
-    rescue IPAddr::InvalidAddressError
-      false
     end
   end
 end

--- a/app/controllers/admin/ip_blocks_controller.rb
+++ b/app/controllers/admin/ip_blocks_controller.rb
@@ -46,13 +46,7 @@ module Admin
     def filter_by_ip
       scope = IpBlock.order(ip: :asc).page(params[:page])
 
-      if params[:ip].present?
-        if cidr?(params[:ip])
-          scope.merge!(IpBlock.contained_by(params[:ip]))
-        else
-          scope.merge!(IpBlock.containing(params[:ip]))
-        end
-      end
+      scope.merge!(IpBlock.overlapping_with(params[:ip])) if params[:ip].present?
       scope
     end
 
@@ -68,14 +62,6 @@ module Admin
     def form_ip_block_batch_params
       params
         .expect(form_ip_block_batch: [ip_block_ids: []])
-    end
-
-    def cidr?(ip)
-      ip_obj = IPAddr.new(ip)
-
-      ip_obj.cidr == ip
-    rescue IPAddr::InvalidAddressError
-      false
     end
   end
 end

--- a/app/models/concerns/inet_container.rb
+++ b/app/models/concerns/inet_container.rb
@@ -6,5 +6,6 @@ module InetContainer
   included do
     scope :containing, ->(value) { where('ip >>= ?', value) }
     scope :contained_by, ->(value) { where('ip <<= ?', value) }
+    scope :overlapping_with, ->(value) { where('ip <<= :value OR ip >>= :value', value: value) }
   end
 end

--- a/app/models/ip_block.rb
+++ b/app/models/ip_block.rb
@@ -33,6 +33,9 @@ class IpBlock < ApplicationRecord
 
   after_commit :reset_cache
 
+  scope :matches_ip, ->(value) { where(ip: value) }
+  scope :matches_partial_ip, ->(value) { where(ip_as_text.matches("#{value}%")) }
+
   def to_cidr
     "#{ip}/#{ip.prefix}"
   end
@@ -41,6 +44,13 @@ class IpBlock < ApplicationRecord
   class << self
     def blocked?(remote_ip)
       blocked_ips_map.include?(remote_ip)
+    end
+
+    def ip_as_text
+      Arel::Nodes::NamedFunction.new(
+        'CAST',
+        [Arel::Nodes::As.new(arel_table[:ip], Arel::Nodes::SqlLiteral.new('text'))]
+      )
     end
 
     private

--- a/app/models/ip_block.rb
+++ b/app/models/ip_block.rb
@@ -33,8 +33,6 @@ class IpBlock < ApplicationRecord
 
   after_commit :reset_cache
 
-  scope :matches_partial_ip, ->(value) { where(ip_as_text.matches("#{value}%")) }
-
   def to_cidr
     "#{ip}/#{ip.prefix}"
   end

--- a/app/models/ip_block.rb
+++ b/app/models/ip_block.rb
@@ -43,13 +43,6 @@ class IpBlock < ApplicationRecord
       blocked_ips_map.include?(remote_ip)
     end
 
-    def ip_as_text
-      Arel::Nodes::NamedFunction.new(
-        'CAST',
-        [Arel::Nodes::As.new(arel_table[:ip], Arel::Nodes::SqlLiteral.new('text'))]
-      )
-    end
-
     private
 
     def blocked_ips_map

--- a/app/models/ip_block.rb
+++ b/app/models/ip_block.rb
@@ -33,7 +33,6 @@ class IpBlock < ApplicationRecord
 
   after_commit :reset_cache
 
-  scope :matches_ip, ->(value) { where(ip: value) }
   scope :matches_partial_ip, ->(value) { where(ip_as_text.matches("#{value}%")) }
 
   def to_cidr

--- a/app/views/admin/ip_blocks/index.html.haml
+++ b/app/views/admin/ip_blocks/index.html.haml
@@ -5,8 +5,23 @@
   - content_for :heading_actions do
     = link_to t('admin.ip_blocks.add_new'), new_admin_ip_block_path, class: 'button'
 
+= form_with url: admin_ip_blocks_path, method: :get, class: :simple_form do |f|
+  .fields-group
+    .input.string.optional
+      = f.text_field :ip,
+                     value: params[:ip],
+                     class: 'string optional',
+                     placeholder: '192.0.2.0/24'
+
+  .actions
+    %button.button= t('admin.ip_blocks.search')
+    = link_to t('admin.ip_blocks.reset'), admin_ip_blocks_path, class: 'button button--dangerous'
+
+%hr.spacer/
+
 = form_with model: @form, url: batch_admin_ip_blocks_path do |f|
   = hidden_field_tag :page, params[:page] || 1
+  = hidden_field_tag :ip, params[:ip] if params[:ip].present?
 
   .batch-table
     .batch-table__toolbar

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -729,6 +729,8 @@ en:
       new:
         title: Create new IP rule
       no_ip_block_selected: No IP rules were changed as none were selected
+      reset: Reset
+      search: Search
       title: IP rules
     relationships:
       title: "%{acct}'s relationships"

--- a/spec/requests/admin/ip_blocks_spec.rb
+++ b/spec/requests/admin/ip_blocks_spec.rb
@@ -23,18 +23,11 @@ RSpec.describe 'Admin IP Blocks' do
     end
   end
 
-  describe 'get /admin/ip_blocks/' do
-    let(:ip_block) { Fabricate(:ip_block, ip: '192.2.2.2/32') }
-    let(:range_ip_block) { Fabricate(:ip_block, ip: '192.2.2.200/32') }
-    let(:anoth_range_ip_block) { Fabricate(:ip_block, ip: '192.2.2.50/32') }
-    let(:other_ip_block) { Fabricate(:ip_block, ip: '192.2.2.0/24') }
-
-    before do
-      ip_block
-      range_ip_block
-      anoth_range_ip_block
-      other_ip_block
-    end
+  describe 'GET /admin/ip_blocks' do
+    let!(:ip_block) { Fabricate(:ip_block, ip: '192.2.2.2/32') }
+    let!(:range_ip_block) { Fabricate(:ip_block, ip: '192.2.2.200/32') }
+    let!(:another_range_ip_block) { Fabricate(:ip_block, ip: '192.2.2.50/32') }
+    let!(:other_ip_block) { Fabricate(:ip_block, ip: '192.2.2.0/24') }
 
     context 'when searching single ip address' do
       let(:params) { { ip: '192.2.2.1' } }
@@ -42,10 +35,10 @@ RSpec.describe 'Admin IP Blocks' do
       it 'renders successfully with partial ip address' do
         get admin_ip_blocks_path(params)
 
-        expect(response.body).to_not include(admin_accounts_path(ip: '192.2.2.2/32'))
-        expect(response.body).to_not include(admin_accounts_path(ip: '192.2.2.200/32'))
-        expect(response.body).to_not include(admin_accounts_path(ip: '192.2.2.50/32'))
-        expect(response.body).to include(admin_accounts_path(ip: '192.2.2.0/24'))
+        expect(response.body).to not_include(admin_accounts_path(ip: ip_block.ip))
+          .and not_include(admin_accounts_path(ip: range_ip_block.ip))
+          .and not_include(admin_accounts_path(ip: another_range_ip_block.ip))
+        expect(response.body).to include(admin_accounts_path(ip: other_ip_block.ip))
       end
     end
 
@@ -55,10 +48,10 @@ RSpec.describe 'Admin IP Blocks' do
       it 'renders ips within range' do
         get admin_ip_blocks_path(params)
 
-        expect(response.body).to include(admin_accounts_path(ip: '192.2.2.2/32'))
-          .and include(admin_accounts_path(ip: '192.2.2.50/32'))
-          .and include(admin_accounts_path(ip: '192.2.2.0/24'))
-          .and include(admin_accounts_path(ip: '192.2.2.200/32'))
+        expect(response.body).to include(admin_accounts_path(ip: ip_block.ip))
+          .and include(admin_accounts_path(ip: range_ip_block.ip))
+          .and include(admin_accounts_path(ip: another_range_ip_block.ip))
+          .and include(admin_accounts_path(ip: other_ip_block.ip))
       end
     end
   end

--- a/spec/requests/admin/ip_blocks_spec.rb
+++ b/spec/requests/admin/ip_blocks_spec.rb
@@ -27,18 +27,40 @@ RSpec.describe 'Admin IP Blocks' do
     let(:ip_block) { Fabricate(:ip_block, ip: '192.2.2.2') }
     let(:other_ip_block) { Fabricate(:ip_block, ip: '192.4.4.2') }
     let(:another_ip_block) { Fabricate(:ip_block, ip: '192.5.5.2') }
-    let(:params) { { ip: '192.2' } }
 
-    before do
-      ip_block
-      other_ip_block
-      another_ip_block
+    context 'with partial ip address in search field' do
+      let(:params) { { ip: '192.2' } }
+
+      before do
+        ip_block
+        other_ip_block
+        another_ip_block
+      end
+
+      it 'renders successfully with partial ip address' do
+        get admin_ip_blocks_path(params)
+
+        expect(response).to have_http_status(200)
+        expect(response.body).to include('192.2.2.2/32')
+        expect(response.body).to_not include('192.4.4.2')
+      end
     end
 
-    it 'renders successfully with partial ip address' do
-      get admin_ip_blocks_path(params)
+    context 'with full ip address in search field' do
+      let(:params) { { ip: '192.2.2.1' } }
 
-      expect(response).to have_http_status(200)
+      before do
+        ip_block
+        other_ip_block
+        another_ip_block
+      end
+
+      it 'renders successfully with partial ip address' do
+        get admin_ip_blocks_path(params)
+
+        expect(response).to have_http_status(200)
+        expect(response.body).to_not include('192.2.2.2')
+      end
     end
   end
 end

--- a/spec/requests/admin/ip_blocks_spec.rb
+++ b/spec/requests/admin/ip_blocks_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin IP Blocks' do
-  describe 'POST /admin/ip_blocks' do
-    before { sign_in Fabricate(:admin_user) }
+  before { sign_in Fabricate(:admin_user) }
 
+  describe 'POST /admin/ip_blocks' do
     it 'gracefully handles invalid nested params' do
       post admin_ip_blocks_path(ip_block: 'invalid')
 
@@ -15,13 +15,30 @@ RSpec.describe 'Admin IP Blocks' do
   end
 
   describe 'POST /admin/ip_blocks/batch' do
-    before { sign_in Fabricate(:admin_user) }
-
     it 'gracefully handles invalid nested params' do
       post batch_admin_ip_blocks_path(form_ip_block_batch: 'invalid')
 
       expect(response)
         .to redirect_to(admin_ip_blocks_path)
+    end
+  end
+
+  describe 'get /admin/ip_blocks/' do
+    let(:ip_block) { Fabricate(:ip_block, ip: '192.2.2.2') }
+    let(:other_ip_block) { Fabricate(:ip_block, ip: '192.4.4.2') }
+    let(:another_ip_block) { Fabricate(:ip_block, ip: '192.5.5.2') }
+    let(:params) { { ip: '192.2' } }
+
+    before do
+      ip_block
+      other_ip_block
+      another_ip_block
+    end
+
+    it 'renders successfully with partial ip address' do
+      get admin_ip_blocks_path(params)
+
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/requests/admin/ip_blocks_spec.rb
+++ b/spec/requests/admin/ip_blocks_spec.rb
@@ -36,19 +36,6 @@ RSpec.describe 'Admin IP Blocks' do
       range_ip_block
     end
 
-    context 'with partial ip address in search field' do
-      let(:params) { { ip: '192.2' } }
-
-      it 'renders successfully with partial ip address' do
-        get admin_ip_blocks_path(params)
-
-        expect(response).to have_http_status(200)
-        expect(response.body).to_not include(admin_accounts_path(ip: '192.4.4.2/32'))
-        expect(response.body).to include(admin_accounts_path(ip: '192.2.2.2/32'))
-          .and include(admin_accounts_path(ip: '192.2.2.200/32'))
-      end
-    end
-
     context 'with full ip address in search field' do
       let(:params) { { ip: '192.2.2.1/32' } }
 

--- a/spec/requests/admin/ip_blocks_spec.rb
+++ b/spec/requests/admin/ip_blocks_spec.rb
@@ -25,37 +25,32 @@ RSpec.describe 'Admin IP Blocks' do
 
   describe 'get /admin/ip_blocks/' do
     let(:ip_block) { Fabricate(:ip_block, ip: '192.2.2.2/32') }
-    let(:other_ip_block) { Fabricate(:ip_block, ip: '192.4.4.2/32') }
-    let(:another_ip_block) { Fabricate(:ip_block, ip: '192.5.5.2/32') }
     let(:range_ip_block) { Fabricate(:ip_block, ip: '192.2.2.200/32') }
+    let(:anoth_range_ip_block) { Fabricate(:ip_block, ip: '192.2.2.50/32') }
+    let(:other_ip_block) { Fabricate(:ip_block, ip: '192.2.2.0/24') }
 
     before do
       ip_block
-      other_ip_block
-      another_ip_block
       range_ip_block
+      anoth_range_ip_block
+      other_ip_block
     end
 
-    context 'with full ip address in search field' do
-      let(:params) { { ip: '192.2.2.1/32' } }
+    context 'when searching single ip address' do
+      let(:params) { { ip: '192.2.2.1' } }
 
       it 'renders successfully with partial ip address' do
         get admin_ip_blocks_path(params)
 
         expect(response.body).to_not include(admin_accounts_path(ip: '192.2.2.2/32'))
+        expect(response.body).to_not include(admin_accounts_path(ip: '192.2.2.200/32'))
+        expect(response.body).to_not include(admin_accounts_path(ip: '192.2.2.50/32'))
+        expect(response.body).to include(admin_accounts_path(ip: '192.2.2.0/24'))
       end
     end
 
     context 'when searching within a range' do
-      let(:anoth_range_ip_block) { Fabricate(:ip_block, ip: '192.2.2.50/32') }
-      let(:ip_block_zero) { Fabricate(:ip_block, ip: '192.2.2.0/24') }
-
-      let(:params) { { ip: '192.2.2.1/24' } }
-
-      before do
-        anoth_range_ip_block
-        ip_block_zero
-      end
+      let(:params) { { ip: '192.2.2.0/24' } }
 
       it 'renders ips within range' do
         get admin_ip_blocks_path(params)

--- a/spec/requests/admin/ip_blocks_spec.rb
+++ b/spec/requests/admin/ip_blocks_spec.rb
@@ -24,42 +24,59 @@ RSpec.describe 'Admin IP Blocks' do
   end
 
   describe 'get /admin/ip_blocks/' do
-    let(:ip_block) { Fabricate(:ip_block, ip: '192.2.2.2') }
-    let(:other_ip_block) { Fabricate(:ip_block, ip: '192.4.4.2') }
-    let(:another_ip_block) { Fabricate(:ip_block, ip: '192.5.5.2') }
+    let(:ip_block) { Fabricate(:ip_block, ip: '192.2.2.2/32') }
+    let(:other_ip_block) { Fabricate(:ip_block, ip: '192.4.4.2/32') }
+    let(:another_ip_block) { Fabricate(:ip_block, ip: '192.5.5.2/32') }
+    let(:range_ip_block) { Fabricate(:ip_block, ip: '192.2.2.200/32') }
+
+    before do
+      ip_block
+      other_ip_block
+      another_ip_block
+      range_ip_block
+    end
 
     context 'with partial ip address in search field' do
       let(:params) { { ip: '192.2' } }
 
-      before do
-        ip_block
-        other_ip_block
-        another_ip_block
-      end
-
       it 'renders successfully with partial ip address' do
         get admin_ip_blocks_path(params)
 
         expect(response).to have_http_status(200)
-        expect(response.body).to include('192.2.2.2/32')
-        expect(response.body).to_not include('192.4.4.2')
+        expect(response.body).to_not include(admin_accounts_path(ip: '192.4.4.2/32'))
+        expect(response.body).to include(admin_accounts_path(ip: '192.2.2.2/32'))
+          .and include(admin_accounts_path(ip: '192.2.2.200/32'))
       end
     end
 
     context 'with full ip address in search field' do
-      let(:params) { { ip: '192.2.2.1' } }
-
-      before do
-        ip_block
-        other_ip_block
-        another_ip_block
-      end
+      let(:params) { { ip: '192.2.2.1/32' } }
 
       it 'renders successfully with partial ip address' do
         get admin_ip_blocks_path(params)
 
-        expect(response).to have_http_status(200)
-        expect(response.body).to_not include('192.2.2.2')
+        expect(response.body).to_not include(admin_accounts_path(ip: '192.2.2.2/32'))
+      end
+    end
+
+    context 'when searching within a range' do
+      let(:anoth_range_ip_block) { Fabricate(:ip_block, ip: '192.2.2.50/32') }
+      let(:ip_block_zero) { Fabricate(:ip_block, ip: '192.2.2.0/24') }
+
+      let(:params) { { ip: '192.2.2.1/24' } }
+
+      before do
+        anoth_range_ip_block
+        ip_block_zero
+      end
+
+      it 'renders ips within range' do
+        get admin_ip_blocks_path(params)
+
+        expect(response.body).to include(admin_accounts_path(ip: '192.2.2.2/32'))
+          .and include(admin_accounts_path(ip: '192.2.2.50/32'))
+          .and include(admin_accounts_path(ip: '192.2.2.0/24'))
+          .and include(admin_accounts_path(ip: '192.2.2.200/32'))
       end
     end
   end


### PR DESCRIPTION
implements WEB-1029

adds search option for IPs.
single IPs and IP ranges search in the range they are containing, as well as the range they are contained in 