### PR TITLE
Fix combobox menu not closing after a selection

### DIFF
--- a/app/javascript/mastodon/components/form_fields/combobox_field.tsx
+++ b/app/javascript/mastodon/components/form_fields/combobox_field.tsx
@@ -239,6 +239,11 @@ const ComboboxWithRef = <Item extends ComboboxItem, GroupKey extends string>(
   const inputRef = useRef<HTMLInputElement | null>();
   const popoverRef = useRef<HTMLDivElement>(null);
 
+  // This ref tracks whether the menu was just closed following a
+  // selection, and prevents the menu from re-opening again
+  // when focus is returned to the input.
+  const wasMenuJustClosedRef = useRef(false);
+
   const [highlightedItemId, setHighlightedItemId] = useState<string | null>(
     null,
   );
@@ -304,7 +309,7 @@ const ComboboxWithRef = <Item extends ComboboxItem, GroupKey extends string>(
 
   const handleFocus: React.FocusEventHandler<HTMLInputElement> = useCallback(
     (e) => {
-      if (openOnFocus) {
+      if (openOnFocus && !wasMenuJustClosedRef.current) {
         setShouldMenuOpen(true);
       }
       onFocus?.(e);
@@ -341,6 +346,10 @@ const ComboboxWithRef = <Item extends ComboboxItem, GroupKey extends string>(
 
           if (closeOnSelect) {
             closeMenu();
+            wasMenuJustClosedRef.current = true;
+            setTimeout(() => {
+              wasMenuJustClosedRef.current = false;
+            }, 50);
           }
         }
       }


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes the combobox menu not closing after a selection was made via mouse, e.g. when adding accounts in the collection editor

### Screenshots

**Before**

https://github.com/user-attachments/assets/ba9b6b0a-7d58-438c-abeb-69b891144c50

**After**

https://github.com/user-attachments/assets/beb8d99f-14aa-4085-afd3-76782e62d4d0

