### PR TITLE
Fix notification filter selection after settings change

### DIFF
--- a/app/javascript/mastodon/features/notifications/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/notifications/containers/column_settings_container.js
@@ -44,7 +44,7 @@ const mapDispatchToProps = (dispatch) => ({
       }
     } else if (path[0] === 'quickFilter') {
       dispatch(changeSetting(['notifications', ...path], checked));
-      dispatch(setNotificationsFilter('all'));
+      dispatch(setNotificationsFilter({ filterType: 'all' }));
     } else if (path[0] === 'alerts' && checked && typeof window.Notification !== 'undefined' && Notification.permission !== 'granted') {
       if (checked && typeof window.Notification !== 'undefined' && Notification.permission !== 'granted') {
         dispatch(requestBrowserPermission((permission) => {


### PR DESCRIPTION
Changing the notification category display setting could leave the previous filter selected, causing user confusion. This change immediately resets the selection to "All"