### PR TITLE
Extend Tag timeline api filter parameters

### DIFF
--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Timelines::TagController < Api::V1::Timelines::TopicController
   before_action -> { authorize_if_got_token! :read, :'read:statuses' }
   before_action :load_tag
 
-  PERMITTED_PARAMS = %i(local limit only_media).freeze
+  PERMITTED_PARAMS = %i(local remote limit only_media any all none).freeze
 
   def show
     cache_if_unauthenticated!


### PR DESCRIPTION
I believe these feed params to the TagFeed Generator.

```
  TagFeed.new(
    @tag,
    current_account,
    any: params[:any], <-- here
    all: params[:all],  <-- here
    none: params[:none], <-- here
    local: truthy_param?(:local),
    remote: truthy_param?(:remote), <-- here
    only_media: truthy_param?(:only_media)
  )
```

Source: Static code tool. Fix by myself.