### PR TITLE
Update dependency `msgpack`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,7 +452,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.8.1)
+    msgpack (1.8.3)
     multi_json (1.21.1)
     mutex_m (0.3.0)
     net-http (0.9.1)


### PR DESCRIPTION
It is only used in bootsnap, so I don't think we are vulnerable, but better safe than sorry, and silences bundler-audit warnings.