### PR TITLE
Update text of PRs created from the Crowdin Download workflows

### DIFF
--- a/.github/workflows/crowdin-download-stable.yml
+++ b/.github/workflows/crowdin-download-stable.yml
@@ -63,7 +63,7 @@ jobs:
             This PR will be updated every day with new translations.
 
             Due to a limitation in GitHub Actions, checks are not running on this PR without manual action.
-            If you want to run the checks, then close and re-open it.
+            If you want to run the checks, then please press “Approve workflows to run”.
           branch: i18n/crowdin/translations-${{ github.base_ref || github.ref_name }}
           base: ${{ github.base_ref || github.ref_name }}
           labels: i18n

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -65,7 +65,7 @@ jobs:
             This PR will be updated every day with new translations.
 
             Due to a limitation in GitHub Actions, checks are not running on this PR without manual action.
-            If you want to run the checks, then close and re-open it.
+            If you want to run the checks, then please press “Approve workflows to run”.
           branch: i18n/crowdin/translations
           base: main
           labels: i18n


### PR DESCRIPTION
They still need manual action for the CI to run, but Github changed how that works and we don't need to close & reopen anymore.