### PR TITLE
Fix selected account being lost when creating a collection

### DIFF
--- a/app/javascript/mastodon/features/collection_adder/index.tsx
+++ b/app/javascript/mastodon/features/collection_adder/index.tsx
@@ -24,6 +24,7 @@ import {
 } from '../collections/overview/created_by_account';
 
 import { CollectionToggle } from './collection_toggle';
+import classes from './styles.module.scss';
 
 const messages = defineMessages({
   close: {
@@ -176,9 +177,14 @@ export const CollectionAdder: React.FC<{
               <NewCollectionButton onClick={handleNewCollection} />
             </EmptyState>
           ) : (
-            collections.map((item) => (
-              <ListItem key={item.id} collection={item} account={account} />
-            ))
+            <>
+              <div className={classes.newCollection}>
+                <NewCollectionButton onClick={handleNewCollection} />
+              </div>
+              {collections.map((item) => (
+                <ListItem key={item.id} collection={item} account={account} />
+              ))}
+            </>
           )}
         </div>
       </div>

--- a/app/javascript/mastodon/features/collection_adder/index.tsx
+++ b/app/javascript/mastodon/features/collection_adder/index.tsx
@@ -10,6 +10,7 @@ import { useCurrentAccountId } from '@/mastodon/hooks/useAccountId';
 import type { Account } from '@/mastodon/models/account';
 import {
   addCollectionItem,
+  collectionEditorActions,
   removeCollectionItem,
 } from '@/mastodon/reducers/slices/collections';
 import CloseIcon from '@/material-icons/400-24px/close.svg?react';
@@ -107,6 +108,23 @@ export const CollectionAdder: React.FC<{
   const account = useAppSelector((state) => state.accounts.get(accountId));
   const currentAccountId = useCurrentAccountId();
   const { collections, status } = useCollectionsCreatedBy(currentAccountId);
+  const dispatch = useAppDispatch();
+
+  const handleNewCollection = useCallback(() => {
+    if (account) {
+      dispatch(
+        collectionEditorActions.initNewCollection({
+          account_id: account.id,
+          state:
+            account.feature_approval.current_user === 'manual'
+              ? 'pending'
+              : 'accepted',
+        }),
+      );
+    }
+
+    onClose();
+  }, [account, dispatch, onClose]);
 
   return (
     <div className='modal-root__modal dialog-modal'>
@@ -155,7 +173,7 @@ export const CollectionAdder: React.FC<{
                 />
               }
             >
-              <NewCollectionButton onClick={onClose} />
+              <NewCollectionButton onClick={handleNewCollection} />
             </EmptyState>
           ) : (
             collections.map((item) => (

--- a/app/javascript/mastodon/features/collection_adder/index.tsx
+++ b/app/javascript/mastodon/features/collection_adder/index.tsx
@@ -10,6 +10,7 @@ import { useCurrentAccountId } from '@/mastodon/hooks/useAccountId';
 import type { Account } from '@/mastodon/models/account';
 import {
   addCollectionItem,
+  collectionEditorActions,
   removeCollectionItem,
 } from '@/mastodon/reducers/slices/collections';
 import CloseIcon from '@/material-icons/400-24px/close.svg?react';
@@ -23,6 +24,7 @@ import {
 } from '../collections/overview/created_by_account';
 
 import { CollectionToggle } from './collection_toggle';
+import classes from './styles.module.scss';
 
 const messages = defineMessages({
   close: {
@@ -107,6 +109,23 @@ export const CollectionAdder: React.FC<{
   const account = useAppSelector((state) => state.accounts.get(accountId));
   const currentAccountId = useCurrentAccountId();
   const { collections, status } = useCollectionsCreatedBy(currentAccountId);
+  const dispatch = useAppDispatch();
+
+  const handleNewCollection = useCallback(() => {
+    if (account) {
+      dispatch(
+        collectionEditorActions.reset({
+          account_id: account.id,
+          state:
+            account.feature_approval.current_user === 'manual'
+              ? 'pending'
+              : 'accepted',
+        }),
+      );
+    }
+
+    onClose();
+  }, [account, dispatch, onClose]);
 
   return (
     <div className='modal-root__modal dialog-modal'>
@@ -155,12 +174,17 @@ export const CollectionAdder: React.FC<{
                 />
               }
             >
-              <NewCollectionButton onClick={onClose} />
+              <NewCollectionButton onClick={handleNewCollection} />
             </EmptyState>
           ) : (
-            collections.map((item) => (
-              <ListItem key={item.id} collection={item} account={account} />
-            ))
+            <>
+              <div className={classes.newCollection}>
+                <NewCollectionButton onClick={handleNewCollection} />
+              </div>
+              {collections.map((item) => (
+                <ListItem key={item.id} collection={item} account={account} />
+              ))}
+            </>
           )}
         </div>
       </div>

--- a/app/javascript/mastodon/features/collection_adder/styles.module.scss
+++ b/app/javascript/mastodon/features/collection_adder/styles.module.scss
@@ -1,0 +1,5 @@
+.newCollection {
+  display: flex;
+  justify-content: center;
+  padding-block: 16px;
+}

--- a/app/javascript/mastodon/features/collections/editor/index.tsx
+++ b/app/javascript/mastodon/features/collections/editor/index.tsx
@@ -19,6 +19,7 @@ import { Column } from 'mastodon/components/column';
 import { ColumnHeader } from 'mastodon/components/column_header';
 import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 import { NotSignedInIndicator } from 'mastodon/components/not_signed_in_indicator';
+import { useAppHistory } from 'mastodon/components/router';
 import { useIdentity } from 'mastodon/identity_context';
 import { initialState } from 'mastodon/initial_state';
 import {
@@ -76,6 +77,7 @@ export const CollectionEditorPage: React.FC<{
 }> = ({ multiColumn }) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
+  const history = useAppHistory();
   const { accountId, signedIn } = useIdentity();
   const { id = null } = useParams<{ id?: string }>();
   const { path } = useRouteMatch();
@@ -114,6 +116,14 @@ export const CollectionEditorPage: React.FC<{
       void dispatch(collectionEditorActions.init(collection));
     }
   }, [dispatch, collection]);
+
+  useEffect(() => {
+    return history.listen((location) => {
+      if (!matchPath(location.pathname, { path })) {
+        void dispatch(collectionEditorActions.reset());
+      }
+    });
+  }, [dispatch, history, path]);
 
   const pageTitle = intl.formatMessage(usePageTitle(id));
 

--- a/app/javascript/mastodon/reducers/slices/collections.ts
+++ b/app/javascript/mastodon/reducers/slices/collections.ts
@@ -114,6 +114,12 @@ const collectionSlice = createSlice({
     reset(state) {
       state.editor = initialCollectionState.editor;
     },
+    initNewCollection(state, action: PayloadAction<EditorCollectionItem>) {
+      state.editor = {
+        ...initialCollectionState.editor,
+        items: [action.payload],
+      };
+    },
     updateEditorField<K extends keyof EditorState>(
       state: CollectionState,
       action: PayloadAction<UpdateEditorFieldPayload<K>>,

--- a/app/javascript/mastodon/reducers/slices/collections.ts
+++ b/app/javascript/mastodon/reducers/slices/collections.ts
@@ -111,8 +111,11 @@ const collectionSlice = createSlice({
         items: getEditorCollectionItems(collection.items),
       };
     },
-    reset(state) {
-      state.editor = initialCollectionState.editor;
+    reset(state, action: PayloadAction<EditorCollectionItem | undefined>) {
+      state.editor =
+        action.payload !== undefined
+          ? { ...initialCollectionState.editor, items: [action.payload] }
+          : initialCollectionState.editor;
     },
     updateEditorField<K extends keyof EditorState>(
       state: CollectionState,


### PR DESCRIPTION
Fixes #39874

### Changes proposed in this PR:

- Fixes the account being viewed getting lost when using `Add to collection…` from a user profile.
- Add a `New collection` button to the dialog when collections already exist like List.
- Clears the preselected account when leaving the collection editor without creating the collection.

### Screenshots

- `New collection` button position
  <img width="590" height="209" alt="image" src="https://github.com/user-attachments/assets/8c61596c-bb04-447e-bbb7-da3c5e4479e6" />
  
- flow
  <img width="600" height="600" alt="mstdn_pr_preview" src="https://github.com/user-attachments/assets/4f874a05-8318-4ece-8d3b-e223ffd11e4b" />
