### PR TITLE
Remove unused private methods

### DIFF
--- a/app/lib/annual_report/time_series.rb
+++ b/app/lib/annual_report/time_series.rb
@@ -23,12 +23,6 @@ class AnnualReport::TimeSeries < AnnualReport::Source
     @followers_this_year ||= @account.passive_relationships.where(created_in_year, @year).count
   end
 
-  def date_part_month
-    Arel.sql(<<~SQL.squish)
-      DATE_PART('month', created_at)::int
-    SQL
-  end
-
   def created_in_year
     Arel.sql(<<~SQL.squish)
       DATE_PART('year', created_at) = ?

--- a/app/lib/annual_report/top_statuses.rb
+++ b/app/lib/annual_report/top_statuses.rb
@@ -27,20 +27,6 @@ class AnnualReport::TopStatuses < AnnualReport::Source
       .first
   end
 
-  def most_favourited_status
-    base_scope
-      .excluding(most_reblogged_status)
-      .order(favourites_count: :desc)
-      .first
-  end
-
-  def most_replied_status
-    base_scope
-      .excluding(most_reblogged_status, most_favourited_status)
-      .order(replies_count: :desc)
-      .first
-  end
-
   def base_scope
     report_statuses
       .distributable_visibility

--- a/app/lib/signed_request.rb
+++ b/app/lib/signed_request.rb
@@ -224,10 +224,6 @@ class SignedRequest
     def body_digest
       @body_digest ||= Digest::SHA256.base64digest(request_body)
     end
-
-    def missing_required_signature_parameters?
-      @signature.parameters['keyid'].blank?
-    end
   end
 
   attr_reader :signature

--- a/lib/paperclip/color_extractor.rb
+++ b/lib/paperclip/color_extractor.rb
@@ -215,18 +215,6 @@ module Paperclip
       ColorDiff::Color::RGB.new(*hsl_to_rgb(hue, saturation, light))
     end
 
-    def palette_from_im_histogram(result, quantity)
-      frequencies       = result.scan(/([0-9]+):/).flatten.map(&:to_f)
-      hex_values        = result.scan(/\#([0-9A-Fa-f]{6,8})/).flatten
-      total_frequencies = frequencies.sum.to_f
-
-      frequencies.map.with_index { |f, i| [f / total_frequencies, hex_values[i]] }
-        .sort_by { |r| -r[0] }
-        .reject { |r| r[1].size == 8 && r[1].end_with?('00') }
-        .map { |r| ColorDiff::Color::RGB.new(*r[1][0..5].scan(/../).map { |c| c.to_i(16) }) }
-        .slice(0, quantity)
-    end
-
     def rgb_to_hex(rgb)
       format('#%02x%02x%02x', rgb.r, rgb.g, rgb.b) # rubocop:disable Style/FormatStringToken
     end

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -16,27 +16,4 @@ RSpec.describe 'Profile' do
     expect(page)
       .to have_title("alice (@alice@#{local_domain_uri.host})")
   end
-
-  def submit_form
-    first('button[type=submit]').click
-  end
-
-  def account_fields_labels
-    page.all('.account_fields_name input')
-  end
-
-  def account_fields_values
-    page.all('.account_fields_value input')
-  end
-
-  def change_account_fields
-    change { bob.account.reload.fields }
-      .from([])
-      .to(
-        contain_exactly(
-          be_a(Account::Field),
-          be_a(Account::Field)
-        )
-      )
-  end
 end

--- a/spec/system/settings/preferences/appearance_spec.rb
+++ b/spec/system/settings/preferences/appearance_spec.rb
@@ -38,10 +38,6 @@ RSpec.describe 'Settings preferences appearance page' do
     form_label('defaults.setting_boost_modal')
   end
 
-  def theme_selection_field
-    form_label('defaults.setting_theme')
-  end
-
   def advanced_layout_field
     form_label('defaults.setting_advanced_layout')
   end


### PR DESCRIPTION
## Summary

Remove ten private methods that became unreachable after earlier feature and test cleanups.

This came from a conservative [Rubydex](https://github.com/Shopify/rubydex) audit of 3,232 tracked Ruby files. Rubydex was used only to rank candidates; each removal below was then checked against the whole tree and repository history.

## Removed methods and history

| Removed method(s) | Historical context |
| --- | --- |
| `AnnualReport::TimeSeries#date_part_month` | Extracted in [`ebc6897afb`](https://github.com/mastodon/mastodon/commit/ebc6897afb) (#35113) for per-month grouping. [`7b8a5d42f1`](https://github.com/mastodon/mastodon/commit/7b8a5d42f1) (#37187) replaced the monthly series with yearly totals and removed every caller, but left the month expression helper behind. |
| `AnnualReport::TopStatuses#most_favourited_status`, `#most_replied_status` | Extracted in [`ad78701b6f`](https://github.com/mastodon/mastodon/commit/ad78701b6f) (#35256). [`addeb28292`](https://github.com/mastodon/mastodon/commit/addeb28292) (#37206) stopped calculating favourite/reply entries and set them to `nil`; `#most_replied_status` became unreachable, and its only remaining dependency on `#most_favourited_status` formed an otherwise-unreachable dead subgraph. |
| `SignedRequest::HttpMessageSignature#missing_required_signature_parameters?` | Added with RFC 9421 support in [`9c80b16401`](https://github.com/mastodon/mastodon/commit/9c80b16401) (#34814), but never called. Verification has always used the separate public `#missing_signature_parameters` method. |
| `Paperclip::ColorExtractor#palette_from_im_histogram` | Added/renamed for the ImageMagick branch in [`5f15a892fa`](https://github.com/mastodon/mastodon/commit/5f15a892fa) (#30090). [`157d8c0d99`](https://github.com/mastodon/mastodon/commit/157d8c0d99) (#37488) removed the ImageMagick path in favor of libvips, leaving this parser without a caller. |
| Profile system-spec helpers `submit_form`, `account_fields_labels`, `account_fields_values`, `change_account_fields` | `submit_form`/`change_account_fields` were introduced in [`4a9c49ee43`](https://github.com/mastodon/mastodon/commit/4a9c49ee43) (#33689); the label/value helpers followed in [`4f41b7c089`](https://github.com/mastodon/mastodon/commit/4f41b7c089) (#35903). [`e4e7e679b3`](https://github.com/mastodon/mastodon/commit/e4e7e679b3) (#38584) removed the profile-editing scenario and left all four helpers behind. |
| Appearance system-spec helper `theme_selection_field` | Added with the system spec in [`efe4e72f93`](https://github.com/mastodon/mastodon/commit/efe4e72f93) (#33323). [`75ba314e6b`](https://github.com/mastodon/mastodon/commit/75ba314e6b) (#37612) removed the old theme selection and its assertion, leaving the helper unused. |

## Audit method

1. Index all tracked `*.rb`, `*.rake`, `*.ru`, and `*.rbs` sources with Rubydex 0.2.9.
2. Resolve the graph and rank private declarations whose names have no ordinary Ruby method reference.
3. Split exact string/symbol literals with Prism to identify possible dynamic dispatch.
4. Search the whole tree, inspect local call paths, and trace introduction/last-caller commits.
5. Remove only methods with an explained transition from live to unreachable, or which were dead on arrival.

