### PR TITLE
Fix hexcode case mismatch on Emoji with borders SVG style.

### DIFF
--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -149,7 +149,6 @@ export function unicodeToTwemojiHex(unicodeHex: string): string {
 }
 
 const CODES_WITH_DARK_BORDER = EMOJIS_WITH_DARK_BORDER.map(emojiToUnicodeHex).map(h => h.toLowerCase());
-
 const CODES_WITH_LIGHT_BORDER = EMOJIS_WITH_LIGHT_BORDER.map(emojiToUnicodeHex).map(h => h.toLowerCase());
 
 export function unicodeHexToUrl({

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -148,8 +148,8 @@ export function unicodeToTwemojiHex(unicodeHex: string): string {
     .toLowerCase();
 }
 
-const CODES_WITH_DARK_BORDER = EMOJIS_WITH_DARK_BORDER.map(emojiToUnicodeHex).toLowerCase());
-const CODES_WITH_LIGHT_BORDER = EMOJIS_WITH_LIGHT_BORDER.map(emojiToUnicodeHex).toLowerCase());
+const CODES_WITH_DARK_BORDER = EMOJIS_WITH_DARK_BORDER.map((e) => emojiToUnicodeHex(e).toLowerCase());
+const CODES_WITH_LIGHT_BORDER = EMOJIS_WITH_LIGHT_BORDER.map((e) => emojiToUnicodeHex(e).toLowerCase());
 
 export function unicodeHexToUrl({
   unicodeHex,

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -148,9 +148,9 @@ export function unicodeToTwemojiHex(unicodeHex: string): string {
     .toLowerCase();
 }
 
-const CODES_WITH_DARK_BORDER = EMOJIS_WITH_DARK_BORDER.map(emojiToUnicodeHex);
+const CODES_WITH_DARK_BORDER = EMOJIS_WITH_DARK_BORDER.map(emojiToUnicodeHex).map(h => h.toLowerCase());
 
-const CODES_WITH_LIGHT_BORDER = EMOJIS_WITH_LIGHT_BORDER.map(emojiToUnicodeHex);
+const CODES_WITH_LIGHT_BORDER = EMOJIS_WITH_LIGHT_BORDER.map(emojiToUnicodeHex).map(h => h.toLowerCase());
 
 export function unicodeHexToUrl({
   unicodeHex,

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -148,8 +148,8 @@ export function unicodeToTwemojiHex(unicodeHex: string): string {
     .toLowerCase();
 }
 
-const CODES_WITH_DARK_BORDER = EMOJIS_WITH_DARK_BORDER.map(emojiToUnicodeHex).map((h) => h.toLowerCase());
-const CODES_WITH_LIGHT_BORDER = EMOJIS_WITH_LIGHT_BORDER.map(emojiToUnicodeHex).map((h) => h.toLowerCase());
+const CODES_WITH_DARK_BORDER = EMOJIS_WITH_DARK_BORDER.map(emojiToUnicodeHex).toLowerCase());
+const CODES_WITH_LIGHT_BORDER = EMOJIS_WITH_LIGHT_BORDER.map(emojiToUnicodeHex).toLowerCase());
 
 export function unicodeHexToUrl({
   unicodeHex,

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -148,8 +148,8 @@ export function unicodeToTwemojiHex(unicodeHex: string): string {
     .toLowerCase();
 }
 
-const CODES_WITH_DARK_BORDER = EMOJIS_WITH_DARK_BORDER.map(emojiToUnicodeHex).map(h => h.toLowerCase());
-const CODES_WITH_LIGHT_BORDER = EMOJIS_WITH_LIGHT_BORDER.map(emojiToUnicodeHex).map(h => h.toLowerCase());
+const CODES_WITH_DARK_BORDER = EMOJIS_WITH_DARK_BORDER.map(emojiToUnicodeHex).map((h) => h.toLowerCase());
+const CODES_WITH_LIGHT_BORDER = EMOJIS_WITH_LIGHT_BORDER.map(emojiToUnicodeHex).map((h) => h.toLowerCase());
 
 export function unicodeHexToUrl({
   unicodeHex,


### PR DESCRIPTION
`const CODES_WITH_DARK_BORDER = EMOJIS_WITH_DARK_BORDER.map(emojiToUnicodeHex);` returns uppercase

`const normalizedHex = unicodeToTwemojiHex(unicodeHex);` returns lowercase

`if (darkTheme && CODES_WITH_LIGHT_BORDER.includes(normalizedHex))` will .includes lower and upper never matching