### PR TITLE
Handling Qt5WebEngine (regression) (variant 1 of 3: emoji .at)

### DIFF
--- a/app/javascript/mastodon/features/emoji/utils.ts
+++ b/app/javascript/mastodon/features/emoji/utils.ts
@@ -61,7 +61,7 @@ export function emojiToUnicodeHex(emoji: string): string {
   // Handles how Emojibase removes the variation selector for single code emojis.
   // See: https://emojibase.dev/docs/spec/#merged-variation-selectors
   if (
-    codes.at(1) === VARIATION_SELECTOR_CODE.toString(16).toUpperCase() &&
+    codes[1] === VARIATION_SELECTOR_CODE.toString(16).toUpperCase() &&
     codes.length === 2
   ) {
     codes.pop();


### PR DESCRIPTION
The user interface doesn't get displayed on my recent compilation of OtterBrowser (Qt5 variant) https://github.com/OtterBrowser/otter-browser The screen is just left blank.

Reason is the use of the Array.at() function https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at#browser_compatibility which is not available in Chrome 87 base of Qt5WebEngine.

I would appreciate when any software, including Mastodon, keeps _some_ support for older platforms so I made following variants:

Variant 1: Remove the .at() use in the top-level emoji initialization. There are still several other places where .at() remains but at least you can see the user interface and it apparently loads some content. **<-- You are here** (PR #39583)

Variant 2:  Remove the .at() use anywhere in the source. (this is covered in PR #39584)

Variant 3: Prepend a check which displays a message in top-level html script which is unaffected by any further delivered js script. (this is covered in PR #39585)

Variant 4: Leave everything as it is. I consider this as a worst variant (no PR for obvious reasons)

Please note that none of my code changes are tested as I am not a front end developer.