### PR TITLE
Fix typo in object_integrity_proof.rb 'eddsa-jcs-2022' removed OpenSSL for Multibase.

### DIFF
--- a/app/lib/activitypub/object_integrity_proof.rb
+++ b/app/lib/activitypub/object_integrity_proof.rb
@@ -30,7 +30,7 @@ class ActivityPub::ObjectIntegrityProof
     return if keypair.nil? || !keypair.usable? || keypair.type != 'ed25519'
 
     keypair.actor if ActivityPub::ObjectIntegrityProof.verify_eddsa_jcs_2022(@json, keypair.keypair)
-  rescue OpenSSL::PKey::RSAError
+  rescue ArgumentError, TypeError
     false
   end
 

--- a/app/lib/activitypub/object_integrity_proof.rb
+++ b/app/lib/activitypub/object_integrity_proof.rb
@@ -30,7 +30,7 @@ class ActivityPub::ObjectIntegrityProof
     return if keypair.nil? || !keypair.usable? || keypair.type != 'ed25519'
 
     keypair.actor if ActivityPub::ObjectIntegrityProof.verify_eddsa_jcs_2022(@json, keypair.keypair)
-  rescue ArgumentError, TypeError
+  rescue ArgumentError
     false
   end
 


### PR DESCRIPTION
Likely copy/pasted from `app/lib/activitypub/linked_data_signature.rb`. Not using OpenSSL in this case.

Detected by static code, Validation and fix by myself.