### PR TITLE
Invoke server load hooks when starting the server

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -5,3 +5,4 @@
 require_relative 'config/environment'
 
 run Rails.application
+Rails.application.load_server


### PR DESCRIPTION
While discussing approaches for how to tell users that they need to run migrations, I brought up the idea of using a `server do ... end` block within a Railtie. @bensheldon pointed out that this would not work without this line (which is present in the Rails template: https://github.com/rails/rails/blob/5c98459181f3c8e22049db934ca52b811202ec3b/railties/lib/rails/generators/rails/app/templates/config.ru.tt#L6)

See also: #39951
cc @renchap @ClearlyClaire 
