### PR TITLE
Move "reconfirm" special case to user mailer spec context

### DIFF
--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -65,22 +65,15 @@ RSpec.describe UserMailer do
         .and match(Rails.configuration.x.local_domain)
     end
 
-    it_behaves_like 'localized subject',
-                    'devise.mailer.confirmation_instructions.subject',
-                    instance: Rails.configuration.x.local_domain
-    it_behaves_like 'delivery to memorialized user'
-  end
+    context 'when the user needs to reconfirm' do
+      before { receiver.update!(email: 'new-email@example.com', locale: nil) }
 
-  describe '#reconfirmation_instructions' do
-    let(:mail) { described_class.confirmation_instructions(receiver, 'spec') }
-
-    it 'renders reconfirmation instructions' do
-      receiver.update!(email: 'new-email@example.com', locale: nil)
-
-      expect(mail.text_part.body)
-        .to match(I18n.t('devise.mailer.reconfirmation_instructions.title'))
-        .and match('spec')
-        .and match(Rails.configuration.x.local_domain)
+      it 'renders reconfirmation instructions' do
+        expect(mail.text_part.body)
+          .to match(I18n.t('devise.mailer.reconfirmation_instructions.title'))
+          .and match('spec')
+          .and match(Rails.configuration.x.local_domain)
+      end
     end
 
     it_behaves_like 'localized subject',


### PR DESCRIPTION
Noticed this while looking at the "missing user" thing in the appeal emails. Two connected changes:

- There is not a special `reconfirmation_instructions` mailer/method ... its just a special case of the `confirmation_instructions` mailer (which chooses content conditionally on whether theres a pending reconfirmation) ... so just logically, move it to be a context instead of its own top level `describe`
- As a side effect of being in its separate describe, the "localize" and "memorial" checks were running twice, needlessly, with same subject/setup, so this deletes those after the scenario move