### PR TITLE
Remove processing of collections of activities

### DIFF
--- a/app/services/activitypub/process_activity_service.rb
+++ b/app/services/activitypub/process_activity_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ActivityPub::ProcessCollectionService < BaseService
+class ActivityPub::ProcessActivityService < BaseService
   include JsonLdHelper
   include DomainControlHelper
 
@@ -64,14 +64,8 @@ class ActivityPub::ProcessCollectionService < BaseService
       @json.delete('signature') unless safe_for_forwarding?(original_json, @json)
     end
 
-    case @json['type']
-    when 'Collection', 'CollectionPage'
-      process_items @json['items']
-    when 'OrderedCollection', 'OrderedCollectionPage'
-      process_items @json['orderedItems']
-    else
-      process_items [@json]
-    end
+    activity = ActivityPub::Activity.factory(@json, @account, **@options)
+    activity&.perform
   rescue JSON::ParserError
     nil
   end
@@ -88,15 +82,6 @@ class ActivityPub::ProcessCollectionService < BaseService
 
   def activity_allowed_while_suspended?
     %w(Delete Reject Undo Update).include?(@json['type'])
-  end
-
-  def process_items(items)
-    items.reverse_each.filter_map { |item| process_item(item) }
-  end
-
-  def process_item(item)
-    activity = ActivityPub::Activity.factory(item, @account, **@options)
-    activity&.perform
   end
 
   def actor_from_verified_ld_signature

--- a/app/workers/activitypub/processing_worker.rb
+++ b/app/workers/activitypub/processing_worker.rb
@@ -13,7 +13,7 @@ class ActivityPub::ProcessingWorker
 
     return if actor.nil?
 
-    ActivityPub::ProcessCollectionService.new.call(body, actor, override_timestamps: true, delivered_to_account_id: delivered_to_account_id, delivery: true)
+    ActivityPub::ProcessActivityService.new.call(body, actor, override_timestamps: true, delivered_to_account_id: delivered_to_account_id, delivery: true)
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.debug { "Error processing incoming ActivityPub object: #{e}" }
   end

--- a/spec/services/activitypub/process_activity_service_spec.rb
+++ b/spec/services/activitypub/process_activity_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ActivityPub::ProcessCollectionService do
+RSpec.describe ActivityPub::ProcessActivityService do
   subject { described_class.new }
 
   let(:actor) { Fabricate(:account, domain: 'example.com', uri: 'http://example.com/account') }

--- a/spec/workers/activitypub/processing_worker_spec.rb
+++ b/spec/workers/activitypub/processing_worker_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe ActivityPub::ProcessingWorker do
   let(:account) { Fabricate(:account) }
 
   describe '#perform' do
-    it 'delegates to ActivityPub::ProcessCollectionService' do
-      allow(ActivityPub::ProcessCollectionService).to receive(:new)
-        .and_return(instance_double(ActivityPub::ProcessCollectionService, call: nil))
+    it 'delegates to ActivityPub::ProcessActivityService' do
+      allow(ActivityPub::ProcessActivityService).to receive(:new)
+        .and_return(instance_double(ActivityPub::ProcessActivityService, call: nil))
       subject.perform(account.id, '')
-      expect(ActivityPub::ProcessCollectionService).to have_received(:new)
+      expect(ActivityPub::ProcessActivityService).to have_received(:new)
     end
   end
 end


### PR DESCRIPTION
This is technically a breaking change, as this removes processing of some ActivityPub payloads.

However, inbox delivery of multiple activities through a `Collection` or `OrderedCollection` is not part of the spec nor any FEP I am aware of. We have never used it, and I don't think anyone else ever used it either.

Furthermore, with the addition of Collections in Mastodon 4.6, the name of this service has been increasingly confusing.

This PR therefore simplifies code by removing an unused feature and picking a more appropriate name for the service.