### PR TITLE
Rely on normalization from scope in report service

### DIFF
--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -84,19 +84,18 @@ class ReportService < BaseService
     return AccountStatusesFilter.new(@target_account, @source_account).results.with_discarded.find(Array(@status_ids)).pluck(:id) if @source_account.local?
 
     # If the account making reports is remote, it is likely anonymized so we have to relax the requirements for attaching statuses.
-    domain = @source_account.domain.to_s.downcase
-    has_followers = @target_account.followers.with_domain(domain).exists?
+    has_followers = @target_account.followers.with_domain(@source_account.domain).exists?
     visibility = has_followers ? %i(public unlisted private) : %i(public unlisted)
     scope = @target_account.statuses.with_discarded
-    scope.merge!(scope.where(visibility: visibility).or(scope.where(domain_mentions(domain))))
+    scope.merge!(scope.where(visibility: visibility).or(scope.where(domain_mentions)))
     # Allow missing posts to not drop reports that include e.g. a deleted post
     scope.where(id: Array(@status_ids)).pluck(:id)
   end
 
-  def domain_mentions(domain)
+  def domain_mentions
     Mention
       .joins(:account)
-      .merge(Account.with_domain(domain))
+      .merge(Account.with_domain(@source_account.domain))
       .select(1).arel.exists
   end
 


### PR DESCRIPTION
The `with_domain` scope handles nils, and calls `to_s`/`downcase` already on the receiving side - so I think we can drop this local var and method arg and just access domain directly from this service/calling side.

Extracted from https://github.com/mastodon/mastodon/pull/37649