### PR TITLE
Add loading feedback to the translate button

### DIFF
--- a/app/javascript/mastodon/actions/statuses.js
+++ b/app/javascript/mastodon/actions/statuses.js
@@ -322,7 +322,11 @@ export function toggleStatusCollapse(id, isCollapsed) {
   };
 }
 
-export const translateStatus = id => (dispatch) => {
+export const translateStatus = id => (dispatch, getState) => {
+  if (getState().statuses.getIn([id, 'isTranslating'])) {
+    return;
+  }
+
   dispatch(translateStatusRequest(id));
 
   api().post(`/api/v1/statuses/${id}/translate`).then(response => {

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 
 import ChevronRightIcon from '@/material-icons/400-24px/chevron_right.svg?react';
 import { Icon }  from 'mastodon/components/icon';
+import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 import { Poll } from 'mastodon/components/poll';
 import { identityContextPropShape, withIdentity } from 'mastodon/identity_context';
 import { languages as preloadedLanguages } from 'mastodon/initial_state';
@@ -35,11 +36,12 @@ class TranslateButton extends PureComponent {
 
   static propTypes = {
     translation: ImmutablePropTypes.map,
+    isTranslating: PropTypes.bool,
     onClick: PropTypes.func,
   };
 
   render () {
-    const { translation, onClick } = this.props;
+    const { translation, isTranslating, onClick } = this.props;
 
     if (translation) {
       const language     = preloadedLanguages.find(lang => lang[0] === translation.get('detected_source_language'));
@@ -56,6 +58,19 @@ class TranslateButton extends PureComponent {
             <FormattedMessage id='status.translated_from_with' defaultMessage='Translated from {lang} using {provider}' values={{ lang: languageName, provider }} />
           </div>
         </div>
+      );
+    }
+
+    if (isTranslating) {
+      return (
+        <button
+          className='status__content__translate-button status__content__translate-button--loading'
+          disabled
+          aria-busy='true'
+        >
+          <LoadingIndicator role='none' />
+          <FormattedMessage id='status.translating' defaultMessage='Translating…' />
+        </button>
       );
     }
 
@@ -204,7 +219,11 @@ class StatusContent extends PureComponent {
     );
 
     const translateButton = renderTranslate && (
-      <TranslateButton onClick={this.handleTranslate} translation={status.get('translation')} />
+      <TranslateButton
+        onClick={this.handleTranslate}
+        translation={status.get('translation')}
+        isTranslating={status.get('isTranslating')}
+      />
     );
 
     const poll = !!status.get('poll') && (

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -1317,6 +1317,7 @@
   "status.title.with_attachments": "{user} posted {attachmentCount, plural, one {an attachment} other {{attachmentCount} attachments}}",
   "status.translate": "Translate",
   "status.translated_from_with": "Translated from {lang} using {provider}",
+  "status.translating": "Translating…",
   "status.uncached_media_warning": "Preview not available",
   "status.unmute_conversation": "Unmute conversation",
   "status.unpin": "Unpin from profile",

--- a/app/javascript/mastodon/reducers/__tests__/statuses-test.js
+++ b/app/javascript/mastodon/reducers/__tests__/statuses-test.js
@@ -1,0 +1,73 @@
+import {
+  STATUS_TRANSLATE_FAIL,
+  STATUS_TRANSLATE_REQUEST,
+  STATUS_TRANSLATE_SUCCESS,
+} from 'mastodon/actions/statuses';
+import { STATUS_IMPORT } from 'mastodon/actions/importer';
+
+import statuses from '../statuses';
+
+const baseStatus = {
+  id: '1',
+  content: '<p>Hola</p>',
+  media_attachments: [],
+};
+
+const translation = {
+  content: '<p>Hello</p>',
+  spoiler_text: '',
+  media_attachments: [],
+  detected_source_language: 'es',
+  language: 'en',
+  provider: 'DeepL.com',
+};
+
+describe('statuses reducer translation loading', () => {
+  const imported = () =>
+    statuses(undefined, {
+      type: STATUS_IMPORT,
+      status: baseStatus,
+    });
+
+  it('sets isTranslating on STATUS_TRANSLATE_REQUEST', () => {
+    const state = statuses(imported(), {
+      type: STATUS_TRANSLATE_REQUEST,
+      id: '1',
+    });
+
+    expect(state.getIn(['1', 'isTranslating'])).toBe(true);
+  });
+
+  it('clears isTranslating and stores translation on STATUS_TRANSLATE_SUCCESS', () => {
+    let state = statuses(imported(), {
+      type: STATUS_TRANSLATE_REQUEST,
+      id: '1',
+    });
+
+    state = statuses(state, {
+      type: STATUS_TRANSLATE_SUCCESS,
+      id: '1',
+      translation,
+    });
+
+    expect(state.getIn(['1', 'isTranslating'])).toBeUndefined();
+    expect(state.getIn(['1', 'translation', 'provider'])).toBe('DeepL.com');
+    expect(state.getIn(['1', 'translation', 'contentHtml'])).toBe('<p>Hello</p>');
+  });
+
+  it('clears isTranslating on STATUS_TRANSLATE_FAIL', () => {
+    let state = statuses(imported(), {
+      type: STATUS_TRANSLATE_REQUEST,
+      id: '1',
+    });
+
+    state = statuses(state, {
+      type: STATUS_TRANSLATE_FAIL,
+      id: '1',
+      error: new Error('fail'),
+    });
+
+    expect(state.getIn(['1', 'isTranslating'])).toBeUndefined();
+    expect(state.getIn(['1', 'translation'])).toBeUndefined();
+  });
+});

--- a/app/javascript/mastodon/reducers/statuses.js
+++ b/app/javascript/mastodon/reducers/statuses.js
@@ -24,7 +24,9 @@ import {
   STATUS_REVEAL,
   STATUS_HIDE,
   STATUS_COLLAPSE,
+  STATUS_TRANSLATE_REQUEST,
   STATUS_TRANSLATE_SUCCESS,
+  STATUS_TRANSLATE_FAIL,
   STATUS_TRANSLATE_UNDO,
   STATUS_FETCH_REQUEST,
   STATUS_FETCH_FAIL,
@@ -146,8 +148,12 @@ export default function statuses(state = initialState, action) {
     return state.setIn([action.id, 'collapsed'], action.isCollapsed);
   case timelineDelete.type:
     return deleteStatus(state, action.payload.statusId, action.payload.references);
+  case STATUS_TRANSLATE_REQUEST:
+    return state.setIn([action.id, 'isTranslating'], true);
   case STATUS_TRANSLATE_SUCCESS:
-    return statusTranslateSuccess(state, action.id, action.translation);
+    return statusTranslateSuccess(state, action.id, action.translation).deleteIn([action.id, 'isTranslating']);
+  case STATUS_TRANSLATE_FAIL:
+    return state.deleteIn([action.id, 'isTranslating']);
   case STATUS_TRANSLATE_UNDO:
     return statusTranslateUndo(state, action.id);
   default:

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1449,6 +1449,29 @@ body > [data-popover-placement] {
     width: 15px;
     height: 15px;
   }
+
+  &--loading {
+    gap: 8px;
+    cursor: wait;
+    pointer-events: none;
+
+    &:hover,
+    &:active {
+      text-decoration: none;
+    }
+
+    .loading-indicator {
+      position: static;
+      transform: none;
+      color: inherit;
+    }
+
+    .circular-progress {
+      color: inherit;
+      width: 14px;
+      height: 14px;
+    }
+  }
 }
 
 .translate-button {


### PR DESCRIPTION
This PR adds visible loading feedback while a status translation request is pending.

Currently, clicking “Translate” produces no visible response until the translation request completes, which can make the action appear unresponsive—especially with slower translation providers.

While the request is pending, this change displays a loading indicator and “Translating…” on the translate button.

This change is already running in production on https://nightcord.de/.