### PR TITLE
Add guardrail to avoid Mastodon running on unsupported database versions

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,7 @@ require_relative '../lib/active_record/database_tasks_extensions'
 require_relative '../lib/active_record/batches'
 require_relative '../lib/simple_navigation/item_extensions'
 require_relative '../lib/json-canonicalization/floats_fix'
+require_relative '../lib/mastodon/database_state_checks'
 
 Bundler.require(:pam_authentication) if ENV['PAM_ENABLED'] == 'true'
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,8 +2,11 @@
 
 require_relative '../../lib/mastodon/sidekiq_middleware'
 require_relative '../../lib/mastodon/worker_batch_middleware'
+require_relative '../../lib/mastodon/database_state_checks'
 
 Sidekiq.configure_server do |config|
+  Mastodon::DatabaseStateChecks.check_database_state!
+
   config.redis = REDIS_CONFIGURATION.sidekiq
 
   # This is used in Kubernetes setups, to signal that the Sidekiq process has started and will begin processing jobs

--- a/lib/mastodon/database_state_checks.rb
+++ b/lib/mastodon/database_state_checks.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Mastodon
+  module DatabaseStateChecks
+    def check_database_state!
+      return unless Rails.env.production?
+
+      check_pending_pre_deployment_migrations!
+      check_database_newer_than_code!
+    end
+    module_function :check_database_state!
+
+    def check_pending_pre_deployment_migrations!
+      migration_context = ActiveRecord::Base.connection_pool.migration_context
+      pre_deployment_migrations = migration_context.migrations.filter_map { |migration| migration.version if migration.filename.start_with?('db/migrate') }
+      return if (pre_deployment_migrations - migration_context.get_all_versions).empty?
+
+      abort <<~MESSAGE # rubocop:disable Rails/Exit
+        Some pre-deployment migrations are pending.
+        Please run migrations (`SKIP_POST_DEPLOYMENT_MIGRATIONS=true RAILS_ENV=production bundle exec rails db:migrate`) before restarting Mastodon.
+      MESSAGE
+    end
+    module_function :check_pending_pre_deployment_migrations!
+
+    def check_database_newer_than_code!
+      migration_context = ActiveRecord::Base.connection_pool.migration_context
+      latest_known_migration = migration_context.migrations.pluck(:version).max
+      current_version = migration_context.current_version
+      return if [current_version, ENV.fetch('MASTODON_ALLOW_UKNOWN_MIGRATIONS', nil)].compact.max <= latest_known_migration
+
+      abort <<~MESSAGE # rubocop:disable Rails/Exit
+        You appear to be running code older than the last migrations you have run. Have you downgraded Mastodon without rolling back migrations?
+
+        Running older Mastodon versions on a newer database version is unadvisable and unsupported.
+
+        Please check that you are running the intended Mastodon version. If you did intend to downgrade, please make a backup of your database and
+        roll back the migrations by doing `bundle exec rails db:migrate VERSION=#{latest_known_migration}` with the most recent code checked out.
+
+        If you know what you are doing and do not want to roll back the migrations, please set `MASTODON_ALLOW_UNKNOWN_MIGRATIONS=#{current_version}`.
+      MESSAGE
+    end
+    module_function :check_database_newer_than_code!
+  end
+end

--- a/lib/mastodon/database_state_checks.rb
+++ b/lib/mastodon/database_state_checks.rb
@@ -42,3 +42,9 @@ module Mastodon
     module_function :check_database_newer_than_code!
   end
 end
+
+class DatabaseCheckRailtie < Rails::Railtie
+  server do
+    Mastodon::DatabaseStateChecks.check_database_state!
+  end
+end


### PR DESCRIPTION
A somewhat common cause of troubleshooting request comes from people restarting Mastodon services *before* performing pre-deployment migrations.

A less common cause is people downgrading Mastodon, accidentally (cc @emilweth) or not after running migrations.

In both cases, running Mastodon in this state may lead to either runtime errors or assumptions on the data model being wrong, so it makes sense to prevent running Mastodon altogether.

An escape hatch is still available in the form of the `MASTODON_ALLOW_UKNOWN_MIGRATIONS` environment variable to run Mastodon with a database that has run newer migrations, as this is somewhat frequent and harmless on developer deployments.

This PR is still a draft because:
- the checks rely on too many explicitly undocumented Rails methods to my taste and I wonder if there are better ways to perform them
- the check is currently only performed for Sidekiq, and not puma; it needs to be performed for puma as well, but obviously not for migration tasks