### PR TITLE
Disable `Style/GuardClause` cop

### DIFF
--- a/.rubocop/style.yml
+++ b/.rubocop/style.yml
@@ -15,6 +15,9 @@ Style/FormatStringToken:
     merge:
       - AllowedMethods
 
+Style/GuardClause:
+  Enabled: false
+
 Style/HashAsLastArrayItem:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -5,8 +5,3 @@
 # one by one as the offenses are removed from the code base.
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: MinBodyLength, AllowConsecutiveConditionals.
-Style/GuardClause:
-  Enabled: false


### PR DESCRIPTION
I had previously proposed this, but then also did a batch of PRs to attempt to resolve some of these instead. Of that batch, we merged maybe 5-10, and a bunch were not reviewed (and since closed). More notably though, there were a good chunk (25+) of the remaining violations which IMO are made worse by solving this. So -- proposing again to just disable and accept that we have mixed styles on this rule and can use discretion/PR-review to figure it out.