### PR TITLE
Fix account backups failing on non-Document attachments

### DIFF
--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -42,7 +42,7 @@ class BackupService < BaseService
 
         unless item[:type] == 'Announce' || item[:object][:attachment].blank?
           item[:object][:attachment].each do |attachment|
-            attachment[:url] = Addressable::URI.parse(attachment[:url]).path.delete_prefix('/system/')
+            attachment[:url] = Addressable::URI.parse(attachment[:url]).path.delete_prefix('/system/') if attachment[:type] == 'Document'
           end
         end
 

--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -42,7 +42,7 @@ class BackupService < BaseService
 
         unless item[:type] == 'Announce' || item[:object][:attachment].blank?
           item[:object][:attachment].each do |attachment|
-            attachment[:url] = Addressable::URI.parse(attachment[:url]).path.delete_prefix('/system/') if attachment[:type] == 'Document'
+            attachment[:url] = Addressable::URI.parse(attachment[:url]).path.delete_prefix('/system/') if attachment[:url].present?
           end
         end
 


### PR DESCRIPTION
In #36104, link embeds were added to ActivityPub status object attachments. However, `BackupService` was not updated accordingly to account for the new attachment type; the result of this is that it attempts to parse a nonexistent URL in `Link` attachments and creates an error, causing the entire `BackupWorker` job to fail. This PR adds a check to ensure that URL parsing/normalization only runs on file/media (`Document`) attachments.

(Please let me know if a test is needed to cover this!)