### PR TITLE
Update link_back_present in verify_link_service.rb to check more than the first "rel=me".

### DIFF
--- a/app/services/verify_link_service.rb
+++ b/app/services/verify_link_service.rb
@@ -31,7 +31,7 @@ class VerifyLinkService < BaseService
     return true if links.any? { |link| link['href']&.downcase == @link_back.downcase }
     return false if links.empty?
 
-    links.first(10).any? { |link| link_redirects_back?(link['href']) }
+    links.any? { |link| link_redirects_back?(link['href']) }
   end
 
   def link_redirects_back?(test_url)

--- a/app/services/verify_link_service.rb
+++ b/app/services/verify_link_service.rb
@@ -42,5 +42,8 @@ class VerifyLinkService < BaseService
     end
 
     redirect_to_url == @link_back
+  rescue *Mastodon::HTTP_CONNECTION_ERRORS, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError, IPAddr::AddressFamilyError => e
+    Rails.logger.debug { "Error checking redirect for #{test_url}: #{e}" }
+    false
   end
 end

--- a/app/services/verify_link_service.rb
+++ b/app/services/verify_link_service.rb
@@ -28,13 +28,10 @@ class VerifyLinkService < BaseService
 
     links = Nokogiri::HTML5(@body).xpath('(//a|//link)[@rel][nokogiri:link_rel_include(@rel, "me")]', NokogiriHandler)
 
-    if links.any? { |link| link['href']&.downcase == @link_back.downcase }
-      true
-    elsif links.empty?
-      false
-    else
-      link_redirects_back?(links.first['href'])
-    end
+    return true if links.any? { |link| link['href']&.downcase == @link_back.downcase }
+    return false if links.empty?
+
+    links.first(10).any? { |link| link_redirects_back?(link['href']) }
   end
 
   def link_redirects_back?(test_url)


### PR DESCRIPTION
People might have multiple IndieWeb/Microformat etc links. I believe the `any?`  should trigger successfully on `false, false, true, false`,

I added the rescue check because I think if the ref=me loop results in a failure, it might not reach the mastodon me ref.

This code looks right?

Source: I was unable to validate a page that had other ref=me's on it (I haven't validate if this actually solves it yet). fix by myself. 