### PR TITLE
Fix tiny spacing above character counter

### DIFF
--- a/app/javascript/mastodon/components/character_counter/styles.module.scss
+++ b/app/javascript/mastodon/components/character_counter/styles.module.scss
@@ -1,4 +1,5 @@
 .counter {
+  display: block;
   margin-top: 4px;
   font-size: 13px;
 }


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes spacing between the character counter and its form field not being applied properly due to the counter being an inline element

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="623" height="478" alt="image" src="https://github.com/user-attachments/assets/e77d4e25-fdfe-46b5-b921-902b7f894fb8" /> | <img width="623" height="474" alt="image" src="https://github.com/user-attachments/assets/90388d07-8b28-462f-bb4d-acc499221f87" /> |