### PR TITLE
Rely on rubyzip auto require file name change

### DIFF
--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'zip'
-
 class BackupService < BaseService
   include Payloadable
   include ContextHelper


### PR DESCRIPTION
Amongst other improvements/fixes, rubyzip 3.4.0 contains a change to add a file named after the gem (rubyzip.rb) which bundler will auto require. That file in turn requires 'zip'. As a result, we can remove this explicit require and rely on that auto loading/requiring.

Depends on https://github.com/mastodon/mastodon/pull/39423 for version bump (or could replace).