### PR TITLE
Fix “Hide media with a warning” filters not being applied correctly

### DIFF
--- a/app/javascript/mastodon/selectors/index.js
+++ b/app/javascript/mastodon/selectors/index.js
@@ -75,8 +75,8 @@ function getStatusResultFunction(
     status: statusBase.withMutations(map => {
       map.set('reblog', statusReblog);
       map.set('account', accountBase);
-      map.set('matched_filters', filtered);
-      map.set('matched_media_filters', mediaFiltered);
+      map.set('matched_filters', filtered ? filtered.toJS() : false);
+      map.set('matched_media_filters', mediaFiltered ? mediaFiltered.toJS() : false);
     }),
     loadingState: statusBase.get('isLoading') ? 'loading' : 'complete'
   };


### PR DESCRIPTION
Fixes #39942

`matched_filters` and `matched_media_filters` as returned by the `makeGetStatus` selector were either `false` or an Immutable.JS `List`, while the consumers treated it as either `undefined` or string array.

For most purposes, this worked thanks to both native arrays and Immutable.JS `List` implementing `join` and boolean testing being equivalent for `undefined` and `false`, but #39677 changed the truthfulness boolean check to a conditional test on `length`, which is supported by native arrays but not Immutable.JS `List`.

Having the selector put non-immutable.JS objects in an immutable JS object is kinda awkward, but this does not touch the store, and it is consistent with what the components currently expect.