### PR TITLE
Add coverage for missing user scenario in user/appeal mailers

### DIFF
--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -210,6 +210,15 @@ RSpec.describe UserMailer do
       expect(mail.text_part.body)
         .to match(I18n.t('user_mailer.appeal_approved.title'))
     end
+
+    context 'when user is missing' do
+      let(:mail) { described_class.appeal_approved(nil, appeal) }
+
+      it 'handles missing value without sending' do
+        expect { mail.deliver }
+          .to_not send_email
+      end
+    end
   end
 
   describe '#appeal_rejected' do
@@ -221,6 +230,15 @@ RSpec.describe UserMailer do
         .to send_email(subject: I18n.t('user_mailer.appeal_rejected.subject', date: I18n.l(appeal.created_at)))
       expect(mail.text_part.body)
         .to match(I18n.t('user_mailer.appeal_rejected.title'))
+    end
+
+    context 'when user is missing' do
+      let(:mail) { described_class.appeal_rejected(nil, appeal) }
+
+      it 'handles missing value without sending' do
+        expect { mail.deliver }
+          .to_not send_email
+      end
     end
   end
 


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/39490 which merged before feedback could be addressed.

If we wanted to expand this handling to more methods in this mailer, and/or more mailers - I'd probably do something like the `rescue_from` we have in the notification mailer to allow the `raise` to kill the sending, and then just exit to avoid a requeue.

