### PR TITLE
Fix CW being copied to body when editing quote posts with empty text

### DIFF
--- a/app/services/update_status_service.rb
+++ b/app/services/update_status_service.rb
@@ -111,7 +111,7 @@ class UpdateStatusService < BaseService
   end
 
   def update_immediate_attributes!
-    @status.text         = @options[:text].presence || @options.delete(:spoiler_text) || '' if @options.key?(:text)
+    @status.text         = @options[:text].presence || @options.delete(:spoiler_text) || '' if @options.key?(:text) && @status.quote.blank?
     @status.spoiler_text = @options[:spoiler_text] || '' if @options.key?(:spoiler_text)
     @status.sensitive    = @options[:sensitive] || @options[:spoiler_text].present? if @options.key?(:sensitive) || @options.key?(:spoiler_text)
     @status.language     = valid_locale_cascade(@options[:language], @status.language, @status.account.user&.preferred_posting_language, I18n.default_locale)


### PR DESCRIPTION
Follow up to #36151

This change was completed previously for the creation, but not the update.