### PR TITLE
[Accessibility] Return alt text for default server thumbnail

### DIFF
--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -31,6 +31,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
     else
       {
         url: frontend_asset_url('images/preview.png'),
+        description: I18n.t('about.default_thumbnail_description', locale: object.languages[0]),
       }
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
     contact_unavailable: N/A
     hosted_on: Mastodon hosted on %{domain}
     title: About
+    default_thumbnail_description: Two smiling cartoon mastodons (who look like elephants) toss a paper plane between them. They're surrounded by a bright blue sky and floating planets with trees and more mastodons on them.
   accounts:
     errors:
       cannot_be_added_to_collections: This account cannot be added to collections.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,9 +4,9 @@ en:
     about_mastodon_html: 'The social network of the future: No ads, no corporate surveillance, ethical design, and decentralization! Own your data with Mastodon!'
     contact_missing: Not set
     contact_unavailable: N/A
+    default_thumbnail_description: Two smiling cartoon mastodons (who look like elephants) toss a paper plane between them. They're surrounded by a bright blue sky and floating planets with trees and more mastodons on them.
     hosted_on: Mastodon hosted on %{domain}
     title: About
-    default_thumbnail_description: Two smiling cartoon mastodons (who look like elephants) toss a paper plane between them. They're surrounded by a bright blue sky and floating planets with trees and more mastodons on them.
   accounts:
     errors:
       cannot_be_added_to_collections: This account cannot be added to collections.


### PR DESCRIPTION
### Changes proposed in this PR:
- Wrapping up the work on #38796, this adds alt text for the default server thumbnail included with Mastodon

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="616" height="443" alt="image" src="https://github.com/user-attachments/assets/4ba90375-9e34-48d7-9621-7b6ab3ee41b5" /> | <img width="612" height="438" alt="image" src="https://github.com/user-attachments/assets/edd28482-b033-4a59-bf26-d16c5f3e0c43" /> |