### PR TITLE
Fix #39489 - NoMethod in sidekiq appeal_rejected job

### DIFF
--- a/app/controllers/admin/disputes/appeals_controller.rb
+++ b/app/controllers/admin/disputes/appeals_controller.rb
@@ -21,7 +21,7 @@ class Admin::Disputes::AppealsController < Admin::BaseController
     authorize @appeal, :reject?
     log_action :reject, @appeal
     @appeal.reject!(current_account)
-    UserMailer.appeal_rejected(@appeal.account.user, @appeal).deliver_later
+    UserMailer.appeal_rejected(@appeal.account.user, @appeal).deliver_later if @appeal.account.user.present?
     redirect_to disputes_strike_path(@appeal.strike)
   end
 

--- a/app/controllers/admin/disputes/appeals_controller.rb
+++ b/app/controllers/admin/disputes/appeals_controller.rb
@@ -21,7 +21,7 @@ class Admin::Disputes::AppealsController < Admin::BaseController
     authorize @appeal, :reject?
     log_action :reject, @appeal
     @appeal.reject!(current_account)
-    UserMailer.appeal_rejected(@appeal.account.user, @appeal).deliver_later if @appeal.account.user.present?
+    UserMailer.appeal_rejected(@appeal.account.user, @appeal).deliver_later
     redirect_to disputes_strike_path(@appeal.strike)
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -172,6 +172,8 @@ class UserMailer < Devise::Mailer
   end
 
   def appeal_approved(user, appeal)
+    return if user.nil?
+
     @resource = user
     @appeal   = appeal
 
@@ -181,6 +183,8 @@ class UserMailer < Devise::Mailer
   end
 
   def appeal_rejected(user, appeal)
+    return if user.nil?
+
     @resource = user
     @appeal   = appeal
 


### PR DESCRIPTION
Fix #39489

This might resolve the failed sidekiq job, but I haven't confirmed the actual root cause... I'm guessing this is happening when a moderator rejects an appeal after the account has been deleted?