### PR TITLE
Accept non-Latin characters to suggest hash tag

### DIFF
--- a/app/javascript/mastodon/components/autosuggest/utils.test.ts
+++ b/app/javascript/mastodon/components/autosuggest/utils.test.ts
@@ -2,11 +2,28 @@ import { textAtCursorMatchesToken } from './utils';
 
 describe('textAtCursorMatchesToken', () => {
   test.concurrent.for([
-    [['#hashtag', 7, ['#']], [1, '#hashtag']],
-    [['#hash tag', 8, ['#']], [1, '#hash tag']],
-    [['#ハッシュタグ', 6, ['#']], [1, '#ハッシュタグ']],
-    [['#ハッシュ タグ', 7, ['#']], [1, '#ハッシュ タグ']],
-  ] as const)('textAtCursorMatchesToken(%s) is %o', ([input, expected], { expect }) => {
-    expect(textAtCursorMatchesToken(input[0], input[1], input[2])).toStrictEqual(expected);
-  });
+    [
+      ['#hashtag', 7, ['#']],
+      [1, '#hashtag'],
+    ],
+    [
+      ['#hash tag', 8, ['#']],
+      [1, '#hash tag'],
+    ],
+    [
+      ['#ハッシュタグ', 6, ['#']],
+      [1, '#ハッシュタグ'],
+    ],
+    [
+      ['#ハッシュ タグ', 7, ['#']],
+      [1, '#ハッシュ タグ'],
+    ],
+  ] as const)(
+    'textAtCursorMatchesToken(%s) is %o',
+    ([input, expected], { expect }) => {
+      expect(
+        textAtCursorMatchesToken(input[0], input[1], input[2]),
+      ).toStrictEqual(expected);
+    },
+  );
 });

--- a/app/javascript/mastodon/components/autosuggest/utils.test.ts
+++ b/app/javascript/mastodon/components/autosuggest/utils.test.ts
@@ -22,7 +22,7 @@ describe('textAtCursorMatchesToken', () => {
     'textAtCursorMatchesToken(%s) is %o',
     ([input, expected], { expect }) => {
       expect(
-        textAtCursorMatchesToken(input[0], input[1], input[2]),
+        textAtCursorMatchesToken(input[0], input[1], Array.from(input[2])),
       ).toStrictEqual(expected);
     },
   );

--- a/app/javascript/mastodon/components/autosuggest/utils.test.ts
+++ b/app/javascript/mastodon/components/autosuggest/utils.test.ts
@@ -1,0 +1,12 @@
+import { textAtCursorMatchesToken } from './utils';
+
+describe('textAtCursorMatchesToken', () => {
+  test.concurrent.for([
+    [['#hashtag', 7, ['#']], [1, '#hashtag']],
+    [['#hash tag', 8, ['#']], [1, '#hash tag']],
+    [['#ハッシュタグ', 6, ['#']], [1, '#ハッシュタグ']],
+    [['#ハッシュ タグ', 7, ['#']], [1, '#ハッシュ タグ']],
+  ] as const)('textAtCursorMatchesToken(%s) is %o', ([input, expected], { expect }) => {
+    expect(textAtCursorMatchesToken(input[0], input[1], input[2])).toStrictEqual(expected);
+  });
+});

--- a/app/javascript/mastodon/components/autosuggest/utils.ts
+++ b/app/javascript/mastodon/components/autosuggest/utils.ts
@@ -7,7 +7,10 @@ export const textAtCursorMatchesToken = (
 ) => {
   let word: string;
 
-  const regex = new RegExp(`[${searchTokens.join('')}${WORD}]+(\\s[${WORD}]+)?$`, 'iu');
+  const regex = new RegExp(
+    `[${searchTokens.join('')}${WORD}]+(\\s[${WORD}]+)?$`,
+    'iu',
+  );
   const left = str.slice(0, caretPosition).search(regex);
   const right = str.slice(caretPosition).search(/\s/);
 

--- a/app/javascript/mastodon/components/autosuggest/utils.ts
+++ b/app/javascript/mastodon/components/autosuggest/utils.ts
@@ -1,3 +1,5 @@
+import { WORD } from '../../utils/hashtags';
+
 export const textAtCursorMatchesToken = (
   str: string,
   caretPosition: number,
@@ -5,7 +7,7 @@ export const textAtCursorMatchesToken = (
 ) => {
   let word: string;
 
-  const regex = new RegExp(`[${searchTokens.join('')}\\w]+(\\s[\\w]+)?$`);
+  const regex = new RegExp(`[${searchTokens.join('')}${WORD}]+(\\s[${WORD}]+)?$`, 'iu');
   const left = str.slice(0, caretPosition).search(regex);
   const right = str.slice(caretPosition).search(/\s/);
 

--- a/app/javascript/mastodon/utils/hashtags.ts
+++ b/app/javascript/mastodon/utils/hashtags.ts
@@ -1,6 +1,6 @@
 const HASHTAG_SEPARATORS = '_\\u00b7\\u200c';
 const ALPHA = '\\p{L}\\p{M}';
-const WORD = '\\p{L}\\p{M}\\p{N}\\p{Pc}';
+export const WORD = '\\p{L}\\p{M}\\p{N}\\p{Pc}';
 
 const buildHashtagPatternRegex = () => {
   try {


### PR DESCRIPTION
This change should allow hash tags in non-Latin characters to be auto-suggested just like #39622 for Latin characters.