### PR TITLE
Change autosuggestions to include second word in web UI

### DIFF
--- a/app/javascript/mastodon/components/autosuggest/utils.ts
+++ b/app/javascript/mastodon/components/autosuggest/utils.ts
@@ -1,0 +1,29 @@
+export const textAtCursorMatchesToken = (
+  str: string,
+  caretPosition: number,
+  searchTokens: string[],
+) => {
+  let word: string;
+
+  const regex = new RegExp(`[${searchTokens.join('')}\\w]+(\\s[\\w]+)?$`);
+  const left = str.slice(0, caretPosition).search(regex);
+  const right = str.slice(caretPosition).search(/\s/);
+
+  if (right < 0) {
+    word = str.slice(left);
+  } else {
+    word = str.slice(left, right + caretPosition);
+  }
+
+  word = word.trim();
+
+  if (word.length < 3 || (word[0] && !searchTokens.includes(word[0]))) {
+    return [null, null];
+  }
+
+  if (word.length > 0) {
+    return [left + 1, word];
+  } else {
+    return [null, null];
+  }
+};

--- a/app/javascript/mastodon/components/autosuggest_input.jsx
+++ b/app/javascript/mastodon/components/autosuggest_input.jsx
@@ -12,31 +12,7 @@ import AutosuggestAccountContainer from '../features/compose/containers/autosugg
 import { AutosuggestEmoji } from './autosuggest_emoji';
 import { AutosuggestHashtag } from './autosuggest_hashtag';
 import { LocalCustomEmojiProvider } from './emoji/context';
-
-const textAtCursorMatchesToken = (str, caretPosition, searchTokens) => {
-  let word;
-
-  let left  = str.slice(0, caretPosition).search(/\S+$/);
-  let right = str.slice(caretPosition).search(/\s/);
-
-  if (right < 0) {
-    word = str.slice(left);
-  } else {
-    word = str.slice(left, right + caretPosition);
-  }
-
-  if (!word || word.trim().length < 3 || searchTokens.indexOf(word[0]) === -1) {
-    return [null, null];
-  }
-
-  word = word.trim();
-
-  if (word.length > 0) {
-    return [left + 1, word];
-  } else {
-    return [null, null];
-  }
-};
+import { textAtCursorMatchesToken } from './autosuggest/utils';
 
 export default class AutosuggestInput extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/components/autosuggest_textarea.jsx
+++ b/app/javascript/mastodon/components/autosuggest_textarea.jsx
@@ -13,31 +13,7 @@ import AutosuggestAccountContainer from '../features/compose/containers/autosugg
 import { AutosuggestEmoji } from './autosuggest_emoji';
 import { AutosuggestHashtag } from './autosuggest_hashtag';
 import { LocalCustomEmojiProvider } from './emoji/context';
-
-const textAtCursorMatchesToken = (str, caretPosition) => {
-  let word;
-
-  let left  = str.slice(0, caretPosition).search(/\S+$/);
-  let right = str.slice(caretPosition).search(/\s/);
-
-  if (right < 0) {
-    word = str.slice(left);
-  } else {
-    word = str.slice(left, right + caretPosition);
-  }
-
-  if (!word || word.trim().length < 3 || ['@', '＠', ':', '#', '＃'].indexOf(word[0]) === -1) {
-    return [null, null];
-  }
-
-  word = word.trim();
-
-  if (word.length > 0) {
-    return [left + 1, word];
-  } else {
-    return [null, null];
-  }
-};
+import { textAtCursorMatchesToken } from './autosuggest/utils';
 
 const AutosuggestTextarea = forwardRef(({
   value,
@@ -64,7 +40,7 @@ const AutosuggestTextarea = forwardRef(({
   const tokenStartRef = useRef(0);
 
   const handleChange = useCallback((e) => {
-    const [ tokenStart, token ] = textAtCursorMatchesToken(e.target.value, e.target.selectionStart);
+    const [ tokenStart, token ] = textAtCursorMatchesToken(e.target.value, e.target.selectionStart, ['@', '＠', ':', '#', '＃']);
 
     if (token !== null && lastTokenRef.current !== token) {
       tokenStartRef.current = tokenStart;


### PR DESCRIPTION
While autosuggestions work based on both username and display name, it was previously only considering one word in the input, making it difficult to find someone by their real name.