### PR TITLE
Update haml_lint to version 0.7.40

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,7 +292,7 @@ GEM
       activesupport (>= 5.1)
       haml (>= 4.0.6)
       railties (>= 5.1)
-    haml_lint (0.73.0)
+    haml_lint (0.74.0)
       haml (>= 5.0)
       parallel (>= 1.10)
       rainbow


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/39568

We have sort of a mix of rubocop disables in views, in helpers, etc for the equivalent cops. Chose to do inline view disable here ... could move to helpers, in which case this haml cop wouldn't trigger but we'd probably have to disable a rubocop cop.

I believe both of these cases are safe to ignore -- one is a literal string (including an html entity) from the i18n, the other generates a raw html string but does not include user-supplied params in the output.