### PR TITLE
Handling Qt5WebEngine (regression) (variant 3 of 3: just a message)

### DIFF
--- a/app/javascript/inline/at-check.js
+++ b/app/javascript/inline/at-check.js
@@ -1,0 +1,14 @@
+
+try {
+	a = new Array(1);
+	a.at(0)
+}
+catch(e) {
+	ele = document.createElement('p')
+	ele.innerText = 'Your browser/JS engine doesn\'t support Array.at(). Therefore Mastodon cannot be loaded'
+	document.body.prepend(ele)
+}
+
+
+
+

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,6 +20,7 @@
     - if use_mask_icon?
       %link{ rel: 'mask-icon', href: frontend_asset_path('images/logo-symbol-icon.svg'), color: '#6364FF' }/
     %link{ rel: 'manifest', href: manifest_path(format: :json) }/
+    = javascript_inline_tag 'at-check.js'
     = javascript_inline_tag 'theme-selection.js'
     = theme_color_tags color_scheme
     %meta{ name: 'mobile-web-app-capable', content: 'yes' }/

--- a/app/views/layouts/embedded.html.haml
+++ b/app/views/layouts/embedded.html.haml
@@ -11,6 +11,7 @@
     - if storage_host?
       %link{ rel: 'dns-prefetch', href: storage_host }/
 
+    = javascript_inline_tag 'at-check.js'
     = javascript_inline_tag 'theme-selection.js'
     = vite_client_tag
     = vite_react_refresh_tag


### PR DESCRIPTION
The user interface doesn't get displayed on my recent compilation of OtterBrowser (Qt5 variant) https://github.com/OtterBrowser/otter-browser The screen is just left blank.

Reason is the use of the Array.at() function https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at#browser_compatibility which is not available in Chrome 87 base of Qt5WebEngine.

I would appreciate when any software, including Mastodon, keeps _some_ support for older platforms so I made following variants:

Variant 1: Remove the .at() use in the top-level emoji initialization. There are still several other places where .at() remains but at least you can see the user interface and it apparently loads some content. (this is covered in PR #39583)

Variant 2:  Remove the .at() use anywhere in the source. (this is covered in PR #39584)

Variant 3: Prepend a check which displays a message in top-level html script which is unaffected by any further delivered js script. **<-- You are here** (PR #39585)

Variant 4: Leave everything as it is. I consider this as a worst variant (no PR for obvious reasons)

Please note that none of my code changes are tested as I am not a front end developer.