### PR TITLE
Fix pagination overlapping announcement reactions bar

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8569,7 +8569,7 @@ noscript {
   }
 
   &__pagination {
-    padding: 15px;
+    padding: 0 12px 15px 0;
     color: var(--color-text-secondary);
     position: absolute;
     bottom: 3px;
@@ -8594,7 +8594,10 @@ noscript {
   align-items: center;
   margin-top: 15px;
   margin-inline-start: -2px;
-  width: calc(100% - (90px - 33px));
+
+  --pagination-width: 70px;
+
+  width: calc(100% - var(--pagination-width));
 
   &__item {
     flex-shrink: 0;


### PR DESCRIPTION
Fixes #39805

### Changes proposed in this PR:
- Prevents the announcement pagination widget from overlapping the announcement's reactions bar in advanced UI
- Slightly tweaks the pagination widget's placement for a visually more even distance from the edges, and to give slightly more room to reactions

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="383" height="277" alt="image" src="https://github.com/user-attachments/assets/1d6c4778-4e51-40fd-a29f-9b21bec078d0" /> | <img width="382" height="304" alt="image" src="https://github.com/user-attachments/assets/58d34971-821e-4d1c-ba49-72c41b9e4cdd" /> |