### PR TITLE
Update remove_quote_hint.tsx to use `strategy='absolute'` over fixed.

### DIFF
--- a/app/javascript/mastodon/components/status_action_bar/remove_quote_hint.tsx
+++ b/app/javascript/mastodon/components/status_action_bar/remove_quote_hint.tsx
@@ -65,6 +65,7 @@ export const RemoveQuoteHint: React.FC<{
           isOpen
           offset={{ mainAxis: 10, crossAxis: 12 }}
           placement='bottom-end'
+          strategy='absolute'
           reference={anchorElement}
           container={anchorElement}
           onClose={dismiss}


### PR DESCRIPTION
seems react-overlays previously defaulted to `strategy='absolute'`, while the current Popover defaults to `strategy='fixed'`

https://github.com/react-bootstrap/react-overlays/blob/d5595ec823e45f7ad1dad0096b7fe08c296433d7/src/usePopper.ts#L130

https://github.com/mastodon/mastodon/blob/52e9ec7814fc971598696ba4bf33d06ac1a51938/app/javascript/mastodon/components/popover/index.tsx#L112

Source: This is static code, I'm planning on starting a staging environment to have before/after evidence as well. Sorry if this is a false positive.