### PR TITLE
Fix `account` and `keypair` fabricators not working outside of rspec

### DIFF
--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../support/signing_keys_helpers'
+
 Fabricator(:account) do
   transient :suspended, :silenced, :legacy_keypair
   username            { sequence(:username) { |i| "#{Faker::Internet.user_name(separators: %w(_))}#{i}" } }

--- a/spec/fabricators/keypair_fabricator.rb
+++ b/spec/fabricators/keypair_fabricator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../support/signing_keys_helpers'
+
 Fabricator(:keypair) do
   account     { Fabricate(:account, keypairs: []) }
   type        :rsa


### PR DESCRIPTION
When outside of rspec (e.g. in a Rails console), the helpers are not loaded, and `Fabricate(:account)` fails.

This PR fixes that by requiring the helpers unconditionally.

I am not too happy with this solution, but none of the solutions I found was good, and this was the simplest. Neither rubocop nor rspec complain.