### PR TITLE
Add ES_VERIFY_SSL to chewy/elasticsearch transport_options for HTTPS using self-signed certs

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -33,12 +33,13 @@ DB_PORT=5432
 # https://docs.joinmastodon.org/admin/elasticsearch/
 # ------------------------
 ES_ENABLED=true
+ES_PRESET=single_node_cluster # single_node_cluster, small_cluster, or large_cluster
 ES_VERIFY_SSL=true # false for self-signed certs
 ES_HOST=localhost
 ES_PORT=9200
+# Authentication for ES (optional)
 ES_USER=elastic
 ES_PASS=password
-ES_PRESET=single_node_cluster # single_node_cluster, small_cluster, or large_cluster
 
 
 # Secrets

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -30,13 +30,16 @@ DB_PASS=
 DB_PORT=5432
 
 # Elasticsearch (optional)
+# https://docs.joinmastodon.org/admin/elasticsearch/
 # ------------------------
-ES_ENABLED=true
-ES_HOST=localhost
-ES_PORT=9200
-# Authentication for ES (optional)
-ES_USER=elastic
-ES_PASS=password
+# ES_ENABLED=true
+# ES_VERIFY_SSL=true
+# ES_HOST=localhost
+# ES_PORT=9200
+# ES_USER=elastic
+# ES_PASS=password
+# ES_PRESET = single_node_cluster, small_cluster or large_cluster 
+
 
 # Secrets
 # -------

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -38,7 +38,7 @@ DB_PORT=5432
 # ES_PORT=9200
 # ES_USER=elastic
 # ES_PASS=password
-# ES_PRESET = single_node_cluster, small_cluster or large_cluster 
+# ES_PRESET = single_node_cluster
 
 
 # Secrets

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -33,7 +33,7 @@ DB_PORT=5432
 # https://docs.joinmastodon.org/admin/elasticsearch/
 # ------------------------
 # ES_ENABLED=true
-# ES_VERIFY_SSL=true
+# ES_VERIFY_SSL=true # false for self-signed certs
 # ES_HOST=localhost
 # ES_PORT=9200
 # ES_USER=elastic

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -41,7 +41,6 @@ ES_PORT=9200
 ES_USER=elastic
 ES_PASS=password
 
-
 # Secrets
 # -------
 # Make sure to use `bundle exec rails secret` to generate secrets

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -32,13 +32,13 @@ DB_PORT=5432
 # Elasticsearch (optional)
 # https://docs.joinmastodon.org/admin/elasticsearch/
 # ------------------------
-# ES_ENABLED=true
-# ES_VERIFY_SSL=true # false for self-signed certs
-# ES_HOST=localhost
-# ES_PORT=9200
-# ES_USER=elastic
-# ES_PASS=password
-# ES_PRESET=single_node_cluster # single_node_cluster, small_cluster, or large_cluster
+ES_ENABLED=true
+ES_VERIFY_SSL=true # false for self-signed certs
+ES_HOST=localhost
+ES_PORT=9200
+ES_USER=elastic
+ES_PASS=password
+ES_PRESET=single_node_cluster # single_node_cluster, small_cluster, or large_cluster
 
 
 # Secrets

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -38,7 +38,7 @@ DB_PORT=5432
 # ES_PORT=9200
 # ES_USER=elastic
 # ES_PASS=password
-# ES_PRESET = single_node_cluster
+# ES_PRESET=single_node_cluster # single_node_cluster, small_cluster, or large_cluster
 
 
 # Secrets

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -34,7 +34,7 @@ DB_PORT=5432
 # ------------------------
 ES_ENABLED=true
 ES_PRESET=single_node_cluster # single_node_cluster, small_cluster, or large_cluster
-ES_VERIFY_SSL=true # false for self-signed certs
+ES_VERIFY_SSL=false # false for self-signed certs
 ES_HOST=localhost
 ES_PORT=9200
 # Authentication for ES (optional)

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -34,7 +34,7 @@ DB_PORT=5432
 # ------------------------
 ES_ENABLED=true
 ES_PRESET=single_node_cluster # single_node_cluster, small_cluster, or large_cluster
-ES_VERIFY_SSL=false # false for self-signed certs
+ES_VERIFY_SSL=true # false for self-signed certs
 ES_HOST=localhost
 ES_PORT=9200
 # Authentication for ES (optional)

--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -7,8 +7,13 @@ user            = ENV.fetch('ES_USER', nil).presence
 password        = ENV.fetch('ES_PASS', nil).presence
 prefix          = ENV.fetch('ES_PREFIX', nil)
 ca_file         = ENV.fetch('ES_CA_FILE', nil).presence
+verify_ssl      = ENV.fetch('ES_VERIFY_SSL', 'true') == 'true'
 
-transport_options = { ssl: { ca_file: ca_file } } if ca_file.present?
+ssl_options = {}
+ssl_options[:ca_file] = ca_file if ca_file.present?
+ssl_options[:verify]  = false unless verify_ssl
+
+transport_options = { ssl: ssl_options } if ssl_options.present?
 
 Chewy.settings = {
   host: "#{host}:#{port}",

--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -7,7 +7,7 @@ user            = ENV.fetch('ES_USER', nil).presence
 password        = ENV.fetch('ES_PASS', nil).presence
 prefix          = ENV.fetch('ES_PREFIX', nil)
 ca_file         = ENV.fetch('ES_CA_FILE', nil).presence
-verify_ssl      = ENV.fetch('ES_VERIFY_SSL', 'true') == 'true'
+verify_ssl      = ENV.fetch('ES_VERIFY_SSL', 'true') != 'false'
 
 ssl_options = {}
 ssl_options[:ca_file] = ca_file if ca_file.present?


### PR DESCRIPTION
`/usr/local/bundle/gems/httpclient-2.9.0/lib/httpclient/ssl_socket.rb:103:in 'OpenSSL::SSL::SSLSocket#connect': SSL_connect returned=1 errno=0 peeraddr=192.168.88.43:9200 state=error: certificate verify failed (self-signed certificate in certificate chain) (OpenSSL::SSL::SSLError)`

using a self signed cert generated by Elasticsearch 9 with security enabled cannot connect to mastodon out of the box.

**Update**: Matching doco PR https://github.com/mastodon/documentation/pull/1929