### PR TITLE
fix tootctl media lookup fails on local media URLs

### DIFF
--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -273,11 +273,12 @@ module Mastodon::CLI
     def lookup(url)
       path = Addressable::URI.parse(url).path
 
-      path_segments = path.split('/')[2..]
-      path_segments.delete('cache')
+      path_segments = path.split('/')
+      segment_count = VALID_PATH_SEGMENTS_SIZE.find { |n| n <= path_segments.length && PRELOADED_MODELS.include?(path_segments[-n].classify) }
 
-      fail_with_message 'Not a media URL' unless VALID_PATH_SEGMENTS_SIZE.include?(path_segments.size)
+      fail_with_message 'Not a media URL' unless segment_count
 
+      path_segments = path_segments[-segment_count..]
       model_name = path_segments.first.classify
       record_id  = path_segments[2...-2].join.to_i
 


### PR DESCRIPTION
fixes mastodon/mastodon#33923

if the URL path started with `/cache/...`, (or anything at all `/asdf123/...`), then that element would be stripped, the following `delete('cache')` would be redundant and do nothing, and the lookup would succeed.

if the URL did not have that extra element, as in the case of local URLs, one too many segments would be stripped, and the lookup would fail.