### PR TITLE
Fix visible transparent navigation link borders in Windows forced-contrast mode

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4091,9 +4091,8 @@ a.account__display-name {
   align-items: center;
   gap: 8px;
   width: 100%;
-  padding: 10px;
-  padding-inline-start: 14px;
-  overflow: hidden;
+  padding: 12px;
+  padding-inline-start: 16px;
   font-size: 16px;
   font-weight: 400;
   text-decoration: none;
@@ -4104,7 +4103,7 @@ a.account__display-name {
     var(--color-text-secondary)
   );
   background: transparent;
-  border: 2px solid transparent;
+  border: none;
   border-radius: 4px;
 
   &:hover,
@@ -4118,14 +4117,14 @@ a.account__display-name {
   }
 
   &:focus-visible {
-    outline: none;
-    border-color: var(--color-border-brand);
+    outline: var(--outline-focus-default);
+    outline-offset: -2px;
     background: var(--color-bg-brand-softest);
   }
 
   &--logo {
-    padding: 8px;
-    padding-inline-start: 12px;
+    padding: 10px;
+    padding-inline-start: 14px;
   }
 }
 


### PR DESCRIPTION
Fixes #39604

### Changes proposed in this PR:
- Replaces the transparent border around main navigation links with increased padding, and uses the `outline` rather than `border` property for the links' focus outlines. This prevents the transparent borders from becoming visible in Windows' High Contrast mode (as can be seen in the screenshots in #39607).
- Fixes cut-off notification badge by removing `overflow: hidden`, it doesn't seem to be necessary on these items.

### Screenshots

| Before | After |
|--------|--------|
| <img width="300" height="276" alt="image" src="https://github.com/user-attachments/assets/d9756d6e-583a-4c56-b4f6-de97eaf4e434" /> | <img width="309" height="280" alt="image" src="https://github.com/user-attachments/assets/23c69e0c-8ff6-44ab-94e6-5a78461474cd" /> | 