### PR TITLE
Fix typo in process_status_update_service.rb allowing more than 4 media attachments

### DIFF
--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -99,7 +99,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
 
       media_attachment_parser = ActivityPub::Parser::MediaAttachmentParser.new(attachment)
 
-      next if media_attachment_parser.remote_url.blank? || @next_media_attachments.size > Status::MEDIA_ATTACHMENTS_LIMIT
+      next if media_attachment_parser.remote_url.blank? || @next_media_attachments.size >= Status::MEDIA_ATTACHMENTS_LIMIT
 
       begin
         media_attachment   = previous_media_attachments.find { |previous_media_attachment| previous_media_attachment.remote_url == media_attachment_parser.remote_url }


### PR DESCRIPTION
`@next_media_attachments.size > Status::MEDIA_ATTACHMENTS_LIMIT` allows for 5 attachments instead of 4.

`app/lib/activitypub/activity/create.rb` has the same line with `>=` so I'm aligning with that.