### PR TITLE
Remove redundant accessibility patch for `simple-navigation`

### DIFF
--- a/app/javascript/entrypoints/public.tsx
+++ b/app/javascript/entrypoints/public.tsx
@@ -523,14 +523,6 @@ on('click', '.rules-list button', ({ target }) => {
  */
 function applyRailsA11yPatches() {
   /**
-   * Mark current navigation item with aria-current
-   */
-  const activeNavLink = document.querySelector(
-    '.simple-navigation-active-leaf a.selected',
-  );
-  activeNavLink?.setAttribute('aria-current', 'page');
-
-  /**
    * Hides the asterisk added to labels of required form fields
    * from assistive tech. (Those fields already have the `required` attribute)
    */


### PR DESCRIPTION
### Changes proposed in this PR:
- Removes a client-side accessibility patch for the simple-navigation library. The patch used to add the `aria-current` attribute to the current navigation link in the settings/mod/admin section, and is not needed anymore as the attribute is now added server-side by the library (updated in #39626). Credits to @oneiros for moving this patch upstream 🎉 