### PR TITLE
Fix invisible username during post highlight animation

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1620,6 +1620,7 @@ body > [data-popover-placement] {
     content: '';
     position: absolute;
     inset: 0;
+    z-index: -1;
     background: var(--color-bg-brand-softest);
     opacity: 0;
     animation: fade 0.7s reverse both 0.3s;


### PR DESCRIPTION
Fixes #39642

### Changes proposed in this PR:
- Fixes username being covered up by the color wash element fading out during the "new post" highlight animation

### Screenshots

**Before**

https://github.com/user-attachments/assets/14305448-8b1e-404d-be2a-81531b00bf94

**After**

https://github.com/user-attachments/assets/fd1440bd-faad-4c0c-8927-66738d27dfc6

