### PR TITLE
Reduce setup step timeout, increase overall timeout

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -76,7 +76,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     needs:
       - build
@@ -142,6 +142,7 @@ jobs:
           tar xvzf artifacts.tar.gz
 
       - name: Set up Ruby environment
+        timeout-minutes: 15
         uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version}}
@@ -178,7 +179,7 @@ jobs:
   test-e2e:
     name: End to End testing
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     needs:
       - build
@@ -238,6 +239,7 @@ jobs:
 
       - name: Set up Ruby environment
         uses: ./.github/actions/setup-ruby
+        timeout-minutes: 15
         with:
           ruby-version: ${{ matrix.ruby-version}}
           additional-system-dependencies: ffmpeg
@@ -282,7 +284,7 @@ jobs:
   test-search:
     name: Elastic Search integration testing
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     needs:
       - build
@@ -373,6 +375,7 @@ jobs:
 
       - name: Set up Ruby environment
         uses: ./.github/actions/setup-ruby
+        timeout-minutes: 15
         with:
           ruby-version: ${{ matrix.ruby-version}}
           additional-system-dependencies: ffmpeg


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/39205#issuecomment-4742194971

The idea here is to allow runs which were slow to do setup but did complete setup not get cancelled if they are about to finish. Nudging up overall allowed time, while adding narrower timeout to just the ruby download/build step.

(Putting this inside the custom action itself is not supported ... has to go on job/step level)