### PR TITLE
Update compose_panel.tsx to pass focusTarget to 

### DIFF
--- a/app/javascript/mastodon/features/ui/components/compose_panel.tsx
+++ b/app/javascript/mastodon/features/ui/components/compose_panel.tsx
@@ -71,7 +71,7 @@ export const RedirectToMobileComposeIfNeeded: React.FC = () => {
 
   useLayoutEffect(() => {
     if (shouldRedirect) {
-      history.push('/publish');
+      history.push('/publish', { focusTarget: false });
     }
   }, [history, shouldRedirect]);
 


### PR DESCRIPTION
matching code from similar parts of the code.

```
 app/javascript/mastodon/features/compose/index.tsx
 app/javascript/mastodon/features/navigation_panel/index.tsx
 app/javascript/mastodon/features/ui/components/column_link.tsx
 app/javascript/mastodon/features/ui/components/navigation_bar.tsx
```

`app/javascript/mastodon/features/ui/components/compose_panel.tsx` is missing focusTarget