### PR TITLE
Add support for outgoing HTTP Message Signatures

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -131,7 +131,11 @@ class Request
 
   def perform
     begin
+      # Try with HTTP Signatures (draft-cavage-http-signatures-12) first
       response = perform_cavage_signed_request
+
+      # Then if it fails, double-knock using RFC 9421: HTTP Message Signatures
+      response = perform_rfc9421_signed_request if @signing_keypair.present? && [400, 401].include?(response.code)
     rescue => e
       raise e.class, "#{e.message} on #{@url}", e.backtrace[0]
     end
@@ -173,6 +177,24 @@ class Request
         http_cavage_signature: {
           keypair: @signing_keypair,
           covered_headers: headers.keys - %w(User-Agent Accept-Encoding Accept),
+        }
+      )
+    end
+
+    client.request(@verb, @url.to_s, @options.merge(headers:))
+  end
+
+  def perform_rfc9421_signed_request
+    headers = @headers
+    headers = headers.merge('content-digest' => "sha-256=:#{OpenSSL::Digest.base64digest('sha256', @options[:body])}:") if @options[:body]
+
+    client = http_client
+
+    if @signing_keypair.present?
+      client = client.use(
+        http_signature: {
+          key: @signing_keypair.linzer_private_key,
+          covered_components: @options.key?(:body) ? %w(@method @target-uri content-digest) : %w(@method @target-uri),
         }
       )
     end

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -135,7 +135,12 @@ class Request
       response = perform_cavage_signed_request
 
       # Then if it fails, double-knock using RFC 9421: HTTP Message Signatures
-      response = perform_rfc9421_signed_request if @signing_keypair.present? && [400, 401].include?(response.code)
+      if @signing_keypair.present? && [400, 401].include?(response.code)
+        # Consume the body of the first response first
+        response.truncated_body if http_client.persistent? && !response.connection.finished_request?
+
+        response = perform_rfc9421_signed_request
+      end
     rescue => e
       raise e.class, "#{e.message} on #{@url}", e.backtrace[0]
     end

--- a/app/lib/signed_request.rb
+++ b/app/lib/signed_request.rb
@@ -171,12 +171,7 @@ class SignedRequest
     end
 
     def verified?(keypair)
-      case keypair.type
-      when 'rsa'
-        key = Linzer.new_rsa_v1_5_sha256_public_key(keypair.public_key)
-      when 'ed25519'
-        key = Linzer.new_ed25519_public_key(keypair.public_key)
-      end
+      key = keypair.linzer_public_key
 
       Linzer.verify(key, @message, @signature)
     rescue Linzer::VerifyError

--- a/app/models/keypair.rb
+++ b/app/models/keypair.rb
@@ -63,6 +63,28 @@ class Keypair < ApplicationRecord
     end
   end
 
+  def linzer_public_key
+    @linzer_public_key ||= begin
+      case type
+      when 'rsa'
+        Linzer.new_rsa_v1_5_sha256_public_key(public_key)
+      when 'ed25519'
+        Linzer.new_ed25519_public_key(public_key)
+      end
+    end
+  end
+
+  def linzer_private_key
+    @linzer_private_key ||= begin
+      case type
+      when 'rsa'
+        Linzer.new_rsa_v1_5_sha256_key(private_key, full_uri)
+      when 'ed25519'
+        Linzer.new_ed25519_key(private_key, full_uri)
+      end
+    end
+  end
+
   def usable?
     !revoked? && !expired?
   end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -98,6 +98,34 @@ RSpec.describe Request do
       end
     end
 
+    context 'with server that only supports RFC 9421' do
+      let(:account) { Fabricate(:account) }
+
+      before do
+        # cavage-12
+        stub_request(:get, 'http://example.com')
+          .with { |request| request.headers.key?('Signature') && !request.headers.key?('Signature-Input') }
+          .to_return(status: 401)
+
+        # RFC 9421
+        stub_request(:get, 'http://example.com')
+          .with { |request| request.headers.key?('Signature') && request.headers.key?('Signature-Input') }
+          .to_return(status: 200)
+      end
+
+      it 'makes two valid requests with the specific signatures' do
+        expect { |block| subject.on_behalf_of(account).perform(&block) }.to yield_control
+
+        # Makes a valid request using cavage-12
+        expect(a_request(:get, 'http://example.com').with { |request| verified_signed_mocked_request?(request, account.keypair) && !request.headers.key?('Signature-Input') })
+          .to have_been_made.once
+
+        # Makes a valid request using RFC 9421
+        expect(a_request(:get, 'http://example.com').with { |request| verified_signed_mocked_request?(request, account.keypair) && request.headers.key?('Signature-Input') })
+          .to have_been_made.once
+      end
+    end
+
     context 'with a redirect and HTTP signatures' do
       let(:account) { Fabricate(:account) }
 


### PR DESCRIPTION
This keeps compatibility with existing implementations and only tries RFC 9421 when the cavage-12 draft signature fails. No implementation is expected to support RFC 9421 without supporting cavage-12 today but:
- this allows compatibility with such implementations in the future
- this allows other implementers to test RFC 9421 compatibility with Mastodon by disabling cavage-12 verification on their end
- this preserves compatibility with Misskey, which does not return errors when failing to verify signatures on actor requests but returns a stripped-down version of actors instead, which would then cause various issues if we were to query using RFC 9421 first and cavage-12 as fallback

TODO:
- [ ] review if the covered components make sense
- [x] consider switching the double-knocking direction
- [x] add tests
- [x] clean up