### PR TITLE
Fix timeline unable to load more when the last item is a `inline-follow-suggestions`

### DIFF
--- a/app/javascript/mastodon/components/status_list.jsx
+++ b/app/javascript/mastodon/components/status_list.jsx
@@ -6,6 +6,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import { debounce } from 'lodash';
 
 import { TIMELINE_GAP, TIMELINE_PINNED_VIEW_ALL, TIMELINE_SUGGESTIONS } from 'mastodon/actions/timelines';
+import { isNonStatusId } from 'mastodon/actions/timelines_typed';
 import { RegenerationIndicator } from 'mastodon/components/regeneration_indicator';
 import { InlineFollowSuggestions } from 'mastodon/features/home_timeline/components/inline_follow_suggestions';
 import { PinnedShowAllButton } from '@/mastodon/features/account_timeline/components/pinned_statuses';
@@ -45,7 +46,7 @@ export default class StatusList extends ImmutablePureComponent {
 
   handleLoadOlder = debounce(() => {
     const { statusIds, lastId, onLoadMore } = this.props;
-    onLoadMore(lastId || (statusIds.size > 0 ? statusIds.last() : undefined));
+    onLoadMore(lastId || statusIds.findLast(id => !isNonStatusId(id)));
   }, 300, { leading: true });
 
   setRef = c => {

--- a/app/javascript/mastodon/features/ui/containers/status_list_container.js
+++ b/app/javascript/mastodon/features/ui/containers/status_list_container.js
@@ -58,7 +58,7 @@ const makeMapStateToProps = () => {
    */
   const mapStateToProps = (state, { timelineId, initialLoadingState = true, maxItems }) => ({
     statusIds: getStatusIds(state, { type: timelineId, maxItems }),
-    lastId:    state.getIn(['timelines', timelineId, 'items'])?.last(),
+    lastId:    state.getIn(['timelines', timelineId, 'items'])?.findLast(id => !isNonStatusId(id)),
     isLoading: state.getIn(['timelines', timelineId, 'isLoading'], initialLoadingState),
     isPartial: state.getIn(['timelines', timelineId, 'isPartial'], false),
     hasMore:   state.getIn(['timelines', timelineId, 'hasMore']),


### PR DESCRIPTION
When loading the timeline scrolling down, if the last item ends up being a non-status object like 'inline follow suggestions' instead of an actual status, the timeline can no longer load more posts.

---

Under certain conditions, `inline-follow-suggestions` may be placed at an incorrect position.

https://github.com/mastodon/mastodon/blob/ba0fadc332b440864e6b6010e749b02a5d94a5de/app/javascript/mastodon/actions/timelines.js#L126-L130

(I did not yet fix this part. If maintainers think that the incorrect insertion needs to be fixed, please feel free to close this PR)

In my case, device A was the one I had been using previously, and I logged in freshly on device B, where this issue occurred. Device A had already dismissed the `inline-follow-suggestions`, and afterward the same issue occurred on A as well.

Therefore, there is a bug where the timeline cannot be loaded further by scrolling down whenever a non-status object (such as a `inline-follow-suggestions`) ends up at the very end of the timeline.