### PR TITLE
Fix advanced UI columns not using mobile styles

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3886,6 +3886,7 @@ a.account__display-name {
 }
 
 .scrollable {
+  container: column / inline-size;
   overflow-y: scroll;
   overflow-x: hidden;
   flex: 1 1 auto;
@@ -4567,6 +4568,7 @@ a.status-card {
 }
 
 .column-header__wrapper {
+  container: column / inline-size;
   position: relative;
   flex: 0 0 auto;
   z-index: 1;


### PR DESCRIPTION
Fixes #39520

### Changes proposed in this PR:
- Fixes mobile styles not being applied in advanced UI. This is because the columns were missing the necessary CSS rule to make each column a container; I don't know where they went missing but I've re-added them for both `.scrollable` and `.column-header__wrapper` even though the latter doesn't currently use container queries. I thought it made sense to add it to all top-level column elements.

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="377" height="814" alt="image" src="https://github.com/user-attachments/assets/d8d5098f-2ed8-41ab-a182-140f7a2b25f1" /> | <img width="376" height="820" alt="image" src="https://github.com/user-attachments/assets/25cc03b2-61e1-42af-902f-12619dcd7cef" /> |