### PR TITLE
Fix performance of user-focused queries in admin dashboard

### DIFF
--- a/app/lib/admin/metrics/measure/new_users_measure.rb
+++ b/app/lib/admin/metrics/measure/new_users_measure.rb
@@ -27,7 +27,7 @@ class Admin::Metrics::Measure::NewUsersMeasure < Admin::Metrics::Measure::BaseMe
         WITH new_users AS (
           SELECT users.id
           FROM users
-          WHERE date_trunc('day', users.created_at)::date = axis.period
+          WHERE users.account_id >= (date_part('epoch', date_trunc('day', axis.period)::date) * 1000)::bigint << 16 AND users.account_id < ((date_part('epoch', date_trunc('day', axis.period)::date + ('1 day')::interval)) * 1000)::bigint << 16
         )
         SELECT count(*) FROM new_users
       ) AS value

--- a/app/lib/admin/metrics/retention.rb
+++ b/app/lib/admin/metrics/retention.rb
@@ -76,7 +76,7 @@ class Admin::Metrics::Retention
         WITH new_users AS (
           SELECT users.id
           FROM users
-          WHERE date_trunc(:frequency, users.created_at)::date = axis.cohort_period
+          WHERE users.account_id >= (date_part('epoch', date_trunc(:frequency, axis.cohort_period)::date) * 1000)::bigint << 16 AND users.account_id < ((date_part('epoch', date_trunc(:frequency, axis.cohort_period)::date + ('1' || :frequency)::interval)) * 1000)::bigint << 16
         ),
         retained_users AS (
           SELECT users.id

--- a/spec/lib/admin/metrics/measure/new_users_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/new_users_measure_spec.rb
@@ -12,9 +12,17 @@ RSpec.describe Admin::Metrics::Measure::NewUsersMeasure do
   describe '#data' do
     context 'with user records' do
       before do
-        3.times { Fabricate :user, created_at: 2.days.ago }
-        2.times { Fabricate :user, created_at: 1.day.ago }
-        Fabricate :user, created_at: 0.days.ago
+        travel_to 2.days.ago do
+          # We specify the `id` because `travel_to` doesn't affect the database
+          3.times { Fabricate :account, id: Mastodon::Snowflake.id_at(Time.now.utc) }
+        end
+
+        travel_to 1.day.ago do
+          # We specify the `id` because `travel_to` doesn't affect the database
+          2.times { Fabricate :account, id: Mastodon::Snowflake.id_at(Time.now.utc) }
+        end
+
+        Fabricate :user
       end
 
       it 'returns correct user counts' do


### PR DESCRIPTION
Stats for new users and user retention filtered users by date of creation, except there is no index for that. Use `users.account_id`, which is indexed and uses Snowflake IDs as a proxy for `users.created_at`.