### PR TITLE
Render post images in emails

### DIFF
--- a/app/views/notification_mailer/_status_content.html.haml
+++ b/app/views/notification_mailer/_status_content.html.haml
@@ -9,7 +9,12 @@
   - if status.ordered_media_attachments.size.positive?
     %p.email-status-media
       - status.ordered_media_attachments.each do |a|
-        - if status.local?
+        - if a.image?
+          - if status.local?
+            %img{ src: full_asset_url(a.file.url(:original)), alt: a.description }
+          - else
+            %img{ src: a.remote_url, alt: a.description }
+        - elsif status.local?
           = link_to full_asset_url(a.file.url(:original)), full_asset_url(a.file.url(:original))
         - else
           = link_to a.remote_url, a.remote_url

--- a/app/views/notification_mailer/_status_content.html.haml
+++ b/app/views/notification_mailer/_status_content.html.haml
@@ -9,7 +9,7 @@
   - if status.ordered_media_attachments.size.positive?
     %p.email-status-media
       - status.ordered_media_attachments.each do |a|
-        - if a.image?
+        - if a.image? && !a.needs_redownload?
           %img{ src: full_asset_url(a.file.url(:original)), alt: a.description }
         - elsif status.local?
           = link_to full_asset_url(a.file.url(:original)), full_asset_url(a.file.url(:original))

--- a/app/views/notification_mailer/_status_content.html.haml
+++ b/app/views/notification_mailer/_status_content.html.haml
@@ -10,10 +10,7 @@
     %p.email-status-media
       - status.ordered_media_attachments.each do |a|
         - if a.image?
-          - if status.local?
-            %img{ src: full_asset_url(a.file.url(:original)), alt: a.description }
-          - else
-            %img{ src: a.remote_url, alt: a.description }
+          %img{ src: full_asset_url(a.file.url(:original)), alt: a.description }
         - elsif status.local?
           = link_to full_asset_url(a.file.url(:original)), full_asset_url(a.file.url(:original))
         - else


### PR DESCRIPTION
Fixes #39461

### Changes proposed in this PR:
- Updates the _status_content email template partial to render image URLs into an img tag rather than just a link.

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="711" height="273" alt="image" src="https://github.com/user-attachments/assets/38beb356-2f38-4be8-bc20-050332fa992c" /> | <img width="708" height="696" alt="image" src="https://github.com/user-attachments/assets/7e4d5183-52c1-4a50-890e-e0e67f8c96ef" /> |