### PR TITLE
Add NodeJS version to the Software section of the Admin Dashboard, per #39510

### DIFF
--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -10,7 +10,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   protected
 
   def perform_query
-    [mastodon_version, ruby_version, postgresql_version, redis_version, elasticsearch_version, libvips_version, ffmpeg_version].compact
+    [mastodon_version, ruby_version, nodejs_version, postgresql_version, redis_version, elasticsearch_version, libvips_version, ffmpeg_version].compact
   end
 
   def mastodon_version
@@ -31,6 +31,18 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
       value: RUBY_DESCRIPTION,
       human_value: "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}",
     }
+  end
+
+  def nodejs_version
+    version = Terrapin::CommandLine.new('nodejs', '-v').run
+    {
+      key: 'nodejs',
+      human_key: 'Node.JS',
+      value: version,
+      human_value: version,
+    }
+  rescue Terrapin::CommandNotFoundError
+    nil
   end
 
   def postgresql_version


### PR DESCRIPTION
Adds the Node.JS version to the list of installed software in the Admin Dashboard, as requested in issue #39510. I set it to be displayed after Ruby, following the same order as the "minimum supported versions" list in the 4.6.0 Releases notes. Figured that since it's a critical dependency, it'd be helpful to be displayed there, rather than at the end of the software list. Fixes #39510.

Tested and verified as working using the `Vagrantfile` shipped with Mastodon. Dashboard screenshot:

<img width="360" height="234" alt="nodejs" src="https://github.com/user-attachments/assets/94c6d503-4dce-4401-bf7b-13e5838d7267" />
