### PR TITLE
Guard against multiple queue_deletions triggering AccountDeletionWorker on already suspended accounts.

### DIFF
--- a/app/services/activitypub/fetch_remote_actor_service.rb
+++ b/app/services/activitypub/fetch_remote_actor_service.rb
@@ -47,7 +47,7 @@ class ActivityPub::FetchRemoteActorService < BaseService
     account = Account.find_by(uri:)
     return unless account&.remote?
     return if account.suspended?
-  
+
     Rails.logger.debug { "Deleting actor #{uri} because of HTTP 410 response" }
 
     account.suspend!(origin: :remote)

--- a/app/services/activitypub/fetch_remote_actor_service.rb
+++ b/app/services/activitypub/fetch_remote_actor_service.rb
@@ -46,7 +46,8 @@ class ActivityPub::FetchRemoteActorService < BaseService
   def queue_deletion!(uri)
     account = Account.find_by(uri:)
     return unless account&.remote?
-
+    return if account.suspended?
+  
     Rails.logger.debug { "Deleting actor #{uri} because of HTTP 410 response" }
 
     account.suspend!(origin: :remote)

--- a/app/services/activitypub/fetch_remote_actor_service.rb
+++ b/app/services/activitypub/fetch_remote_actor_service.rb
@@ -46,7 +46,7 @@ class ActivityPub::FetchRemoteActorService < BaseService
   def queue_deletion!(uri)
     account = Account.find_by(uri:)
     return unless account&.remote?
-    return if account.suspended?
+    return if account&.suspended?
 
     Rails.logger.debug { "Deleting actor #{uri} because of HTTP 410 response" }
 

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -132,7 +132,7 @@ class ResolveAccountService < BaseService
   end
 
   def queue_deletion!
-    return if account.suspended?
+    return if @account.suspended?
 
     @account.suspend!(origin: :remote)
     AccountDeletionWorker.perform_async(@account.id, { 'reserve_username' => false, 'skip_activitypub' => true })

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -132,6 +132,8 @@ class ResolveAccountService < BaseService
   end
 
   def queue_deletion!
+    return if account.suspended?
+
     @account.suspend!(origin: :remote)
     AccountDeletionWorker.perform_async(@account.id, { 'reserve_username' => false, 'skip_activitypub' => true })
   end


### PR DESCRIPTION
Calling queue_deletion! on an already-suspended account should not trigger another AccountDeletionWorker