### PR TITLE
fix inert state on active carousel slide

### DIFF
--- a/app/javascript/mastodon/components/carousel/index.tsx
+++ b/app/javascript/mastodon/components/carousel/index.tsx
@@ -235,7 +235,7 @@ const CarouselSlideWrapper = <SlideProps extends CarouselSlideProps>({
       className={className}
       role='group'
       aria-roledescription='slide'
-      inert={active}
+      inert={!active}
       data-index={index}
     >
       {children}


### PR DESCRIPTION
applies `inert` only to inactive carousel slides.

issued on https://github.com/glitch-soc/mastodon/issues/3564