### PR TITLE
Fix swapped order of "accept/reject" actions in follow requests

### DIFF
--- a/app/javascript/mastodon/features/notifications_v2/components/notification_follow_request.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_follow_request.tsx
@@ -62,16 +62,16 @@ export const NotificationFollowRequest: React.FC<{
   const actions = (
     <>
       <IconButton
-        title={intl.formatMessage(messages.reject)}
-        icon='times'
-        iconComponent={CloseIcon}
-        onClick={onReject}
-      />
-      <IconButton
         title={intl.formatMessage(messages.authorize)}
         icon='check'
         iconComponent={CheckIcon}
         onClick={onAuthorize}
+      />
+      <IconButton
+        title={intl.formatMessage(messages.reject)}
+        icon='times'
+        iconComponent={CloseIcon}
+        onClick={onReject}
       />
     </>
   );


### PR DESCRIPTION
### Changes proposed in this PR:
- Currently, the order of the "Accept" and "Reject" actions for follow requests is not unified between notifications and the "Follow requests" page which can lead to confusion. (Brought to my attention via https://glitterkitten.co.uk/@FrazzledBrynn/116194566357441353)
  
  This PR changes the order of the actions for notifications to match the Follow requests page.

### Screenshots

| **Context** | **Before** | **After** |
|--------|--------|--------|
| Notification | <img width="610" height="100" alt="image" src="https://github.com/user-attachments/assets/2ed881d3-a64f-448a-8543-6d3fa42d43c5" /> | <img width="608" height="104" alt="image" src="https://github.com/user-attachments/assets/482e7762-0b1b-449c-a2c6-db4b271c6e2a" /> |
| Follow request (unchanged) | <img width="607" height="188" alt="image" src="https://github.com/user-attachments/assets/7fa53568-0ed3-4a23-a24a-105c2076134c" /> | <img width="607" height="188" alt="image" src="https://github.com/user-attachments/assets/1682d2b1-1b52-4959-a035-9955ff088241" /> |