### PR TITLE
Fix Vite build warning

### DIFF
--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -5,6 +5,7 @@ import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
 
 import { openEmojiDB } from './db-schema';
 import type { Database } from './db-schema';
+import { importEmojiData } from './loader';
 import { localeToSegmenter, toSupportedLocale } from './locale';
 import {
   extractTokens,
@@ -437,7 +438,6 @@ async function toLoadedLocale(localeString: string) {
   }
   if (!loadedLocales.has(locale)) {
     log('Locale %s not loaded, importing...', locale);
-    const { importEmojiData } = await import('./loader');
     await importEmojiData(locale);
     return locale;
   }


### PR DESCRIPTION
Fixes issue from #39558 where Vite is throwing an `INEFFECTIVE_DYNAMIC_IMPORT` warning during build due to the lazy-loaded import of `loader.ts` from `database.ts`. This replaces that dynamic import with a static one- I tested and it doesn't seem to result in a circular dependency.