### PR TITLE
Add support for Ed25519 signatures in HTTP Message Signatures

### DIFF
--- a/app/lib/activitypub/linked_data_signature.rb
+++ b/app/lib/activitypub/linked_data_signature.rb
@@ -22,7 +22,7 @@ class ActivityPub::LinkedDataSignature
 
     keypair = Keypair.from_keyid(creator_uri)
     keypair = ActivityPub::FetchRemoteKeyService.new.call(creator_uri) if keypair&.public_key.blank?
-    return if keypair.nil? || !keypair.usable?
+    return if keypair.nil? || !keypair.usable? || keypair.type != 'rsa'
 
     options_hash   = hash(@json['signature'].without('type', 'id', 'signatureValue').merge('@context' => CONTEXT))
     document_hash  = hash(@json.without('signature'))

--- a/app/lib/signed_request.rb
+++ b/app/lib/signed_request.rb
@@ -171,7 +171,12 @@ class SignedRequest
     end
 
     def verified?(keypair)
-      key = Linzer.new_rsa_v1_5_sha256_public_key(keypair.public_key)
+      case keypair.type
+      when 'rsa'
+        key = Linzer.new_rsa_v1_5_sha256_public_key(keypair.public_key)
+      when 'ed25519'
+        key = Linzer.new_ed25519_public_key(keypair.public_key)
+      end
 
       Linzer.verify(key, @message, @signature)
     rescue Linzer::VerifyError

--- a/app/models/keypair.rb
+++ b/app/models/keypair.rb
@@ -25,7 +25,10 @@ class Keypair < ApplicationRecord
 
   belongs_to :account
 
-  enum :type, { rsa: 0 }
+  enum :type, {
+    rsa: 0,
+    ed25519: 1,
+  }, validate: true
 
   attr_accessor :require_private_key
 
@@ -46,6 +49,8 @@ class Keypair < ApplicationRecord
       case type
       when 'rsa'
         OpenSSL::PKey::RSA.new(private_key || public_key)
+      when 'ed25519'
+        OpenSSL::PKey.read(private_key || public_key)
       end
     end
   end

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -341,6 +341,14 @@ class ActivityPub::ProcessAccountService < BaseService
     case tag
     when :'rsa-pub'
       [:rsa, OpenSSL::PKey::RSA.new(key).to_pem]
+    when :'ed25519-pub'
+      asn1 = OpenSSL::ASN1::Sequence(
+        [
+          OpenSSL::ASN1::Sequence([OpenSSL::ASN1::ObjectId('ED25519')]),
+          OpenSSL::ASN1::BitString(key),
+        ]
+      )
+      [:ed25519, OpenSSL::PKey.read(asn1.to_der).public_to_pem]
     end
   rescue ArgumentError
     nil

--- a/spec/requests/signature_verification_spec.rb
+++ b/spec/requests/signature_verification_spec.rb
@@ -693,6 +693,48 @@ RSpec.describe 'signature verification concern' do
       end
     end
 
+    context 'with a Ed25519 key' do
+      # Include the private key so the tests can be easily adjusted and reviewed
+      let(:actor_keypair) do
+        OpenSSL::PKey.read(<<~PEM_TEXT)
+          -----BEGIN PRIVATE KEY-----
+          MC4CAQAwBQYDK2VwBCIEIE4+t/Xnl3lEh/Uw72qW2IWlMQJOHaLuFUipMUHPfO2M
+          -----END PRIVATE KEY-----
+        PEM_TEXT
+      end
+
+      context 'with a known account' do
+        let!(:actor) { Fabricate(:account, domain: 'remote.domain', uri: 'https://remote.domain/users/bob', private_key: nil, public_key: '') }
+
+        before do
+          Fabricate(:keypair, account: actor, type: :ed25519, public_key: actor_keypair.public_to_pem, uri: 'https://remote.domain/users/bob#main-key')
+        end
+
+        context 'with a valid signature on a GET request' do
+          let(:signature_input) do
+            'sig1=("@method" "@target-uri");created=1703066400;keyid="https://remote.domain/users/bob#main-key"'
+          end
+          let(:signature_header) do
+            'sig1=:o5DKH6Bge3pkaSs4UHqa1lMmbzTyBKOrDkILRA7OQ4La2d1HgM2CbIhi30KwemP+Jd5tgSv8NL65/H+57QbwDQ==:'
+          end
+
+          it 'successfully verifies signature', :aggregate_failures do
+            get '/activitypub/success', headers: {
+              'Host' => 'www.example.com',
+              'Signature-Input' => signature_input,
+              'Signature' => signature_header,
+            }
+
+            expect(response).to have_http_status(200)
+            expect(response.parsed_body).to match(
+              signed_request: true,
+              signature_actor_id: actor.id.to_s
+            )
+          end
+        end
+      end
+    end
+
     context 'with an inaccessible key' do
       let(:signature_input) do
         'sig1=("@method" "@target-uri");created=1703066400;keyid="https://remote.domain/users/alice#main-key"'

--- a/spec/services/activitypub/fetch_remote_key_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_key_service_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe ActivityPub::FetchRemoteKeyService do
         stub_request(:get, public_key_id).to_return(body: key_json.merge({ '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'] }).to_json, headers: { 'Content-Type': 'application/activity+json' })
       end
 
-      it 'returns the nil' do
+      it 'returns nil' do
         expect(keypair).to be_nil
       end
     end
@@ -126,6 +126,13 @@ RSpec.describe ActivityPub::FetchRemoteKeyService do
         controller: 'https://example.com/alice',
         publicKeyMultibase: 'z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK',
       }
+    end
+    let(:ed25519_key_pem) do
+      <<~TEXT
+        -----BEGIN PUBLIC KEY-----
+        MCowBQYDK2VwAyEALm/M42cB3HkUiODQsXRcweM6TByfzEHGO9ND274JcOY=
+        -----END PUBLIC KEY-----
+      TEXT
     end
 
     let(:rsa_key_id) { 'https://example.com/alice#rsa-key' }
@@ -218,8 +225,61 @@ RSpec.describe ActivityPub::FetchRemoteKeyService do
           stub_request(:get, rsa_key_id).to_return(body: rsa_multikey.merge({ '@context': ['https://www.w3.org/ns/cid/v1'] }).to_json, headers: { 'Content-Type': 'application/activity+json' })
         end
 
-        it 'returns the nil' do
+        it 'returns nil' do
           expect(keypair).to be_nil
+        end
+      end
+
+      context 'with an Ed25519 key' do
+        let(:keypair) { subject.call(ed25519_key_id) }
+
+        context 'when the key is a sub-object from the actor' do
+          before do
+            stub_request(:get, ed25519_key_id).to_return(body: actor.to_json, headers: { 'Content-Type': 'application/activity+json' })
+          end
+
+          it 'returns the expected account' do
+            expect(keypair.account.uri).to eq 'https://example.com/alice'
+
+            expect(keypair)
+              .to have_attributes(
+                uri: ed25519_key_id,
+                type: 'ed25519',
+                public_key: ed25519_key_pem
+              )
+          end
+        end
+
+        context 'when the key is a separate document' do
+          let(:ed25519_key_id) { 'https://example.com/alice-public-key.json' }
+          let(:actor_ed25519_key) { ed25519_key_id }
+
+          before do
+            stub_request(:get, ed25519_key_id).to_return(body: ed25519_multikey.merge({ '@context': ['https://www.w3.org/ns/cid/v1'] }).to_json, headers: { 'Content-Type': 'application/activity+json' })
+          end
+
+          it 'returns the expected account' do
+            expect(keypair.account.uri).to eq 'https://example.com/alice'
+            expect(keypair)
+              .to have_attributes(
+                uri: ed25519_key_id,
+                type: 'ed25519',
+                public_key: ed25519_key_pem
+              )
+          end
+        end
+
+        context 'when the key and owner do not match' do
+          let(:ed25519_key_id) { 'https://example.com/fake-public-key.json' }
+          let(:actor_ed25519_key) { 'https://example.com/alice-public-key.json' }
+
+          before do
+            stub_request(:get, ed25519_key_id).to_return(body: ed25519_multikey.merge({ '@context': ['https://www.w3.org/ns/cid/v1'] }).to_json, headers: { 'Content-Type': 'application/activity+json' })
+          end
+
+          it 'returns nil' do
+            expect(keypair).to be_nil
+          end
         end
       end
     end


### PR DESCRIPTION
Mastodon has supported HTTP Message Signatures (RFC9421) since v4.5.0, but only with the [RSASSA-PKCS1-v1_5](https://datatracker.ietf.org/doc/html/rfc9421#name-rsassa-pkcs1-v1_5-using-sha) signature scheme.

This PR adds support for Ed25519 signatures.

One reason for adding Ed25519 support is potentially supporting [FEP-8b32](https://codeberg.org/fediverse/fep/src/branch/main/fep/8b32/fep-8b32.md) in the future, though this PR itself does not implement it.

This PR *does not* change how Mastodon signs any activity, RSASSA-PKCS1-v1_5 is still used for HTTP Signatures, and the only supported Linked Data Signature scheme is still `RsaSignature2017`.