### PR TITLE
Relax account display name length limit

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -76,7 +76,7 @@ class Account < ApplicationRecord
   URL_PREFIX_RE = %r{\Ahttp(s?)://[^/]+}
   USERNAME_ONLY_RE = /\A#{USERNAME_RE}\z/i
   USERNAME_LENGTH_LIMIT = 30
-  DISPLAY_NAME_LENGTH_LIMIT = 30
+  DISPLAY_NAME_LENGTH_LIMIT = 40
   NOTE_LENGTH_LIMIT = 500
 
   # Hard limits for federated content


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/39416

Confirmed that the tilde-containing name in the issue is now valid.

It would be more psychologically harmonious from the computer's POV to make this "64" instead, I suspect. For now, just bump to 40.