### PR TITLE
Change FEP-521 processing to happen in addition of old security context instead of replacing it

### DIFF
--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -271,7 +271,7 @@ class ActivityPub::ProcessAccountService < BaseService
   end
 
   def public_keys
-    @public_keys ||= fep_521a_public_keys.presence || legacy_public_keys
+    @public_keys ||= (fep_521a_public_keys + legacy_public_keys).uniq { |key| key[:uri] }
   end
 
   def legacy_public_keys
@@ -305,8 +305,6 @@ class ActivityPub::ProcessAccountService < BaseService
   end
 
   def fep_521a_public_keys
-    return if @json['assertionMethod'].blank?
-
     as_array(@json['assertionMethod']).take(MAX_PUBLIC_KEYS).filter_map do |value|
       next if value.nil?
 


### PR DESCRIPTION
Fixes #39720

I assumed servers implementing FEP-521 would announce their RSA key using it, but that is not the case of Hubzilla.