### PR TITLE
Fix categorised custom emojis missing from the emoji picker

### DIFF
--- a/app/javascript/mastodon/features/emoji/picker.ts
+++ b/app/javascript/mastodon/features/emoji/picker.ts
@@ -103,7 +103,9 @@ const selectPickerData = createAppSelector(
       categories: [
         'recent',
         'custom',
-        ...Object.keys(categories).toSorted(),
+        ...Object.keys(categories)
+          .toSorted()
+          .map((category) => `custom-${category}`),
         ...defaultCategories,
       ] as CategoryName[],
     };


### PR DESCRIPTION
emoji-mart generates custom category ids as `custom-<name>` (nimble-picker), and filters categories against `include` by `id`. The picker selector passed raw category names in `include`, so every categorised custom emoji was filtered out and never rendered. Uncategorised emojis (id `custom`) and recents were unaffected.

Prefix the custom category entries in `include` with `custom-` to match the ids emoji-mart produces. The per-emoji `customCategory` stays as the raw name, since emoji-mart adds the prefix itself.

Regression from #39402.