### PR TITLE
Change how URIs are stored for local keypairs

### DIFF
--- a/app/models/keypair.rb
+++ b/app/models/keypair.rb
@@ -10,7 +10,7 @@
 #  public_key  :string           not null
 #  revoked     :boolean          default(FALSE), not null
 #  type        :integer          not null
-#  uri         :string           not null
+#  uri         :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  account_id  :bigint(8)        not null
@@ -32,7 +32,9 @@ class Keypair < ApplicationRecord
 
   attr_accessor :require_private_key
 
-  validates :uri, presence: true, uniqueness: true
+  validates :uri, presence: true, uniqueness: true, if: -> { account.remote? }
+  validates :uri, absence: true, if: -> { account.local? }
+
   validates :public_key, presence: true
   validates :private_key, presence: true, if: -> { account.local? }
 
@@ -60,6 +62,8 @@ class Keypair < ApplicationRecord
   end
 
   def self.from_keyid(uri)
+    return if uri.blank?
+
     keypair = find_by(uri: uri)
     return keypair unless keypair.nil?
 

--- a/app/models/keypair.rb
+++ b/app/models/keypair.rb
@@ -4,16 +4,17 @@
 #
 # Table name: keypairs
 #
-#  id          :bigint(8)        not null, primary key
-#  expires_at  :datetime
-#  private_key :string
-#  public_key  :string           not null
-#  revoked     :boolean          default(FALSE), not null
-#  type        :integer          not null
-#  uri         :string
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  account_id  :bigint(8)        not null
+#  id             :bigint(8)        not null, primary key
+#  expires_at     :datetime
+#  local_fragment :string
+#  private_key    :string
+#  public_key     :string           not null
+#  revoked        :boolean          default(FALSE), not null
+#  type           :integer          not null
+#  uri            :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  account_id     :bigint(8)        not null
 #
 
 class Keypair < ApplicationRecord
@@ -34,6 +35,9 @@ class Keypair < ApplicationRecord
 
   validates :uri, presence: true, uniqueness: true, if: -> { account.remote? }
   validates :uri, absence: true, if: -> { account.local? }
+
+  validates :local_fragment, presence: true, uniqueness: { scope: :account_id }, format: { with: /\A#[A-Z0-9-]+\Z/i }, if: -> { account.local? }
+  validates :local_fragment, absence: true, if: -> { account.remote? }
 
   validates :public_key, presence: true
   validates :private_key, presence: true, if: -> { account.local? }

--- a/db/migrate/20260629124055_add_new_index_on_uri_to_keypairs.rb
+++ b/db/migrate/20260629124055_add_new_index_on_uri_to_keypairs.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddNewIndexOnUriToKeypairs < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :keypairs, :uri, name: :index_keypairs_on_non_null_uri, unique: true, where: 'uri IS NOT NULL', algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260629124613_remove_old_index_on_uri_from_keypair.rb
+++ b/db/migrate/20260629124613_remove_old_index_on_uri_from_keypair.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveOldIndexOnUriFromKeypair < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :keypairs, :uri, name: :index_keypairs_on_uri, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260629124918_change_keypair_uri_non_nullable.rb
+++ b/db/migrate/20260629124918_change_keypair_uri_non_nullable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeKeypairUriNonNullable < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :keypairs, :uri, true
+  end
+end

--- a/db/migrate/20260629125635_add_local_fragment_to_keypair.rb
+++ b/db/migrate/20260629125635_add_local_fragment_to_keypair.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLocalFragmentToKeypair < ActiveRecord::Migration[8.1]
+  def change
+    add_column :keypairs, :local_fragment, :string, null: true
+  end
+end

--- a/db/migrate/20260629125939_add_index_account_id_local_fragment_to_keypair.rb
+++ b/db/migrate/20260629125939_add_index_account_id_local_fragment_to_keypair.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexAccountIdLocalFragmentToKeypair < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :keypairs, [:account_id, :local_fragment], unique: true, where: 'local_fragment IS NOT NULL', algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_29_124918) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_29_125939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -705,12 +705,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_124918) do
     t.bigint "account_id", null: false
     t.datetime "created_at", null: false
     t.datetime "expires_at"
+    t.string "local_fragment"
     t.string "private_key"
     t.string "public_key", null: false
     t.boolean "revoked", default: false, null: false
     t.integer "type", null: false
     t.datetime "updated_at", null: false
     t.string "uri"
+    t.index ["account_id", "local_fragment"], name: "index_keypairs_on_account_id_and_local_fragment", unique: true, where: "(local_fragment IS NOT NULL)"
     t.index ["account_id"], name: "index_keypairs_on_account_id"
     t.index ["uri"], name: "index_keypairs_on_non_null_uri", unique: true, where: "(uri IS NOT NULL)"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_18_114230) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_29_124918) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -710,9 +710,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_114230) do
     t.boolean "revoked", default: false, null: false
     t.integer "type", null: false
     t.datetime "updated_at", null: false
-    t.string "uri", null: false
+    t.string "uri"
     t.index ["account_id"], name: "index_keypairs_on_account_id"
-    t.index ["uri"], name: "index_keypairs_on_uri", unique: true
+    t.index ["uri"], name: "index_keypairs_on_non_null_uri", unique: true, where: "(uri IS NOT NULL)"
   end
 
   create_table "list_accounts", force: :cascade do |t|

--- a/spec/fabricators/keypair_fabricator.rb
+++ b/spec/fabricators/keypair_fabricator.rb
@@ -12,7 +12,10 @@ Fabricator(:keypair) do
   revoked     false
 
   after_build do |keypair|
-    keypair.uri ||= ActivityPub::TagManager.instance.key_uri_for(keypair.account)
-    keypair.private_key ||= private_key if keypair.account.local?
+    if keypair.account.local?
+      keypair.private_key ||= private_key
+    else
+      keypair.uri ||= ActivityPub::TagManager.instance.key_uri_for(keypair.account)
+    end
   end
 end

--- a/spec/fabricators/keypair_fabricator.rb
+++ b/spec/fabricators/keypair_fabricator.rb
@@ -14,6 +14,7 @@ Fabricator(:keypair) do
   after_build do |keypair|
     if keypair.account.local?
       keypair.private_key ||= private_key
+      keypair.local_fragment ||= "##{Random.hex}"
     else
       keypair.uri ||= ActivityPub::TagManager.instance.key_uri_for(keypair.account)
     end


### PR DESCRIPTION
This changes keypair URIs to only be stored in full for remote keypairs, and to only store a fragment for local users.

For local users, URI generation will then be computed at serialization time by appending the fragment to the URI of the actor.

This reduces the length of strings stored in the database and makes the code simpler.