### PR TITLE
Redesign Components: Text Input

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -204,6 +204,14 @@ const preview: Preview = {
         </IdentityContext.Provider>
       );
     },
+    (Story, { parameters }) => {
+      useEffect(() => {
+        document.documentElement.dataset.redesign = parameters.redesign
+          ? 'true'
+          : 'false';
+      }, [parameters.redesign]);
+      return <Story />;
+    },
   ],
   loaders: [
     mswLoader,

--- a/.storybook/storybook.d.ts
+++ b/.storybook/storybook.d.ts
@@ -39,6 +39,8 @@ declare module 'storybook/internal/csf' {
     state?: TypedRootState;
     /** Callback that is run with the story arguments to generate Redux state for the component. */
     stateFn?: (args: any) => TypedRootState;
+    /** True to set the redesign global settings. */
+    redesign?: boolean;
   }
 }
 

--- a/app/javascript/mastodon/components/form_fields/redesign.module.scss
+++ b/app/javascript/mastodon/components/form_fields/redesign.module.scss
@@ -16,10 +16,12 @@ input.input {
   border-radius: var(--space-xs);
   border: 0.5px solid var(--color-text-tertiary);
   padding: var(--space-xs);
+  transition: background 200ms;
 
   &:hover:not(:disabled) {
     box-shadow: 0 1px var(--space-2xs) 0
       rgb(from var(--color-text-primary) r g b / 10%);
+    background: var(--color-bg-highlight);
   }
 
   &:focus {
@@ -27,9 +29,7 @@ input.input {
   }
 
   &:disabled {
-    color: var(--color-text-primary);
-    border-color: var(--color-text-tertiary);
-    background: var(--color-bg-highlight);
+    border-color: var(--color-bg-disabled);
   }
 }
 

--- a/app/javascript/mastodon/components/form_fields/redesign.module.scss
+++ b/app/javascript/mastodon/components/form_fields/redesign.module.scss
@@ -4,6 +4,7 @@
   }
 
   span {
+    color: var(--color-text-tertiary);
     font-size: var(--fs-2xs);
     line-height: var(--fs-lg);
   }
@@ -13,11 +14,7 @@ input.input {
   font-size: var(--fs-lg);
   background: none;
   border-radius: var(--space-xs);
-  border-color: color-mix(
-    in srgb,
-    var(--color-border-strong) 70%,
-    var(--color-bg-primary)
-  );
+  border: 0.5px solid var(--color-text-tertiary);
   padding: var(--space-xs);
 
   &:hover:not(:disabled) {
@@ -26,17 +23,19 @@ input.input {
   }
 
   &:focus {
-    outline: 2px solid var(--color-border-brand);
+    outline: 2px solid var(--color-border-strong);
   }
 
   &:disabled {
-    border-color: var(--color-text-disabled);
+    color: var(--color-text-primary);
+    border-color: var(--color-text-tertiary);
+    background: var(--color-bg-highlight);
   }
 }
 
 // Use double class to override original styles.
 .toggle.toggle {
-  background: rgb(from var(--color-bg-inverted) r g b / 70%);
+  background: var(--color-text-tertiary);
 
   &::before {
     box-shadow: none;

--- a/app/javascript/mastodon/components/form_fields/redesign.module.scss
+++ b/app/javascript/mastodon/components/form_fields/redesign.module.scss
@@ -1,3 +1,40 @@
+.inputWrapper {
+  label {
+    font-size: var(--fs-sm);
+  }
+
+  span {
+    font-size: var(--fs-2xs);
+    line-height: var(--fs-lg);
+  }
+}
+
+input.input {
+  font-size: var(--fs-lg);
+  background: none;
+  border-radius: var(--space-xs);
+  border-color: color-mix(
+    in srgb,
+    var(--color-border-strong) 70%,
+    var(--color-bg-primary)
+  );
+  padding: var(--space-xs);
+
+  &:hover:not(:disabled) {
+    box-shadow: 0 1px var(--space-2xs) 0
+      rgb(from var(--color-text-primary) r g b / 10%);
+  }
+
+  &:focus {
+    outline: 2px solid var(--color-border-brand);
+  }
+
+  &:disabled {
+    border-color: var(--color-text-disabled);
+  }
+}
+
+// Use double class to override original styles.
 .toggle.toggle {
   background: rgb(from var(--color-bg-inverted) r g b / 70%);
 

--- a/app/javascript/mastodon/components/form_fields/redesign.stories.tsx
+++ b/app/javascript/mastodon/components/form_fields/redesign.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { ToggleField } from './redesign';
+import { TextInputField, ToggleField } from './redesign';
 
 interface FieldProps {
   label: string;
@@ -19,11 +19,20 @@ const meta = {
     hint: 'This is a description of this form field',
     disabled: false,
   },
+  parameters: {
+    redesign: true,
+  },
 } satisfies Meta<FieldProps>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
+
+export const TextInput: Story = {
+  render(args) {
+    return <TextInputField {...args} />;
+  },
+};
 
 export const Toggle: Story = {
   render(args) {

--- a/app/javascript/mastodon/components/form_fields/redesign.tsx
+++ b/app/javascript/mastodon/components/form_fields/redesign.tsx
@@ -18,8 +18,6 @@ type RedesignComponent<
   P = object,
 > = React.FC<Merge<React.ComponentProps<T>, P>>;
 
-// export const TextInput:
-
 export const TextInputField: RedesignComponent<typeof OldTextInputField> = ({
   className,
   wrapperClassName,

--- a/app/javascript/mastodon/components/form_fields/redesign.tsx
+++ b/app/javascript/mastodon/components/form_fields/redesign.tsx
@@ -18,6 +18,8 @@ type RedesignComponent<
   P = object,
 > = React.FC<Merge<React.ComponentProps<T>, P>>;
 
+// Text field
+
 export const TextInputField: RedesignComponent<typeof OldTextInputField> = ({
   className,
   wrapperClassName,
@@ -36,6 +38,8 @@ export const TextInput: RedesignComponent<typeof OldTextInput> = ({
 }) => (
   <OldTextInput {...props} className={classNames(className, classes.input)} />
 );
+
+// Toggles
 
 interface ToggleProps {
   size?: 'sm' | 'lg';

--- a/app/javascript/mastodon/components/form_fields/redesign.tsx
+++ b/app/javascript/mastodon/components/form_fields/redesign.tsx
@@ -4,21 +4,46 @@ import type { Merge } from 'type-fest';
 
 import classes from './redesign.module.scss';
 import {
+  TextInput as OldTextInput,
+  TextInputField as OldTextInputField,
+} from './text_input_field';
+import {
   Toggle as OldToggle,
   ToggleField as OldToggleField,
 } from './toggle_field';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ToggleComponent<T extends React.JSXElementConstructor<any>> = React.FC<
-  Merge<
-    React.ComponentProps<T>,
-    {
-      size?: 'sm' | 'lg';
-    }
-  >
->;
+type RedesignComponent<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends React.JSXElementConstructor<any>,
+  P = object,
+> = React.FC<Merge<React.ComponentProps<T>, P>>;
 
-export const Toggle: ToggleComponent<typeof OldToggle> = ({
+// export const TextInput:
+
+export const TextInputField: RedesignComponent<typeof OldTextInputField> = ({
+  className,
+  wrapperClassName,
+  ...props
+}) => (
+  <OldTextInputField
+    {...props}
+    className={classNames(className, classes.input)}
+    wrapperClassName={classNames(wrapperClassName, classes.inputWrapper)}
+  />
+);
+
+export const TextInput: RedesignComponent<typeof OldTextInput> = ({
+  className,
+  ...props
+}) => (
+  <OldTextInput {...props} className={classNames(className, classes.input)} />
+);
+
+interface ToggleProps {
+  size?: 'sm' | 'lg';
+}
+
+export const Toggle: RedesignComponent<typeof OldToggle, ToggleProps> = ({
   className,
   size,
   ...props
@@ -33,11 +58,10 @@ export const Toggle: ToggleComponent<typeof OldToggle> = ({
   />
 );
 
-export const ToggleField: ToggleComponent<typeof OldToggleField> = ({
-  className,
-  size,
-  ...props
-}) => (
+export const ToggleField: RedesignComponent<
+  typeof OldToggleField,
+  ToggleProps
+> = ({ className, size, ...props }) => (
   <OldToggleField
     {...props}
     className={classNames(


### PR DESCRIPTION
This restyles the text inputs for the new design:

<img width="588" height="260" alt="Screenshot 2026-07-24 at 10 07 22" src="https://github.com/user-attachments/assets/efdc1e7f-d548-4e7f-b2e5-5fa127f36ae3" />
<img width="588" height="260" alt="Screenshot 2026-07-24 at 10 07 45" src="https://github.com/user-attachments/assets/2b8fe187-7411-42bb-8224-7b2e688b4b8e" />
<img width="588" height="260" alt="Screenshot 2026-07-24 at 10 08 01" src="https://github.com/user-attachments/assets/24d8dfe4-ddf4-478f-9a43-ea1d1832c646" />
<img width="588" height="260" alt="Screenshot 2026-07-24 at 10 08 13" src="https://github.com/user-attachments/assets/0fecdebf-1e13-4cf0-b987-79d9ad050aed" />
