### PR TITLE
Use `truncate_html` i18n key for safe html entity in pagination gap partial

### DIFF
--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -6,4 +6,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 %span.page.gap
-  = t('pagination.truncate')
+  = t('pagination.truncate_html')

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -6,4 +6,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 %span.page.gap
-  != t('pagination.truncate')
+  = t('pagination.truncate')

--- a/config/locales/an.yml
+++ b/config/locales/an.yml
@@ -1252,7 +1252,6 @@ an:
     next: Proximo
     older: Mas antigo
     prev: Anterior
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Ya has votau en esta enqüesta

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1894,7 +1894,6 @@ ar:
     next: التالي
     older: الأقدَم
     prev: السابق
-    truncate: و
   polls:
     errors:
       already_voted: لقد قمت بالتصويت على استطلاع الرأي هذا مِن قبل

--- a/config/locales/ast.yml
+++ b/config/locales/ast.yml
@@ -690,7 +690,6 @@ ast:
     wrong_code: "¡El códigu introducíu nun yera válidu! ¿La hora del sirvidor y la del preséu son correutes?"
   pagination:
     next: Siguiente
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Yá votesti nesta encuesta

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -2025,7 +2025,6 @@ be:
     next: Далей
     older: Старэйшае
     prev: Папярэдні
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Вы ўжо прагаласавалі ў апытанні

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -1698,7 +1698,6 @@ bg:
     next: Напред
     older: По-старо
     prev: Назад
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Вече сте гласували в тази анкета

--- a/config/locales/br.yml
+++ b/config/locales/br.yml
@@ -723,7 +723,6 @@ br:
     next: Da-heul
     older: Koshoc'h
     prev: A-raok
-    truncate: "&hellip;"
   polls:
     errors:
       self_vote: N'hallit ket votiñ en ho sontadegoù deoc'h-c'hwi

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1723,7 +1723,6 @@ ca:
     next: Endavant
     older: Més vell
     prev: Enrere
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Ja has votat en aquesta enquesta

--- a/config/locales/co.yml
+++ b/config/locales/co.yml
@@ -793,7 +793,6 @@ co:
     next: Dopu
     older: Più vechju
     prev: Nanzu
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Avete digià vutatu nant'à stu scandagliu

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1864,7 +1864,6 @@ cs:
     next: Další
     older: Starší
     prev: Předchozí
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: V této anketě jste již hlasovali

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -2115,7 +2115,6 @@ cy:
     next: Nesaf
     older: Hŷn
     prev: Blaenorol
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Rydych chi eisoes wedi pleidleisio ar yr arolwg hwn

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -1935,7 +1935,6 @@ da:
     next: Næste
     older: Ældre
     prev: Foregående
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Du har allerede stemt i denne afstemning

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1936,7 +1936,6 @@ de:
     next: Weiter
     older: Älter
     prev: Zurück
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: An dieser Umfrage hast du bereits teilgenommen

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -1935,7 +1935,6 @@ el:
     next: Επόμενη
     older: Παλαιότερες
     prev: Προηγούμενη
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Έχετε ήδη ψηφίσει σε αυτή τη δημοσκόπηση

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1794,7 +1794,6 @@ en-GB:
     next: Next
     older: Older
     prev: Prev
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: You have already voted on this poll

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1936,7 +1936,7 @@ en:
     next: Next
     older: Older
     prev: Prev
-    truncate: "&hellip;"
+    truncate_html: "&hellip;"
   polls:
     errors:
       already_voted: You have already voted on this poll

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -1692,7 +1692,6 @@ eo:
     next: Sekva
     older: Malpli nova
     prev: Antaŭa
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Vi jam voĉdonis al ĉi tiu enketa

--- a/config/locales/es-AR.yml
+++ b/config/locales/es-AR.yml
@@ -1935,7 +1935,6 @@ es-AR:
     next: Siguiente
     older: Más antiguos
     prev: Anterior
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Ya votaste en esta encuesta

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -1935,7 +1935,6 @@ es-MX:
     next: Próximo
     older: Más antiguo
     prev: Anterior
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Ya has votado en esta encuesta

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1937,7 +1937,6 @@ es:
     next: Próximo
     older: Más antiguo
     prev: Anterior
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Ya has votado en esta encuesta

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -1924,7 +1924,6 @@ et:
     next: Järgmine
     older: Vanemad
     prev: Eelm
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Oled siin hääletusel juba hääletanud

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -1639,7 +1639,6 @@ eu:
     next: Hurrengoa
     older: Zaharragoa
     prev: Aurrekoa
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Inkesta honetan dagoeneko bozkatu duzu

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1851,7 +1851,6 @@ fa:
     next: بعدی
     older: قدیمی‌تر
     prev: قبلی
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: شما قبلاً در این نظرسنجی رأی داده‌اید

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1919,7 +1919,6 @@ fi:
     next: Seuraava
     older: Vanhemmat
     prev: Edellinen
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Olet jo osallistunut tähän äänestykseen

--- a/config/locales/fo.yml
+++ b/config/locales/fo.yml
@@ -1753,7 +1753,6 @@ fo:
     next: Næsta
     older: Eldri
     prev: Fyrra
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Tú hevur longu atkvøtt í hesi atkvøðugreiðsluni

--- a/config/locales/fr-CA.yml
+++ b/config/locales/fr-CA.yml
@@ -1935,7 +1935,6 @@ fr-CA:
     next: Suivant
     older: Plus ancien
     prev: Précédent
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Vous avez déjà voté sur ce sondage

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1935,7 +1935,6 @@ fr:
     next: Suivant
     older: Plus ancien
     prev: Précédent
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Vous avez déjà voté sur ce sondage

--- a/config/locales/fy.yml
+++ b/config/locales/fy.yml
@@ -1693,7 +1693,6 @@ fy:
     next: Folgjende
     older: Alder
     prev: Foarige
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Jo hawwe al op dizze enkête stimd

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -2072,7 +2072,6 @@ ga:
     next: An céad eile
     older: Níos sine
     prev: Ceann roimhe seo
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Tá tú tar éis vótáil ar an vótaíocht seo cheana féin

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -2025,7 +2025,6 @@ gd:
     next: Air adhart
     older: Nas sine
     prev: Air ais
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Chuir thu bhòt sa chunntas-bheachd seo mu thràth

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -1935,7 +1935,6 @@ gl:
     next: Seguinte
     older: Máis antigo
     prev: Previo
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Xa votaches nesta enquisa

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2025,7 +2025,6 @@ he:
     next: הבא
     older: ישן יותר
     prev: הקודם
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: כבר הצבעת בסקר זה

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1935,7 +1935,6 @@ hu:
     next: Következő
     older: Régebbi
     prev: Előző
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Ezen a szavazáson már voksoltál

--- a/config/locales/ia.yml
+++ b/config/locales/ia.yml
@@ -1717,7 +1717,6 @@ ia:
     next: Sequente
     older: Plus ancian
     prev: Previe
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Tu jam ha votate in iste sondage

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1228,7 +1228,6 @@ id:
     next: Selanjutnya
     older: Lebih lama
     prev: Sebelumnya
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Anda sudah mengikuti japat ini

--- a/config/locales/ie.yml
+++ b/config/locales/ie.yml
@@ -1424,7 +1424,6 @@ ie:
     next: Seq
     older: Plu old
     prev: Prec
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Tu ja votat in ti-ci balotation

--- a/config/locales/io.yml
+++ b/config/locales/io.yml
@@ -1557,7 +1557,6 @@ io:
     next: Sequanta
     older: Olda
     prev: Preiranta
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Vu ja votis sur ca votinquesto

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -1939,7 +1939,6 @@ is:
     next: Næsta
     older: Eldra
     prev: Fyrra
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Þú hefur þegar greitt atkvæði í þessari könnun

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1935,7 +1935,6 @@ it:
     next: Avanti
     older: Più vecchio
     prev: Indietro
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Hai già votato in questo sondaggio

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1675,7 +1675,6 @@ ja:
     next: 次
     older: 以前の投稿
     prev: 前
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: このアンケートには投票済みです

--- a/config/locales/kab.yml
+++ b/config/locales/kab.yml
@@ -927,7 +927,6 @@ kab:
     next: Ɣer zdat
     older: Aqbuṛ
     prev: Win iɛeddan
-    truncate: "&hellip;"
   polls:
     vote: Dɣer
   preferences:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1864,7 +1864,6 @@ ko:
     next: 다음
     older: 이전
     prev: 이전
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: 이미 참여한 설문

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -1250,7 +1250,6 @@ ku:
     next: Pêş
     older: Kevntir
     prev: Paş
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Te berê deng dabû vê rapirsîyê

--- a/config/locales/lad.yml
+++ b/config/locales/lad.yml
@@ -1635,7 +1635,6 @@ lad:
     next: Sigiente
     older: Mas viejo
     prev: Anterior
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Ya tienes votado en esta anketa

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -1130,7 +1130,6 @@ lt:
     next: Kitas
     older: Senesnis
     prev: Ankstesnis
-    truncate: "&hellip;"
   preferences:
     other: Kita
     posting_defaults: Skelbimo numatytosios nuostatos

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1696,7 +1696,6 @@ lv:
     next: Nākamais
     older: Vecāks
     prev: Iepr
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Šajā aptaujā tu esi jau balsojis

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -1373,7 +1373,6 @@ ms:
     next: Seterusnya
     older: Lebih lama
     prev: Sebelum ini
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Anda telah pun mengundi pada tinjauan pendapat ini

--- a/config/locales/my.yml
+++ b/config/locales/my.yml
@@ -1371,7 +1371,6 @@ my:
     next: ရှေ့သို့
     older: ပိုဟောင်းသော
     prev: ရှေ့သို့
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: ဤစစ်တမ်းတွင် သင်ပါဝင်ပြီးဖြစ်သည်

--- a/config/locales/nan-TW.yml
+++ b/config/locales/nan-TW.yml
@@ -1890,7 +1890,6 @@ nan-TW:
     next: 後一頁
     older: 較舊ê
     prev: 頂一頁
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Lí有投票ah

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1935,7 +1935,6 @@ nl:
     next: Volgende
     older: Ouder
     prev: Vorige
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Je hebt al aan deze peiling deelgenomen

--- a/config/locales/nn.yml
+++ b/config/locales/nn.yml
@@ -1935,7 +1935,6 @@ nn:
     next: Neste
     older: Eldre
     prev: Førre
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Du har allereie røysta i denne rundspørjinga

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -1448,7 +1448,6 @@
     next: Neste
     older: Eldre
     prev: Forrige
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Du har allerede stemt i denne avstemningen

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1870,7 +1870,6 @@ pl:
     next: Następna
     older: Starsze
     prev: Poprzednia
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Już oddałeś(-aś) głos w tym głosowaniu

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1936,7 +1936,6 @@ pt-BR:
     next: Próximo
     older: Mais antigo
     prev: Anterior
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Enquete votada

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -1794,7 +1794,6 @@ pt-PT:
     next: Seguinte
     older: Mais antiga
     prev: Anterior
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Já votaste nesta sondagem

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1856,7 +1856,6 @@ ru:
     next: Вперёд
     older: Раньше
     prev: Назад
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Вы уже проголосовали в этом опросе

--- a/config/locales/sc.yml
+++ b/config/locales/sc.yml
@@ -1001,7 +1001,6 @@ sc:
     next: Sighi
     older: Prus betzu
     prev: A coa
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: As giai votadu in custu sondàgiu

--- a/config/locales/sco.yml
+++ b/config/locales/sco.yml
@@ -1240,7 +1240,6 @@ sco:
     next: Neist
     older: Aulder
     prev: Prev
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Ye'v votit in this poll awriddy

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -1118,7 +1118,6 @@ si:
     next: ඊළඟ
     older: වැඩිහිටි
     prev: පෙර
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: ඔබ මෙම මත විමසුමට ඡන්දය දී ඇත

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -1785,7 +1785,6 @@ sl:
     next: Naprej
     older: Starejše
     prev: Nazaj
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Na tej anketi ste že glasovali

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -1920,7 +1920,6 @@ sq:
     next: Pasuesi
     older: Më të vjetër
     prev: I mëparshmi
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Keni votuar tashmë në këtë pyetësor

--- a/config/locales/sr-Latn.yml
+++ b/config/locales/sr-Latn.yml
@@ -1453,7 +1453,6 @@ sr-Latn:
     next: Sledeće
     older: Starije
     prev: Prethodni
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Već ste glasali u ovoj anketi

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -1483,7 +1483,6 @@ sr:
     next: Следеће
     older: Старије
     prev: Претходни
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Већ сте гласали у овој анкети

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1935,7 +1935,6 @@ sv:
     next: Nästa
     older: Äldre
     prev: Tidigare
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Du har redan röstat på den här undersökningen

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -1601,7 +1601,6 @@ th:
     next: ถัดไป
     older: เก่ากว่า
     prev: ก่อนหน้า
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: คุณได้ลงคะแนนในการสำรวจความคิดเห็นนี้ไปแล้ว

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1935,7 +1935,6 @@ tr:
     next: Sonraki
     older: Daha eski
     prev: Önceki
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Bu ankete daha önce oy verdiniz

--- a/config/locales/tt.yml
+++ b/config/locales/tt.yml
@@ -442,7 +442,6 @@ tt:
     next: Киләсе
     older: Искерәк
     prev: Алдыгы
-    truncate: "&hellip;"
   preferences:
     other: Башка
   privacy_policy:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1670,7 +1670,6 @@ uk:
     next: Далі
     older: Старіші
     prev: Назад
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Ви вже голосували в цьому опитуванні

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1890,7 +1890,6 @@ vi:
     next: Kế tiếp
     older: Cũ hơn
     prev: Trước đó
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: Bạn đã vốt xong rồi

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1890,7 +1890,6 @@ zh-CN:
     next: 下一页
     older: 更早
     prev: 上一页
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: 你已经在这里投过票了

--- a/config/locales/zh-HK.yml
+++ b/config/locales/zh-HK.yml
@@ -1437,7 +1437,6 @@ zh-HK:
     next: 下一頁
     older: 較舊
     prev: 上一頁
-    truncate: "……"
   polls:
     errors:
       already_voted: 你已投票

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1894,7 +1894,6 @@ zh-TW:
     next: 下一頁
     older: 較舊
     prev: 上一頁
-    truncate: "&hellip;"
   polls:
     errors:
       already_voted: 您已經投過票了


### PR DESCRIPTION
Background in https://github.com/mastodon/mastodon/pull/39575

I assume this is the correct way to get crowdin to update (remove the old name, add the new name to `en` only) but let me know if I should move/rename instead.

Remove the html safe call, changed to use `_html` naming. Confirmed output the same.

Will rebase linked issue after this one.