### PR TITLE
Add Status component stories

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -16,6 +16,7 @@ import {
   importLegacyShortcodes,
   importEmojiData,
 } from '@/mastodon/features/emoji/loader';
+import { IdentityContext } from '@/mastodon/identity_context';
 import type { LocaleData } from '@/mastodon/locales';
 import { reducerWithInitialState } from '@/mastodon/reducers';
 import { defaultMiddleware } from '@/mastodon/store/store';
@@ -55,15 +56,28 @@ const preview: Preview = {
       description: 'Theme for the story',
       toolbar: {
         title: 'Theme',
-        icon: 'circlehollow',
-        items: [{ value: 'light' }, { value: 'dark' }],
-        dynamicTitle: true,
+        items: [
+          { value: 'light', icon: 'circlehollow' },
+          { value: 'dark', icon: 'circle' },
+        ],
+      },
+    },
+    loggedIn: {
+      description: 'Whether a user is logged in',
+      toolbar: {
+        title: 'Logged in',
+        icon: 'user',
+        items: [
+          { value: 'true', title: 'logged in' },
+          { value: 'false', title: 'logged out' },
+        ],
       },
     },
   },
   initialGlobals: {
     locale: 'en',
     theme: 'light',
+    loggedIn: 'true',
   },
   decorators: [
     (Story, { parameters, globals, args, argTypes }) => {
@@ -115,7 +129,7 @@ const preview: Preview = {
       );
     },
     (Story, { globals }) => {
-      const currentLocale = (globals.locale as string) || 'en';
+      const currentLocale = globals.locale || 'en';
       const [messages, setMessages] = useState<
         Record<string, Record<string, string>>
       >({});
@@ -143,7 +157,7 @@ const preview: Preview = {
       );
     },
     (Story, { globals }) => {
-      const theme = (globals.theme as string) || 'light';
+      const theme = globals.theme;
       useEffect(() => {
         document.body.setAttribute('data-color-scheme', theme);
       }, [theme]);
@@ -164,12 +178,27 @@ const preview: Preview = {
         />
       </MemoryRouter>
     ),
+    (Story, { globals }) => {
+      const signedIn = globals.loggedIn !== 'false';
+      return (
+        <IdentityContext.Provider
+          value={{
+            signedIn,
+            accountId: signedIn ? '123' : undefined,
+            disabledAccountId: undefined,
+            permissions: 0,
+          }}
+        >
+          <Story />
+        </IdentityContext.Provider>
+      );
+    },
   ],
   loaders: [
     mswLoader,
     importCustomEmojiData,
     importLegacyShortcodes,
-    ({ globals: { locale } }) => importEmojiData(locale as string),
+    ({ globals: { locale } }) => importEmojiData(locale),
   ],
   parameters: {
     layout: 'centered',

--- a/.storybook/storybook.d.ts
+++ b/.storybook/storybook.d.ts
@@ -15,6 +15,12 @@ declare module 'storybook/internal/csf' {
       | `${RootPathKeys}.${string}`
       | [RootPathKeys, ...(string | number)[]];
   }
+
+  export interface Globals {
+    locale: string;
+    theme: 'light' | 'dark';
+    loggedIn: 'true' | 'false';
+  }
 }
 
 export {};

--- a/app/javascript/mastodon/api_types/media_attachments.ts
+++ b/app/javascript/mastodon/api_types/media_attachments.ts
@@ -7,7 +7,7 @@ export type MediaAttachmentType =
   | 'unknown'
   | 'audio';
 
-interface BaseApiMediaAttachmentJSON {
+export interface BaseApiMediaAttachmentJSON {
   id: string;
   type: MediaAttachmentType;
   url: string;
@@ -19,7 +19,7 @@ interface BaseApiMediaAttachmentJSON {
   blurhash: string;
 }
 
-interface ApiImageAttachmentJSON extends BaseApiMediaAttachmentJSON {
+export interface ApiImageAttachmentJSON extends BaseApiMediaAttachmentJSON {
   type: 'image';
   meta: {
     original: ApiImageAttachmentMetaJSON;
@@ -27,7 +27,7 @@ interface ApiImageAttachmentJSON extends BaseApiMediaAttachmentJSON {
   };
 }
 
-interface ApiAudioAttachmentJSON extends BaseApiMediaAttachmentJSON {
+export interface ApiAudioAttachmentJSON extends BaseApiMediaAttachmentJSON {
   type: 'audio';
   meta: {
     colors: ApiColorsAttachmentMetaJSON;
@@ -36,7 +36,7 @@ interface ApiAudioAttachmentJSON extends BaseApiMediaAttachmentJSON {
   };
 }
 
-interface ApiVideoAttachmentJSON extends BaseApiMediaAttachmentJSON {
+export interface ApiVideoAttachmentJSON extends BaseApiMediaAttachmentJSON {
   type: 'video';
   meta: {
     colors: ApiColorsAttachmentMetaJSON;
@@ -49,7 +49,7 @@ interface ApiVideoAttachmentJSON extends BaseApiMediaAttachmentJSON {
   };
 }
 
-interface ApiGifvAttachmentJSON extends BaseApiMediaAttachmentJSON {
+export interface ApiGifvAttachmentJSON extends BaseApiMediaAttachmentJSON {
   type: 'gifv';
   meta: {
     original: ApiVideoAttachmentMetaJSON;
@@ -57,7 +57,7 @@ interface ApiGifvAttachmentJSON extends BaseApiMediaAttachmentJSON {
   };
 }
 
-interface ApiUnknownAttachmentJSON extends BaseApiMediaAttachmentJSON {
+export interface ApiUnknownAttachmentJSON extends BaseApiMediaAttachmentJSON {
   type: 'unknown';
   meta: unknown;
 }

--- a/app/javascript/mastodon/api_types/quotes.ts
+++ b/app/javascript/mastodon/api_types/quotes.ts
@@ -22,7 +22,7 @@ interface ApiNestedQuoteJSON {
 interface ApiQuoteAcceptedJSON {
   state: 'accepted';
   quoted_status: Omit<ApiStatusJSON, 'quote'> & {
-    quote: ApiNestedQuoteJSON | ApiQuoteEmptyJSON;
+    quote?: ApiNestedQuoteJSON | ApiQuoteEmptyJSON;
   };
 }
 

--- a/app/javascript/mastodon/components/status/status.stories.tsx
+++ b/app/javascript/mastodon/components/status/status.stories.tsx
@@ -514,8 +514,27 @@ export const LongText: Story = {
   },
 };
 
+export const Images: Story = {
+  args: {
+    attachments: 'image-3',
+  },
+};
+
+export const Video: Story = {
+  args: {
+    attachments: 'video',
+  },
+};
+
+export const Audio: Story = {
+  args: {
+    attachments: 'audio',
+  },
+};
+
 export const Poll: Story = {
   args: {
     isPoll: true,
+    hasVoted: true,
   },
 };

--- a/app/javascript/mastodon/components/status/status.stories.tsx
+++ b/app/javascript/mastodon/components/status/status.stories.tsx
@@ -1,58 +1,179 @@
+import type { FC } from 'react';
+import { useMemo } from 'react';
+
 import { Map as ImmutableMap } from 'immutable';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
-import { accountFactoryState, statusFactoryState } from '@/testing/factories';
+import type { StatusVisibility } from '@/mastodon/api_types/statuses';
+import {
+  accountFactoryState,
+  pollFactory,
+  statusFactory,
+  statusFactoryState,
+} from '@/testing/factories';
 
-import Status from './index';
-import type { StatusComponent, StatusProps } from './types';
+import { TypedStatus } from './types';
+
+interface StatusStoryProps {
+  visibility: StatusVisibility;
+  isFavourited?: boolean;
+  isReblogged?: boolean;
+  isReply?: boolean;
+  isQuote?: boolean;
+  isPoll?: boolean;
+
+  attachments?: 'image-1' | 'image-2' | 'image-3' | 'video';
+  favouriteCount?: number;
+  reblogCount?: number;
+  replyCount?: number;
+
+  hasNextReply?: boolean;
+  disableActions?: boolean;
+}
+
+const StatusStoryComponent: FC<StatusStoryProps> = ({
+  visibility,
+  isReply,
+  isReblogged,
+  isFavourited,
+  isQuote,
+  isPoll,
+  hasNextReply,
+  favouriteCount = 0,
+  replyCount = 0,
+  reblogCount = 0,
+  disableActions = false,
+}) => {
+  const { account, status } = useMemo(() => {
+    const account = accountFactoryState();
+    return {
+      account,
+      status: statusFactoryState({
+        reblogged: isReblogged,
+        favourited: isFavourited,
+        visibility,
+        in_reply_to_account_id: isReply ? '2' : undefined,
+        in_reply_to_id: isReply ? '2' : undefined,
+        quote: isQuote
+          ? {
+              state: 'accepted',
+              quoted_status: { ...statusFactory(), quote: undefined },
+            }
+          : undefined,
+        favourites_count: favouriteCount,
+        reblogs_count: reblogCount,
+        replies_count: replyCount,
+      }).withMutations((status) => {
+        status.set('account', account);
+        if (isPoll) {
+          status.set('poll', '1');
+        }
+      }),
+    };
+  }, [
+    favouriteCount,
+    isFavourited,
+    isPoll,
+    isQuote,
+    isReblogged,
+    isReply,
+    reblogCount,
+    replyCount,
+    visibility,
+  ]);
+
+  return (
+    <TypedStatus
+      {...staticProps}
+      status={status}
+      account={account}
+      previousId={isReply ? '2' : undefined}
+      isQuotedPost={isQuote}
+      nextInReplyToId={hasNextReply ? '1' : undefined}
+      showActions={!disableActions}
+      showThread={isReply}
+    />
+  );
+};
+
+const staticProps = {
+  onReply: fn(),
+  onFavourite: fn(),
+  onMention: fn(),
+  onOpenMedia: fn(),
+  onOpenVideo: fn(),
+  onQuote: fn(),
+  onReblog: fn(),
+  onToggleCollapsed: fn(),
+  onToggleHidden: fn(),
+  onTranslate: fn(),
+  onAddFilter: fn(),
+  onBlock: fn(),
+  onClick: fn(),
+  onDelete: fn(),
+  onDirect: fn(),
+  onEmbed: fn(),
+  onHeightChange: fn(),
+  onInteractionModal: fn(),
+  onPin: fn(),
+  deployPictureInPicture: fn(),
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  pictureInPicture: ImmutableMap<'inUse' | 'available', boolean>({
+    inUse: false,
+    available: true,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Casting to solves infinite recursion errors.
+  }) as any,
+} as const;
 
 const meta = {
   title: 'Components/Status/Status',
-  args: {
-    status: statusFactoryState(),
-    account: accountFactoryState(),
-    onReply: fn(),
-    onFavourite: fn(),
-    onMention: fn(),
-    onOpenMedia: fn(),
-    onOpenVideo: fn(),
-    onQuote: fn(),
-    onReblog: fn(),
-    onToggleCollapsed: fn(),
-    onToggleHidden: fn(),
-    onTranslate: fn(),
-    onAddFilter: fn(),
-    onBlock: fn(),
-    onClick: fn(),
-    onDelete: fn(),
-    onDirect: fn(),
-    onEmbed: fn(),
-    onHeightChange: fn(),
-    onInteractionModal: fn(),
-    onPin: fn(),
-    deployPictureInPicture: fn(),
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    pictureInPicture: ImmutableMap<'inUse' | 'available', boolean>({
-      inUse: false,
-      available: true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Casting to solves infinite recursion errors.
-    }) as any,
-  } satisfies StatusProps,
-  render({ status, account, ...rest }) {
-    return (
-      <Status
-        {...rest}
-        status={status.set('account', account)}
-        account={account}
-      />
-    );
+  component: StatusStoryComponent,
+  argTypes: {
+    visibility: {
+      text: {
+        control: 'text',
+      },
+      control: 'inline-radio',
+      options: [
+        'direct',
+        'private',
+        'public',
+        'unlisted',
+      ] satisfies StatusVisibility[],
+    },
   },
-} satisfies Meta<StatusComponent>;
+  args: {
+    visibility: 'public',
+    isQuote: false,
+    isReply: false,
+    isFavourited: false,
+    isPoll: false,
+    isReblogged: false,
+    hasNextReply: false,
+    favouriteCount: 0,
+    reblogCount: 0,
+    replyCount: 0,
+    disableActions: false,
+  } satisfies StatusStoryProps,
+  parameters: {
+    state: {
+      polls: {
+        '1': pollFactory(),
+      },
+    },
+  },
+} satisfies Meta<typeof StatusStoryComponent>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const Reply: Story = {
+  args: {
+    isReply: true,
+  },
+};

--- a/app/javascript/mastodon/components/status/status.stories.tsx
+++ b/app/javascript/mastodon/components/status/status.stories.tsx
@@ -179,6 +179,7 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
         muted={muted}
         hidden={hidden && !contentWarning && !hasFilter}
         skipPrepend={!showPrepend}
+        withDismiss={contextType === 'notifications'}
       />
     </div>
   );
@@ -355,6 +356,9 @@ const meta = {
           },
         },
       },
+    },
+    controls: {
+      disableSaveFromUI: true,
     },
   },
 } satisfies Meta<typeof StatusStoryComponent>;

--- a/app/javascript/mastodon/components/status/status.stories.tsx
+++ b/app/javascript/mastodon/components/status/status.stories.tsx
@@ -42,16 +42,19 @@ interface StatusStoryProps {
   // Interactions
   hasFavourited?: boolean;
   hasReblogged?: boolean;
+  hasBookmarked?: boolean;
+  hasReplied?: boolean;
   hasVoted?: boolean;
-  favouriteCount?: number;
-  reblogCount?: number;
-  replyCount?: number;
+  disableActions?: boolean;
+  showTranslate?: boolean;
 
   // Display
   showThread?: boolean;
   contextType?: ContextTypes;
-  disableActions?: boolean;
-  showTranslate?: boolean;
+  showCounters?: boolean;
+  favouriteCount?: number;
+  reblogCount?: number;
+  replyCount?: number;
 }
 
 const otherAccount = accountFactoryState({
@@ -71,14 +74,15 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
     hasFavourited,
     hasReblogged,
     hasVoted,
-    favouriteCount = 0,
-    replyCount = 0,
-    reblogCount = 0,
+    showTranslate,
     disableActions = false,
 
     contextType,
-    showTranslate,
     showThread,
+    showCounters,
+    favouriteCount = 0,
+    replyCount = 0,
+    reblogCount = 0,
   } = props;
   const { account, status } = useMemo(() => {
     const account = accountFactoryState();
@@ -105,6 +109,12 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
         status.set('account', account);
         status.set('matched_filters', false);
         status.set('matched_media_filters', false);
+
+        // StatusActionBar checks specifically for null so undefined doesn't work.
+        if (!status.get('in_reply_to_id')) {
+          status.set('in_reply_to_id', null);
+        }
+
         if (isReblog) {
           status.set(
             'reblog',
@@ -142,6 +152,7 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
         isQuotedPost={isQuote}
         showActions={!disableActions}
         contextType={contextType}
+        withCounters={showCounters}
         // Either we are showing a thread (in a timeline) or it's a full reply chain view.
         showThread={isReply && showThread}
         previousId={isReply && !showThread ? '2' : undefined}
@@ -211,6 +222,7 @@ const meta = {
   title: 'Components/Status/Status',
   component: StatusStoryComponent,
   argTypes: {
+    // Contents
     visibility: {
       ...categoryContents,
       control: 'inline-radio',
@@ -227,6 +239,7 @@ const meta = {
     isQuote: categoryContents,
     text: categoryContents,
 
+    // Interactions
     hasFavourited: categoryInteraction,
     hasReblogged: categoryInteraction,
     hasVoted: {
@@ -236,12 +249,14 @@ const meta = {
         truthy: true,
       },
     },
-    favouriteCount: categoryInteraction,
-    reblogCount: categoryInteraction,
-    replyCount: categoryInteraction,
     disableActions: categoryInteraction,
     showTranslate: categoryInteraction,
 
+    // Display
+    showCounters: categoryDisplay,
+    favouriteCount: categoryDisplay,
+    reblogCount: categoryDisplay,
+    replyCount: categoryDisplay,
     showThread: categoryDisplay,
     contextType: {
       ...categoryDisplay,
@@ -262,20 +277,23 @@ const meta = {
   args: {
     text: 'This is a status',
     visibility: 'public',
-    contextType: 'home',
     isReblog: false,
     isReply: false,
     isPoll: false,
     isQuote: false,
+
     hasFavourited: false,
     hasVoted: false,
     hasReblogged: false,
-    showThread: false,
+    disableActions: false,
     showTranslate: false,
+
     favouriteCount: 0,
     reblogCount: 0,
     replyCount: 0,
-    disableActions: false,
+    showCounters: true,
+    contextType: 'home',
+    showThread: false,
   } satisfies StatusStoryProps,
   parameters: {
     state: {

--- a/app/javascript/mastodon/components/status/status.stories.tsx
+++ b/app/javascript/mastodon/components/status/status.stories.tsx
@@ -16,31 +16,53 @@ import {
 
 import { TypedStatus } from './types';
 
+type ContextTypes =
+  | 'account'
+  | 'bookmarks'
+  | 'detailed'
+  | 'favourites'
+  | 'home'
+  | 'notifications'
+  | 'public'
+  | 'search'
+  | 'thread';
+
+type AttachmentTypes = 'image-1' | 'image-2' | 'image-3' | 'video' | 'audio';
+
 interface StatusStoryProps {
+  // Contents
+  text: string;
   visibility: StatusVisibility;
-  isFavourited?: boolean;
-  isReblogged?: boolean;
   isReply?: boolean;
   isQuote?: boolean;
   isPoll?: boolean;
+  attachments?: AttachmentTypes;
 
-  attachments?: 'image-1' | 'image-2' | 'image-3' | 'video';
+  // Interactions
+  hasFavourited?: boolean;
+  hasReblogged?: boolean;
+  hasVoted?: boolean;
   favouriteCount?: number;
   reblogCount?: number;
   replyCount?: number;
 
+  // Display
   hasNextReply?: boolean;
+  contextType?: ContextTypes;
   disableActions?: boolean;
 }
 
 const StatusStoryComponent: FC<StatusStoryProps> = ({
+  text,
   visibility,
   isReply,
-  isReblogged,
-  isFavourited,
+  hasReblogged: isReblogged,
+  hasFavourited: isFavourited,
   isQuote,
   isPoll,
+  hasVoted,
   hasNextReply,
+  contextType,
   favouriteCount = 0,
   replyCount = 0,
   reblogCount = 0,
@@ -51,6 +73,7 @@ const StatusStoryComponent: FC<StatusStoryProps> = ({
     return {
       account,
       status: statusFactoryState({
+        text,
         reblogged: isReblogged,
         favourited: isFavourited,
         visibility,
@@ -68,12 +91,13 @@ const StatusStoryComponent: FC<StatusStoryProps> = ({
       }).withMutations((status) => {
         status.set('account', account);
         if (isPoll) {
-          status.set('poll', '1');
+          status.set('poll', hasVoted ? '2' : '1');
         }
       }),
     };
   }, [
     favouriteCount,
+    hasVoted,
     isFavourited,
     isPoll,
     isQuote,
@@ -81,6 +105,7 @@ const StatusStoryComponent: FC<StatusStoryProps> = ({
     isReply,
     reblogCount,
     replyCount,
+    text,
     visibility,
   ]);
 
@@ -94,37 +119,64 @@ const StatusStoryComponent: FC<StatusStoryProps> = ({
       nextInReplyToId={hasNextReply ? '1' : undefined}
       showActions={!disableActions}
       showThread={isReply}
+      contextType={contextType}
     />
   );
 };
 
-const staticProps = {
-  onReply: fn(),
-  onFavourite: fn(),
-  onMention: fn(),
-  onOpenMedia: fn(),
-  onOpenVideo: fn(),
-  onQuote: fn(),
-  onReblog: fn(),
-  onToggleCollapsed: fn(),
-  onToggleHidden: fn(),
-  onTranslate: fn(),
-  onAddFilter: fn(),
-  onBlock: fn(),
-  onClick: fn(),
-  onDelete: fn(),
-  onDirect: fn(),
-  onEmbed: fn(),
-  onHeightChange: fn(),
-  onInteractionModal: fn(),
-  onPin: fn(),
-  deployPictureInPicture: fn(),
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  pictureInPicture: ImmutableMap<'inUse' | 'available', boolean>({
-    inUse: false,
-    available: true,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Casting to solves infinite recursion errors.
-  }) as any,
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const staticProps = Object.fromEntries(
+  // As Storybook auto-names from args only,
+  // we need to manually name these for proper action tracking.
+  Object.entries({
+    onReply: fn(),
+    onFavourite: fn(),
+    onMention: fn(),
+    onOpenMedia: fn(),
+    onOpenVideo: fn(),
+    onQuote: fn(),
+    onReblog: fn(),
+    onToggleCollapsed: fn(),
+    onToggleHidden: fn(),
+    onTranslate: fn(),
+    onAddFilter: fn(),
+    onBlock: fn(),
+    onClick: fn(),
+    onDelete: fn(),
+    onDirect: fn(),
+    onEmbed: fn(),
+    onHeightChange: fn(),
+    onInteractionModal: fn(),
+    onPin: fn(),
+    deployPictureInPicture: fn(),
+  } as const)
+    .map(([key, value]) => [key, value.mockName(key)])
+    .concat([
+      [
+        'pictureInPicture',
+        ImmutableMap<'inUse' | 'available', boolean>({
+          inUse: false,
+          available: true,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Casting to solves infinite recursion errors.
+        }) as any,
+      ],
+    ]),
+);
+
+const categoryContents = {
+  table: {
+    category: 'contents',
+  },
+} as const;
+const categoryInteraction = {
+  table: {
+    category: 'interactions',
+  },
+} as const;
+const displayInteraction = {
+  table: {
+    category: 'display',
+  },
 } as const;
 
 const meta = {
@@ -132,9 +184,7 @@ const meta = {
   component: StatusStoryComponent,
   argTypes: {
     visibility: {
-      text: {
-        control: 'text',
-      },
+      ...categoryContents,
       control: 'inline-radio',
       options: [
         'direct',
@@ -143,14 +193,50 @@ const meta = {
         'unlisted',
       ] satisfies StatusVisibility[],
     },
+    isPoll: categoryContents,
+    isQuote: categoryContents,
+    isReply: categoryContents,
+    text: categoryContents,
+    contextType: {
+      ...displayInteraction,
+      control: 'select',
+      options: [
+        'account',
+        'bookmarks',
+        'detailed',
+        'favourites',
+        'home',
+        'notifications',
+        'public',
+        'search',
+        'thread',
+      ] satisfies ContextTypes[],
+    },
+    hasFavourited: categoryInteraction,
+    hasReblogged: categoryInteraction,
+    hasVoted: {
+      ...categoryInteraction,
+      if: {
+        arg: 'isPoll',
+        truthy: true,
+      },
+    },
+    favouriteCount: categoryInteraction,
+    reblogCount: categoryInteraction,
+    replyCount: categoryInteraction,
+    disableActions: displayInteraction,
+    hasNextReply: displayInteraction,
   },
   args: {
+    text: 'This is a status',
     visibility: 'public',
+    contextType: 'home',
     isQuote: false,
     isReply: false,
-    isFavourited: false,
+    hasFavourited: false,
     isPoll: false,
-    isReblogged: false,
+    hasVoted: false,
+    hasReblogged: false,
     hasNextReply: false,
     favouriteCount: 0,
     reblogCount: 0,
@@ -161,6 +247,12 @@ const meta = {
     state: {
       polls: {
         '1': pollFactory(),
+        '2': pollFactory({
+          voted: true,
+          voters_count: 1,
+          votes_count: 1,
+          own_votes: [0],
+        }),
       },
     },
   },
@@ -175,5 +267,22 @@ export const Default: Story = {};
 export const Reply: Story = {
   args: {
     isReply: true,
+  },
+};
+
+export const LongText: Story = {
+  args: {
+    text: [
+      'This is a long-form piece of text that wraps multiple lines.',
+      'It is here to test what a longer status looks like.',
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    ].join('\n'),
+  },
+};
+
+export const Poll: Story = {
+  args: {
+    isPoll: true,
   },
 };

--- a/app/javascript/mastodon/components/status/status.stories.tsx
+++ b/app/javascript/mastodon/components/status/status.stories.tsx
@@ -6,9 +6,11 @@ import { Map as ImmutableMap } from 'immutable';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
+import type { ApiMediaAttachmentJSON } from '@/mastodon/api_types/media_attachments';
 import type { StatusVisibility } from '@/mastodon/api_types/statuses';
 import {
   accountFactoryState,
+  mediaAttachmentFactory,
   pollFactory,
   statusFactory,
   statusFactoryState,
@@ -27,7 +29,14 @@ type ContextTypes =
   | 'search'
   | 'thread';
 
-type AttachmentTypes = 'image-1' | 'image-2' | 'image-3' | 'video' | 'audio';
+type AttachmentTypes =
+  | 'image-1'
+  | 'image-2'
+  | 'image-3'
+  | 'video'
+  | 'audio'
+  | 'gifv'
+  | 'unknown';
 
 interface StatusStoryProps {
   // Contents
@@ -75,6 +84,7 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
     isReply,
     isPoll,
     isQuote,
+    attachments,
     contentWarning,
 
     hasFavourited,
@@ -97,14 +107,109 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
   } = props;
   const { account, status } = useMemo(() => {
     const account = accountFactoryState();
+
+    const media_attachments: ApiMediaAttachmentJSON[] = [];
+    switch (attachments) {
+      // Use fall through add attachments depending on count.
+      case 'image-3':
+        media_attachments.push(
+          mediaAttachmentFactory({
+            id: '2',
+            url: 'https://cataas.com/cat/EbVq9zMc4Xxv7s73',
+            meta: {
+              original: {
+                width: 960,
+                height: 1280,
+                size: '960x1280',
+                aspect: 0.75,
+              },
+            },
+          }),
+        );
+      // eslint-disable-next-line no-fallthrough
+      case 'image-2':
+        media_attachments.push(
+          mediaAttachmentFactory({
+            id: '3',
+            url: 'https://cataas.com/cat/YFaQ4xWYoWURSz37',
+            meta: {
+              original: {
+                width: 964,
+                height: 1280,
+                size: '964x1280',
+                aspect: 0.753125,
+              },
+            },
+          }),
+        );
+      // eslint-disable-next-line no-fallthrough
+      case 'image-1':
+        media_attachments.push(
+          mediaAttachmentFactory({
+            id: '4',
+            url: 'https://cataas.com/cat/bYBTjiFUqjUPIBUD',
+            meta: {
+              original: {
+                width: 1280,
+                height: 964,
+                size: '1280x964',
+                aspect: 1.32780083,
+              },
+            },
+          }),
+        );
+        break;
+      case 'video':
+        media_attachments.push(
+          mediaAttachmentFactory({
+            type: 'video',
+            url: 'https://www.pexels.com/download/video/11760787/',
+            meta: {
+              original: {
+                width: 2160,
+                height: 4096,
+              },
+            },
+          }),
+        );
+        break;
+      case 'audio':
+        media_attachments.push(
+          mediaAttachmentFactory({
+            type: 'audio',
+            url: 'https://upload.wikimedia.org/wikipedia/commons/4/40/Elephant_voice_-_trumpeting.ogg',
+          }),
+        );
+        break;
+      case 'gifv':
+        media_attachments.push(
+          mediaAttachmentFactory({
+            type: 'gifv',
+            url: 'https://www.pexels.com/download/video/11760787/',
+            meta: {
+              original: {
+                width: 2160,
+                height: 4096,
+              },
+            },
+          }),
+        );
+        break;
+      case 'unknown':
+        media_attachments.push(mediaAttachmentFactory({ type: attachments }));
+        break;
+    }
+
     return {
       account,
       status: statusFactoryState({
         text,
+        spoiler_text: contentWarning,
+        visibility,
+        media_attachments,
         reblogged: hasReblogged,
         favourited: hasFavourited,
         bookmarked: hasBookmarked,
-        visibility,
         in_reply_to_account_id: isReply ? '2' : undefined,
         in_reply_to_id: isReply ? '2' : undefined,
         quote: isQuote
@@ -117,7 +222,6 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
         reblogs_count: reblogCount,
         replies_count: replyCount,
         language: showTranslate ? 'xx' : undefined,
-        spoiler_text: contentWarning,
       }).withMutations((status) => {
         status.set('account', account);
         status.set('matched_filters', hasFilter ? ['test'] : false);
@@ -141,18 +245,19 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
       }),
     };
   }, [
+    attachments,
     text,
+    contentWarning,
+    visibility,
     hasReblogged,
     hasFavourited,
     hasBookmarked,
-    visibility,
     isReply,
     isQuote,
     favouriteCount,
     reblogCount,
     replyCount,
     showTranslate,
-    contentWarning,
     hasFilter,
     hidden,
     isReblog,
@@ -260,6 +365,28 @@ const meta = {
     isPoll: categoryContents,
     isQuote: categoryContents,
     text: categoryContents,
+    attachments: {
+      ...categoryContents,
+      control: 'select',
+      options: [
+        'One image',
+        'Two images',
+        'Three images',
+        'Video',
+        'Audio',
+        'GIF',
+        'Other',
+      ],
+      mapping: {
+        'One image': 'image-1',
+        'Two images': 'image-2',
+        'Three images': 'image-3',
+        Video: 'video',
+        Audio: 'audio',
+        GIF: 'gifv',
+        Other: 'unknown',
+      } satisfies Record<string, AttachmentTypes>,
+    },
     contentWarning: categoryContents,
 
     // Interactions
@@ -316,6 +443,7 @@ const meta = {
     isPoll: false,
     isQuote: false,
     contentWarning: '',
+    attachments: undefined,
 
     hasFavourited: false,
     hasReblogged: false,

--- a/app/javascript/mastodon/components/status/status.stories.tsx
+++ b/app/javascript/mastodon/components/status/status.stories.tsx
@@ -1,0 +1,58 @@
+import { Map as ImmutableMap } from 'immutable';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { accountFactoryState, statusFactoryState } from '@/testing/factories';
+
+import Status from './index';
+import type { StatusComponent, StatusProps } from './types';
+
+const meta = {
+  title: 'Components/Status/Status',
+  args: {
+    status: statusFactoryState(),
+    account: accountFactoryState(),
+    onReply: fn(),
+    onFavourite: fn(),
+    onMention: fn(),
+    onOpenMedia: fn(),
+    onOpenVideo: fn(),
+    onQuote: fn(),
+    onReblog: fn(),
+    onToggleCollapsed: fn(),
+    onToggleHidden: fn(),
+    onTranslate: fn(),
+    onAddFilter: fn(),
+    onBlock: fn(),
+    onClick: fn(),
+    onDelete: fn(),
+    onDirect: fn(),
+    onEmbed: fn(),
+    onHeightChange: fn(),
+    onInteractionModal: fn(),
+    onPin: fn(),
+    deployPictureInPicture: fn(),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    pictureInPicture: ImmutableMap<'inUse' | 'available', boolean>({
+      inUse: false,
+      available: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Casting to solves infinite recursion errors.
+    }) as any,
+  } satisfies StatusProps,
+  render({ status, account, ...rest }) {
+    return (
+      <Status
+        {...rest}
+        status={status.set('account', account)}
+        account={account}
+      />
+    );
+  },
+} satisfies Meta<StatusComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/app/javascript/mastodon/components/status/status.stories.tsx
+++ b/app/javascript/mastodon/components/status/status.stories.tsx
@@ -73,6 +73,7 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
 
     hasFavourited,
     hasReblogged,
+    hasBookmarked,
     hasVoted,
     showTranslate,
     disableActions = false,
@@ -92,6 +93,7 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
         text,
         reblogged: hasReblogged,
         favourited: hasFavourited,
+        bookmarked: hasBookmarked,
         visibility,
         in_reply_to_account_id: isReply ? '2' : undefined,
         in_reply_to_id: isReply ? '2' : undefined,
@@ -130,6 +132,7 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
     text,
     hasReblogged,
     hasFavourited,
+    hasBookmarked,
     visibility,
     isReply,
     isQuote,
@@ -242,6 +245,7 @@ const meta = {
     // Interactions
     hasFavourited: categoryInteraction,
     hasReblogged: categoryInteraction,
+    hasBookmarked: categoryInteraction,
     hasVoted: {
       ...categoryInteraction,
       if: {
@@ -283,8 +287,9 @@ const meta = {
     isQuote: false,
 
     hasFavourited: false,
-    hasVoted: false,
     hasReblogged: false,
+    hasBookmarked: false,
+    hasVoted: false,
     disableActions: false,
     showTranslate: false,
 

--- a/app/javascript/mastodon/components/status/status.stories.tsx
+++ b/app/javascript/mastodon/components/status/status.stories.tsx
@@ -38,12 +38,14 @@ interface StatusStoryProps {
   isPoll?: boolean;
   isQuote?: boolean;
   attachments?: AttachmentTypes;
+  contentWarning?: string;
 
   // Interactions
   hasFavourited?: boolean;
   hasReblogged?: boolean;
   hasBookmarked?: boolean;
   hasReplied?: boolean;
+  hasFilter?: boolean;
   hasVoted?: boolean;
   disableActions?: boolean;
   showTranslate?: boolean;
@@ -55,6 +57,8 @@ interface StatusStoryProps {
   favouriteCount?: number;
   reblogCount?: number;
   replyCount?: number;
+  hidden?: boolean;
+  muted?: boolean;
 }
 
 const otherAccount = accountFactoryState({
@@ -70,10 +74,12 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
     isReply,
     isPoll,
     isQuote,
+    contentWarning,
 
     hasFavourited,
     hasReblogged,
     hasBookmarked,
+    hasFilter,
     hasVoted,
     showTranslate,
     disableActions = false,
@@ -84,6 +90,8 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
     favouriteCount = 0,
     replyCount = 0,
     reblogCount = 0,
+    hidden,
+    muted,
   } = props;
   const { account, status } = useMemo(() => {
     const account = accountFactoryState();
@@ -107,10 +115,12 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
         reblogs_count: reblogCount,
         replies_count: replyCount,
         language: showTranslate ? 'xx' : undefined,
+        spoiler_text: contentWarning,
       }).withMutations((status) => {
         status.set('account', account);
-        status.set('matched_filters', false);
-        status.set('matched_media_filters', false);
+        status.set('matched_filters', hasFilter ? ['test'] : false);
+        status.set('matched_media_filters', hasFilter ? ['test'] : false);
+        status.set('hidden', hidden);
 
         // StatusActionBar checks specifically for null so undefined doesn't work.
         if (!status.get('in_reply_to_id')) {
@@ -140,6 +150,9 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
     reblogCount,
     replyCount,
     showTranslate,
+    contentWarning,
+    hasFilter,
+    hidden,
     isReblog,
     isPoll,
     hasVoted,
@@ -161,6 +174,8 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
         previousId={isReply && !showThread ? '2' : undefined}
         rootId={isReply && !showThread ? '2' : undefined}
         nextInReplyToId={isReply && !showThread ? '1' : undefined}
+        muted={muted}
+        hidden={hidden && !contentWarning && !hasFilter}
       />
     </div>
   );
@@ -241,11 +256,13 @@ const meta = {
     isPoll: categoryContents,
     isQuote: categoryContents,
     text: categoryContents,
+    contentWarning: categoryContents,
 
     // Interactions
     hasFavourited: categoryInteraction,
     hasReblogged: categoryInteraction,
     hasBookmarked: categoryInteraction,
+    hasFilter: categoryInteraction,
     hasVoted: {
       ...categoryInteraction,
       if: {
@@ -277,6 +294,8 @@ const meta = {
         'thread',
       ] satisfies ContextTypes[],
     },
+    hidden: categoryDisplay,
+    muted: categoryDisplay,
   },
   args: {
     text: 'This is a status',
@@ -285,10 +304,12 @@ const meta = {
     isReply: false,
     isPoll: false,
     isQuote: false,
+    contentWarning: '',
 
     hasFavourited: false,
     hasReblogged: false,
     hasBookmarked: false,
+    hasFilter: false,
     hasVoted: false,
     disableActions: false,
     showTranslate: false,
@@ -299,6 +320,8 @@ const meta = {
     showCounters: true,
     contextType: 'home',
     showThread: false,
+    hidden: false,
+    muted: false,
   } satisfies StatusStoryProps,
   parameters: {
     state: {

--- a/app/javascript/mastodon/components/status/status.stories.tsx
+++ b/app/javascript/mastodon/components/status/status.stories.tsx
@@ -59,6 +59,7 @@ interface StatusStoryProps {
   replyCount?: number;
   hidden?: boolean;
   muted?: boolean;
+  showPrepend?: boolean;
 }
 
 const otherAccount = accountFactoryState({
@@ -92,6 +93,7 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
     reblogCount = 0,
     hidden,
     muted,
+    showPrepend = true,
   } = props;
   const { account, status } = useMemo(() => {
     const account = accountFactoryState();
@@ -176,6 +178,7 @@ const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
         nextInReplyToId={isReply && !showThread ? '1' : undefined}
         muted={muted}
         hidden={hidden && !contentWarning && !hasFilter}
+        skipPrepend={!showPrepend}
       />
     </div>
   );
@@ -278,7 +281,14 @@ const meta = {
     favouriteCount: categoryDisplay,
     reblogCount: categoryDisplay,
     replyCount: categoryDisplay,
-    showThread: categoryDisplay,
+    showPrepend: categoryDisplay,
+    showThread: {
+      ...categoryDisplay,
+      if: {
+        arg: 'showPrepend',
+        truthy: true,
+      },
+    },
     contextType: {
       ...categoryDisplay,
       control: 'select',
@@ -319,6 +329,7 @@ const meta = {
     replyCount: 0,
     showCounters: true,
     contextType: 'home',
+    showPrepend: true,
     showThread: false,
     hidden: false,
     muted: false,

--- a/app/javascript/mastodon/components/status/status.stories.tsx
+++ b/app/javascript/mastodon/components/status/status.stories.tsx
@@ -33,9 +33,10 @@ interface StatusStoryProps {
   // Contents
   text: string;
   visibility: StatusVisibility;
+  isReblog?: boolean;
   isReply?: boolean;
-  isQuote?: boolean;
   isPoll?: boolean;
+  isQuote?: boolean;
   attachments?: AttachmentTypes;
 
   // Interactions
@@ -47,35 +48,46 @@ interface StatusStoryProps {
   replyCount?: number;
 
   // Display
-  hasNextReply?: boolean;
+  showThread?: boolean;
   contextType?: ContextTypes;
   disableActions?: boolean;
+  showTranslate?: boolean;
 }
 
-const StatusStoryComponent: FC<StatusStoryProps> = ({
-  text,
-  visibility,
-  isReply,
-  hasReblogged: isReblogged,
-  hasFavourited: isFavourited,
-  isQuote,
-  isPoll,
-  hasVoted,
-  hasNextReply,
-  contextType,
-  favouriteCount = 0,
-  replyCount = 0,
-  reblogCount = 0,
-  disableActions = false,
-}) => {
+const otherAccount = accountFactoryState({
+  id: '2',
+  display_name: 'Another user',
+});
+
+const StatusStoryComponent: FC<StatusStoryProps> = (props) => {
+  const {
+    text,
+    visibility,
+    isReblog,
+    isReply,
+    isPoll,
+    isQuote,
+
+    hasFavourited,
+    hasReblogged,
+    hasVoted,
+    favouriteCount = 0,
+    replyCount = 0,
+    reblogCount = 0,
+    disableActions = false,
+
+    contextType,
+    showTranslate,
+    showThread,
+  } = props;
   const { account, status } = useMemo(() => {
     const account = accountFactoryState();
     return {
       account,
       status: statusFactoryState({
         text,
-        reblogged: isReblogged,
-        favourited: isFavourited,
+        reblogged: hasReblogged,
+        favourited: hasFavourited,
         visibility,
         in_reply_to_account_id: isReply ? '2' : undefined,
         in_reply_to_id: isReply ? '2' : undefined,
@@ -88,39 +100,55 @@ const StatusStoryComponent: FC<StatusStoryProps> = ({
         favourites_count: favouriteCount,
         reblogs_count: reblogCount,
         replies_count: replyCount,
+        language: showTranslate ? 'xx' : undefined,
       }).withMutations((status) => {
         status.set('account', account);
+        status.set('matched_filters', false);
+        status.set('matched_media_filters', false);
+        if (isReblog) {
+          status.set(
+            'reblog',
+            statusFactoryState({ id: '2' }).set('account', otherAccount),
+          );
+        }
         if (isPoll) {
           status.set('poll', hasVoted ? '2' : '1');
         }
       }),
     };
   }, [
-    favouriteCount,
-    hasVoted,
-    isFavourited,
-    isPoll,
-    isQuote,
-    isReblogged,
+    text,
+    hasReblogged,
+    hasFavourited,
+    visibility,
     isReply,
+    isQuote,
+    favouriteCount,
     reblogCount,
     replyCount,
-    text,
-    visibility,
+    showTranslate,
+    isReblog,
+    isPoll,
+    hasVoted,
   ]);
 
   return (
-    <TypedStatus
-      {...staticProps}
-      status={status}
-      account={account}
-      previousId={isReply ? '2' : undefined}
-      isQuotedPost={isQuote}
-      nextInReplyToId={hasNextReply ? '1' : undefined}
-      showActions={!disableActions}
-      showThread={isReply}
-      contextType={contextType}
-    />
+    <div style={{ width: 'min(600px, 80vw)' }}>
+      <TypedStatus
+        {...staticProps}
+        key={JSON.stringify(props)} // Update on any props change. Required because Status has updateOnProps set.
+        status={status}
+        account={isReblog ? account : undefined}
+        isQuotedPost={isQuote}
+        showActions={!disableActions}
+        contextType={contextType}
+        // Either we are showing a thread (in a timeline) or it's a full reply chain view.
+        showThread={isReply && showThread}
+        previousId={isReply && !showThread ? '2' : undefined}
+        rootId={isReply && !showThread ? '2' : undefined}
+        nextInReplyToId={isReply && !showThread ? '1' : undefined}
+      />
+    </div>
   );
 };
 
@@ -173,7 +201,7 @@ const categoryInteraction = {
     category: 'interactions',
   },
 } as const;
-const displayInteraction = {
+const categoryDisplay = {
   table: {
     category: 'display',
   },
@@ -193,12 +221,30 @@ const meta = {
         'unlisted',
       ] satisfies StatusVisibility[],
     },
+    isReblog: categoryContents,
+    isReply: categoryContents,
     isPoll: categoryContents,
     isQuote: categoryContents,
-    isReply: categoryContents,
     text: categoryContents,
+
+    hasFavourited: categoryInteraction,
+    hasReblogged: categoryInteraction,
+    hasVoted: {
+      ...categoryInteraction,
+      if: {
+        arg: 'isPoll',
+        truthy: true,
+      },
+    },
+    favouriteCount: categoryInteraction,
+    reblogCount: categoryInteraction,
+    replyCount: categoryInteraction,
+    disableActions: categoryInteraction,
+    showTranslate: categoryInteraction,
+
+    showThread: categoryDisplay,
     contextType: {
-      ...displayInteraction,
+      ...categoryDisplay,
       control: 'select',
       options: [
         'account',
@@ -212,32 +258,20 @@ const meta = {
         'thread',
       ] satisfies ContextTypes[],
     },
-    hasFavourited: categoryInteraction,
-    hasReblogged: categoryInteraction,
-    hasVoted: {
-      ...categoryInteraction,
-      if: {
-        arg: 'isPoll',
-        truthy: true,
-      },
-    },
-    favouriteCount: categoryInteraction,
-    reblogCount: categoryInteraction,
-    replyCount: categoryInteraction,
-    disableActions: displayInteraction,
-    hasNextReply: displayInteraction,
   },
   args: {
     text: 'This is a status',
     visibility: 'public',
     contextType: 'home',
-    isQuote: false,
+    isReblog: false,
     isReply: false,
-    hasFavourited: false,
     isPoll: false,
+    isQuote: false,
+    hasFavourited: false,
     hasVoted: false,
     hasReblogged: false,
-    hasNextReply: false,
+    showThread: false,
+    showTranslate: false,
     favouriteCount: 0,
     reblogCount: 0,
     replyCount: 0,
@@ -245,6 +279,9 @@ const meta = {
   } satisfies StatusStoryProps,
   parameters: {
     state: {
+      accounts: {
+        '2': otherAccount,
+      },
       polls: {
         '1': pollFactory(),
         '2': pollFactory({
@@ -253,6 +290,13 @@ const meta = {
           votes_count: 1,
           own_votes: [0],
         }),
+      },
+      server: {
+        translationLanguages: {
+          item: {
+            xx: ['en', 'de', 'fr'],
+          },
+        },
       },
     },
   },

--- a/app/javascript/mastodon/components/status/types.ts
+++ b/app/javascript/mastodon/components/status/types.ts
@@ -1,16 +1,47 @@
 import type { ComponentClass, MouseEventHandler, ReactNode } from 'react';
 
 import type { Account } from '@/mastodon/models/account';
+import type { Status } from '@/mastodon/models/status';
 
 import type { StatusHeaderRenderFn } from './header';
 
 // Taken from the Status component.
 export interface StatusProps {
-  account?: Account;
+  status: Status;
+  account: Account;
   children?: ReactNode;
   previousId?: string;
+  nextInReplyToId?: string;
   rootId?: string;
   onClick?: MouseEventHandler<HTMLDivElement>;
+  onReply: (status: Status) => void;
+  onFavourite: (status: Status) => void;
+  onReblog: (status: Status, event?: unknown) => void;
+  onQuote: (status: Status) => void;
+  onDelete?: (status: Status) => void;
+  onDirect?: (status: Status) => void;
+  onMention: (account: Account) => void;
+  onPin?: (status: Status) => void;
+  onOpenMedia: (
+    statusId: string,
+    media: unknown,
+    index: number,
+    lang?: string,
+  ) => void;
+  onOpenVideo: (
+    statusId: string,
+    media: unknown,
+    lang?: string,
+    options?: unknown,
+  ) => void;
+  onBlock?: (status: Status) => void;
+  onAddFilter?: (status: Status) => void;
+  onEmbed?: (status: Status) => void;
+  onHeightChange?: () => void;
+  onToggleHidden: (status: Status) => void;
+  onToggleCollapsed: (status: Status, isCollapsed: boolean) => void;
+  onTranslate: (status: Status) => void;
+  onInteractionModal?: (type: string, status: Status) => void;
   muted?: boolean;
   hidden?: boolean;
   unread?: boolean;
@@ -26,9 +57,20 @@ export interface StatusProps {
   scrollKey?: string;
   skipPrepend?: boolean;
   avatarSize?: number;
+  deployPictureInPicture: (
+    status: Status,
+    type: string,
+    mediaProps: unknown,
+  ) => void;
   unfocusable?: boolean;
   headerRenderFn?: StatusHeaderRenderFn;
+  pictureInPicture: Immutable.Map<'inUse' | 'available', boolean>;
   contextType?: string;
+  history?: {
+    location: { pathname: string };
+    push: (path: string, state?: unknown) => void;
+    replace: (path: string, state?: unknown) => void;
+  };
 }
 
 export type StatusComponent = ComponentClass<

--- a/app/javascript/mastodon/components/status/types.ts
+++ b/app/javascript/mastodon/components/status/types.ts
@@ -3,8 +3,9 @@ import type { ComponentType, MouseEventHandler, ReactNode } from 'react';
 import type { Account as TAccount } from '@/mastodon/models/account';
 import type { Status as TStatus } from '@/mastodon/models/status';
 
+import Status from '../status';
+
 import type { StatusHeaderRenderFn } from './header';
-import Status from './index';
 
 // Taken from the Status component.
 export interface StatusProps {

--- a/app/javascript/mastodon/components/status/types.ts
+++ b/app/javascript/mastodon/components/status/types.ts
@@ -10,7 +10,7 @@ import type { StatusHeaderRenderFn } from './header';
 // Taken from the Status component.
 export interface StatusProps {
   status: TStatus;
-  account: TAccount;
+  account?: TAccount;
   children?: ReactNode;
   previousId?: string;
   nextInReplyToId?: string;
@@ -68,6 +68,7 @@ export interface StatusProps {
   headerRenderFn?: StatusHeaderRenderFn;
   pictureInPicture: Immutable.Map<'inUse' | 'available', boolean>;
   contextType?: string;
+  withCounters?: boolean;
 }
 
 export const TypedStatus = Status as ComponentType<StatusProps>;

--- a/app/javascript/mastodon/components/status/types.ts
+++ b/app/javascript/mastodon/components/status/types.ts
@@ -1,27 +1,28 @@
-import type { ComponentClass, MouseEventHandler, ReactNode } from 'react';
+import type { ComponentType, MouseEventHandler, ReactNode } from 'react';
 
-import type { Account } from '@/mastodon/models/account';
-import type { Status } from '@/mastodon/models/status';
+import type { Account as TAccount } from '@/mastodon/models/account';
+import type { Status as TStatus } from '@/mastodon/models/status';
 
 import type { StatusHeaderRenderFn } from './header';
+import Status from './index';
 
 // Taken from the Status component.
 export interface StatusProps {
-  status: Status;
-  account: Account;
+  status: TStatus;
+  account: TAccount;
   children?: ReactNode;
   previousId?: string;
   nextInReplyToId?: string;
   rootId?: string;
   onClick?: MouseEventHandler<HTMLDivElement>;
-  onReply: (status: Status) => void;
-  onFavourite: (status: Status) => void;
-  onReblog: (status: Status, event?: unknown) => void;
-  onQuote: (status: Status) => void;
-  onDelete?: (status: Status) => void;
-  onDirect?: (status: Status) => void;
-  onMention: (account: Account) => void;
-  onPin?: (status: Status) => void;
+  onReply: (status: TStatus) => void;
+  onFavourite: (status: TStatus) => void;
+  onReblog: (status: TStatus, event?: unknown) => void;
+  onQuote: (status: TStatus) => void;
+  onDelete?: (status: TStatus) => void;
+  onDirect?: (status: TStatus) => void;
+  onMention: (account: TAccount) => void;
+  onPin?: (status: TStatus) => void;
   onOpenMedia: (
     statusId: string,
     media: unknown,
@@ -34,14 +35,14 @@ export interface StatusProps {
     lang?: string,
     options?: unknown,
   ) => void;
-  onBlock?: (status: Status) => void;
-  onAddFilter?: (status: Status) => void;
-  onEmbed?: (status: Status) => void;
+  onBlock?: (status: TStatus) => void;
+  onAddFilter?: (status: TStatus) => void;
+  onEmbed?: (status: TStatus) => void;
   onHeightChange?: () => void;
-  onToggleHidden: (status: Status) => void;
-  onToggleCollapsed: (status: Status, isCollapsed: boolean) => void;
-  onTranslate: (status: Status) => void;
-  onInteractionModal?: (type: string, status: Status) => void;
+  onToggleHidden: (status: TStatus) => void;
+  onToggleCollapsed: (status: TStatus, isCollapsed: boolean) => void;
+  onTranslate: (status: TStatus) => void;
+  onInteractionModal?: (type: string, status: TStatus) => void;
   muted?: boolean;
   hidden?: boolean;
   unread?: boolean;
@@ -58,7 +59,7 @@ export interface StatusProps {
   skipPrepend?: boolean;
   avatarSize?: number;
   deployPictureInPicture: (
-    status: Status,
+    status: TStatus,
     type: string,
     mediaProps: unknown,
   ) => void;
@@ -73,7 +74,4 @@ export interface StatusProps {
   };
 }
 
-export type StatusComponent = ComponentClass<
-  StatusProps,
-  { showMedia?: boolean; showDespiteFilter?: boolean }
->;
+export const TypedStatus = Status as ComponentType<StatusProps>;

--- a/app/javascript/mastodon/components/status/types.ts
+++ b/app/javascript/mastodon/components/status/types.ts
@@ -68,11 +68,6 @@ export interface StatusProps {
   headerRenderFn?: StatusHeaderRenderFn;
   pictureInPicture: Immutable.Map<'inUse' | 'available', boolean>;
   contextType?: string;
-  history?: {
-    location: { pathname: string };
-    push: (path: string, state?: unknown) => void;
-    replace: (path: string, state?: unknown) => void;
-  };
 }
 
 export const TypedStatus = Status as ComponentType<StatusProps>;

--- a/app/javascript/mastodon/utils/types.ts
+++ b/app/javascript/mastodon/utils/types.ts
@@ -21,9 +21,13 @@ export type OmitValueType<T, V> = {
   [K in keyof T as T[K] extends V ? never : K]: T[K];
 };
 
-export type AnyFunction = (...args: never) => unknown;
-
 export type OmitUnion<TUnion, TBase> = TBase & Omit<TUnion, keyof TBase>;
+
+export type PickValueType<T, V> = {
+  [K in keyof T as T[K] extends V | undefined ? K : never]: T[K];
+};
+
+export type AnyFunction = (...args: never) => unknown;
 
 export type SnakeToCamelCase<S extends string> =
   S extends `${infer T}_${infer U}`

--- a/app/javascript/mastodon/utils/types.ts
+++ b/app/javascript/mastodon/utils/types.ts
@@ -11,6 +11,12 @@
  * type PersonWithSomeOptional = SomeOptional<Person, 'name' >;
  */
 
+export type DeepPartial<T> = T extends object
+  ? {
+      [K in keyof T]?: DeepPartial<T[K]>;
+    }
+  : T;
+
 export type SomeRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
 export type SomeOptional<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>> &
   Partial<Pick<T, K>>;

--- a/app/javascript/testing/factories.ts
+++ b/app/javascript/testing/factories.ts
@@ -1,5 +1,6 @@
-import { Map as ImmutableMap, List } from 'immutable';
+import { fromJS } from 'immutable';
 
+import { normalizeStatus } from '@/mastodon/actions/importer/statuses';
 import type { ApiPollJSON } from '@/mastodon/api_types/polls';
 import type { ApiRelationshipJSON } from '@/mastodon/api_types/relationships';
 import type { ApiStatusJSON } from '@/mastodon/api_types/statuses';
@@ -88,18 +89,17 @@ export const statusFactory: FactoryFunction<ApiStatusJSON> = ({
   tags: [],
   emojis: [],
   tagged_collections: [],
-  contentHtml: data.text ?? '<p>This is a test status.</p>',
+  contentHtml:
+    data.text
+      ?.split('\n')
+      .map((line) => `<p>${line}</p>`)
+      .join('\n') ?? '<p>This is a test status.</p>',
   ...data,
 });
 
 export const statusFactoryState = (
   options: FactoryOptions<ApiStatusJSON> = {},
-) =>
-  ImmutableMap<string, unknown>({
-    ...(statusFactory(options) as unknown as Record<string, unknown>),
-    account: options.account?.id ?? '1',
-    tags: List(options.tags),
-  }) as unknown as Status;
+) => fromJS(normalizeStatus(statusFactory(options))) as unknown as Status;
 
 export const pollFactory: FactoryFunction<ApiPollJSON> = (data = {}) => ({
   id: '1',

--- a/app/javascript/testing/factories.ts
+++ b/app/javascript/testing/factories.ts
@@ -89,7 +89,7 @@ export const statusFactory: FactoryFunction<ApiStatusJSON> = ({
   tags: [],
   emojis: [],
   tagged_collections: [],
-  contentHtml:
+  content:
     data.text
       ?.split('\n')
       .map((line) => `<p>${line}</p>`)

--- a/app/javascript/testing/factories.ts
+++ b/app/javascript/testing/factories.ts
@@ -1,6 +1,14 @@
 import { fromJS } from 'immutable';
 
 import { normalizeStatus } from '@/mastodon/actions/importer/statuses';
+import type {
+  ApiAudioAttachmentJSON,
+  ApiGifvAttachmentJSON,
+  ApiImageAttachmentJSON,
+  ApiMediaAttachmentJSON,
+  ApiVideoAttachmentJSON,
+  BaseApiMediaAttachmentJSON,
+} from '@/mastodon/api_types/media_attachments';
 import type { ApiPollJSON } from '@/mastodon/api_types/polls';
 import type { ApiRelationshipJSON } from '@/mastodon/api_types/relationships';
 import type { ApiStatusJSON } from '@/mastodon/api_types/statuses';
@@ -11,6 +19,7 @@ import type {
 import { createAccountFromServerJSON } from '@/mastodon/models/account';
 import type { AnnualReport } from '@/mastodon/models/annual_report';
 import type { Status } from '@/mastodon/models/status';
+import type { DeepPartial } from '@/mastodon/utils/types';
 import type { ApiAccountJSON } from 'mastodon/api_types/accounts';
 
 type FactoryOptions<T> = {
@@ -100,6 +109,120 @@ export const statusFactory: FactoryFunction<ApiStatusJSON> = ({
 export const statusFactoryState = (
   options: FactoryOptions<ApiStatusJSON> = {},
 ) => fromJS(normalizeStatus(statusFactory(options))) as unknown as Status;
+
+const baseAttachment = {
+  id: '1',
+  url: 'https://example.com/image/1',
+  preview_url: 'https://example.com/image/1/preview',
+  blurhash: '',
+} as const;
+const imageMeta = {
+  width: 100,
+  height: 100,
+  aspect: 1,
+  size: '100x100',
+} as const;
+const videoMeta = {
+  width: 100,
+  height: 100,
+  frame_rate: '24',
+  duration: 120,
+  bitrate: 100,
+} as const;
+const colorsMeta = {
+  background: '#ffffff',
+  foreground: '#000000',
+  accent: '#ff0000',
+} as const;
+
+type MediaFactoryArg<T extends BaseApiMediaAttachmentJSON> = Omit<
+  DeepPartial<T>,
+  'type'
+>;
+
+export const imageAttachmentFactory = (
+  data: MediaFactoryArg<ApiImageAttachmentJSON> = {},
+): ApiImageAttachmentJSON => ({
+  ...baseAttachment,
+  ...data,
+  type: 'image',
+  meta: {
+    original: { ...imageMeta, ...data.meta?.original },
+    small: { ...imageMeta, ...data.meta?.small },
+  },
+});
+
+export const videoAttachmentFactory = (
+  data: MediaFactoryArg<ApiVideoAttachmentJSON> = {},
+): ApiVideoAttachmentJSON => ({
+  ...baseAttachment,
+  ...data,
+  type: 'video',
+  meta: {
+    colors: { ...colorsMeta, ...data.meta?.colors },
+    original: { ...videoMeta, ...data.meta?.original },
+    small: { ...imageMeta, ...data.meta?.small },
+    focus: {
+      x: 0,
+      y: 0,
+      ...data.meta?.focus,
+    },
+  },
+});
+
+export const audioAttachmentFactory = (
+  data: MediaFactoryArg<ApiAudioAttachmentJSON> = {},
+): ApiAudioAttachmentJSON => ({
+  ...baseAttachment,
+  ...data,
+  type: 'audio',
+  meta: {
+    colors: { ...colorsMeta, ...data.meta?.colors },
+    original: { ...videoMeta, ...data.meta?.original },
+    small: { ...imageMeta, ...data.meta?.small },
+  },
+});
+
+export const gifvAttachmentFactory = (
+  data: MediaFactoryArg<ApiGifvAttachmentJSON> = {},
+): ApiGifvAttachmentJSON => ({
+  ...baseAttachment,
+  ...data,
+  type: 'gifv',
+  meta: {
+    original: { ...videoMeta, ...data.meta?.original },
+    small: { ...imageMeta, ...data.meta?.small },
+  },
+});
+
+export function mediaAttachmentFactory(
+  data: DeepPartial<ApiMediaAttachmentJSON> = {},
+): ApiMediaAttachmentJSON {
+  switch (data.type ?? 'image') {
+    case 'image':
+      return imageAttachmentFactory(
+        data as DeepPartial<ApiImageAttachmentJSON>,
+      );
+    case 'video':
+      return videoAttachmentFactory(
+        data as DeepPartial<ApiVideoAttachmentJSON>,
+      );
+    case 'audio':
+      return audioAttachmentFactory(
+        data as DeepPartial<ApiAudioAttachmentJSON>,
+      );
+    case 'gifv':
+      return gifvAttachmentFactory(data as DeepPartial<ApiGifvAttachmentJSON>);
+    default: {
+      return {
+        ...baseAttachment,
+        meta: {},
+        ...data,
+        type: 'unknown',
+      };
+    }
+  }
+}
 
 export const pollFactory: FactoryFunction<ApiPollJSON> = (data = {}) => ({
   id: '1',

--- a/app/javascript/testing/factories.ts
+++ b/app/javascript/testing/factories.ts
@@ -1,5 +1,6 @@
 import { Map as ImmutableMap, List } from 'immutable';
 
+import type { ApiPollJSON } from '@/mastodon/api_types/polls';
 import type { ApiRelationshipJSON } from '@/mastodon/api_types/relationships';
 import type { ApiStatusJSON } from '@/mastodon/api_types/statuses';
 import type {
@@ -99,6 +100,28 @@ export const statusFactoryState = (
     account: options.account?.id ?? '1',
     tags: List(options.tags),
   }) as unknown as Status;
+
+export const pollFactory: FactoryFunction<ApiPollJSON> = (data = {}) => ({
+  id: '1',
+  expires_at: '',
+  expired: false,
+  multiple: false,
+  voters_count: 0,
+  votes_count: 0,
+  voted: false,
+  options: [
+    {
+      title: 'Option 1',
+      votes_count: 0,
+    },
+    {
+      title: 'Option 2',
+      votes_count: 0,
+    },
+  ],
+  emojis: [],
+  ...data,
+});
 
 export const relationshipsFactory: FactoryFunction<ApiRelationshipJSON> = ({
   id,


### PR DESCRIPTION
Related to WEB-742.

This adds some stories for the Status component. This doesn't cover all edge cases, but it covers some of the main Status use cases.

Remaining:
- [ ] Cards
- [ ] Mentions
- [ ] Custom emojis
- [ ] Collections
- [ ] Tags