### PR TITLE
Fix bio text overflow on account profile page

### DIFF
--- a/app/javascript/mastodon/components/account_header/styles.module.scss
+++ b/app/javascript/mastodon/components/account_header/styles.module.scss
@@ -278,6 +278,7 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
   font-size: 15px;
   color: var(--color-text-primary);
   unicode-bidi: plaintext;
+  overflow-wrap: anywhere;
 
   p {
     margin-bottom: 20px;

--- a/app/javascript/mastodon/features/account_edit/styles.module.scss
+++ b/app/javascript/mastodon/features/account_edit/styles.module.scss
@@ -41,6 +41,7 @@
 
 .bio {
   unicode-bidi: plaintext;
+  overflow-wrap: anywhere;
 
   p:not(:last-child) {
     margin-bottom: 20px;


### PR DESCRIPTION
Fix #39157

Reverted the previous change to the hover card because bio text is not displayed there.
Moved `overflow-wrap: anywhere;` to what appears to be the correct location.