### PR TITLE
Fix custom profile field overflow

### DIFF
--- a/app/javascript/mastodon/components/account_header/fields.tsx
+++ b/app/javascript/mastodon/components/account_header/fields.tsx
@@ -337,10 +337,12 @@ function useFieldOverflow() {
     if (!wrapperEle) return;
 
     const wrapperStyles = getComputedStyle(wrapperEle);
-    const maxWidth =
-      wrapperEle.offsetWidth -
-      (parseFloat(wrapperStyles.paddingLeft) +
-        parseFloat(wrapperStyles.paddingRight));
+    const nonContentWidth =
+      parseFloat(wrapperStyles.paddingLeft) +
+      parseFloat(wrapperStyles.paddingRight) +
+      parseFloat(wrapperStyles.borderLeftWidth) +
+      parseFloat(wrapperStyles.borderRightWidth);
+    const availableContentWidth = wrapperEle.offsetWidth - nonContentWidth;
 
     const label = wrapperEle.querySelector<HTMLSpanElement>(
       'dt > [data-contents]',
@@ -349,8 +351,12 @@ function useFieldOverflow() {
       'dd > [data-contents]',
     );
 
-    setIsLabelOverflowing(label ? label.scrollWidth > maxWidth : false);
-    setIsValueOverflowing(value ? value.scrollWidth > maxWidth : false);
+    setIsLabelOverflowing(
+      label ? label.scrollWidth > availableContentWidth : false,
+    );
+    setIsValueOverflowing(
+      value ? value.scrollWidth > availableContentWidth : false,
+    );
   }, []);
 
   const observer = useResizeObserver(handleRecalculate);

--- a/app/javascript/mastodon/components/account_header/styles.module.scss
+++ b/app/javascript/mastodon/components/account_header/styles.module.scss
@@ -356,7 +356,7 @@ $button-fallback-breakpoint: $button-breakpoint + 55px;
 
   &.fieldItem {
     border-color: var(--color-border-success-soft);
-    padding-right: 32px; // 8px padding + 16px for the icon + 8px gap
+    padding-right: 30px; // 8px padding + 16px for the icon + 8px gap - 2px tolerance
   }
 }
 


### PR DESCRIPTION
Fixes #39502

### Changes proposed in this PR:
- Fixes a custom profile field overflow issue caused by the calculation not taking into account the card border
- Added a small tolerance (-2px) to the verified icon safe zone, allowing ever-so-slightly longer content to be displayed without causing overflow

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="172" height="79" alt="image" src="https://github.com/user-attachments/assets/2880f943-6421-4252-88e7-133d7236542e" /> | <img width="163" height="65" alt="image" src="https://github.com/user-attachments/assets/da7920c5-4c82-4e99-b727-7e7837e5db1b" /> |

After without added CSS tolerance:
<img width="173" height="73" alt="image" src="https://github.com/user-attachments/assets/21c237d1-a86a-4fb8-b123-d8c9fbc1f494" />
