### PR TITLE
Always use `public/packs` and not `public/packs-test` for assets

### DIFF
--- a/config/vite.json
+++ b/config/vite.json
@@ -17,7 +17,7 @@
   },
   "test": {
     "autoBuild": true,
-    "publicOutputDir": "packs-test",
+    "publicOutputDir": "packs",
     "port": 3037
   }
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -33,9 +33,7 @@ export const config: UserConfigFnPromise = async ({ mode, command }) => {
   const isProdBuild = mode === 'production' && command === 'build';
 
   let outDirName = 'packs-dev';
-  if (mode === 'test') {
-    outDirName = 'packs-test';
-  } else if (mode === 'production') {
+  if (mode === 'test' || mode === 'production') {
     outDirName = 'packs';
   }
   const outDir = path.resolve('public', outDirName);


### PR DESCRIPTION
Alternative to #39616

This builds both packs in the same path, as the only differences in the build process are the production of sourcemaps and pre-compressed files.