### PR TITLE
Fix "private mention" post heading overlapping thread line

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1586,6 +1586,10 @@ body > [data-popper-placement] {
     top: 0;
     inset-inline-start: 16px + ((46px - 2px) * 0.5);
 
+    .status__wrapper:has(> .status__prepend) &:not(&--full, &--first) {
+      height: 50px;
+    }
+
     &--full {
       top: 0;
       height: 100%;
@@ -1737,6 +1741,12 @@ body > [data-popper-placement] {
   line-height: 22px;
   font-weight: 500;
   color: var(--color-text-secondary);
+
+  .status__wrapper-reply & {
+    --thread-margin: calc(46px + 8px);
+
+    margin-inline-start: var(--thread-margin);
+  }
 
   &__icon {
     display: flex;


### PR DESCRIPTION
Fixes https://github.com/mastodon/mastodon/issues/27058#issuecomment-4751126178

### Changes proposed in this PR:
- Fixes the thread line being overlapped by the "private mention" post title
- Extends the thread line a bit if it belongs to the last post of a thread and if that post has a post heading, too, to avoid it from appearing to not be connected to the post

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="379" height="683" alt="image" src="https://github.com/user-attachments/assets/5f9a3501-567e-4767-94bc-d34b18b5378e" /> | <img width="343" height="684" alt="image" src="https://github.com/user-attachments/assets/a2be075d-86ea-41ac-8f76-4de108a08b80" /> |