### PR TITLE
Handle missing `sw.js` in test environment assets

### DIFF
--- a/lib/mastodon/middleware/public_file_server.rb
+++ b/lib/mastodon/middleware/public_file_server.rb
@@ -16,6 +16,7 @@ module Mastodon
 
       def call(env)
         file = @file_handler.attempt(env)
+
         # If the request is not a static file, move on!
         return @app.call(env) if file.nil?
 

--- a/lib/mastodon/middleware/public_file_server.rb
+++ b/lib/mastodon/middleware/public_file_server.rb
@@ -5,8 +5,9 @@ require 'action_dispatch/middleware/static'
 module Mastodon
   module Middleware
     class PublicFileServer
+      CACHE_TTL = 28.days.to_i
+      SERVICE_WORKER_PATH = '/sw.js'
       SERVICE_WORKER_TTL = 7.days.to_i
-      CACHE_TTL          = 28.days.to_i
 
       def initialize(app)
         @app = app
@@ -15,7 +16,6 @@ module Mastodon
 
       def call(env)
         file = @file_handler.attempt(env)
-
         # If the request is not a static file, move on!
         return @app.call(env) if file.nil?
 
@@ -24,7 +24,7 @@ module Mastodon
         # Set cache headers on static files. Some paths require different cache headers
         request = Rack::Request.new env
         headers['cache-control'] = begin
-          if request.path.start_with?('/sw.js')
+          if request.path.start_with?(SERVICE_WORKER_PATH)
             "public, max-age=#{SERVICE_WORKER_TTL}, must-revalidate"
           elsif request.path.start_with?(paperclip_root_url)
             "public, max-age=#{CACHE_TTL}, immutable"

--- a/spec/requests/public_files_spec.rb
+++ b/spec/requests/public_files_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe 'Public files' do
   include RoutingHelper
 
   context 'when requesting service worker file' do
+    before { stub_const 'Mastodon::Middleware::PublicFileServer::SERVICE_WORKER_PATH', '/robots.txt' }
+
     it 'returns the file with the expected headers' do
-      get '/sw.js'
+      get Mastodon::Middleware::PublicFileServer::SERVICE_WORKER_PATH
 
       expect(response)
         .to have_http_status(200)


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/39410 which has background as well.

I started with an approach of using an anonymous controller at that path ... but the middleware specifically operates on actual files on disk only, so routing something there in the spec skips the middleware.

I then tried variations on touching/symlinking the file and cleaning up after, but I agree with the sentiment on the linked issue of "lets not put test build files into the production dirs", so bailed on that as well.

I wound up moving the expected path to a constant, and then stubbing that constant with a file which will (likely?) be around forever. I think this is safe because we care more about what the middleware is doing here than the hard-coded path (I think?). Could contemplate a routing spec and/or some other spec which validates the output of the build process if we want to assert on the contents of that file or presence of the symlink or whatever.

Possible followup would be to move this whole spec file to a "middleware unit test" instead (set up dummy rack app) of the request spec to flow through just that middleware ... though I guess an upside of the current approach is we get the full stack results and would presumably notice if something else clobbered the headers.

Another approach would be to go through source of actiondispatch file handler and stub out whatever its calling at the file system level ... but that feels like we're getting sort of deep into internals of something outside our scope.