### PR TITLE
Improve emoji search for mixed query

### DIFF
--- a/app/javascript/mastodon/features/emoji/search.ts
+++ b/app/javascript/mastodon/features/emoji/search.ts
@@ -155,8 +155,8 @@ export async function search({
   }
 
   // Iterate over all maps, getting a combined score for emojis that exist in all results.
-  const allEmojiIds = resultArrays.reduce((prev, map) => {
-    if (prev.size === 0) {
+  const allEmojiIds = resultArrays.reduce((prev, map, index) => {
+    if (index === 0) {
       return new Set(map.keys());
     }
     return new Set(map.keys()).intersection(prev);


### PR DESCRIPTION
"banana man" and "man banana" should successfully find "banana_man" now

Reference https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#currentindex

Caught by static code, fix by myself.