### PR TITLE
Fix new posts not appearing on own profile without refresh

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -14,6 +14,7 @@ import { useEmoji } from './emojis';
 import { importFetchedAccounts, importFetchedStatus } from './importer';
 import { openModal } from './modal';
 import { updateTimeline } from './timelines';
+import { insertStatusIntoAccountTimelines } from './timelines_typed';
 
 /** @type {AbortController | undefined} */
 let fetchComposeSuggestionsAccountsController;
@@ -281,7 +282,12 @@ export function submitCompose(successCallback) {
       if (statusId === null && response.data.in_reply_to_id === null && response.data.visibility === 'public') {
         insertIfOnline('community');
         insertIfOnline('public');
-        insertIfOnline(`account:${response.data.account.id}`);
+      }
+
+      // Account timelines use keys like `account:${id}:0000` (see timelineKey)
+      // and are not streamed, so insert optimistically into matching loaded views.
+      if (statusId === null) {
+        dispatch(insertStatusIntoAccountTimelines(response.data));
       }
 
       dispatch(showAlert({

--- a/app/javascript/mastodon/actions/timelines_typed.test.ts
+++ b/app/javascript/mastodon/actions/timelines_typed.test.ts
@@ -1,0 +1,167 @@
+import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
+
+import { accountTimelineAcceptsStatus, timelineKey } from './timelines_typed';
+import type { AccountTimelineParams } from './timelines_typed';
+
+/** Minimal status shape used by compose / account timeline insertion. */
+interface StatusLike {
+  id: string;
+  account: { id: string };
+  visibility: string;
+  in_reply_to_id: string | null;
+  reblog: unknown;
+  media_attachments: unknown[];
+  tags?: { name: string }[];
+}
+
+const baseStatus = (overrides: Partial<StatusLike> = {}): StatusLike => ({
+  id: 'status-1',
+  account: { id: '42' },
+  visibility: 'public',
+  in_reply_to_id: null,
+  reblog: null,
+  media_attachments: [],
+  tags: [],
+  ...overrides,
+});
+
+const defaultParams = (
+  overrides: Partial<AccountTimelineParams> = {},
+): AccountTimelineParams => ({
+  type: 'account',
+  userId: '42',
+  boosts: false,
+  replies: false,
+  media: false,
+  pinned: false,
+  ...overrides,
+});
+
+describe('account timeline key format (profile vs compose regression)', () => {
+  // Regression for #39625: profile uses timelineKey(); compose used to insert
+  // into the legacy `account:${id}` key, so new posts never appeared without refresh.
+  test('profile page key is not the legacy account:${id} key', () => {
+    const accountId = '42';
+    const profileKey = timelineKey({ type: 'account', userId: accountId });
+    const legacyComposeKey = `account:${accountId}`;
+
+    expect(profileKey).toBe('account:42:0000');
+    expect(legacyComposeKey).not.toBe(profileKey);
+  });
+
+  test('inserting only into legacy key would miss the loaded profile timeline', () => {
+    const accountId = '42';
+    const profileKey = timelineKey({ type: 'account', userId: accountId });
+    const legacyComposeKey = `account:${accountId}`;
+
+    const timelines = ImmutableMap({
+      [profileKey]: ImmutableMap({
+        items: ImmutableList(['existing-status']),
+        online: false,
+      }),
+    });
+
+    // What compose used to do: look up the legacy key only.
+    const legacyTimeline = timelines.get(legacyComposeKey);
+    // Profile timeline is loaded, but under the new key — so optimistic insert missed it.
+    expect(legacyTimeline).toBeUndefined();
+    const profileItems = timelines.get(profileKey)?.get('items');
+    expect(ImmutableList.isList(profileItems) && profileItems.size).toBe(1);
+  });
+});
+
+describe('accountTimelineAcceptsStatus', () => {
+  test('accepts a top-level public post on the default posts timeline', () => {
+    expect(accountTimelineAcceptsStatus(defaultParams(), baseStatus())).toBe(
+      true,
+    );
+  });
+
+  test('rejects direct messages', () => {
+    expect(
+      accountTimelineAcceptsStatus(
+        defaultParams(),
+        baseStatus({ visibility: 'direct' }),
+      ),
+    ).toBe(false);
+  });
+
+  test('accepts unlisted and private posts on own profile timelines', () => {
+    expect(
+      accountTimelineAcceptsStatus(
+        defaultParams(),
+        baseStatus({ visibility: 'unlisted' }),
+      ),
+    ).toBe(true);
+    expect(
+      accountTimelineAcceptsStatus(
+        defaultParams(),
+        baseStatus({ visibility: 'private' }),
+      ),
+    ).toBe(true);
+  });
+
+  test('rejects replies unless the replies filter is on', () => {
+    const reply = baseStatus({ in_reply_to_id: 'parent-1' });
+    expect(accountTimelineAcceptsStatus(defaultParams(), reply)).toBe(false);
+    expect(
+      accountTimelineAcceptsStatus(defaultParams({ replies: true }), reply),
+    ).toBe(true);
+  });
+
+  test('rejects boosts unless the boosts filter is on', () => {
+    const boost = baseStatus({ reblog: { id: 'original' } });
+    expect(accountTimelineAcceptsStatus(defaultParams(), boost)).toBe(false);
+    expect(
+      accountTimelineAcceptsStatus(defaultParams({ boosts: true }), boost),
+    ).toBe(true);
+  });
+
+  test('rejects media-only timelines when the status has no media', () => {
+    expect(
+      accountTimelineAcceptsStatus(
+        defaultParams({ media: true }),
+        baseStatus(),
+      ),
+    ).toBe(false);
+    expect(
+      accountTimelineAcceptsStatus(
+        defaultParams({ media: true }),
+        baseStatus({ media_attachments: [{ id: 'm1' }] }),
+      ),
+    ).toBe(true);
+  });
+
+  test('rejects tagged timelines when the status lacks that tag', () => {
+    expect(
+      accountTimelineAcceptsStatus(
+        defaultParams({ tagged: 'nature' }),
+        baseStatus({ tags: [{ name: 'art' }] }),
+      ),
+    ).toBe(false);
+    expect(
+      accountTimelineAcceptsStatus(
+        defaultParams({ tagged: 'nature' }),
+        baseStatus({ tags: [{ name: 'nature' }] }),
+      ),
+    ).toBe(true);
+  });
+
+  test('never accepts pinned timelines (pins are managed separately)', () => {
+    expect(
+      accountTimelineAcceptsStatus(
+        defaultParams({ pinned: true }),
+        baseStatus(),
+      ),
+    ).toBe(false);
+  });
+
+  test('rejects timelines for a different account', () => {
+    expect(
+      accountTimelineAcceptsStatus(
+        defaultParams({ userId: '99' }),
+        baseStatus({ account: { id: '42' } }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/app/javascript/mastodon/actions/timelines_typed.ts
+++ b/app/javascript/mastodon/actions/timelines_typed.ts
@@ -10,6 +10,7 @@ import {
   expandTimeline,
   insertIntoTimeline,
   TIMELINE_NON_STATUS_MARKERS,
+  updateTimeline,
 } from './timelines';
 
 export const expandTimelineByKey = createAppThunk(
@@ -207,6 +208,116 @@ export const timelineDeleteStatus = createAction<{
   statusId: string;
   timelineKey: string;
 }>('timelines/deleteStatus');
+
+/** Minimal status fields needed to decide which account timelines to update. */
+export interface AccountTimelineStatusLike {
+  id: string;
+  account: { id: string };
+  visibility: string;
+  in_reply_to_id: string | null;
+  reblog: unknown;
+  media_attachments?: unknown[] | null;
+  tags?: { name: string }[] | null;
+}
+
+/**
+ * Whether a newly created status belongs in the given account timeline view
+ * (posts / replies / media / tagged filters). Pinned timelines are excluded.
+ */
+export function accountTimelineAcceptsStatus(
+  params: AccountTimelineParams,
+  status: AccountTimelineStatusLike,
+): boolean {
+  if (params.userId !== status.account.id) {
+    return false;
+  }
+
+  if (params.pinned) {
+    return false;
+  }
+
+  if (status.visibility === 'direct') {
+    return false;
+  }
+
+  const isReply = status.in_reply_to_id != null;
+  if (isReply && !params.replies) {
+    return false;
+  }
+
+  const isReblog = status.reblog != null;
+  if (isReblog && !params.boosts) {
+    return false;
+  }
+
+  if (params.media) {
+    const mediaCount = status.media_attachments?.length ?? 0;
+    if (mediaCount === 0) {
+      return false;
+    }
+  }
+
+  if (params.tagged) {
+    const tagNames = status.tags?.map((tag) => tag.name) ?? [];
+    if (!tagNames.includes(params.tagged)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Optimistically insert a status into loaded account timelines that would
+ * display it (own profile after compose). Account timelines are not streamed,
+ * so we do not require `online` — only that the timeline is already populated.
+ */
+export const insertStatusIntoAccountTimelines = createAppThunk(
+  (status: AccountTimelineStatusLike, { dispatch, getState }) => {
+    const accountId = status.account.id;
+    const timelines = getState().timelines as ImmutableMap<
+      string,
+      ImmutableMap<string, unknown>
+    >;
+
+    timelines.forEach((timeline, key) => {
+      if (
+        !key.startsWith(`account:${accountId}:`) &&
+        key !== `account:${accountId}`
+      ) {
+        return;
+      }
+
+      const parsed = parseTimelineKey(key);
+      if (parsed?.type !== 'account') {
+        return;
+      }
+
+      if (!accountTimelineAcceptsStatus(parsed, status)) {
+        return;
+      }
+
+      const items = timeline.get('items') as
+        | ImmutableList<string | null>
+        | undefined;
+      if (
+        !items ||
+        items.size === 0 ||
+        items.get(0) === null ||
+        items.includes(status.id)
+      ) {
+        return;
+      }
+
+      // Avoid inserting into partial timelines that will be reloaded anyway
+      if (timeline.get('isPartial')) {
+        return;
+      }
+
+      dispatch(updateTimeline(key, status));
+    });
+  },
+);
 
 export const insertPinnedStatusIntoTimelines = createAppThunk(
   (status: Status, { dispatch, getState }) => {


### PR DESCRIPTION
I've analyzed the issue to understand the problem and propose a solution. AI was used for the execution of that as I need to assess it's performance and decided to contribute to the project as I do that.

## Summary
- Fixes #39625: newly composed posts did not show on your own profile until a full page refresh.
- Root cause: after the profile timeline key redesign (`account:${id}:0000` etc.), compose still optimistically inserted into the legacy `account:${id}` key and required the timeline to be `online`. Account timelines are not streamed, so the insert never ran against the loaded profile view.
- Inserts the new status into all matching loaded account timeline views (filters, tags, visibility), without requiring a stream connection.

## Test plan
- [x] Added regression tests in `timelines_typed.test.ts` that document the key mismatch and cover `accountTimelineAcceptsStatus` filter rules.
- [x] `yarn test:js run app/javascript/mastodon/actions/timelines_typed.test.ts` passes.
- [x] On web UI: open your own profile, compose a public post from the same session; it should appear in the profile timeline without refreshing.
- [x] Confirm replies only appear when the replies filter is enabled; media-only and tagged views only get matching posts.
- [x] Confirm direct messages are not inserted into the profile timeline.

## AI
Assisted by: Grok