### PR TITLE
Cancel emoji search requests

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -20,6 +20,8 @@ import { insertStatusIntoAccountTimelines } from './timelines_typed';
 let fetchComposeSuggestionsAccountsController;
 /** @type {AbortController | undefined} */
 let fetchComposeSuggestionsTagsController;
+/** @type {AbortController | undefined} */
+let searchComposeSuggestionsEmojiController;
 
 export const COMPOSE_CHANGE          = 'COMPOSE_CHANGE';
 export const COMPOSE_SUBMIT_REQUEST  = 'COMPOSE_SUBMIT_REQUEST';
@@ -500,9 +502,8 @@ export function undoUploadCompose(media_id) {
 }
 
 export function clearComposeSuggestions() {
-  if (fetchComposeSuggestionsAccountsController) {
-    fetchComposeSuggestionsAccountsController.abort();
-  }
+  fetchComposeSuggestionsAccountsController?.abort();
+  searchComposeSuggestionsEmojiController?.abort();
   return {
     type: COMPOSE_SUGGESTIONS_CLEAR,
   };
@@ -535,12 +536,25 @@ const fetchComposeSuggestionsAccounts = throttle((dispatch, token) => {
   });
 }, 200, { leading: true, trailing: true });
 
-const fetchComposeSuggestionsEmojis = async (dispatch, token) => {
-  // Right now we are hard-coding the locale to English since the picker search only supports English.
-  // Once we replace the legacy picker we can remove this and use the actual locale of the user.
-  const results = await emojiMartSearch(token, 'en', 5);
-  dispatch(readyComposeSuggestionsEmojis(token, results));
-};
+const fetchComposeSuggestionsEmojis = throttle((dispatch, token) => {
+  dispatch(clearComposeSuggestions());
+  searchComposeSuggestionsEmojiController = new AbortController();
+
+  void emojiMartSearch({
+    token,
+    // Right now we are hard-coding the locale to English since the picker search only supports English.
+    // Once we replace the legacy picker we can remove this and use the actual locale of the user.
+    locale: 'en',
+    limit: 5,
+    signal: searchComposeSuggestionsEmojiController.signal,
+  }).then((results) => {
+    if (results) {
+      dispatch(readyComposeSuggestionsEmojis(token, results));
+    }
+  }).finally(() => {
+    searchComposeSuggestionsEmojiController = undefined;
+  });
+}, 200, { leading: true, trailing: true });
 
 const fetchComposeSuggestionsTags = throttle((dispatch, token) => {
   if (fetchComposeSuggestionsTagsController) {

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -536,7 +536,7 @@ const fetchComposeSuggestionsAccounts = throttle((dispatch, token) => {
   });
 }, 200, { leading: true, trailing: true });
 
-const fetchComposeSuggestionsEmojis = throttle((dispatch, token) => {
+const fetchComposeSuggestionsEmojis = (dispatch, token) => {
   dispatch(clearComposeSuggestions());
   searchComposeSuggestionsEmojiController = new AbortController();
 
@@ -554,7 +554,7 @@ const fetchComposeSuggestionsEmojis = throttle((dispatch, token) => {
   }).finally(() => {
     searchComposeSuggestionsEmojiController = undefined;
   });
-}, 200, { leading: true, trailing: true });
+}
 
 const fetchComposeSuggestionsTags = throttle((dispatch, token) => {
   if (fetchComposeSuggestionsTagsController) {

--- a/app/javascript/mastodon/features/emoji/picker.ts
+++ b/app/javascript/mastodon/features/emoji/picker.ts
@@ -13,6 +13,7 @@ import { emojiLogger } from './utils';
 const log = emojiLogger('picker');
 
 const searchCache = createLimitedCache<LegacyEmoji[]>({ maxSize: 10, log });
+const searchAbortController = new AbortController();
 
 type LegacyEmoji =
   | { id: string; custom?: false; native: string }
@@ -27,6 +28,7 @@ export async function emojiMartSearch(
   locale: string,
   limit = 5,
 ): Promise<LegacyEmoji[]> {
+  searchAbortController.abort(); // If we are starting a new search, abort the old one.
   const query = token.replace(':', '').trim();
   if (!query.length) {
     return [];
@@ -38,18 +40,27 @@ export async function emojiMartSearch(
     return cachedResult;
   }
 
-  const results = await search({ query, locale, limit });
-  const legacyResults = results.map((emoji) =>
-    'shortcode' in emoji
-      ? ({ id: emoji.shortcode, custom: true } as const)
-      : {
-          id: emoji.label.replaceAll(' ', '_').toLowerCase(),
-          native: emoji.unicode,
-        },
-  );
-  searchCache.set(cacheKey, legacyResults);
+  try {
+    const results = await search({
+      query,
+      locale,
+      limit,
+      signal: searchAbortController.signal,
+    });
+    const legacyResults = results.map((emoji) =>
+      'shortcode' in emoji
+        ? ({ id: emoji.shortcode, custom: true } as const)
+        : {
+            id: emoji.label.replaceAll(' ', '_').toLowerCase(),
+            native: emoji.unicode,
+          },
+    );
+    searchCache.set(cacheKey, legacyResults);
 
-  return legacyResults;
+    return legacyResults;
+  } catch {
+    return [];
+  }
 }
 
 const defaultCategories = [

--- a/app/javascript/mastodon/features/emoji/picker.ts
+++ b/app/javascript/mastodon/features/emoji/picker.ts
@@ -13,7 +13,6 @@ import { emojiLogger } from './utils';
 const log = emojiLogger('picker');
 
 const searchCache = createLimitedCache<LegacyEmoji[]>({ maxSize: 10, log });
-const searchAbortController = new AbortController();
 
 type LegacyEmoji =
   | { id: string; custom?: false; native: string }
@@ -23,29 +22,34 @@ type LegacyEmoji =
     };
 
 // Replicates the old legacy search function.
-export async function emojiMartSearch(
-  token: string,
-  locale: string,
+export async function emojiMartSearch({
+  token,
+  locale,
   limit = 5,
-): Promise<LegacyEmoji[]> {
-  searchAbortController.abort(); // If we are starting a new search, abort the old one.
-  const query = token.replace(':', '').trim();
-  if (!query.length) {
-    return [];
-  }
-
-  const cacheKey = `${query}|${locale}|${limit}`;
-  const cachedResult = searchCache.get(cacheKey);
-  if (cachedResult) {
-    return cachedResult;
-  }
-
+  signal,
+}: {
+  token: string;
+  locale: string;
+  limit?: number;
+  signal?: AbortSignal;
+}): Promise<LegacyEmoji[] | null> {
   try {
+    const query = token.replace(':', '').trim();
+    if (!query.length) {
+      return [];
+    }
+
+    const cacheKey = `${query}|${locale}|${limit}`;
+    const cachedResult = searchCache.get(cacheKey);
+    if (cachedResult) {
+      return cachedResult;
+    }
+
     const results = await search({
       query,
       locale,
       limit,
-      signal: searchAbortController.signal,
+      signal,
     });
     const legacyResults = results.map((emoji) =>
       'shortcode' in emoji
@@ -59,7 +63,8 @@ export async function emojiMartSearch(
 
     return legacyResults;
   } catch {
-    return [];
+    log('aborted search for "%s"', token);
+    return null;
   }
 }
 

--- a/app/javascript/mastodon/features/emoji/search.ts
+++ b/app/javascript/mastodon/features/emoji/search.ts
@@ -63,12 +63,10 @@ export async function search({
   limit?: number;
   signal?: AbortSignal;
 }) {
+  log('searching for "%s"', rawQuery);
   performance.mark('emoji-search-start');
 
-  // Handle the abort signal
-  signal?.addEventListener('abort', () => {
-    signal.throwIfAborted();
-  });
+  signal?.throwIfAborted();
 
   // Get the locale, and extract tokens from the query.
   const locale = toSupportedLocale(localeString);
@@ -100,6 +98,7 @@ export async function search({
       locale,
       i === queryTokens.length - 1,
     );
+    signal?.throwIfAborted();
     const resultMap: ScoreMap = new Map();
     const checkedSet = new Set<string>();
 
@@ -128,6 +127,7 @@ export async function search({
     }
 
     // Score based on legacy shortcodes, using the higher score if there's a match.
+    signal?.throwIfAborted();
     for (const shortcodeResult of shortcodeResults) {
       const emoji =
         resultMap.get(shortcodeResult.hexcode) ??
@@ -190,7 +190,9 @@ export async function search({
 
   // If there are no results, try a cursor-based custom emoji search instead.
   if (mixedResults.length === 0 || mixedResults.length < limit) {
+    signal?.throwIfAborted();
     const customEmojisFound = await fullCustomSearch(query, allEmojiIds);
+    signal?.throwIfAborted();
     if (customEmojisFound.length > 0) {
       log(
         'cursor search found %d results for "%s"',
@@ -380,6 +382,8 @@ async function fullCustomSearch(query: string, existing = new Set<string>()) {
 
   // First iterate over chunks of 1,000 custom emoji keys and find any matches.
   const chunkSize = 1_000;
+  const maxIterations = 10;
+  let index = 0;
   let lastKey: string | null = null;
   let keys: string[] = [];
   do {
@@ -395,6 +399,10 @@ async function fullCustomSearch(query: string, existing = new Set<string>()) {
       if (!foundEmojis.has(key) && !existing.has(key) && key.includes(query)) {
         foundEmojis.add(key);
       }
+    }
+    index++;
+    if (index >= maxIterations) {
+      break;
     }
   } while (keys.length === chunkSize);
 

--- a/app/javascript/mastodon/features/emoji/search.ts
+++ b/app/javascript/mastodon/features/emoji/search.ts
@@ -56,12 +56,19 @@ export async function search({
   query: rawQuery,
   locale: localeString,
   limit = 0,
+  signal,
 }: {
   query: string;
   locale: string;
   limit?: number;
+  signal?: AbortSignal;
 }) {
   performance.mark('emoji-search-start');
+
+  // Handle the abort signal
+  signal?.addEventListener('abort', () => {
+    signal.throwIfAborted();
+  });
 
   // Get the locale, and extract tokens from the query.
   const locale = toSupportedLocale(localeString);

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -518,7 +518,7 @@ body > [data-popover-placement] {
 }
 
 .autosuggest-account .account__avatar,
-.autosuggest-emoji img {
+.autosuggest-emoji .emojione {
   display: block;
   width: 24px;
   height: 24px;


### PR DESCRIPTION
Fixes #39687 (potentially).

This PR attempts to address lagginess with the emoji search results in a few ways:
- Adds throttling for emoji search for 200ms, with leading and trailing queries.
- Implements an AbortController to stop any pending requests if the search changes.
- Limits the cursor search to 10 iterations for a maximum of 10,000 custom emoji searched. This may need to be tweaked, and it does mean that emojis past 10k will never be found via cursor search. A future iteration will improve this feature.

These changes mirrors the implementation of tag and account search, which rely on querying the API. While emoji search should be fast, in certain cases (cursor searches) it can lag more than expected.