### PR TITLE
Include tag_follows in ASSOCIATIONS_ON_SUSPEND to suspended users

### DIFF
--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -26,6 +26,7 @@ class DeleteAccountService < BaseService
     report_notes
     scheduled_statuses
     status_pins
+    tag_follows
   ).freeze
 
   # The following associations have no important side-effects


### PR DESCRIPTION
As always, I believe this is correct. Might be missing something tho.

Source: Static code tool. Fix by myself.