### PR TITLE
Fix N+1 queries when rendering accounts on the admin collection page

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -51,7 +51,7 @@ module Admin
     end
 
     def set_collection
-      @collection = @account.collections.includes(accepted_collection_items: :account).find(params[:id])
+      @collection = @account.collections.includes(accepted_collection_items: { account: [:account_stat, user: [:ips, :invite_request]] }).find(params[:id])
     end
 
     def set_collections


### PR DESCRIPTION
On `/admin/accounts/:account_id/collections/:id`, the accounts belonging to the collection are rendered through the `admin/accounts/account` partial, which reads `statuses_count` / `followers_count` (via the `account_stat` association) and `user_pending?` / `user_email` / `user_current_sign_in_at` (via the `user` association) for each row. `set_collection` currently preloads only `accepted_collection_items: :account`, so every rendered row issues an additional `AccountStat` query and a `User` query (plus `invite_request` for local pending accounts).

This extends the preload to mirror what `AccountFilter` already sets up for the same partial on the admin accounts index (`Account.includes(:account_stat, user: [:ips, :invite_request])`).

Surfaced by static analysis of the view/controller pair; verified by hand against the partial's association reads.