### PR TITLE
Fix remote users not being re-followed after URI change

### DIFF
--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -57,6 +57,7 @@ class ActivityPub::ProcessAccountService < BaseService
       @old_public_keys = @account.present? ? (@account.keypairs.pluck(:public_key) + [@account.public_key.presence].compact) : []
       @old_protocol = @account&.protocol
       @suspension_changed = false
+      @uri_changed = @account.present? && @account.uri != @uri
 
       if @account.nil?
         with_redis do |redis|
@@ -82,9 +83,7 @@ class ActivityPub::ProcessAccountService < BaseService
     end
 
     after_protocol_change! if protocol_changed?
-
-    # TODO: extend this to an identity change, and do this on `uri` change as well
-    after_key_change! if all_public_keys_changed? && !signed_with_known_key
+    after_identity_change! if @uri_changed || (!signed_with_known_key && all_public_keys_changed?)
 
     # TODO: maybe tie tombstones to specific keys? i.e. we don't need to keep tombstones if all keys changed
     clear_tombstones! if all_public_keys_changed?
@@ -300,7 +299,7 @@ class ActivityPub::ProcessAccountService < BaseService
     ActivityPub::PostUpgradeWorker.perform_async(@account.domain)
   end
 
-  def after_key_change!
+  def after_identity_change!
     RefollowWorker.perform_async(@account.id)
   end
 


### PR DESCRIPTION
From the start, Mastodon has considered the `username@domain` handle to prevail over the ActivityPub `id` to identify an account.

However, changing ActivityPub `id` is exceedingly rare, and a strong indication that the remote's state has been wiped clean. For years we have already handled unexpected key changes as such an indication, it makes sense to me to also handle URI changes for this too.

EDIT: as I write that, I realize that such a state change would almost certainly cause the public keys to change as well, so maybe this change is not warranted and I should just remove/update the comment instead