### PR TITLE
Fix not being able to edit quote post text

### DIFF
--- a/app/services/update_status_service.rb
+++ b/app/services/update_status_service.rb
@@ -111,7 +111,10 @@ class UpdateStatusService < BaseService
   end
 
   def update_immediate_attributes!
-    @status.text         = @options[:text].presence || @options.delete(:spoiler_text) || '' if @options.key?(:text) && @status.quote.blank?
+    if @options.key?(:text)
+      @status.text = @options[:text].presence || ''
+      @status.text = @options.delete(:spoiler_text) || '' if @status.text.blank? && @status.quote.blank?
+    end
     @status.spoiler_text = @options[:spoiler_text] || '' if @options.key?(:spoiler_text)
     @status.sensitive    = @options[:sensitive] || @options[:spoiler_text].present? if @options.key?(:sensitive) || @options.key?(:spoiler_text)
     @status.language     = valid_locale_cascade(@options[:language], @status.language, @status.account.user&.preferred_posting_language, I18n.default_locale)

--- a/spec/services/update_status_service_spec.rb
+++ b/spec/services/update_status_service_spec.rb
@@ -40,6 +40,37 @@ RSpec.describe UpdateStatusService do
         )
       expect(status.edits.ordered.pluck(:text)).to eq %w(Foo Bar)
     end
+
+    context 'when the status has a quote' do
+      before { Fabricate(:quote, status: status) }
+
+      it 'updates text, resets card, saves edit history' do
+        subject.call(status, status.account_id, text: 'Bar')
+
+        expect(status.reload)
+          .to have_attributes(
+            text: 'Bar',
+            preview_card: be_nil
+          )
+        expect(status.edits.ordered.pluck(:text)).to eq %w(Foo Bar)
+      end
+    end
+
+    context 'when the status has a quote and has a spoiler' do
+      before { Fabricate(:quote, status: status) }
+
+      it 'updates text, resets card, saves edit history' do
+        subject.call(status, status.account_id, spoiler_text: 'Bar', text: '')
+
+        expect(status.reload)
+          .to have_attributes(
+            text: '',
+            spoiler_text: 'Bar',
+            preview_card: be_nil
+          )
+        expect(status.edits.ordered.pluck(:text)).to eq ['Foo', '']
+      end
+    end
   end
 
   context 'when content warning changes' do


### PR DESCRIPTION
Fix issue introduced in #39823, which I failed to notice at review time.