### PR TITLE
Fix API error when terms or privacy policy text contains percent signs

### DIFF
--- a/app/serializers/rest/privacy_policy_serializer.rb
+++ b/app/serializers/rest/privacy_policy_serializer.rb
@@ -8,7 +8,7 @@ class REST::PrivacyPolicySerializer < ActiveModel::Serializer
   end
 
   def content
-    markdown.render(format(object.text, domain: Rails.configuration.x.local_domain))
+    markdown.render(object.text.gsub(/%{domain}/, Rails.configuration.x.local_domain))
   end
 
   private

--- a/app/serializers/rest/terms_of_service_serializer.rb
+++ b/app/serializers/rest/terms_of_service_serializer.rb
@@ -16,7 +16,7 @@ class REST::TermsOfServiceSerializer < ActiveModel::Serializer
   end
 
   def content
-    markdown.render(format(object.text, domain: Rails.configuration.x.local_domain))
+    markdown.render(object.text.gsub(/%{domain}/, Rails.configuration.x.local_domain))
   end
 
   private

--- a/spec/requests/api/v1/instances/privacy_policies_spec.rb
+++ b/spec/requests/api/v1/instances/privacy_policies_spec.rb
@@ -16,5 +16,22 @@ RSpec.describe 'Privacy Policy' do
         .to be_present
         .and include(:content)
     end
+
+    context 'when text contains percent signs' do
+      before do
+        Setting.site_terms = '100% compliant on %{domain}'
+      end
+
+      it 'returns content without error' do
+        get api_v1_instance_privacy_policy_path
+
+        expect(response)
+          .to have_http_status(200)
+
+        expect(response.parsed_body[:content])
+          .to include('100%')
+          .and include(Rails.configuration.x.local_domain)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/instances/terms_of_services_spec.rb
+++ b/spec/requests/api/v1/instances/terms_of_services_spec.rb
@@ -23,6 +23,27 @@ RSpec.describe 'Terms of Service' do
       end
     end
 
+    context 'when text contains percent signs' do
+      before do
+        Fabricate(
+          :terms_of_service,
+          text: '100% compliant on %{domain}',
+          effective_date: Date.yesterday,
+        )
+      end
+
+      it 'returns content without error' do
+        get api_v1_instance_terms_of_service_index_path
+
+        expect(response)
+          .to have_http_status(200)
+
+        expect(response.parsed_body[:content])
+          .to include('100%')
+          .and include(Rails.configuration.x.local_domain)
+      end
+    end
+
     context 'without a current TOS record' do
       it 'returns http success' do
         get api_v1_instance_terms_of_service_index_path


### PR DESCRIPTION
Fixes #39653

## Summary

When terms of service or privacy policy text contains percent signs (e.g. `100%`), the instance API endpoints return 500 because `format()` treats the entire admin-authored markdown as a sprintf template.

This replaces `format()` with a targeted `gsub` for `%{domain}`, which is the only placeholder substituted at render time.

## User impact

- `/terms-of-service` and `/privacy-policy` no longer break when the text includes `%`
- Instance admins no longer need to escape `%` as `%%`

## Test plan

- [x] Added request specs for both API endpoints with `100%` in the text
- [ ] `bundle exec rspec spec/requests/api/v1/instances/terms_of_services_spec.rb spec/requests/api/v1/instances/privacy_policies_spec.rb`

Made with [Cursor](https://cursor.com)