### PR TITLE
Update js-yaml to version 5.2.1

### DIFF
--- a/config/vite/plugin-mastodon-themes.ts
+++ b/config/vite/plugin-mastodon-themes.ts
@@ -4,7 +4,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import type { Plugin } from 'vite';
 
 type Themes = Record<string, string>;

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "idb": "^8.0.3",
     "immutable": "^4.3.0",
     "intl-messageformat": "^11.0.0",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^5.1.0",
     "lande": "^1.0.10",
     "lodash": "^4.17.21",
     "marky": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "idb": "^8.0.3",
     "immutable": "^4.3.0",
     "intl-messageformat": "^11.0.0",
-    "js-yaml": "^5.1.0",
+    "js-yaml": "^5.2.1",
     "lande": "^1.0.10",
     "lodash": "^4.17.21",
     "marky": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3010,7 +3010,7 @@ __metadata:
     idb: "npm:^8.0.3"
     immutable: "npm:^4.3.0"
     intl-messageformat: "npm:^11.0.0"
-    js-yaml: "npm:^5.1.0"
+    js-yaml: "npm:^5.2.1"
     lande: "npm:^1.0.10"
     lint-staged: "npm:^17.0.0"
     lodash: "npm:^4.17.21"
@@ -9461,14 +9461,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "js-yaml@npm:5.1.0"
+"js-yaml@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "js-yaml@npm:5.2.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.mjs
-  checksum: 10c0/a21c3817fb736ab3215c9d1ffb0a94823d02ecb51b481e88ab4bf0f9522baccbe9168bdf265bc315124d5087e2261de93e56176c2a7cd589d8275a18d7b3316e
+  checksum: 10c0/8eadf08efc738a656c2838f6617b0cc508944f66f568eb4d435e858261b889a6806d98f44fb6ffdba21a0c68e4bdff1ac35516724882e1dab8fc2cc59150c881
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3010,7 +3010,7 @@ __metadata:
     idb: "npm:^8.0.3"
     immutable: "npm:^4.3.0"
     intl-messageformat: "npm:^11.0.0"
-    js-yaml: "npm:^4.1.0"
+    js-yaml: "npm:^5.1.0"
     lande: "npm:^1.0.10"
     lint-staged: "npm:^17.0.0"
     lodash: "npm:^4.17.21"
@@ -9458,6 +9458,17 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "js-yaml@npm:5.1.0"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.mjs
+  checksum: 10c0/a21c3817fb736ab3215c9d1ffb0a94823d02ecb51b481e88ab4bf0f9522baccbe9168bdf265bc315124d5087e2261de93e56176c2a7cd589d8275a18d7b3316e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/39541

Informed by scanning https://github.com/nodeca/js-yaml/blob/master/docs/migrate_v4_to_v5.md 

I think this dependency is only used in this one spot to read the themes yml file. Verified change by watching vite build and confirming that entries from the yaml still wind up producing output files.

There are multiple ways to update this from the guide ... chose what I think was the smallest diff one here (ESM namespace import) to avoid call-site changes, but let me know if another approach is preferred.