### PR TITLE
Fix call to undefined Base64 method in Multibase

### DIFF
--- a/app/lib/multibase.rb
+++ b/app/lib/multibase.rb
@@ -24,7 +24,7 @@ class Multibase
 
     case string[0]
     when 'u'
-      Base64.decode64(string[1...])
+      Base64.urlsafe_decode64(string[1...])
     when 'z'
       Base58.base58_to_binary(string[1...], :bitcoin)
     else

--- a/app/lib/multibase.rb
+++ b/app/lib/multibase.rb
@@ -24,7 +24,7 @@ class Multibase
 
     case string[0]
     when 'u'
-      Base64.decode(string[1...])
+      Base64.decode64(string[1...])
     when 'z'
       Base58.base58_to_binary(string[1...], :bitcoin)
     else


### PR DESCRIPTION
https://docs.ruby-lang.org/en/3.3/Base64.html

No idea if you want `strict` or `urlsafe_decode64`