### PR TITLE
Fix fetching unknown key when it's not the actor's first, and add error handling for unavailable keys

### DIFF
--- a/app/services/activitypub/fetch_remote_key_service.rb
+++ b/app/services/activitypub/fetch_remote_key_service.rb
@@ -77,6 +77,6 @@ class ActivityPub::FetchRemoteKeyService < BaseService
   end
 
   def confirmed_owner?
-    value_or_id(@owner['publicKey']) == @json['id']
+    as_array(@owner['publicKey']).map { |value| value_or_id(value) }.include?(@json['id'])
   end
 end

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -290,6 +290,7 @@ class ActivityPub::ProcessAccountService < BaseService
 
       # Key is fetched without ID validation because of a GoToSocial bug
       value = fetch_resource_without_id_validation(key_id)
+      next if value.blank?
 
       # Special handling for GoToSocial which returns the whole actor for the key ID
       value = first_of_value(value['publicKey']) if value.is_a?(Hash) && value.key?('publicKey')

--- a/spec/services/activitypub/fetch_remote_key_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_key_service_spec.rb
@@ -81,6 +81,25 @@ RSpec.describe ActivityPub::FetchRemoteKeyService do
         expect(keypair.uri).to eq public_key_id
         expect(keypair.public_key).to eq public_key_pem
       end
+
+      context 'when there are multiple keys' do
+        let(:actor_public_key) do
+          [
+            'https://example.com/unavailable-key.json',
+            public_key_id,
+          ]
+        end
+
+        before do
+          stub_request(:get, 'https://example.com/unavailable-key.json').to_return(status: 404)
+        end
+
+        it 'returns the expected account' do
+          expect(keypair.account.uri).to eq 'https://example.com/alice'
+          expect(keypair.uri).to eq public_key_id
+          expect(keypair.public_key).to eq public_key_pem
+        end
+      end
     end
 
     context 'when the key and owner do not match' do


### PR DESCRIPTION
Found this issue while working on #39497. Requires a backport to stable-4.6.

For owner verification, it was assuming the owner had a single key.