### PR TITLE
Fix missing unique index on keypairs URI

### DIFF
--- a/db/migrate/20260629124055_add_new_index_on_uri_to_keypairs.rb
+++ b/db/migrate/20260629124055_add_new_index_on_uri_to_keypairs.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class AddNewIndexOnUriToKeypairs < ActiveRecord::Migration[8.1]
-  disable_ddl_transaction!
-
-  def change
-    add_index :keypairs, :uri, name: :index_keypairs_on_non_null_uri, unique: true, where: 'uri IS NOT NULL', algorithm: :concurrently
-  end
-end

--- a/db/migrate/20260629124613_remove_old_index_on_uri_from_keypair.rb
+++ b/db/migrate/20260629124613_remove_old_index_on_uri_from_keypair.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class RemoveOldIndexOnUriFromKeypair < ActiveRecord::Migration[8.1]
-  disable_ddl_transaction!
-
-  def change
-    remove_index :keypairs, :uri, name: :index_keypairs_on_uri, unique: true, algorithm: :concurrently
-  end
-end

--- a/db/migrate/20260630070531_revert_add_new_index_on_uri_to_keypairs.rb
+++ b/db/migrate/20260630070531_revert_add_new_index_on_uri_to_keypairs.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-require_relative '20260629124055_add_new_index_on_uri_to_keypairs'
-
 class RevertAddNewIndexOnUriToKeypairs < ActiveRecord::Migration[8.1]
   disable_ddl_transaction!
 
-  def change
-    revert AddNewIndexOnUriToKeypairs
+  def up
+    return unless index_exists?(:keypairs, :uri, name: :index_keypairs_on_non_null_uri)
+
+    remove_index :keypairs, :uri, name: :index_keypairs_on_non_null_uri
   end
+
+  def down; end
 end

--- a/db/migrate/20260630070531_revert_add_new_index_on_uri_to_keypairs.rb
+++ b/db/migrate/20260630070531_revert_add_new_index_on_uri_to_keypairs.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative '20260629124055_add_new_index_on_uri_to_keypairs'
+
+class RevertAddNewIndexOnUriToKeypairs < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    revert AddNewIndexOnUriToKeypairs
+  end
+end

--- a/db/migrate/20260630070600_revert_remove_old_index_on_uri_from_keypair.rb
+++ b/db/migrate/20260630070600_revert_remove_old_index_on_uri_from_keypair.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-require_relative '20260629124613_remove_old_index_on_uri_from_keypair'
-
 class RevertRemoveOldIndexOnUriFromKeypair < ActiveRecord::Migration[8.1]
   disable_ddl_transaction!
 
-  def change
-    revert RemoveOldIndexOnUriFromKeypair
+  def up
+    return if index_exists?(:keypairs, :uri, name: :index_keypairs_on_uri)
+
+    add_index :keypairs, :uri, name: :index_keypairs_on_uri, unique: true, algorithm: :concurrently
   end
+
+  def down; end
 end

--- a/db/migrate/20260630070600_revert_remove_old_index_on_uri_from_keypair.rb
+++ b/db/migrate/20260630070600_revert_remove_old_index_on_uri_from_keypair.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative '20260629124613_remove_old_index_on_uri_from_keypair'
+
+class RevertRemoveOldIndexOnUriFromKeypair < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    revert RemoveOldIndexOnUriFromKeypair
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_29_125939) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_30_070600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -714,7 +714,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_125939) do
     t.string "uri"
     t.index ["account_id", "local_fragment"], name: "index_keypairs_on_account_id_and_local_fragment", unique: true, where: "(local_fragment IS NOT NULL)"
     t.index ["account_id"], name: "index_keypairs_on_account_id"
-    t.index ["uri"], name: "index_keypairs_on_non_null_uri", unique: true, where: "(uri IS NOT NULL)"
+    t.index ["uri"], name: "index_keypairs_on_uri", unique: true
   end
 
   create_table "list_accounts", force: :cascade do |t|


### PR DESCRIPTION
In #39658, I replaced the `index_keypairs_on_uri` unique index to a more complex `index_keypairs_on_non_null_uri` index with a `WHERE uri IS NOT NULL` condition.

However, that condition is not necessary, as `NULL != NULL` and local keypairs would not violate that condition.

Furthermore, the absence of a simple condition would prevent existing `UPSERT` calls, like the following from executing properly:
https://github.com/mastodon/mastodon/blob/52b781c2f4e65d6782e9a120e2fd595d332c03a9/app/services/activitypub/process_account_service.rb#L157

This PR reverts the migrations, but also actually removes them so that the majority of servers, which have not run them yet, does not have to run them at all.