### PR TITLE
Refactor Multibase error handling and clean up ObjectIntegrityProof

### DIFF
--- a/app/lib/activitypub/object_integrity_proof.rb
+++ b/app/lib/activitypub/object_integrity_proof.rb
@@ -4,9 +4,6 @@
 class ActivityPub::ObjectIntegrityProof
   include JsonLdHelper
 
-  CONTEXT = 'https://w3id.org/identity/v1'
-  SIGNATURE_CONTEXT = 'https://w3id.org/security/v1'
-
   def initialize(json)
     @json = json
   end
@@ -15,9 +12,8 @@ class ActivityPub::ObjectIntegrityProof
     return unless @json.is_a?(Hash) && @json['proof'].is_a?(Hash)
 
     proof = @json['proof']
-    return unless proof['type'].present? && proof['verificationMethod'].present? && proof['proofPurpose'].present?
+    return unless proof['type'] == 'DataIntegrityProof' && proof['verificationMethod'].present? && proof['proofPurpose'] == proof_purpose
 
-    return if proof_purpose != proof['proofPurpose'] || proof['type'] != 'DataIntegrityProof'
     return if proof['expires']&.to_datetime&.past?
 
     cryptosuite = proof['cryptosuite']
@@ -30,7 +26,7 @@ class ActivityPub::ObjectIntegrityProof
     return if keypair.nil? || !keypair.usable? || keypair.type != 'ed25519'
 
     keypair.actor if ActivityPub::ObjectIntegrityProof.verify_eddsa_jcs_2022(@json, keypair.keypair)
-  rescue OpenSSL::PKey::RSAError
+  rescue Multibase::Error, OpenSSL::PKey::PKeyError
     false
   end
 

--- a/app/lib/multibase.rb
+++ b/app/lib/multibase.rb
@@ -22,8 +22,10 @@ class Multibase
   ED25519_PUB_DER_HEADER = ['302a300506032b6570032100'].pack('H*').freeze
   ML_DSA_44_PUB_DER_HEADER = ['30820532300b06096086480165030403110382052100'].pack('H*').freeze
 
+  class Error < StandardError; end
+
   def self.decode(string)
-    raise ArgumentError if string.nil?
+    raise Error, 'Multibase string is null' if string.nil?
 
     case string[0]
     when 'u'
@@ -31,7 +33,7 @@ class Multibase
     when 'z'
       Base58.base58_to_binary(string[1...], :bitcoin)
     else
-      raise ArgumentError
+      raise Error, 'Invalid Multibase base'
     end
   end
 
@@ -42,7 +44,7 @@ class Multibase
       return [tag, binary[prefix.length..]] if binary.starts_with?(prefix)
     end
 
-    raise ArgumentError
+    raise Error, 'Unknown Multicodec tag'
   end
 
   def self.decode_key_to_pem(string)
@@ -52,17 +54,19 @@ class Multibase
     when :'rsa-pub'
       [:rsa, OpenSSL::PKey::RSA.new(binary).to_pem]
     when :'ed25519-pub'
-      raise ArgumentError unless binary.size == 32
+      raise Error, 'Invalid data size for ed25519-pub' unless binary.size == 32
 
       der = ED25519_PUB_DER_HEADER + binary
       [:ed25519, "-----BEGIN PUBLIC KEY-----\n#{Base64.strict_encode64(der)}\n-----END PUBLIC KEY-----\n"]
     when :'mldsa-44-pub'
-      raise ArgumentError unless binary.size == 1312
+      raise Error, 'Invalid data size for mldsa-44-pub' unless binary.size == 1312
 
       der = ML_DSA_44_PUB_DER_HEADER + binary
       [:'ml-dsa-44', "-----BEGIN PUBLIC KEY-----\n#{Base64.strict_encode64(der).scan(/.{,64}/).join("\n")}-----END PUBLIC KEY-----\n"]
     else
-      raise ArgumentError
+      raise Error, 'Unsupported key type'
     end
+  rescue OpenSSL::PKey::RSAError => e
+    raise Error, e
   end
 end

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -335,7 +335,7 @@ class ActivityPub::ProcessAccountService < BaseService
 
   def key_from_multikey(value)
     Multibase.decode_key_to_pem(value)
-  rescue ArgumentError
+  rescue Multibase::Error
     nil
   end
 


### PR DESCRIPTION
Use more specific and informative errors for Multibase processing, simplify guard clauses a little, remove unused constants, and fix irrelevant error handling copied over from `ActivityPub::LinkedDataSignature` (thanks @shleeable for pointing out the error class discrepancy).

Closes #39750