### PR TITLE
Fix typo in `ActivityTracker#sum` excluding current day from the results

### DIFF
--- a/app/lib/activity_tracker.rb
+++ b/app/lib/activity_tracker.rb
@@ -39,7 +39,7 @@ class ActivityTracker
   end
 
   def sum(start_at, end_at = Time.now.utc)
-    keys = (start_at.to_date...end_at.to_date).flat_map { |date| [key_at(date.to_time(:utc)), legacy_key_at(date)] }.uniq
+    keys = (start_at.to_date..end_at.to_date).flat_map { |date| [key_at(date.to_time(:utc)), legacy_key_at(date)] }.uniq
 
     case @type
     when :basic


### PR DESCRIPTION
the #get is using inclusive `..`.  but the #sum is using `...` so we're missing the end date

```
(1...5).to_a  # => [1, 2, 3, 4]  (5 is excluded)
(1..5).to_a   # => [1, 2, 3, 4, 5] (5 is included)
```