### PR TITLE
Prevent crash trying to access nullish location state

### DIFF
--- a/app/javascript/mastodon/components/navigation_focus_target/index.tsx
+++ b/app/javascript/mastodon/components/navigation_focus_target/index.tsx
@@ -55,13 +55,11 @@ export const FocusTargetProvider: React.FC<{
     | null
   >(null);
 
-  const {
-    pathname,
-    search,
-    state = {},
-  } = useLocation<{ focusTarget?: FocusTarget } | undefined>();
+  const { pathname, search, state } = useLocation<{
+    focusTarget?: FocusTarget;
+  } | null>();
 
-  const { focusTarget } = state;
+  const { focusTarget } = state ?? {};
 
   useLayoutEffect(() => {
     // We never want to set focus on page load, so we keep


### PR DESCRIPTION
Fixes #39406
Fixes #39407

### Changes proposed in this PR:
- I was not able to recreate the issue, so the fix is based on the error message `Cannot destructure property 'focusTarget' of 'a' as it is null.` from #39406 – it seems like in some conditions, the default/empty value of React Router's location state is `null`, not `undefined`, which prevents the fallback value `{}` from being applied.
