### PR TITLE
Fix attachment_batch to correctly resets retries for S3 storage loops.

### DIFF
--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -54,10 +54,9 @@ class AttachmentBatch
     records.each do |record|
       @attachment_names.each do |attachment_name|
         attachment = record.public_send(attachment_name)
-        styles     = BASE_STYLES | attachment.styles.keys
-
         next if attachment.blank?
 
+        styles = BASE_STYLES | attachment.styles.keys
         styles.each do |style|
           case @storage_mode
           when :s3

--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -110,7 +110,7 @@ class AttachmentBatch
 
     keys.each_slice(LIMIT) do |keys_slice|
       logger.debug { "Deleting #{keys_slice.size} objects" }
-      retries = 0  # Reset for each slice
+      retries = 0 # Reset for each slice
       begin
         with_overridden_timeout(bucket.client, 120) do
           bucket.delete_objects(delete: {

--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -108,26 +108,26 @@ class AttachmentBatch
     # objects can be processed at once, so we have to potentially
     # separate them into multiple calls.
 
-    retries = 0
     keys.each_slice(LIMIT) do |keys_slice|
       logger.debug { "Deleting #{keys_slice.size} objects" }
-
-      with_overridden_timeout(bucket.client, 120) do
-        bucket.delete_objects(delete: {
-          objects: keys_slice.map { |key| { key: key } },
-          quiet: true,
-        })
-      end
-    rescue => e
-      retries += 1
-
-      if retries < MAX_RETRY
-        logger.debug "Retry #{retries}/#{MAX_RETRY} after #{e.message}"
-        sleep 2**retries
-        retry
-      else
-        logger.error "Batch deletion from S3 failed after #{e.message}"
-        raise e
+      retries = 0  # Reset for each slice
+      begin
+        with_overridden_timeout(bucket.client, 120) do
+          bucket.delete_objects(delete: {
+            objects: keys_slice.map { |key| { key: key } },
+            quiet: true,
+          })
+        end
+      rescue => e
+        retries += 1
+        if retries < MAX_RETRY
+          logger.debug "Retry #{retries}/#{MAX_RETRY} after #{e.message}"
+          sleep 2**retries
+          retry
+        else
+          logger.error "Batch deletion from S3 failed after #{e.message}"
+          raise e
+        end
       end
     end
   end


### PR DESCRIPTION
`retries` is shared across delete_object calls. Causing later slices to fail.

Note: this might be one of the `S3 bloat bugs` that has haunted us.

This needs tests?

Detected by static code tool, fix by me.