### PR TITLE
Add support for ML-DSA-44 keys

### DIFF
--- a/app/lib/activitypub/linked_data_signature.rb
+++ b/app/lib/activitypub/linked_data_signature.rb
@@ -33,7 +33,7 @@ class ActivityPub::LinkedDataSignature
     to_be_verified = options_hash + document_hash
 
     keypair.actor if keypair.keypair.public_key.verify(OpenSSL::Digest.new('SHA256'), Base64.decode64(signature), to_be_verified)
-  rescue OpenSSL::PKey::RSAError
+  rescue OpenSSL::PKey::PKeyError
     false
   end
 

--- a/app/lib/multibase.rb
+++ b/app/lib/multibase.rb
@@ -7,6 +7,7 @@ class Multibase
   MULTICODEC_PREFIXES = {
     'rsa-pub': 0x1205,
     'ed25519-pub': 0xED,
+    'mldsa-44-pub': 0x1210,
   }.transform_values do |code|
     bytes = []
 

--- a/app/lib/multibase.rb
+++ b/app/lib/multibase.rb
@@ -67,7 +67,7 @@ class Multibase
     else
       raise Error, 'Unsupported key type'
     end
-  rescue OpenSSL::PKey::RSAError => e
+  rescue OpenSSL::PKey::PKeyError => e
     raise Error, e
   end
 end

--- a/app/lib/signed_request.rb
+++ b/app/lib/signed_request.rb
@@ -101,7 +101,7 @@ class SignedRequest
 
     def verify_signature(keypair, signature, compare_signed_string)
       true if keypair.keypair.public_key.verify(OpenSSL::Digest.new('SHA256'), signature, compare_signed_string)
-    rescue OpenSSL::PKey::RSAError
+    rescue OpenSSL::PKey::PKeyError
       nil
     end
 

--- a/app/models/keypair.rb
+++ b/app/models/keypair.rb
@@ -29,6 +29,7 @@ class Keypair < ApplicationRecord
   enum :type, {
     rsa: 0,
     ed25519: 1,
+    'ml-dsa-44': 2,
   }, validate: true
 
   validates :uri, presence: true, uniqueness: true, if: -> { account.remote? }
@@ -57,7 +58,7 @@ class Keypair < ApplicationRecord
       case type
       when 'rsa'
         OpenSSL::PKey::RSA.new(private_key || public_key)
-      when 'ed25519'
+      when 'ed25519', 'ml-dsa-44'
         OpenSSL::PKey.read(private_key || public_key)
       end
     end


### PR DESCRIPTION
Extracted from #39522, only covers reading ML-DSA-44 keys and storing them in the database, not using them, as that depends on OpenSSL 3.5+, and storing them can still be useful.