### PR TITLE
Toggles with redesign tokens

### DIFF
--- a/app/javascript/mastodon/components/form_fields/redesign.module.scss
+++ b/app/javascript/mastodon/components/form_fields/redesign.module.scss
@@ -1,8 +1,19 @@
-.toggle {
+.toggle.toggle {
   background: rgb(from var(--color-bg-inverted) r g b / 70%);
 
   &::before {
     box-shadow: none;
     background: var(--color-bg-primary);
   }
+}
+
+.toggle.toggleSmall {
+  --padding: 2px;
+  --diameter: 14px;
+
+  width: 32px;
+}
+
+input:checked + .toggle.toggleSmall::before {
+  transform: translateX(var(--diameter));
 }

--- a/app/javascript/mastodon/components/form_fields/redesign.module.scss
+++ b/app/javascript/mastodon/components/form_fields/redesign.module.scss
@@ -1,0 +1,8 @@
+.toggle {
+  background: rgb(from var(--color-bg-inverted) r g b / 70%);
+
+  &::before {
+    box-shadow: none;
+    background: var(--color-bg-primary);
+  }
+}

--- a/app/javascript/mastodon/components/form_fields/redesign.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/redesign.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ToggleField } from './redesign';
+
+interface FieldProps {
+  label: string;
+  hint?: string;
+  disabled?: boolean;
+}
+
+const meta = {
+  title: 'Redesign/Form Fields',
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- We need to add args or TS doesn't see it in other render functions.
+  render(args) {
+    return <>Empty</>; // Override elsewhere
+  },
+  args: {
+    label: 'Label',
+    hint: 'This is a description of this form field',
+    disabled: false,
+  },
+} satisfies Meta<FieldProps>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Toggle: Story = {
+  render(args) {
+    return <ToggleField {...args} />;
+  },
+};

--- a/app/javascript/mastodon/components/form_fields/redesign.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/redesign.stories.tsx
@@ -30,3 +30,9 @@ export const Toggle: Story = {
     return <ToggleField {...args} />;
   },
 };
+
+export const ToggleSmall: Story = {
+  render(args) {
+    return <ToggleField {...args} size='sm' />;
+  },
+};

--- a/app/javascript/mastodon/components/form_fields/redesign.tsx
+++ b/app/javascript/mastodon/components/form_fields/redesign.tsx
@@ -1,23 +1,49 @@
 import classNames from 'classnames';
 
+import type { Merge } from 'type-fest';
+
 import classes from './redesign.module.scss';
 import {
   Toggle as OldToggle,
   ToggleField as OldToggleField,
 } from './toggle_field';
 
-export const Toggle: React.FC<React.ComponentProps<typeof OldToggle>> = ({
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ToggleComponent<T extends React.JSXElementConstructor<any>> = React.FC<
+  Merge<
+    React.ComponentProps<T>,
+    {
+      size?: 'sm' | 'lg';
+    }
+  >
+>;
+
+export const Toggle: ToggleComponent<typeof OldToggle> = ({
   className,
+  size,
   ...props
 }) => (
-  <OldToggle {...props} className={classNames(className, classes.toggle)} />
+  <OldToggle
+    {...props}
+    className={classNames(
+      className,
+      classes.toggle,
+      size === 'sm' && classes.toggleSmall,
+    )}
+  />
 );
 
-export const ToggleField: React.FC<
-  React.ComponentProps<typeof OldToggleField>
-> = ({ className, ...props }) => (
+export const ToggleField: ToggleComponent<typeof OldToggleField> = ({
+  className,
+  size,
+  ...props
+}) => (
   <OldToggleField
     {...props}
-    className={classNames(className, classes.toggle)}
+    className={classNames(
+      className,
+      classes.toggle,
+      size === 'sm' && classes.toggleSmall,
+    )}
   />
 );

--- a/app/javascript/mastodon/components/form_fields/redesign.tsx
+++ b/app/javascript/mastodon/components/form_fields/redesign.tsx
@@ -1,0 +1,23 @@
+import classNames from 'classnames';
+
+import classes from './redesign.module.scss';
+import {
+  Toggle as OldToggle,
+  ToggleField as OldToggleField,
+} from './toggle_field';
+
+export const Toggle: React.FC<React.ComponentProps<typeof OldToggle>> = ({
+  className,
+  ...props
+}) => (
+  <OldToggle {...props} className={classNames(className, classes.toggle)} />
+);
+
+export const ToggleField: React.FC<
+  React.ComponentProps<typeof OldToggleField>
+> = ({ className, ...props }) => (
+  <OldToggleField
+    {...props}
+    className={classNames(className, classes.toggle)}
+  />
+);


### PR DESCRIPTION
This adds a redesign file for the form field components that overrides styles with the newer tokens as needed. Once the old designs aren't used we can merge the changes back to the original files.