### PR TITLE
Add `inline_qrcode_svg` helper for confirmation page

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -9,6 +9,12 @@ module SettingsHelper
     LanguagesHelper.sorted_locale_keys(I18n.available_locales)
   end
 
+  def inline_qrcode_svg(code)
+    code
+      .as_svg(padding: 0, module_size: 4, use_path: true)
+      .html_safe # rubocop:disable Rails/OutputSafety
+  end
+
   def featured_tags_hint(recently_used_tags)
     recently_used_tags.present? &&
       safe_join(

--- a/app/views/settings/two_factor_authentication/confirmations/new.html.haml
+++ b/app/views/settings/two_factor_authentication/confirmations/new.html.haml
@@ -5,7 +5,7 @@
   %p.hint= t('otp_authentication.instructions_html')
 
   .qr-wrapper
-    .qr-code!= @qrcode.as_svg(padding: 0, module_size: 4, use_path: true)
+    .qr-code= inline_qrcode_svg(@qrcode)
 
     .qr-alternative
       %p.hint= t('otp_authentication.manual_instructions')

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe SettingsHelper do
     end
   end
 
+  describe '#inline_qrcode_svg' do
+    subject { inline_qrcode_svg(code) }
+
+    let(:code) { RQRCode::QRCode.new('https://host.example') }
+
+    it { is_expected.to include('</svg>').and(be_html_safe) }
+  end
+
   describe 'session_device_icon' do
     context 'with a mobile device' do
       let(:session) { SessionActivation.new(user_agent: 'Mozilla/5.0 (iPhone)') }


### PR DESCRIPTION
Alternative to disable approach in https://github.com/mastodon/mastodon/pull/39575 - and slightly more consistent with other helper methods that do something like this (basically, keep the cop disables on the rubocop/helper side and out of the haml views).

This and https://github.com/mastodon/mastodon/pull/39632 are pre-req for the linked haml lint bump, which I'll rebase after.