### PR TITLE
Fix error handling in `ActivityPub::ProcessFeaturedItemService`

### DIFF
--- a/app/services/activitypub/process_featured_item_service.rb
+++ b/app/services/activitypub/process_featured_item_service.rb
@@ -66,8 +66,8 @@ class ActivityPub::ProcessFeaturedItemService
     return false if local_actor_uri?
     return false if Account.exists?(uri: @actor_uri)
 
-    object_json = fetch_resource(@actor_uri, true)
-    (Array(object_json['type']) & ActivityPub::FetchRemoteActorService::SUPPORTED_TYPES).empty?
+    object_json = fetch_resource(@actor_uri, true, raise_on_error: :temporary)
+    object_json.nil? || (as_array(object_json['fetch']) & ActivityPub::FetchRemoteActorService::SUPPORTED_TYPES).empty?
   end
 
   def verify_authorization!

--- a/spec/services/activitypub/process_featured_item_service_spec.rb
+++ b/spec/services/activitypub/process_featured_item_service_spec.rb
@@ -143,6 +143,28 @@ RSpec.describe ActivityPub::ProcessFeaturedItemService do
         end.to_not change(CollectionItem, :count)
       end
     end
+
+    context 'when featured object cannot be fetched' do
+      let(:hashtag_json) do
+        {
+          'id' => 'https://example.com/hashtags/people',
+          'type' => 'Hashtag',
+          'name' => '#people',
+        }
+      end
+      let(:featured_object_uri) { hashtag_json['id'] }
+
+      before do
+        stub_request(:get, featured_object_uri)
+          .to_return(status: 404)
+      end
+
+      it 'does not create a collection item and returns `nil`' do
+        expect do
+          expect(subject.call(collection, object, position:)).to be_nil
+        end.to_not change(CollectionItem, :count)
+      end
+    end
   end
 
   context 'when only the id of the collection item is given' do


### PR DESCRIPTION
This caused the following error when the actor could not be fetched for any reason at all.

```
NoMethodError:
  undefined method '[]' for nil
```

This PR changes the error handling so that it ignores items that can't be fetched due to a non-temporary reason.