### PR TITLE
Refactor Multikey decoding and avoid OpenSSL calls

### DIFF
--- a/app/lib/multibase.rb
+++ b/app/lib/multibase.rb
@@ -19,6 +19,9 @@ class Multibase
     bytes.pack('C*')
   end.freeze
 
+  ED25519_PUB_DER_HEADER = ['302a300506032b6570032100'].pack('H*').freeze
+  ML_DSA_44_PUB_DER_HEADER = ['30820532300b06096086480165030403110382052100'].pack('H*').freeze
+
   def self.decode(string)
     raise ArgumentError if string.nil?
 
@@ -40,5 +43,26 @@ class Multibase
     end
 
     raise ArgumentError
+  end
+
+  def self.decode_key_to_pem(string)
+    tag, binary = decode_multicodec(string)
+
+    case tag
+    when :'rsa-pub'
+      [:rsa, OpenSSL::PKey::RSA.new(binary).to_pem]
+    when :'ed25519-pub'
+      raise ArgumentError unless binary.size == 32
+
+      der = ED25519_PUB_DER_HEADER + binary
+      [:ed25519, "-----BEGIN PUBLIC KEY-----\n#{Base64.strict_encode64(der)}\n-----END PUBLIC KEY-----\n"]
+    when :'mldsa-44-pub'
+      raise ArgumentError unless binary.size == 1312
+
+      der = ML_DSA_44_PUB_DER_HEADER + binary
+      [:'ml-dsa-44', "-----BEGIN PUBLIC KEY-----\n#{Base64.strict_encode64(der).scan(/.{,64}/).join("\n")}-----END PUBLIC KEY-----\n"]
+    else
+      raise ArgumentError
+    end
   end
 end

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -334,20 +334,7 @@ class ActivityPub::ProcessAccountService < BaseService
   end
 
   def key_from_multikey(value)
-    tag, key = Multibase.decode_multicodec(value)
-
-    case tag
-    when :'rsa-pub'
-      [:rsa, OpenSSL::PKey::RSA.new(key).to_pem]
-    when :'ed25519-pub'
-      asn1 = OpenSSL::ASN1::Sequence(
-        [
-          OpenSSL::ASN1::Sequence([OpenSSL::ASN1::ObjectId('ED25519')]),
-          OpenSSL::ASN1::BitString(key),
-        ]
-      )
-      [:ed25519, OpenSSL::PKey.read(asn1.to_der).public_to_pem]
-    end
+    Multibase.decode_key_to_pem(value)
   rescue ArgumentError
     nil
   end

--- a/spec/lib/activitypub/object_integrity_proof_spec.rb
+++ b/spec/lib/activitypub/object_integrity_proof_spec.rb
@@ -47,15 +47,9 @@ RSpec.describe ActivityPub::ObjectIntegrityProof do
 
     context 'when the signature is correct' do
       before do
-        asn1 = OpenSSL::ASN1::Sequence(
-          [
-            OpenSSL::ASN1::Sequence([OpenSSL::ASN1::ObjectId('ED25519')]),
-            OpenSSL::ASN1::BitString(Multibase.decode_multicodec('z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2')[1]),
-          ]
-        )
-        keypair = OpenSSL::PKey.read(asn1.to_der)
+        _, pem = Multibase.decode_key_to_pem('z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2')
 
-        Fabricate(:keypair, account: actor, uri: 'https://server.example/users/alice#ed25519-key', type: :ed25519, public_key: keypair.public_to_pem)
+        Fabricate(:keypair, account: actor, uri: 'https://server.example/users/alice#ed25519-key', type: :ed25519, public_key: pem)
       end
 
       it 'returns the actor' do
@@ -108,15 +102,9 @@ RSpec.describe ActivityPub::ObjectIntegrityProof do
       end
 
       before do
-        asn1 = OpenSSL::ASN1::Sequence(
-          [
-            OpenSSL::ASN1::Sequence([OpenSSL::ASN1::ObjectId('ED25519')]),
-            OpenSSL::ASN1::BitString(Multibase.decode_multicodec('z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2')[1]),
-          ]
-        )
-        keypair = OpenSSL::PKey.read(asn1.to_der)
+        _, pem = Multibase.decode_key_to_pem('z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2')
 
-        Fabricate(:keypair, account: actor, uri: 'https://server.example/users/alice#ed25519-key', type: :ed25519, public_key: keypair.public_to_pem)
+        Fabricate(:keypair, account: actor, uri: 'https://server.example/users/alice#ed25519-key', type: :ed25519, public_key: pem)
       end
 
       it 'returns the actor' do
@@ -159,15 +147,9 @@ RSpec.describe ActivityPub::ObjectIntegrityProof do
       end
 
       before do
-        asn1 = OpenSSL::ASN1::Sequence(
-          [
-            OpenSSL::ASN1::Sequence([OpenSSL::ASN1::ObjectId('ED25519')]),
-            OpenSSL::ASN1::BitString(Multibase.decode_multicodec('z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2')[1]),
-          ]
-        )
-        keypair = OpenSSL::PKey.read(asn1.to_der)
+        _, pem = Multibase.decode_key_to_pem('z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2')
 
-        Fabricate(:keypair, account: actor, uri: 'https://server.example/users/alice#ed25519-key', type: :ed25519, public_key: keypair.public_to_pem)
+        Fabricate(:keypair, account: actor, uri: 'https://server.example/users/alice#ed25519-key', type: :ed25519, public_key: pem)
       end
 
       it 'returns nil' do
@@ -180,14 +162,9 @@ RSpec.describe ActivityPub::ObjectIntegrityProof do
     # https://www.w3.org/TR/vc-di-eddsa/#representation-eddsa-jcs-2022
 
     let(:keypair) do
-      asn1 = OpenSSL::ASN1::Sequence(
-        [
-          OpenSSL::ASN1::Sequence([OpenSSL::ASN1::ObjectId('ED25519')]),
-          OpenSSL::ASN1::BitString(Multibase.decode_multicodec('z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2')[1]),
-        ]
-      )
+      _, pem = Multibase.decode_key_to_pem('z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2')
 
-      OpenSSL::PKey.read(asn1.to_der)
+      OpenSSL::PKey.read(pem)
     end
 
     let(:secured_json) do


### PR DESCRIPTION
This makes the tests more concise, and producing PEM files without calling OpenSSL will allow us to ingest ML-DSA-44 keys in #39522 even without OpenSSL support.

Of course, actually using those keys will fail, but I think it's more likely for implementations to advertise ML-DSA-44 keys before using them. Ingesting them means Mastodon can learn about these keys and know them by the time they are ready for use, even if it originally runs with an OpenSSL version that doesn't support them.