### PR TITLE
Update dependency `crass`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     css_parser (3.0.0)
       addressable
       ssrf_filter (~> 1.5)


### PR DESCRIPTION
We are likely not affected by the vulnerability, but update to prevent `bundler-audit` from complaining.