### PR TITLE
Fix very wide images overflowing posts horizontally

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7251,6 +7251,7 @@ a.status-card {
   border-radius: 8px;
   position: relative;
   width: 100%;
+  max-width: 100%;
   min-height: 64px;
   display: grid;
   grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
### Changes proposed in this PR:
- Prevents images from overflowing posts horizontally if they're very short and wide

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="616" height="394" alt="image" src="https://github.com/user-attachments/assets/27fc767a-2106-4b13-a749-ebeb435bf02d" /> | <img width="614" height="392" alt="image" src="https://github.com/user-attachments/assets/1bb7717a-bbde-4d0e-ba53-8968ce1f1428" /> |