### PR TITLE
Fix redundant indentation on Post reply indicator

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -591,7 +591,7 @@ class Status extends ImmutablePureComponent {
 
     return (
       <Hotkeys handlers={handlers} focusable={!unfocusable}>
-        <div className={classNames('status__wrapper', `status__wrapper-${status.get('visibility')}`, { 'status__wrapper-reply': !!status.get('in_reply_to_id'), unread, focusable: !this.props.muted })} tabIndex={this.props.muted || unfocusable ? null : 0} data-featured={featured ? 'true' : null} aria-label={textForScreenReader({intl, status, rebloggedByText, isQuote: isQuotedPost})} ref={this.handleRef} data-nosnippet={status.getIn(['account', 'noindex'], true) || undefined}>
+        <div className={classNames('status__wrapper', `status__wrapper-${status.get('visibility')}`, { 'status__wrapper-reply': !!status.get('in_reply_to_id'), 'status__wrapper--in-thread': !!rootId, unread, focusable: !this.props.muted })} tabIndex={this.props.muted || unfocusable ? null : 0} data-featured={featured ? 'true' : null} aria-label={textForScreenReader({intl, status, rebloggedByText, isQuote: isQuotedPost})} ref={this.handleRef} data-nosnippet={status.getIn(['account', 'noindex'], true) || undefined}>
           {!skipPrepend && prepend}
 
           <div

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1742,7 +1742,7 @@ body > [data-popper-placement] {
   font-weight: 500;
   color: var(--color-text-secondary);
 
-  .status__wrapper-reply & {
+  .status__wrapper-reply.status__wrapper--in-thread & {
     --thread-margin: calc(46px + 8px);
 
     margin-inline-start: var(--thread-margin);


### PR DESCRIPTION
Fixes #39546

### Changes proposed in this PR:
- Fixes redundant indentation on Post reply indicator outside of threads, a regression from #39521

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="611" height="322" alt="image" src="https://github.com/user-attachments/assets/f2c1e59a-83a2-46a5-a624-e320150f3af4" /> | <img width="613" height="323" alt="image" src="https://github.com/user-attachments/assets/2d13a379-2b8b-434f-90c2-f392e1ccc7a5" /> |