### PR TITLE
Fix duplicate "clear" button shown in main search input in Chrome

### DIFF
--- a/app/javascript/mastodon/features/compose/components/search.tsx
+++ b/app/javascript/mastodon/features/compose/components/search.tsx
@@ -560,7 +560,8 @@ export const Search: React.FC<{
       <input
         ref={searchInputRef}
         className='search__input'
-        type='search'
+        type='text'
+        enterKeyHint='search'
         placeholder={intl.formatMessage(
           signedIn ? messages.placeholderSignedIn : messages.placeholder,
         )}

--- a/app/javascript/mastodon/features/compose/components/search.tsx
+++ b/app/javascript/mastodon/features/compose/components/search.tsx
@@ -561,7 +561,7 @@ export const Search: React.FC<{
         ref={searchInputRef}
         className='search__input'
         type='text'
-        enterKeyHint='search'
+        inputMode='search'
         placeholder={intl.formatMessage(
           signedIn ? messages.placeholderSignedIn : messages.placeholder,
         )}


### PR DESCRIPTION
### Changes proposed in this PR:
- Changes the type of the main search input back from "search" to "text" to fix the duplicate clear button shown in Chrome. (a regression from #39133)
- Adds a matching `enterKeyHint` attribute to still show a search icon on the enter key in mobile keyboards.

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="305" height="176" alt="image" src="https://github.com/user-attachments/assets/07ed2581-6e29-4212-9e60-8d7b10b824f4" /> | <img width="302" height="174" alt="image" src="https://github.com/user-attachments/assets/7fc38ebe-baed-4f38-b0f0-220043693a02" /> |