### PR TITLE
Fix `ActivityPub::Activity::Create` trying to re-create known statuses when author changes

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -36,6 +36,9 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
       if @status.nil?
         process_status
+      elsif @status.account_id != @account.id
+        Rails.logger.debug { "Not processing #{object_uri}: authorship change is not supported" }
+        return reject_payload!
       elsif @options[:delivered_to_account_id].present?
         postprocess_audience_and_deliver
       end
@@ -92,7 +95,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def find_existing_status
     status   = status_from_uri(object_uri)
     status ||= Status.find_by(uri: @object['atomUri']) if @object['atomUri'].present?
-    status if status&.account_id == @account.id
+    status
   end
 
   def process_status_params

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -500,6 +500,30 @@ RSpec.describe ActivityPub::Activity::Create do
         end
       end
 
+      context 'when the status is already known' do
+        let(:recipient) { Fabricate(:account) }
+
+        let(:object_json) do
+          build_object(
+            to: ActivityPub::TagManager.instance.uri_for(recipient)
+          )
+        end
+
+        let!(:status) { Fabricate(:status, uri: object_json[:id], account: sender, text: object_json[:content]) }
+
+        it 'keeps the status intact' do
+          expect(subject.perform).to eq status
+        end
+
+        context 'when the known status is attributed to a different actor' do
+          let!(:status) { Fabricate(:status, uri: object_json[:id], account: Fabricate(:remote_account)) }
+
+          it 'returns nil' do
+            expect(subject.perform).to be_nil
+          end
+        end
+      end
+
       context 'when direct' do
         let(:recipient) { Fabricate(:account) }
 
@@ -1419,7 +1443,7 @@ RSpec.describe ActivityPub::Activity::Create do
 
     def build_object(options = {})
       {
-        id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
+        id: [ActivityPub::TagManager.instance.uri_for(sender), '/bar'].join,
         type: 'Note',
         content: 'Lorem ipsum',
       }.merge(options)


### PR DESCRIPTION
Our handler for post creation handles re-processing known statuses in order to expand their audience.

However, when a status is found to be known but written under a different actor, the code tried to re-create the same post, leading to a validation error.

With this PR, post authorship change remains unsupported, but the error handling immediately returns `nil` rather than spending time re-processing a status that *will* fail validation and raise an error.

Since this raised an unexpected `ActiveRecord::RecordInvalid`, it also made `ProcessLinksService` abort processing of any local post with a link to an existing status which had changed authors.