### PR TITLE
Remove support for `Reject` and `Accept` of `QuoteRequest` that cannot be found by `id`

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -122,20 +122,6 @@ class ActivityPub::Activity
     fetch_remote_original_status
   end
 
-  def quote_from_request_json(json)
-    quoted_status_uri = value_or_id(json['object'])
-    quoting_status_uri = value_or_id(json['instrument'])
-    return if quoting_status_uri.nil? || quoted_status_uri.nil?
-
-    quoting_status = status_from_uri(quoting_status_uri)
-    return unless quoting_status.present? && quoting_status.quote.present?
-
-    quoted_status = status_from_uri(quoted_status_uri)
-    return unless quoted_status.present? && quoted_status.account == @account && quoting_status.quote.quoted_status == quoted_status
-
-    quoting_status.quote
-  end
-
   def dereference_object!
     return unless @object.is_a?(String)
 

--- a/app/lib/activitypub/activity/accept.rb
+++ b/app/lib/activitypub/activity/accept.rb
@@ -10,8 +10,6 @@ class ActivityPub::Activity::Accept < ActivityPub::Activity
     case @object['type']
     when 'Follow'
       accept_embedded_follow
-    when 'QuoteRequest'
-      accept_embedded_quote_request
     end
   end
 
@@ -33,16 +31,6 @@ class ActivityPub::Activity::Accept < ActivityPub::Activity
     request.authorize!
 
     RemoteAccountRefreshWorker.perform_async(request.target_account_id) if is_first_follow
-  end
-
-  def accept_embedded_quote_request
-    approval_uri = value_or_id(first_of_value(@json['result']))
-    return if approval_uri.nil?
-
-    quote = quote_from_request_json(@object)
-    return unless quote.present? && quote.status.local?
-
-    accept_quote!(quote)
   end
 
   def accept_feature_request!

--- a/app/lib/activitypub/activity/reject.rb
+++ b/app/lib/activitypub/activity/reject.rb
@@ -11,8 +11,6 @@ class ActivityPub::Activity::Reject < ActivityPub::Activity
     case @object['type']
     when 'Follow'
       reject_embedded_follow
-    when 'QuoteRequest'
-      reject_embedded_quote_request
     end
   end
 
@@ -31,13 +29,6 @@ class ActivityPub::Activity::Reject < ActivityPub::Activity
 
   def reject_follow_for_relay
     relay.update!(state: :rejected)
-  end
-
-  def reject_embedded_quote_request
-    quote = quote_from_request_json(@object)
-    return unless quote.present? && quote.status.local?
-
-    reject_quote!(quote)
   end
 
   def reject_quote!(quote)


### PR DESCRIPTION
See in https://github.com/mastodon/mastodon/pull/39820#pullrequestreview-4704035126

In itself, the behavior is not really harmful, but it should not really be useful, it's there to account for implementation issues that do not exist in the while, and removing it would simplify code a bit.