### PR TITLE
LDAP: Fix attempted modification of frozen hash

### DIFF
--- a/app/models/concerns/user/ldap_authenticable.rb
+++ b/app/models/concerns/user/ldap_authenticable.rb
@@ -58,7 +58,7 @@ module User::LdapAuthenticable
       if [:simple_tls, :start_tls].include?(Devise.ldap_method)
         opts[:encryption] = {
           method: Devise.ldap_method,
-          tls_options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.tap { |options| options[:verify_mode] = OpenSSL::SSL::VERIFY_NONE if Devise.ldap_tls_no_verify },
+          tls_options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.dup.tap { |options| options[:verify_mode] = OpenSSL::SSL::VERIFY_NONE if Devise.ldap_tls_no_verify },
         }
       end
 

--- a/spec/models/concerns/user/ldap_authenticable_spec.rb
+++ b/spec/models/concerns/user/ldap_authenticable_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User::LdapAuthenticable do
+  describe '::ldap_options' do
+    subject { User.ldap_options }
+
+    it 'returns a hash' do
+      expect(subject).to be_a Hash
+    end
+
+    context 'when `Devise.ldap_method` is `simple_tls`' do
+      before do
+        Devise.ldap_method = :simple_tls
+      end
+
+      after do
+        Devise.ldap_method = nil
+      end
+
+      it 'includes `encryption` key' do
+        expect(subject).to have_key :encryption
+      end
+
+      context 'when `Devise.ldap_tls_no_verify` is set to `true`' do
+        before do
+          Devise.ldap_tls_no_verify = true
+        end
+
+        after do
+          Devise.ldap_tls_no_verify = false
+        end
+
+        it 'sets `verify_mode` correctly' do
+          expect(subject[:encryption][:tls_options][:verify_mode]).to eq OpenSSL::SSL::VERIFY_NONE
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
`OpenSSL::SSL::SSLContext::DEFAULT_PARAMS` is a frozen hash now (as it should have been to begin with). The fix is to modify a copy instead.

Fixes #39535