### PR TITLE
Adds feature flag for 5.0 redesign

### DIFF
--- a/app/javascript/mastodon/utils/environment.ts
+++ b/app/javascript/mastodon/utils/environment.ts
@@ -18,7 +18,7 @@ export function isServerFeatureEnabled(feature: ServerFeatures) {
   return initialState?.features.includes(feature) ?? false;
 }
 
-type ClientFeatures = never;
+type ClientFeatures = 'redesign';
 
 export function isClientFeatureEnabled(feature: ClientFeatures) {
   try {
@@ -29,4 +29,9 @@ export function isClientFeatureEnabled(feature: ClientFeatures) {
     console.warn('Could not access localStorage to get client features', err);
     return false;
   }
+}
+
+/* Checks if the 5.0 redesign features are enabled or not. */
+export function isRedesignEnabled() {
+  return isClientFeatureEnabled('redesign');
 }


### PR DESCRIPTION
This adds a feature flag for the 5.0 redesign. It's client-side now as the changes will be actively under development and not something we want server admins to enable given how unstable it will be.