### PR TITLE
Add missing `to_json` to publish announcement reaction worker

### DIFF
--- a/app/workers/publish_announcement_reaction_worker.rb
+++ b/app/workers/publish_announcement_reaction_worker.rb
@@ -11,7 +11,7 @@ class PublishAnnouncementReactionWorker
     reaction ||= announcement.announcement_reactions.new(name: name)
 
     payload = InlineRenderer.render(reaction, nil, :reaction).tap { |h| h[:announcement_id] = announcement_id.to_s }
-    payload = { event: :'announcement.reaction', payload: payload }
+    payload = { event: :'announcement.reaction', payload: payload }.to_json
 
     FeedManager.instance.with_active_accounts do |account|
       redis.publish("timeline:#{account.id}", payload) if redis.exists?("subscribed:timeline:#{account.id}")

--- a/spec/workers/publish_announcement_reaction_worker_spec.rb
+++ b/spec/workers/publish_announcement_reaction_worker_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PublishAnnouncementReactionWorker do
 
       worker.perform(announcement.id, name)
 
-      expect(redis).to have_received(:publish)
+      expect(redis).to have_received(:publish).with(include('timeline'), be_a(String))
     end
 
     it 'does not send the announcement and name to the service when not subscribed' do


### PR DESCRIPTION
In this bulk conversion I missed the `to_json` on one of them - https://github.com/mastodon/mastodon/pull/38215/changes#diff-1e8c444e16382e49507dc69e442066e4d2165ce4acf2b3604f11b5d045e426bcR14

Added basic test which would have blown up on the incorrect hash arg.

Resolves https://github.com/mastodon/mastodon/issues/39688