### PR TITLE
Fix missing AccountWarning from merging.rb

### DIFF
--- a/app/models/concerns/account/merging.rb
+++ b/app/models/concerns/account/merging.rb
@@ -16,10 +16,10 @@ module Account::Merging
       Notification, NotificationPermission, NotificationRequest
     ],
     target_account_id: [
-      Follow, FollowRequest, Block, Mute, AccountModerationNote, AccountPin, AccountNote
+      Follow, FollowRequest, Block, Mute, AccountModerationNote, AccountPin, AccountNote,
+      AccountWarning
     ],
     reference_account_id: [CanonicalEmailBlock],
-    account_warning_id: [Appeal],
     local_account_id: [SeveredRelationship],
     remote_account_id: [SeveredRelationship],
     quoted_account_id: [Quote],


### PR DESCRIPTION
1. AccountNote/AccountModerationNote is included but AccountWarning is missing.
2. `account_warning_id` is broken because it's not an `other_account.id`. 

Detected by static code. fix by myself.