### PR TITLE
Add another permission check to admin area

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -7,6 +7,7 @@ module Admin
 
     layout 'admin'
 
+    before_action :require_moderator_or_admin_permissions
     before_action :set_referrer_policy_header
 
     after_action :verify_authorized
@@ -19,6 +20,11 @@ module Admin
 
     def set_user
       @user = Account.find(params[:account_id]).user || raise(ActiveRecord::RecordNotFound)
+    end
+
+    def require_moderator_or_admin_permissions
+      # not using #authorize here, so #verify_authorized still makes sure more fine-grained rules are enforced down the line
+      forbidden unless Admin::BasePolicy.new(current_account, :base).access?
     end
   end
 end

--- a/app/policies/admin/base_policy.rb
+++ b/app/policies/admin/base_policy.rb
@@ -2,6 +2,6 @@
 
 class Admin::BasePolicy < ApplicationPolicy
   def access?
-    role.administrator? || role.can?(*UserRole::Flags::CATEGORIES[:moderation]) || role.can?(*UserRole::Flags::CATEGORIES[:administration])
+    role.administrator? || role.can?(*UserRole::Flags::CATEGORIES.fetch_values(:moderation, :administration, :devops).flatten)
   end
 end

--- a/app/policies/admin/base_policy.rb
+++ b/app/policies/admin/base_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Admin::BasePolicy < ApplicationPolicy
+  def access?
+    role.administrator? || role.can?(*UserRole::Flags::CATEGORIES[:moderation]) || role.can?(*UserRole::Flags::CATEGORIES[:administration])
+  end
+end

--- a/spec/policies/admin/base_policy_spec.rb
+++ b/spec/policies/admin/base_policy_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Admin::BasePolicy do
   let(:policy) { described_class }
+  let(:custom_devops_role) do
+    Fabricate(:user_role, permissions_as_keys: [:view_devops])
+  end
   let(:custom_role_with_one_admin_permission) do
     Fabricate(:user_role, permissions_as_keys: [:manage_announcements])
   end
@@ -12,6 +15,7 @@ RSpec.describe Admin::BasePolicy do
   end
   let(:admin) { Fabricate(:admin_user).account }
   let(:moderator) { Fabricate(:moderator_user).account }
+  let(:devops_user) { Fabricate(:user, role: custom_devops_role).account }
   let(:custom_admin) { Fabricate(:user, role: custom_role_with_one_admin_permission).account }
   let(:custom_moderator) { Fabricate(:user, role: custom_role_with_one_moderator_permission).account }
   let(:regular_user) { Fabricate(:account) }
@@ -26,6 +30,12 @@ RSpec.describe Admin::BasePolicy do
     context 'with a moderator' do
       it 'permits' do
         expect(policy).to permit(moderator, :base)
+      end
+    end
+
+    context 'with a user with devops permissions' do
+      it 'permits' do
+        expect(policy).to permit(devops_user, :base)
       end
     end
 

--- a/spec/policies/admin/base_policy_spec.rb
+++ b/spec/policies/admin/base_policy_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::BasePolicy do
+  let(:policy) { described_class }
+  let(:custom_role_with_one_admin_permission) do
+    Fabricate(:user_role, permissions_as_keys: [:manage_announcements])
+  end
+  let(:custom_role_with_one_moderator_permission) do
+    Fabricate(:user_role, permissions_as_keys: [:manage_invites])
+  end
+  let(:admin) { Fabricate(:admin_user).account }
+  let(:moderator) { Fabricate(:moderator_user).account }
+  let(:custom_admin) { Fabricate(:user, role: custom_role_with_one_admin_permission).account }
+  let(:custom_moderator) { Fabricate(:user, role: custom_role_with_one_moderator_permission).account }
+  let(:regular_user) { Fabricate(:account) }
+
+  permissions :access? do
+    context 'with an admin' do
+      it 'permits' do
+        expect(policy).to permit(admin, :base)
+      end
+    end
+
+    context 'with a moderator' do
+      it 'permits' do
+        expect(policy).to permit(moderator, :base)
+      end
+    end
+
+    context 'with a user with a custom role that grants a single admin permission' do
+      it 'permits' do
+        expect(policy).to permit(custom_admin, :base)
+      end
+    end
+
+    context 'with a user with a custom role that grants a single moderator permission' do
+      it 'permits' do
+        expect(policy).to permit(custom_moderator, :base)
+      end
+    end
+
+    context 'with a non-admin' do
+      it 'denies' do
+        expect(policy).to_not permit(regular_user, :base)
+      end
+    end
+  end
+end


### PR DESCRIPTION
To keep out non-admin, non-moderator users as early as possible.

This would have mitigated two of the recent vulnerabilities to some extent.