### PR TITLE
Fix service worker failing to load due to 404 on chunk dependencies

### DIFF
--- a/config/vite/plugin-sw-chunk-paths.ts
+++ b/config/vite/plugin-sw-chunk-paths.ts
@@ -1,0 +1,51 @@
+/* The service worker is built as a regular Vite entry point and is served from
+   `/sw.js` (a symlink to `packs/sw.js`), while the chunks it depends on live in
+   the build output directory (e.g. `/packs/`).
+
+   Browsers resolve a module's static import specifiers relative to the *URL* of
+   the script, not its location on disk. Because the worker is served from the
+   root, relative specifiers such as `./chunk-abc123.js` resolve to
+   `/chunk-abc123.js` and return a 404, which prevents the service worker from
+   installing.
+
+   This plugin rewrites those relative specifiers in the service worker output
+   to absolute paths pointing at the build output directory, so they resolve
+   correctly regardless of the URL the worker is served from.
+*/
+
+import type { Plugin } from 'vite';
+
+const SERVICE_WORKER_FILENAME = 'sw.js';
+
+export function MastodonServiceWorkerChunkPaths(base: string): Plugin {
+  return {
+    name: 'mastodon-sw-chunk-paths',
+    renderChunk(code, chunk) {
+      if (chunk.fileName !== SERVICE_WORKER_FILENAME) {
+        return null;
+      }
+
+      // Drive the rewrite from the chunk's actual dependency list rather than a
+      // generic regex, so we only ever touch real (hashed) chunk specifiers and
+      // never accidentally match similar-looking text inside string literals.
+      const dependencies = [...chunk.imports, ...chunk.dynamicImports];
+
+      let rewritten = code;
+      for (const dependency of dependencies) {
+        // The worker sits at the root of the output directory, so each
+        // dependency is imported with a leading `./`.
+        rewritten = rewritten
+          .replaceAll(`"./${dependency}"`, `"${base}${dependency}"`)
+          .replaceAll(`'./${dependency}'`, `'${base}${dependency}'`);
+      }
+
+      if (rewritten === code) {
+        return null;
+      }
+
+      // Only import specifiers are changed, so the existing source map stays
+      // accurate enough; returning `null` avoids a spurious sourcemap warning.
+      return { code: rewritten, map: null };
+    },
+  };
+}

--- a/config/vite/plugin-sw-chunk-paths.ts
+++ b/config/vite/plugin-sw-chunk-paths.ts
@@ -13,17 +13,27 @@
    correctly regardless of the URL the worker is served from.
 */
 
-import type { Plugin } from 'vite';
+import type { Plugin, ResolvedConfig } from 'vite';
 
 const SERVICE_WORKER_FILENAME = 'sw.js';
 
-export function MastodonServiceWorkerChunkPaths(base: string): Plugin {
+export function MastodonServiceWorkerChunkPaths(): Plugin {
+  let config: ResolvedConfig;
+
   return {
     name: 'mastodon-sw-chunk-paths',
+    configResolved(resolvedConfig) {
+      config = resolvedConfig;
+    },
     renderChunk(code, chunk) {
       if (chunk.fileName !== SERVICE_WORKER_FILENAME) {
         return null;
       }
+
+      // Resolve the base from the final Vite config rather than receiving it as
+      // an argument, so forks or other plugins that alter `base` are respected.
+      // Vite normalises `base` to always include a trailing slash.
+      const { base } = config;
 
       // Drive the rewrite from the chunk's actual dependency list rather than a
       // generic regex, so we only ever touch real (hashed) chunk specifiers and

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -22,6 +22,7 @@ import svgr from 'vite-plugin-svgr';
 import { MastodonAssetsManifest } from './config/vite/plugin-assets-manifest';
 import { MastodonThemes } from './config/vite/plugin-mastodon-themes';
 import { MastodonNameLookup } from './config/vite/plugin-name-lookup';
+import { MastodonServiceWorkerChunkPaths } from './config/vite/plugin-sw-chunk-paths';
 import { MastodonServiceWorkerLocales } from './config/vite/plugin-sw-locales';
 
 const jsRoot = path.resolve(__dirname, 'app/javascript');
@@ -185,6 +186,7 @@ export const config: UserConfigFnPromise = async ({ mode, command }) => {
       MastodonThemes(),
       MastodonAssetsManifest(),
       MastodonServiceWorkerLocales(),
+      MastodonServiceWorkerChunkPaths(`/${outDirName}/`),
       legacy({
         renderLegacyChunks: false,
         modernPolyfills: true,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -186,7 +186,7 @@ export const config: UserConfigFnPromise = async ({ mode, command }) => {
       MastodonThemes(),
       MastodonAssetsManifest(),
       MastodonServiceWorkerLocales(),
-      MastodonServiceWorkerChunkPaths(`/${outDirName}/`),
+      MastodonServiceWorkerChunkPaths(),
       legacy({
         renderLegacyChunks: false,
         modernPolyfills: true,


### PR DESCRIPTION
Since #39250 the service worker is built as a regular Vite entry point and served from `/sw.js` (a symlink to `packs/sw.js`), while its split chunks live under `/packs/`. Browsers resolve a module's static import specifiers relative to the URL of the script, so the worker's relative imports (e.g. `./react-intl-<hash>.js`) resolved to `/react-intl-<hash>.js` and returned 404, preventing the service worker from installing.

Added a Vite plugin that rewrites the service worker's chunk import specifiers to absolute paths under the build output directory. The rewrite is driven by the chunk's actual dependency list so only real hashed specifiers are touched.

I've personally created the symlinks to these chunks on my self-hosted instance, but it's just a workaround with Dockerfile. Like this:

```Dockerfile
RUN corepack prepare yarn@stable --activate && \
    yarn install --immutable && \
    RAILS_ENV=production \
    NODE_ENV=production \
    SECRET_KEY_BASE_DUMMY=1 \
    bundle exec rails assets:precompile && \
    cd /opt/mastodon/public && \
    rm -f sw.js sw.js.map chunk-*.js react-intl-*.js isSymbol-*.js toString-*.js && \
    ln -sf packs/sw.js sw.js && \
    if [ -f packs/sw.js.map ]; then ln -sf packs/sw.js.map sw.js.map; fi && \
    for dep in $(grep -oE '\./[^"]+\.js' packs/sw.js | sed 's|^\./||'); do \
      ln -sf "packs/$dep" "$dep"; \
      if [ -f "packs/$dep" ]; then \
        for ndep in $(grep -oE '\./[^"]+\.js' "packs/$dep" 2>/dev/null | sed 's|^\./||'); do \
          ln -sf "packs/$ndep" "$ndep"; \
        done; \
      fi; \
    done && \
    yarn cache clean --all
```

But it's non-sustainable solution as for me so that's the purpose of this PR.

## Testing

Verified locally with a production build (`yarn build:production`):

## before (broken, as on mastodon.social/sw.js)
`import{...}from"./react-intl-Cop388b4.js";`
## after (this PR)
`import{...}from"/packs/react-intl-Cop388b4.js";`

Also ran:
- `yarn lint:js` on the changed files - no errors.
- `yarn typecheck` (`tsc --noEmit`) - passes.
The generated chunk hashes match what mastodon.social currently serves
(`chunk-CMxvf4Kt.js`, `react-intl-Cop388b4.js`), confirming this reproduces and
fixes the issue described.

Closes #39431