### PR TITLE
Bump chromaui/action to v17

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -55,7 +55,7 @@ jobs:
         run: yarn build-storybook
 
       - name: Run Chromatic
-        uses: chromaui/action@07791f8243f4cb2698bf4d00426baf4b2d1cb7e0 # v13
+        uses: chromaui/action@7804f34e4e59c0d9b3c856848f46ad96d7897429 # v17
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           zip: true


### PR DESCRIPTION
Noticed a node20 deprecation warning in output of https://github.com/mastodon/mastodon/actions/runs/27830999264/job/82367529979?pr=39528

I'm assuming we can safely bump to this action version (v17 handled node 20 change in the action) since chromatic itself was bumped in https://github.com/mastodon/mastodon/pull/39094 ? - but will watch CI