### PR TITLE
Fix suspended accounts not being removed from follow request count in `/api/v1/accounts/verify_credentials`

### DIFF
--- a/app/serializers/rest/credential_account_serializer.rb
+++ b/app/serializers/rest/credential_account_serializer.rb
@@ -14,7 +14,7 @@ class REST::CredentialAccountSerializer < REST::AccountSerializer
       language: user.setting_default_language,
       note: object.note,
       fields: object.fields.map(&:to_h),
-      follow_requests_count: FollowRequest.where(target_account: object).limit(40).count,
+      follow_requests_count: Account.without_suspended.joins(:follow_requests).merge(FollowRequest.where(target_account: object)).limit(40).count,
       hide_collections: object.hide_collections,
       discoverable: object.discoverable,
       indexable: object.indexable,

--- a/app/serializers/rest/credential_account_serializer.rb
+++ b/app/serializers/rest/credential_account_serializer.rb
@@ -14,7 +14,7 @@ class REST::CredentialAccountSerializer < REST::AccountSerializer
       language: user.setting_default_language,
       note: object.note,
       fields: object.fields.map(&:to_h),
-      follow_requests_count: Account.without_suspended.joins(:follow_requests).merge(FollowRequest.where(target_account: object)).limit(40).count,
+      follow_requests_count: Account.without_suspended.joins(:follow_requests).where(follow_requests: { target_account: object }).limit(40).count,
       hide_collections: object.hide_collections,
       discoverable: object.discoverable,
       indexable: object.indexable,


### PR DESCRIPTION
Fixes #39838