### PR TITLE
Handling Qt5WebEngine (regression) (variant 2 of 3: all .at)

### DIFF
--- a/app/javascript/mastodon/actions/notification_groups.ts
+++ b/app/javascript/mastodon/actions/notification_groups.ts
@@ -128,7 +128,7 @@ export const fetchNotifications = createDataLoadingThunk(
     // TODO: might be worth not using gaps for that…
     // if (nextLink) payload.push({ type: 'gap', loadUrl: nextLink.uri });
     if (notifications.length > 1)
-      payload.push({ type: 'gap', maxId: notifications.at(-1)?.page_min_id });
+      payload.push({ type: 'gap', maxId: notifications[notifications.length-1]?.page_min_id });
 
     return payload;
     // dispatch(submitMarkers());

--- a/app/javascript/mastodon/components/familiar_followers/index.tsx
+++ b/app/javascript/mastodon/components/familiar_followers/index.tsx
@@ -16,12 +16,12 @@ const FamiliarFollowersReadout: React.FC<{ familiarFollowers: Account[] }> = ({
   const messageData = {
     name1: (
       <LinkedDisplayName
-        displayProps={{ account: familiarFollowers.at(0), variant: 'simple' }}
+        displayProps={{ account: familiarFollowers[0], variant: 'simple' }}
       />
     ),
     name2: (
       <LinkedDisplayName
-        displayProps={{ account: familiarFollowers.at(1), variant: 'simple' }}
+        displayProps={{ account: familiarFollowers[1], variant: 'simple' }}
       />
     ),
     othersCount: familiarFollowers.length - 2,

--- a/app/javascript/mastodon/components/form_fields/combobox_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/combobox_field.tsx
@@ -364,10 +364,10 @@ const ComboboxWithRef = <Item extends ComboboxItem, GroupKey extends string>(
       if (highlightedItemIndex === -1) {
         // If no item is highlighted yet, highlight the first or last
         if (direction > 0) {
-          const firstItem = flatItems.at(0);
+          const firstItem = flatItems[0];
           highlightItem(firstItem ? getItemId(firstItem) : null);
         } else {
-          const lastItem = flatItems.at(-1);
+          const lastItem = flatItems[flatItems.length-1];
           highlightItem(lastItem ? getItemId(lastItem) : null);
         }
       } else {

--- a/app/javascript/mastodon/components/hotkeys/index.tsx
+++ b/app/javascript/mastodon/components/hotkeys/index.tsx
@@ -96,7 +96,7 @@ function optionPlus(key: string): KeyMatcher {
  */
 function sequence(...sequence: string[]): KeyMatcher {
   return (event, bufferedKeys) => {
-    const lastKeyInSequence = sequence.at(-1);
+    const lastKeyInSequence = sequence[sequence.length-1];
     const startOfSequence = sequence.slice(0, -1);
     const relevantBufferedKeys = bufferedKeys?.slice(-startOfSequence.length);
 
@@ -237,7 +237,7 @@ export function useHotkeys<T extends HTMLElement>(handlers: HandlerMap) {
         // Sort all matches by priority
         matchCandidates.sort((a, b) => b.priority - a.priority);
 
-        const bestMatchingHandler = matchCandidates.at(0)?.handler;
+        const bestMatchingHandler = matchCandidates[0]?.handler;
         if (bestMatchingHandler) {
           const wasHandled = bestMatchingHandler(event);
           if (wasHandled !== false) {

--- a/app/javascript/mastodon/features/account_timeline/modals/join_modal.tsx
+++ b/app/javascript/mastodon/features/account_timeline/modals/join_modal.tsx
@@ -39,7 +39,7 @@ const selectServerName = createAppSelector(
       return undefined;
     }
 
-    const domain = acct.split('@').at(1);
+    const domain = acct.split('@')[1];
     if (domain) {
       return domain;
     }

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.tsx
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.tsx
@@ -139,7 +139,7 @@ const PrivacyDropdown: React.FC<PrivacyDropdownProps> = ({
   }
 
   const selectedOption =
-    options.find((item) => item.value === value) ?? options.at(0);
+    options.find((item) => item.value === value) ?? options[0];
 
   return (
     <div ref={overlayTargetRef}>

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -69,7 +69,7 @@ export async function search({
     log('no tokens extracted from query "%s"', query);
     return [];
   }
-  const lastToken = queryTokens.at(-1);
+  const lastToken = queryTokens[queryTokens.length-1];
   if (!lastToken) {
     throw new Error('Missing tokens from query');
   }
@@ -238,7 +238,7 @@ async function fullCustomSearch(query: string, existing = new Set<string>()) {
       break;
     }
     log('cursor search got batch of %d emojis', keys.length);
-    lastKey = keys.at(-1) ?? null;
+    lastKey = keys[keys.length-1] ?? null;
 
     for (const key of keys) {
       if (!foundEmojis.has(key) && !existing.has(key) && key.includes(query)) {
@@ -384,7 +384,7 @@ export async function searchCustomEmojisByShortcodes(shortcodes: string[]) {
   const sortedCodes = shortcodes.toSorted();
   const results = await db.getAll(
     'custom',
-    IDBKeyRange.bound(sortedCodes.at(0), sortedCodes.at(-1)),
+    IDBKeyRange.bound(sortedCodes[0], sortedCodes[sortedCodes.length-1]),
   );
   return results.filter((emoji) => shortcodes.includes(emoji.shortcode));
 }

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -130,11 +130,11 @@ export function unicodeToTwemojiHex(unicodeHex: string): string {
     // Some emoji have their variation selector removed
     if (code === VARIATION_SELECTOR_CODE) {
       // Key emoji
-      if (i === 1 && codes.at(-1) === KEYCAP_CODE) {
+      if (i === 1 && codes[codes.length-1] === KEYCAP_CODE) {
         continue;
       }
       // Eye in speech bubble
-      if (codes.at(0) === EYE_CODE && codes.at(-2) === SPEECH_BUBBLE_CODE) {
+      if (codes[0] === EYE_CODE && codes[codes.length-2] === SPEECH_BUBBLE_CODE) {
         continue;
       }
     }

--- a/app/javascript/mastodon/features/emoji/render.ts
+++ b/app/javascript/mastodon/features/emoji/render.ts
@@ -201,7 +201,7 @@ export async function loadEmojiDataToState(
         type: EMOJI_TYPE_UNICODE,
         data,
         // TODO: Use CLDR shortcodes when the picker supports them.
-        shortcode: legacyCode?.shortcodes.at(0),
+        shortcode: legacyCode?.shortcodes[0],
       };
     }
 

--- a/app/javascript/mastodon/features/emoji/utils.ts
+++ b/app/javascript/mastodon/features/emoji/utils.ts
@@ -61,7 +61,7 @@ export function emojiToUnicodeHex(emoji: string): string {
   // Handles how Emojibase removes the variation selector for single code emojis.
   // See: https://emojibase.dev/docs/spec/#merged-variation-selectors
   if (
-    codes.at(1) === VARIATION_SELECTOR_CODE.toString(16).toUpperCase() &&
+    codes[1] === VARIATION_SELECTOR_CODE.toString(16).toUpperCase() &&
     codes.length === 2
   ) {
     codes.pop();

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
@@ -62,7 +62,7 @@ export const NotificationGroupWithStatus: React.FC<{
 }) => {
   const dispatch = useAppDispatch();
   const account = useAppSelector((state) =>
-    state.accounts.get(accountIds.at(0) ?? ''),
+    state.accounts.get(accountIds[0] ?? ''),
   );
 
   const label = useMemo(

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_with_status.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_with_status.tsx
@@ -40,7 +40,7 @@ export const NotificationWithStatus: React.FC<{
   const dispatch = useAppDispatch();
 
   const account = useAppSelector((state) =>
-    state.accounts.get(accountIds.at(0) ?? ''),
+    state.accounts.get(accountIds[0] ?? ''),
   );
   const label = useMemo(
     () =>

--- a/app/javascript/mastodon/features/notifications_v2/index.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/index.tsx
@@ -66,7 +66,7 @@ export const Notifications: React.FC<{
   const notifications = useAppSelector(selectNotificationGroups, isEqual);
   const dispatch = useAppDispatch();
   const isLoading = useAppSelector((s) => s.notificationGroups.isLoading);
-  const hasMore = notifications.at(-1)?.type === 'gap';
+  const hasMore = notifications[notifications.length-1]?.type === 'gap';
 
   const lastReadId = useAppSelector((s) =>
     selectSettingsNotificationsShowUnread(s)
@@ -117,7 +117,7 @@ export const Notifications: React.FC<{
 
   const handleLoadOlder = useDebouncedCallback(
     () => {
-      const gap = notifications.at(-1);
+      const gap = notifications[notifications.length-1];
       if (gap?.type === 'gap') void dispatch(fetchNotificationsGap({ gap }));
     },
     300,

--- a/app/javascript/mastodon/hooks/useVisibility.ts
+++ b/app/javascript/mastodon/hooks/useVisibility.ts
@@ -9,7 +9,7 @@ export function useVisibility({
   const [isIntersecting, setIsIntersecting] = useState(false);
   const handleIntersect: IntersectionObserverCallback = useCallback(
     (entries) => {
-      const entry = entries.at(0);
+      const entry = entries[0];
       if (!entry) {
         return;
       }

--- a/app/javascript/mastodon/reducers/notification_groups.ts
+++ b/app/javascript/mastodon/reducers/notification_groups.ts
@@ -275,7 +275,7 @@ function shouldMarkNewNotificationsAsRead(
 ) {
   const isMounted = mounted > 0;
   const oldestGroup = groups.findLast(isNotificationGroup);
-  const hasMore = groups.at(-1)?.type === 'gap';
+  const hasMore = groups[groups.length-1]?.type === 'gap';
   const oldestGroupReached =
     !hasMore ||
     lastReadId === '0' ||
@@ -339,7 +339,7 @@ function fillNotificationsGap(
   // discarded, while any information on groups appearing after the gap
   // can be updated and re-ordered.
 
-  const oldestPageNotification = notifications.at(-1)?.page_min_id;
+  const oldestPageNotification = notifications[notifications.length-1]?.page_min_id;
 
   // replace the gap with the notifications + a new gap
 
@@ -369,7 +369,7 @@ function fillNotificationsGap(
     // Similarly, if we've fetched more than the gap's, this means we have completely filled it
     toInsert.push({
       type: 'gap',
-      maxId: notifications.at(-1)?.page_max_id,
+      maxId: notifications[notifications.length-1]?.page_max_id,
       sinceId,
     } as NotificationGap);
   }
@@ -414,7 +414,7 @@ function ensureLeadingGap(
 function ensureTrailingGap(
   groups: NotificationGroupsState['groups'],
 ): NotificationGap {
-  const groupOrGap = groups.at(-1);
+  const groupOrGap = groups[groups.length-1];
 
   if (groupOrGap?.type === 'gap') {
     // We're expecting older notifications, so discard sinceId if it's set

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -147,7 +147,7 @@ export const config: UserConfigFnPromise = async ({ mode, command }) => {
               // Use a custom name for chunks, to avoid having too many of them called "index"
               const parts = facadeModuleId.split('/');
 
-              const parent = parts.at(-2);
+              const parent = parts[parts.length-2];
 
               if (parent) {
                 return `${parent}-[name]-[hash].js`;


### PR DESCRIPTION
The user interface doesn't get displayed on my recent compilation of OtterBrowser (Qt5 variant) https://github.com/OtterBrowser/otter-browser The screen is just left blank.

Reason is the use of the Array.at() function https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at#browser_compatibility which is not available in Chrome 87 base of Qt5WebEngine.

I would appreciate when any software, including Mastodon, keeps _some_ support for older platforms so I made following variants:

Variant 1: Remove the .at() use in the top-level emoji initialization. There are still several other places where .at() remains but at least you can see the user interface and it apparently loads some content. (this is covered in PR #39583)

Variant 2:  Remove the .at() use anywhere in the source. **<-- You are here** (PR #39584)

Variant 3: Prepend a check which displays a message in top-level html script which is unaffected by any further delivered js script. (this is covered in PR #39585)

Variant 4: Leave everything as it is. I consider this as a worst variant (no PR for obvious reasons)

Please note that none of my code changes are tested as I am not a front end developer.