### PR TITLE
Change handling of handle conflicts to invalidate known-outdated account handle

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -237,7 +237,17 @@ class Account < ApplicationRecord
     local? ? username : "#{username}@#{domain}"
   end
 
+  def pretty_username
+    # Return special username for user-facing invalid handle accounts
+    return id.to_s if invalidated_username?
+
+    username
+  end
+
   def pretty_acct
+    # Return special handle for user-facing invalid handle accounts
+    return "#{id}@handle.invalid" if invalidated_username?
+
     local? ? username : "#{username}@#{Addressable::IDNA.to_unicode(domain)}"
   end
 
@@ -254,17 +264,20 @@ class Account < ApplicationRecord
   end
 
   def invalidate_username!
+    raise ArgumentError if local?
     return if invalidated_username?
 
-    # This uses some characters (`{`, `}`, `!`) that we are extremely unlikely to allow
-    # i nthe future, in order to ensure this will never match a webfinger handle.
+    # It is very unlikely that we will allow `!` in usernames in the future,
+    # and we will never allow ` ` in them either, so this ensure this will never
+    # match a valid username on a remote server.
+
     # Using the local ID ensures we won't have any conflict.
 
-    update_attribute(:username, "{invalid!#{id}}")
+    update_attribute(:username, "! #{id}")
   end
 
   def invalidated_username?
-    username.start_with?('{invalid!')
+    username.start_with?('! ')
   end
 
   def possibly_stale?

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -253,14 +253,28 @@ class Account < ApplicationRecord
     "acct:#{local_username_and_domain}"
   end
 
+  def invalidate_username!
+    return if invalidated_username?
+
+    # This uses some characters (`{`, `}`, `!`) that we are extremely unlikely to allow
+    # i nthe future, in order to ensure this will never match a webfinger handle.
+    # Using the local ID ensures we won't have any conflict.
+
+    update_attribute(:username, "{invalid!#{id}}")
+  end
+
+  def invalidated_username?
+    username.start_with?('{invalid!')
+  end
+
   def possibly_stale?
-    last_webfingered_at.nil? || last_webfingered_at <= STALE_THRESHOLD.ago
+    last_webfingered_at.nil? || last_webfingered_at <= STALE_THRESHOLD.ago || invalidated_username?
   end
 
   def needs_background_refresh?
     return false if local?
 
-    return true if last_webfingered_at.blank? || last_webfingered_at <= BACKGROUND_REFRESH_INTERVAL.ago
+    return true if last_webfingered_at.blank? || last_webfingered_at <= BACKGROUND_REFRESH_INTERVAL.ago || invalidated_username?
 
     # TODO: Remove some time after 4.6
     # This is temporary workaround to speed up account refreshs after

--- a/app/models/concerns/account/finder_concern.rb
+++ b/app/models/concerns/account/finder_concern.rb
@@ -25,6 +25,8 @@ module Account::FinderConcern
     end
 
     def find_remote(username, domain)
+      return if domain == 'handle.invalid'
+
       Account
         .with_username(username)
         .with_domain(domain)

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -24,6 +24,8 @@ class REST::AccountSerializer < ActiveModel::Serializer
   attribute :feature_approval
   attribute :email_subscriptions, if: -> { Rails.application.config.x.email_subscriptions && Setting.email_subscriptions }
 
+  attribute :invalid_handle, if: :invalid_handle?
+
   class AccountDecorator < SimpleDelegator
     def self.model_name
       Account.model_name
@@ -151,6 +153,11 @@ class REST::AccountSerializer < ActiveModel::Serializer
   def memorial
     object.memorial?
   end
+
+  def invalid_handle
+    object.invalidated_username?
+  end
+  alias invalid_handle? invalid_handle
 
   def roles
     if object.unavailable? || object.user.nil?

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -154,6 +154,10 @@ class REST::AccountSerializer < ActiveModel::Serializer
     object.memorial?
   end
 
+  def username
+    object.pretty_username
+  end
+
   def invalid_handle
     object.invalidated_username?
   end

--- a/app/serializers/rest/announcement_serializer.rb
+++ b/app/serializers/rest/announcement_serializer.rb
@@ -41,6 +41,10 @@ class REST::AnnouncementSerializer < ActiveModel::Serializer
       object.id.to_s
     end
 
+    def username
+      object.pretty_username
+    end
+
     def url
       ActivityPub::TagManager.instance.url_for(object)
     end

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -201,7 +201,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
     end
 
     def username
-      object.account_username
+      object.account.pretty_username
     end
 
     def url

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -114,13 +114,21 @@ class ActivityPub::ProcessAccountService < BaseService
       @account.update!(username: @username, domain: @domain)
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
       # This account (identified by ActivityPub `id`) is being renamed to a handle that was
-      # previously known by this Mastodon server as a different account… ignore the renaming for now
+      # previously known by this Mastodon server as a different account…
 
-      # TODO: better handle this scenario, by e.g. renaming the user to something unique
-      # and scheduling re-discovery
+      rename_conflicting_account!
 
-      @account.restore_attributes([:username, :domain])
+      retry
     end
+  end
+
+  def rename_conflicting_account!
+    conflicting_account = Account.find_remote(@username, @domain)
+    return if conflicting_account.nil? || conflicting_account.local? || conflicting_account.uri == @account.uri
+
+    conflicting_account.invalidate_username!
+
+    AccountRefreshWorker.perform_async(conflicting_account.id, { 'request_id' => @request_id })
   end
 
   def extract_username_and_domain!

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -25,7 +25,7 @@ class ResolveAccountService < BaseService
     # First of all we want to check if we've got the account
     # record with the URI already, and if so, we can exit early
 
-    return if domain_not_allowed?(@domain)
+    return if domain_not_allowed?(@domain) || @domain == 'handle.invalid'
 
     @account ||= Account.find_remote(@username, @domain)
 

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -13,11 +13,14 @@ class ResolveAccountService < BaseService
   # @option options [Boolean] :skip_webfinger Do not attempt any webfinger query or refreshing account data
   # @option options [Boolean] :skip_cache Get the latest data from origin even if cache is not due to update yet
   # @option options [Boolean] :suppress_errors When failing, return nil instead of raising an error
+  # @option options [String]  :request_id Used to limit the number of HTTP requests issued from a single outside request
   # @return [Account]
   def call(uri, options = {})
     return if uri.blank?
 
     process_options!(uri, options)
+
+    return ActivityPub::FetchRemoteAccountService.new.call(@account.uri, suppress_errors: @options[:suppress_errors], request_id: options[:request_id]) if @account&.remote? && @account.invalidated_username?
 
     # First of all we want to check if we've got the account
     # record with the URI already, and if so, we can exit early

--- a/app/workers/account_refresh_worker.rb
+++ b/app/workers/account_refresh_worker.rb
@@ -5,10 +5,10 @@ class AccountRefreshWorker
 
   sidekiq_options queue: 'pull', retry: 3, dead: false, lock: :until_executed, lock_ttl: 1.day.to_i
 
-  def perform(account_id)
+  def perform(account_id, options = {})
     account = Account.find_by(id: account_id)
     return unless account&.needs_background_refresh?
 
-    ResolveAccountService.new.call(account)
+    ResolveAccountService.new.call(account, { request_id: options['request_id'] })
   end
 end

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -496,13 +496,16 @@ RSpec.describe ActivityPub::ProcessAccountService do
     context 'when the destination handle is already occupied' do
       let!(:conflicting_account) { Fabricate(:remote_account, username: 'alice', domain: 'example.com', uri: 'https://foo.test/original_alice', inbox_url: 'https://foo.test/original_alice/inbox') }
 
-      it 'updates the profile but does not touch the usernames or call AccountMergingWorker' do
+      it 'updates the profile without creating a new one or calling AccountMergingWorker, renames conflicting and schedules refresh' do
         expect { subject.call(payload) }
-          .to not_change { account.reload.username }
-          .and not_change { account.reload.domain }
+          .to change { account.reload.username }.from('bob').to('alice')
+          .and change { account.reload.domain }.from('foo.test').to('example.com')
           .and not_change { account.reload.uri }
-          .and not_change { conflicting_account.reload.acct }
+          .and change { conflicting_account.reload.username }.from('alice').to("{invalid!#{conflicting_account.id}}")
           .and(not_change { Account.count })
+
+        expect(AccountRefreshWorker)
+          .to have_enqueued_sidekiq_job(conflicting_account.id, { 'request_id' => /.*-.*@.*/ })
 
         expect(AccountMergingWorker)
           .to_not have_enqueued_sidekiq_job
@@ -575,13 +578,16 @@ RSpec.describe ActivityPub::ProcessAccountService do
     context 'when the destination handle is already occupied' do
       let!(:conflicting_account) { Fabricate(:remote_account, username: 'alice', domain: 'foo.test', uri: 'https://foo.test/original_alice', inbox_url: 'https://foo.test/original_alice/inbox') }
 
-      it 'updates the profile but does not touch the usernames or call AccountMergingWorker' do
+      it 'updates the profile without creating a new one or calling AccountMergingWorker, renames conflicting and schedules refresh' do
         expect { subject.call(payload) }
-          .to not_change { account.reload.username }
+          .to change { account.reload.username }.from('bob').to('alice')
           .and not_change { account.reload.domain }
           .and not_change { account.reload.uri }
-          .and not_change { conflicting_account.reload.acct }
+          .and change { conflicting_account.reload.username }.from('alice').to("{invalid!#{conflicting_account.id}}")
           .and(not_change { Account.count })
+
+        expect(AccountRefreshWorker)
+          .to have_enqueued_sidekiq_job(conflicting_account.id, { 'request_id' => /.*-.*@.*/ })
 
         expect(AccountMergingWorker)
           .to_not have_enqueued_sidekiq_job

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -501,7 +501,7 @@ RSpec.describe ActivityPub::ProcessAccountService do
           .to change { account.reload.username }.from('bob').to('alice')
           .and change { account.reload.domain }.from('foo.test').to('example.com')
           .and not_change { account.reload.uri }
-          .and change { conflicting_account.reload.username }.from('alice').to("{invalid!#{conflicting_account.id}}")
+          .and change { conflicting_account.reload.username }.from('alice').to("! #{conflicting_account.id}")
           .and(not_change { Account.count })
 
         expect(AccountRefreshWorker)
@@ -583,7 +583,7 @@ RSpec.describe ActivityPub::ProcessAccountService do
           .to change { account.reload.username }.from('bob').to('alice')
           .and not_change { account.reload.domain }
           .and not_change { account.reload.uri }
-          .and change { conflicting_account.reload.username }.from('alice').to("{invalid!#{conflicting_account.id}}")
+          .and change { conflicting_account.reload.username }.from('alice').to("! #{conflicting_account.id}")
           .and(not_change { Account.count })
 
         expect(AccountRefreshWorker)


### PR DESCRIPTION
This aims to address the edge cases listed in https://github.com/mastodon/mastodon/pull/39785:

> - three (or more) accounts A, B, C, who renamed into B, C and A respectively. With our current model, there is no way we can rename those one at a time. How can we handle that?
> - `a@foo` and `b@bar` are operated by the same person, using different pieces of software, `b@bar` is shut down without the Mastodon instance being made aware that `b@bar` has been deleted, `a@foo` is later renamed to `b@bar`

Conflict happens when a known account A is renamed to a username that is that of a different known account B. Because we just did verify the webfinger mapping, we know that the handle is unambiguously A's, and so that B's is outdated.

We thus rename B to an invalid (so that it won't conflict with any valid known or unknown remote actor) and locally-unique (using the database ID) handle so that we can rename A. We then immediately schedule a refresh of B's profile to find out its correct handle, or find out that it has been deleted. The scheme I chose was to change the username to `! :id` (e.g. `! id`), preserving the domain name because it is unlikely to change and can be used in domain-based moderation operations.

This invalidated username is not exposed to the REST API. Instead, the handle `:id@handle.invalid` is exposed to the REST API, keeping existing assumptions, but clearly marking it invalid.