### PR TITLE
Add category selection to collection report modal

### DIFF
--- a/app/javascript/mastodon/features/report/category.jsx
+++ b/app/javascript/mastodon/features/report/category.jsx
@@ -68,7 +68,7 @@ class Category extends PureComponent {
   render () {
     const { category, startedFrom, rules, intl } = this.props;
 
-    const options = rules.length > 0 ? [
+    let options = rules.length > 0 ? [
       'dislike',
       'spam',
       'legal',
@@ -81,10 +81,21 @@ class Category extends PureComponent {
       'other',
     ];
 
+    if (startedFrom === 'collection') {
+      options = options.filter(item => item !== 'dislike');
+    }
+
     return (
       <>
         <NavigationFocusTarget as='h1' className='report-dialog-modal__title'>
-          <FormattedMessage id='report.category.title' defaultMessage="Tell us what's going on with this {type}" values={{ type: intl.formatMessage(messages[startedFrom]) }} />
+          {startedFrom === 'collection' ? (
+            <FormattedMessage
+              id='report.collection_comment'
+              defaultMessage='Why do you want to report this collection?'
+            />
+          ) : (
+            <FormattedMessage id='report.category.title' defaultMessage="Tell us what's going on with this {type}" values={{ type: intl.formatMessage(messages[startedFrom]) }} />
+          )}
         </NavigationFocusTarget>
         <p className='report-dialog-modal__lead'><FormattedMessage id='report.category.subtitle' defaultMessage='Choose the best match' /></p>
 

--- a/app/javascript/mastodon/features/ui/components/report_collection_modal.tsx
+++ b/app/javascript/mastodon/features/ui/components/report_collection_modal.tsx
@@ -13,6 +13,7 @@ import { NavigationFocusTarget } from 'mastodon/components/navigation_focus_targ
 import { useAccount } from 'mastodon/hooks/useAccount';
 import { useAppDispatch } from 'mastodon/store';
 
+import Category from '../../report/category';
 import Comment from '../../report/comment';
 
 const messages = defineMessages({
@@ -60,8 +61,11 @@ export const ReportCollectionModal: React.FC<{
     'idle' | 'submitting' | 'submitted' | 'error'
   >('idle');
 
-  const [step, setStep] = useState<'comment' | 'thanks'>('comment');
+  const [step, setStep] = useState<'category' | 'comment' | 'thanks'>(
+    'category',
+  );
 
+  const [category, setCategory] = useState<string | null>(null);
   const [comment, setComment] = useState('');
   const [selectedDomains, setSelectedDomains] = useState<string[]>([]);
 
@@ -71,6 +75,10 @@ export const ReportCollectionModal: React.FC<{
     } else {
       setSelectedDomains((domains) => domains.filter((d) => d !== domain));
     }
+  }, []);
+
+  const submitCategory = useCallback(() => {
+    setStep('comment');
   }, []);
 
   const handleSubmit = useCallback(() => {
@@ -85,7 +93,7 @@ export const ReportCollectionModal: React.FC<{
           forward_to_domains: selectedDomains,
           comment,
           forward: selectedDomains.length > 0,
-          category: 'spam',
+          category: category ?? 'other',
         },
         () => {
           setSubmitState('submitted');
@@ -96,7 +104,7 @@ export const ReportCollectionModal: React.FC<{
         },
       ),
     );
-  }, [account_id, comment, dispatch, collectionId, selectedDomains]);
+  }, [account_id, category, comment, dispatch, collectionId, selectedDomains]);
 
   if (!account) {
     return null;
@@ -108,15 +116,19 @@ export const ReportCollectionModal: React.FC<{
   let stepComponent;
 
   switch (step) {
+    case 'category':
+      stepComponent = (
+        <Category
+          onNextStep={submitCategory}
+          startedFrom='collection'
+          category={category}
+          onChangeCategory={setCategory}
+        />
+      );
+      break;
     case 'comment':
       stepComponent = (
         <Comment
-          modalTitle={
-            <FormattedMessage
-              id='report.collection_comment'
-              defaultMessage='Why do you want to report this collection?'
-            />
-          }
           submitError={
             submitState === 'error' && (
               <Callout

--- a/app/javascript/mastodon/features/ui/components/report_collection_modal.tsx
+++ b/app/javascript/mastodon/features/ui/components/report_collection_modal.tsx
@@ -65,7 +65,9 @@ export const ReportCollectionModal: React.FC<{
     'category',
   );
 
-  const [category, setCategory] = useState<string | null>(null);
+  const [category, setCategory] = useState<
+    'spam' | 'legal' | 'violation' | 'other' | null
+  >(null);
   const [comment, setComment] = useState('');
   const [selectedDomains, setSelectedDomains] = useState<string[]>([]);
 

--- a/app/javascript/mastodon/features/ui/components/report_collection_modal.tsx
+++ b/app/javascript/mastodon/features/ui/components/report_collection_modal.tsx
@@ -90,7 +90,7 @@ export const ReportCollectionModal: React.FC<{
   }, []);
 
   const handleNextStep = useCallback(() => {
-    if (step === 'category' && category === 'legal') {
+    if (step === 'category' && category === 'violation') {
       setStep('rules');
     } else {
       setStep('comment');

--- a/app/javascript/mastodon/features/ui/components/report_collection_modal.tsx
+++ b/app/javascript/mastodon/features/ui/components/report_collection_modal.tsx
@@ -15,6 +15,7 @@ import { useAppDispatch } from 'mastodon/store';
 
 import Category from '../../report/category';
 import Comment from '../../report/comment';
+import Rules from '../../report/rules';
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },
@@ -61,13 +62,14 @@ export const ReportCollectionModal: React.FC<{
     'idle' | 'submitting' | 'submitted' | 'error'
   >('idle');
 
-  const [step, setStep] = useState<'category' | 'comment' | 'thanks'>(
+  const [step, setStep] = useState<'category' | 'rules' | 'comment' | 'thanks'>(
     'category',
   );
 
   const [category, setCategory] = useState<
     'spam' | 'legal' | 'violation' | 'other' | null
   >(null);
+  const [selectedRuleIds, setSelectedRuleIds] = useState<string[]>([]);
   const [comment, setComment] = useState('');
   const [selectedDomains, setSelectedDomains] = useState<string[]>([]);
 
@@ -79,9 +81,21 @@ export const ReportCollectionModal: React.FC<{
     }
   }, []);
 
-  const submitCategory = useCallback(() => {
-    setStep('comment');
+  const handleRuleToggle = useCallback((ruleId: string) => {
+    setSelectedRuleIds((ruleIds) =>
+      ruleIds.includes(ruleId)
+        ? ruleIds.filter((id) => ruleId !== id)
+        : [...ruleIds, ruleId],
+    );
   }, []);
+
+  const handleNextStep = useCallback(() => {
+    if (step === 'category' && category === 'legal') {
+      setStep('rules');
+    } else {
+      setStep('comment');
+    }
+  }, [category, step]);
 
   const handleSubmit = useCallback(() => {
     setSubmitState('submitting');
@@ -96,6 +110,7 @@ export const ReportCollectionModal: React.FC<{
           comment,
           forward: selectedDomains.length > 0,
           category: category ?? 'other',
+          rule_ids: selectedRuleIds,
         },
         () => {
           setSubmitState('submitted');
@@ -106,7 +121,15 @@ export const ReportCollectionModal: React.FC<{
         },
       ),
     );
-  }, [account_id, category, comment, dispatch, collectionId, selectedDomains]);
+  }, [
+    account_id,
+    category,
+    selectedRuleIds,
+    comment,
+    dispatch,
+    collectionId,
+    selectedDomains,
+  ]);
 
   if (!account) {
     return null;
@@ -121,10 +144,19 @@ export const ReportCollectionModal: React.FC<{
     case 'category':
       stepComponent = (
         <Category
-          onNextStep={submitCategory}
+          onNextStep={handleNextStep}
           startedFrom='collection'
           category={category}
           onChangeCategory={setCategory}
+        />
+      );
+      break;
+    case 'rules':
+      stepComponent = (
+        <Rules
+          onNextStep={handleNextStep}
+          selectedRuleIds={selectedRuleIds}
+          onToggle={handleRuleToggle}
         />
       );
       break;


### PR DESCRIPTION
### Changes proposed in this PR:
- Allows selecting a category when reporting a collection, instead of hard-coding it to 'spam'. The "server rules" option leads to the rules selection UI, the other ones to the freeform comment field.

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="510" height="753" alt="image" src="https://github.com/user-attachments/assets/df1f4281-f1bc-4283-af3c-5ce9e11ad4ed" /> | <img width="523" height="762" alt="image" src="https://github.com/user-attachments/assets/57ae2160-a212-42e2-9422-444d109a5fa0" /> |
| n/a | <img width="505" height="759" alt="image" src="https://github.com/user-attachments/assets/1277179c-d114-4afc-a10c-71f2bbc5e443" /> |