### PR TITLE
Guard against null values when processing tags and serializing tagged objects

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -219,6 +219,8 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     return if @object['tag'].nil?
 
     as_array(@object['tag']).each do |tag|
+      next if tag.nil?
+
       if equals_or_includes?(tag['type'], 'Hashtag')
         process_hashtag tag
       elsif equals_or_includes?(tag['type'], 'Mention')

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -139,7 +139,7 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
   end
 
   def virtual_tags
-    object.active_mentions.to_a.sort_by(&:id) + object.tags + object.emojis + object.tagged_objects.map(&:object)
+    object.active_mentions.to_a.sort_by(&:id) + object.tags + object.emojis + object.tagged_objects.filter_map(&:object)
   end
 
   def atom_uri


### PR DESCRIPTION
Updated Serializer to remove null values

detected by static code, fix by myself.