### PR TITLE
Fix Web Push subscription deletion endpoint incorrectly expecting anti-CSRF tokens

### DIFF
--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -6,6 +6,8 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
   before_action :destroy_previous_subscriptions, only: :create, if: :prior_subscriptions?
   after_action :update_session_with_subscription, only: :create
 
+  skip_forgery_protection only: :destroy
+
   def create
     @push_subscription = ::Web::PushSubscription.create!(web_push_subscription_params)
 

--- a/spec/requests/api/web/push_subscriptions_spec.rb
+++ b/spec/requests/api/web/push_subscriptions_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe 'API Web Push Subscriptions' do
   describe 'DELETE /api/web/push_subscriptions/:id' do
     subject { delete api_web_push_subscription_path(token) }
 
+    around do |example|
+      old = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+
+      example.run
+
+      ActionController::Base.allow_forgery_protection = old
+    end
+
     context 'when the subscription exists' do
       let!(:web_push_subscription) do
         Fabricate(:web_push_subscription)


### PR DESCRIPTION
Those requests are not meant to be issued by a web browser.