### PR TITLE
Stop scheduling the `RepairRemoteCollectionsScheduler`

### DIFF
--- a/app/workers/scheduler/repair_remote_collections_scheduler.rb
+++ b/app/workers/scheduler/repair_remote_collections_scheduler.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# TODO: Remove in the next version
+# TODO: Remove in Mastodon 5.0
 class Scheduler::RepairRemoteCollectionsScheduler
   include Sidekiq::Worker
   include JsonLdHelper

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -76,7 +76,3 @@
       interval: 1 hour
       class: Scheduler::CollectionItemCleanupScheduler
       queue: scheduler
-    repair_remote_collections_scheduler:
-      every: ['24h', first_in: '1s']
-      class: Scheduler::RepairRemoteCollectionsScheduler
-      queue: scheduler


### PR DESCRIPTION
This was added in 4.6.1 to retroactively fix an issue introduced in 4.6.0. We should stop using it in 4.7.0 or 5.0.

This is only relevant for servers which ran on Mastodon 4.6.0 long enough to process a bogus remote collection and did not run a later v4.6.x version long enough for it to get fixed.

The release notes of the versions in which this releases should mention it.