### PR TITLE
Add Json schema validation for action logs

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -38,8 +38,8 @@ module Admin
 
     def log_action_from_change
       action_log = current_account.action_logs.new(action: 'update', target: @tag)
-
       action_log.recorded_changes = @tag.saved_changes.slice('usable', 'trendable', 'listable').transform_values(&:last)
+      action_log.recorded_changes_format = 'tags_format_1.0'
       action_log.save
     end
 

--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -55,6 +55,7 @@ module Admin::ActionLogsHelper
   end
 
   def permutation_of_key(log, key)
+    # we're utilizing the store_accessors here, to get the values from the jsonb like: log.listable => true
     return if log.public_send(key).nil?
 
     log.public_send(key) ? key : :"not_#{key}"

--- a/spec/requests/admin/tags_spec.rb
+++ b/spec/requests/admin/tags_spec.rb
@@ -20,12 +20,18 @@ RSpec.describe 'Admin Tags' do
     let(:tag) { Fabricate :tag, name: '#supertag' }
 
     it 'redirects to tag page and saves update log action for all attribute statuses' do
-      put admin_tag_path(tag.id, params: { tag: { trendable: true, listable: false } })
+      put admin_tag_path(tag.id, params: { tag: { trendable: true, listable: false, unallowed: true } })
 
       expect(response).to have_http_status(302)
-      expect(Admin::ActionLog.last.human_identifier).to eq('#supertag')
-      expect(Admin::ActionLog.pluck(:action)).to eq(%w(update))
       expect(Admin::ActionLog.pluck(:recorded_changes)).to eq([{ 'listable' => false, 'trendable' => true }])
+      expect(Admin::ActionLog.last.recorded_changes).to match_json_schema('tags_format_1.0')
+    end
+
+    it 'returns invalid when the schema does not match' do
+      put admin_tag_path(tag.id, params: { tag: { trendable: true } })
+
+      Admin::ActionLog.last.update(recorded_changes: { 'unallowed' => false })
+      expect(Admin::ActionLog.last.recorded_changes).to_not match_json_schema('tags_format_1.0')
     end
   end
 end

--- a/spec/support/schema/tags_format_1.0.json
+++ b/spec/support/schema/tags_format_1.0.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "properties": {
+    "usable": { "type": "boolean" },
+    "trendable": { "type": "boolean" },
+    "listable": { "type": "boolean" }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
cherry picked from #39655
Adds json validation for tags action logs.

the validation checks are handled in specs.
we decided to go this route since there is not much we could do, when we check during runtime, since we don't want the logging to silently fail, or make a transaction including the action to be logged fail.

in any case, all current guardrails are not binding, so for more models being added to the `recorded_changes` we should try to stick to the pattern.

the `action_log.recorded_changes` is a hash that accepts _any_ key value pair.
and the  `action_log.recorded_changes_format` should match the name of the respective json schema you define in spec/support/schema/xxx.json

`#permutation_of_key(log, key)` in the action_logs_helper.rb utilizes the attribute_accessors from the ActionLog model, if you want to fetch your translations via this method, you have to add the json fields of the model you are adding to the accessor. This is a lightweight second layer, that makes sure you only access fields you registered.