### PR TITLE
Fix accounts not visible in collection editor in advanced web interface

### DIFF
--- a/app/javascript/mastodon/features/collections/editor/accounts.tsx
+++ b/app/javascript/mastodon/features/collections/editor/accounts.tsx
@@ -24,7 +24,6 @@ import {
 import {
   Article,
   ItemList,
-  Scrollable,
 } from 'mastodon/components/scrollable_list/components';
 import { useAccount } from 'mastodon/hooks/useAccount';
 import { useSearchAccounts } from 'mastodon/hooks/useSearchAccounts';
@@ -417,43 +416,42 @@ export const CollectionAccounts: React.FC<{
             </AccountsHeadingElement>
           )}
 
-          <Scrollable className={classes.scrollableWrapper}>
-            <ItemList
-              emptyMessage={
-                <EmptyState
-                  title={
-                    <FormattedMessage
-                      id='collections.accounts.empty_editor_title'
-                      defaultMessage='No one is in this collection yet'
-                    />
-                  }
-                  message={
-                    <FormattedMessage
-                      id='collections.accounts.empty_description'
-                      defaultMessage='Add up to {count} accounts'
-                      values={{
-                        count: MAX_COLLECTION_ACCOUNT_COUNT,
-                      }}
-                    />
-                  }
-                />
-              }
-            >
-              {editorItems.map(({ account_id, state }, index) => (
-                <Article
-                  key={account_id}
-                  aria-posinset={index}
-                  aria-setsize={editorItems.length}
-                >
-                  <AddedAccountItem
-                    accountId={account_id}
-                    pending={state === 'pending'}
-                    onRemove={handleRemoveAccountItem}
+          <ItemList
+            className={classes.accountList}
+            emptyMessage={
+              <EmptyState
+                title={
+                  <FormattedMessage
+                    id='collections.accounts.empty_editor_title'
+                    defaultMessage='No one is in this collection yet'
                   />
-                </Article>
-              ))}
-            </ItemList>
-          </Scrollable>
+                }
+                message={
+                  <FormattedMessage
+                    id='collections.accounts.empty_description'
+                    defaultMessage='Add up to {count} accounts'
+                    values={{
+                      count: MAX_COLLECTION_ACCOUNT_COUNT,
+                    }}
+                  />
+                }
+              />
+            }
+          >
+            {editorItems.map(({ account_id, state }, index) => (
+              <Article
+                key={account_id}
+                aria-posinset={index}
+                aria-setsize={editorItems.length}
+              >
+                <AddedAccountItem
+                  accountId={account_id}
+                  pending={state === 'pending'}
+                  onRemove={handleRemoveAccountItem}
+                />
+              </Article>
+            ))}
+          </ItemList>
         </div>
       </FormStack>
       {!isEditMode && hasItems && (

--- a/app/javascript/mastodon/features/collections/editor/styles.module.scss
+++ b/app/javascript/mastodon/features/collections/editor/styles.module.scss
@@ -55,7 +55,7 @@
   gap: 16px;
 }
 
-.scrollableWrapper {
+.accountList {
   margin-inline: -16px;
 }
 


### PR DESCRIPTION
Fixes #39531

### Changes proposed in this PR:
- Fixes accounts not being visible in the collection editor when the advanced web interface is used

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="475" height="897" alt="image" src="https://github.com/user-attachments/assets/3728a475-1d3a-42b7-8827-105d44d109d1" /> | <img width="485" height="903" alt="image" src="https://github.com/user-attachments/assets/90feb86c-3a6c-4d0c-b397-430bccdeb26b" /> |