### PR TITLE
Fix ghost filtered notifications after delete_account_service

### DIFF
--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -187,6 +187,7 @@ class DeleteAccountService < BaseService
 
     Notification.where(from_account: @account).in_batches.delete_all
     NotificationRequest.where(from_account: @account).in_batches.delete_all
+    NotificationRequest.where(account: @account).in_batches.delete_all
   end
 
   def purge_favourites!


### PR DESCRIPTION
This will delete notifications with the account targeted at the account such as "filtered notifications".