### PR TITLE
Rename `ASSOCIATIONS_ON_SUSPEND` to `ASSOCIATIONS_ON_PURGE`

### DIFF
--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -3,7 +3,7 @@
 class DeleteAccountService < BaseService
   include Payloadable
 
-  ASSOCIATIONS_ON_SUSPEND = %w(
+  ASSOCIATIONS_ON_PURGE = %w(
     account_notes
     account_pins
     active_relationships
@@ -304,9 +304,9 @@ class DeleteAccountService < BaseService
 
   def associations_for_destruction
     if keep_account_record?
-      ASSOCIATIONS_ON_SUSPEND
+      ASSOCIATIONS_ON_PURGE
     else
-      ASSOCIATIONS_ON_SUSPEND + ASSOCIATIONS_ON_DESTROY
+      ASSOCIATIONS_ON_PURGE + ASSOCIATIONS_ON_DESTROY
     end
   end
 

--- a/spec/services/delete_account_service_spec.rb
+++ b/spec/services/delete_account_service_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe DeleteAccountService do
     end
   end
 
+  describe 'ASSOCIATIONS_WITHOUT_SIDE_EFFECTS' do
+    it 'is a subset of ASSOCIATIONS_ON_PURGE' do
+      expect(described_class::ASSOCIATIONS_WITHOUT_SIDE_EFFECTS - described_class::ASSOCIATIONS_ON_PURGE).to eq []
+    end
+  end
+
   describe '#call on local account', :inline_jobs do
     before do
       stub_request(:post, remote_alice.inbox_url).to_return(status: 201)


### PR DESCRIPTION
`ASSOCIATIONS_ON_SUSPEND` is confusing, as it does not trigger on suspension, but when the suspension turns into a deletion. It pre-dates the moment when we changed suspensions to not be immediately as destructive and instead trigger data purge after 30 days.

Also added a test to catch issues such as the one fixed in #39824