### PR TITLE
Removes comment as it was breaking Vite rewriting import path

### DIFF
--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -437,8 +437,7 @@ async function toLoadedLocale(localeString: string) {
   }
   if (!loadedLocales.has(locale)) {
     log('Locale %s not loaded, importing...', locale);
-    // Ignore the INEFFECTIVE_DYNAMIC_IMPORT Vite warning, since the static import location is inside an inlined web worker.
-    const { importEmojiData } = await import(/* @vite-ignore */ './loader');
+    const { importEmojiData } = await import('./loader');
     await importEmojiData(locale);
     return locale;
   }


### PR DESCRIPTION
Fixes #39117.

This fixes a regression from #38541 that was causing Vite to not properly rewrite the path instead of just suppressing the warning. With this fix there will be a `INEFFECTIVE_DYNAMIC_IMPORT` warning on builds which will still need to be resolved.

Marking to backport as this affects 4.6.