### PR TITLE
Compact validation matcher checks where possible

### DIFF
--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -547,10 +547,7 @@ RSpec.describe Account do
 
       it { is_expected.to_not allow_values(account_note_over_limit).for(:note) }
 
-      it { is_expected.to validate_absence_of(:followers_url).on(:create) }
-      it { is_expected.to validate_absence_of(:inbox_url).on(:create) }
-      it { is_expected.to validate_absence_of(:shared_inbox_url).on(:create) }
-      it { is_expected.to validate_absence_of(:uri).on(:create) }
+      it { is_expected.to validate_absence_of(:inbox_url, :followers_url, :shared_inbox_url, :uri).on(:create) }
 
       it { is_expected.to allow_values([], ['example.com'], (1..domains_limit).to_a).for(:attribution_domains) }
       it { is_expected.to_not allow_values(['example com'], ['@'], (1..(domains_limit + 1)).to_a).for(:attribution_domains) }

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -29,9 +29,7 @@ RSpec.describe Collection do
 
       it { is_expected.to validate_length_of(:description_html).is_at_most(Collection::DESCRIPTION_LENGTH_HARD_LIMIT) }
 
-      it { is_expected.to validate_presence_of(:uri) }
-
-      it { is_expected.to validate_presence_of(:original_number_of_items) }
+      it { is_expected.to validate_presence_of(:original_number_of_items, :uri) }
 
       it { is_expected.to allow_value('randomstuff').for(:language) }
     end

--- a/spec/models/custom_filter_spec.rb
+++ b/spec/models/custom_filter_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe CustomFilter do
 
   describe 'Validations' do
     it { is_expected.to validate_length_of(:title).is_at_most(described_class::TITLE_LENGTH_LIMIT) }
-    it { is_expected.to validate_presence_of(:context) }
-    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:context, :title) }
 
     it { is_expected.to_not allow_values([], %w(invalid)).for(:context) }
     it { is_expected.to allow_values(%w(home)).for(:context) }

--- a/spec/models/instance_moderation_note_spec.rb
+++ b/spec/models/instance_moderation_note_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe InstanceModerationNote do
 
     it { is_expected.to allow_value('non-existent.example').for(:domain) }
     it { is_expected.to validate_length_of(:content).is_at_most(described_class::CONTENT_SIZE_LIMIT) }
-    it { is_expected.to validate_presence_of(:content) }
-    it { is_expected.to validate_presence_of(:domain) }
+    it { is_expected.to validate_presence_of(:content, :domain) }
   end
 end

--- a/spec/models/ip_block_spec.rb
+++ b/spec/models/ip_block_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe IpBlock do
   describe 'Validations' do
     subject { Fabricate.build :ip_block }
 
-    it { is_expected.to validate_presence_of(:ip) }
-    it { is_expected.to validate_presence_of(:severity) }
+    it { is_expected.to validate_presence_of(:ip, :severity) }
 
     it { is_expected.to validate_uniqueness_of(:ip) }
 

--- a/spec/models/rule_translation_spec.rb
+++ b/spec/models/rule_translation_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe RuleTranslation do
   describe 'Validations' do
     subject { Fabricate.build :rule_translation }
 
-    it { is_expected.to validate_presence_of(:language) }
-    it { is_expected.to validate_presence_of(:text) }
+    it { is_expected.to validate_presence_of(:language, :text) }
     it { is_expected.to validate_length_of(:text).is_at_most(Rule::TEXT_SIZE_LIMIT) }
     it { is_expected.to validate_uniqueness_of(:language).scoped_to(:rule_id) }
   end

--- a/spec/models/terms_of_service_spec.rb
+++ b/spec/models/terms_of_service_spec.rb
@@ -25,8 +25,7 @@ RSpec.describe TermsOfService do
     context 'when published' do
       subject { Fabricate.build :terms_of_service, published_at: Time.zone.today }
 
-      it { is_expected.to validate_presence_of(:changelog) }
-      it { is_expected.to validate_presence_of(:effective_date) }
+      it { is_expected.to validate_presence_of(:changelog, :effective_date) }
     end
   end
 

--- a/spec/models/webauthn_credential_spec.rb
+++ b/spec/models/webauthn_credential_spec.rb
@@ -6,10 +6,7 @@ RSpec.describe WebauthnCredential do
   describe 'Validations' do
     subject { Fabricate.build :webauthn_credential }
 
-    it { is_expected.to validate_presence_of(:external_id) }
-    it { is_expected.to validate_presence_of(:public_key) }
-    it { is_expected.to validate_presence_of(:nickname) }
-    it { is_expected.to validate_presence_of(:sign_count) }
+    it { is_expected.to validate_presence_of(:external_id, :nickname, :public_key, :sign_count) }
 
     it { is_expected.to validate_uniqueness_of(:external_id) }
     it { is_expected.to validate_uniqueness_of(:nickname).scoped_to(:user_id) }


### PR DESCRIPTION
The shoulda matchers 8.0 release is mostly a version drop release, but also includes a new feature to combine matcher examples when you are doing certain validation assertions with the same options or no options.

The checks remain the same, just a terser call style.

Needs https://github.com/mastodon/mastodon/pull/39405 to merge first.