### PR TITLE
Update local_uri function in tag_manager.rb to normalise the uri to clean unrequired port detecting as remote

### DIFF
--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -240,7 +240,7 @@ class ActivityPub::TagManager
   def local_uri?(uri)
     return false if uri.nil?
 
-    uri  = Addressable::URI.parse(uri)
+    uri  = Addressable::URI.parse(uri).normalize
     host = uri.normalized_host
     host = "#{host}:#{uri.port}" if uri.port
 


### PR DESCRIPTION
The mistaken default port `https://mastodon.social:443/users/alice` would be considered remote.

This strips the 443 from https because it's the default. This is very unlikely but not impossible (see ratio on screenshot).

Source: I noticed that more than zero requests come in from services including the port. There are likely multiple places this needs to be placed.

<img width="675" height="152" alt="image" src="https://github.com/user-attachments/assets/a7d70a0c-f82f-4f30-86e2-210da86273d6" />
