### PR TITLE
Refer to correct scope from `User.matches_ip` and expand `InetContainer` coverage

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,7 +110,7 @@ class User < ApplicationRecord
   scope :disabled, -> { where(disabled: true) }
   scope :active, -> { confirmed.signed_in_recently.account_not_suspended }
   scope :matches_email, ->(value) { where(arel_table[:email].matches("#{value}%")) }
-  scope :matches_ip, ->(value) { left_joins(:ips).merge(IpBlock.contained_by(value)).group(users: [:id]) }
+  scope :matches_ip, ->(value) { left_joins(:ips).merge(UserIp.contained_by(value)).group(users: [:id]) }
 
   before_validation :sanitize_role
   before_create :set_approved

--- a/spec/models/ip_block_spec.rb
+++ b/spec/models/ip_block_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe IpBlock do
   it_behaves_like 'Expireable'
+  it_behaves_like 'InetContainer'
 
   describe 'Validations' do
     subject { Fabricate.build :ip_block }

--- a/spec/models/user_ip_spec.rb
+++ b/spec/models/user_ip_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserIp do
+  describe 'Scopes' do
+    describe '.by_latest_used' do
+      let!(:user) { Fabricate :user, sign_up_ip: '192.168.0.1', created_at: 15.days.ago }
+      let!(:other_user) { Fabricate :user, sign_up_ip: '10.0.10.0', created_at: 10.days.ago }
+
+      it 'returns records ordered by most recent usage' do
+        expect(described_class.by_latest_used)
+          .to eq([other_user.ips.last, user.ips.last])
+      end
+    end
+
+    describe '.contained_by' do
+      let!(:user) { Fabricate :user, sign_up_ip: '192.168.0.1' }
+      let!(:other_user) { Fabricate :user, sign_up_ip: '10.0.10.0' }
+
+      it 'returns records ordered by rank' do
+        expect(described_class.contained_by('192.168.0.0/24'))
+          .to include(user.ips.last)
+          .and not_include(other_user.ips.last)
+      end
+    end
+  end
+end

--- a/spec/support/examples/models/concerns/inet_container.rb
+++ b/spec/support/examples/models/concerns/inet_container.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'InetContainer' do
+  describe 'Scopes' do
+    describe '.containing' do
+      let!(:contained) { Fabricate factory_name, ip: '192.168.0.0/24' }
+      let!(:uncontained) { Fabricate factory_name, ip: '10.0.0.0/16' }
+
+      it 'returns records containing the value' do
+        expect(described_class.containing('192.168.0.1'))
+          .to include(contained)
+          .and not_include(uncontained)
+      end
+    end
+
+    describe '.contained_by' do
+      let!(:contained) { Fabricate factory_name, ip: '192.168.0.1' }
+      let!(:uncontained) { Fabricate factory_name, ip: '10.0.10.0' }
+
+      it 'returns records contained by the value' do
+        expect(described_class.contained_by('192.168.0.0/24'))
+          .to include(contained)
+          .and not_include(uncontained)
+      end
+    end
+
+    describe '.overlapping_with' do
+      let!(:contained) { Fabricate factory_name, ip: '192.168.0.0/16' }
+      let!(:contained_also) { Fabricate factory_name, ip: '192.168.0.1' }
+      let!(:uncontained) { Fabricate factory_name, ip: '10.0.10.0' }
+
+      it 'returns records containing or contained by the value' do
+        expect(described_class.overlapping_with('192.168.0.0/24'))
+          .to include(contained)
+          .and include(contained_also)
+          .and not_include(uncontained)
+      end
+    end
+  end
+
+  def factory_name
+    described_class.name.underscore.to_sym
+  end
+end


### PR DESCRIPTION
During review of https://github.com/mastodon/mastodon/pull/39404 I expected to find this concern spec and did not, so adding here.

Mix of related changes:

- https://github.com/mastodon/mastodon/pull/32802 had a small error/oversight, which is that user model was calling `IpBlock` scope instead of `UserIp` scope. Practically speaking this didn't matter, because the scopes generate string queries so the output was the same ... but it seems more correct/futureproof to have it use the scope more relevant to what it is joining against? Updated user model to do that.
- Add concern specs for `InetContainer`
- Add model spec for `UserIp` ... this can't just include the shared example because its a DB view so the factory generation stuff would not work the same way. `IpBlock` uses all the scopes but `UserIp` only uses `contained_by`.

Possible followups:

- The new "overlapping" scope could probably "or" the other ones instead of repeating?
- There's a `to_s` call on many caller locations using these scopes ... we could move that into the scope itself to make the call sites slightly cleaner
- Could contemplate how to handle both the view and factory style of record prep for the shared example

Let me know if better split into smaller parts.