### PR TITLE
Fix `AddUniqueIndexOnAccountsUri` migration trying to reattribute `Appeal` objects with incorrect column

### DIFF
--- a/db/post_migrate/20260720104058_add_unique_index_on_accounts_uri.rb
+++ b/db/post_migrate/20260720104058_add_unique_index_on_accounts_uri.rb
@@ -98,7 +98,6 @@ class AddUniqueIndexOnAccountsUri < ActiveRecord::Migration[8.1]
         Follow, FollowRequest, Block, Mute, AccountModerationNote, AccountPin, AccountNote
       ],
       reference_account_id: [CanonicalEmailBlock],
-      account_warning_id: [Appeal],
       local_account_id: [SeveredRelationship],
       remote_account_id: [SeveredRelationship],
       quoted_account_id: [Quote],


### PR DESCRIPTION
Related: #39982

We don't need `AccountWarning` from that PR as those are only relevant for local users.