### PR TITLE
Fix hovercard not showing in compose column

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3017,7 +3017,6 @@ a.account__display-name {
 
     &__pane {
       height: 100%;
-      overflow: hidden;
       display: flex;
       justify-content: flex-end;
       min-width: 285px;


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes an (I believe) old regression that prevents the hovercard from showing up in the compose column. Since it's been like this since at least 4.5 and there have been no bug reports, I'm not sure if we even want this; but technically it's a bug (as the hover card is triggered & opened invisibly in the current code)
   - The bug originates from PopperJS: https://github.com/floating-ui/floating-ui/issues/2276
- I couldn't find any negative side-effects of the removal of `overflow: hidden` here. Changing it to `overflow: clip` works, too, but I'm not sure why that would be needed at all.

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="335" height="363" alt="image" src="https://github.com/user-attachments/assets/35174c54-1e91-4bc5-95d8-c259b3bbfad7" /> | <img width="342" height="367" alt="image" src="https://github.com/user-attachments/assets/39e324c6-851b-4fa6-8ca2-a9e853a0b000" /> |