### PR TITLE
Add RACK_COMPRESS env to enable Rack::Deflater middleware

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -86,6 +86,7 @@ module Mastodon
     # We use our own middleware for this
     config.public_file_server.enabled = false
 
+    config.middleware.use Rack::Deflater if ENV['RACK_COMPRESS'] == 'true'
     config.middleware.use Mastodon::Middleware::PublicFileServer if Rails.env.local? || ENV['RAILS_SERVE_STATIC_FILES'] == 'true'
     config.middleware.use Rack::Attack
     config.middleware.use Mastodon::Middleware::SocketCleanup


### PR DESCRIPTION
Pangolin and other reverse proxies don't support compression or expect the server side to compress (Pangolin does not support compress/cache at all yet so this is not optional).

This change is critical for those environments, even if rare