### PR TITLE
Fix page refresh when trying to save custom profile fields

### DIFF
--- a/app/javascript/mastodon/features/ui/components/confirmation_modals/confirmation_modal.tsx
+++ b/app/javascript/mastodon/features/ui/components/confirmation_modals/confirmation_modal.tsx
@@ -52,13 +52,18 @@ export const ConfirmationModal: React.FC<
   noCloseOnConfirm = false,
   noFocusButton = false,
 }) => {
-  const handleClick = useCallback(() => {
-    if (!noCloseOnConfirm) {
-      onClose();
-    }
+  const handleSubmit = useCallback<React.SubmitEventHandler<HTMLFormElement>>(
+    (e) => {
+      e.preventDefault();
 
-    void onConfirm();
-  }, [onClose, onConfirm, noCloseOnConfirm]);
+      if (!noCloseOnConfirm) {
+        onClose();
+      }
+
+      void onConfirm();
+    },
+    [onClose, onConfirm, noCloseOnConfirm],
+  );
 
   const handleSecondary = useCallback(() => {
     onClose();
@@ -66,7 +71,7 @@ export const ConfirmationModal: React.FC<
   }, [onClose, onSecondary]);
 
   return (
-    <ModalShell onSubmit={handleClick}>
+    <ModalShell onSubmit={handleSubmit}>
       <ModalShellBody className={className}>
         {noFocusButton ? (
           <NavigationFocusTarget as='h1' id={titleId}>
@@ -107,7 +112,6 @@ export const ConfirmationModal: React.FC<
         {/* eslint-disable jsx-a11y/no-autofocus -- we are in a modal and thus autofocusing is justified */}
         <Button
           type='submit'
-          onClick={handleClick}
           loading={updating}
           disabled={disabled}
           autoFocus={!noFocusButton}


### PR DESCRIPTION
Fixes #39818

### Changes proposed in this PR:
- Fixes page refresh when trying to update or create a custom profile field. This was caused by an un-`defaultPrevented` submit event for that modal. It was not caught until now because on most servers, the form submission was blocked by a CSP error