### PR TITLE
Fix navigation switching to user “Account” category when rejecting or accepting appeal

### DIFF
--- a/app/controllers/admin/disputes/appeals_controller.rb
+++ b/app/controllers/admin/disputes/appeals_controller.rb
@@ -14,7 +14,7 @@ class Admin::Disputes::AppealsController < Admin::BaseController
     authorize @appeal, :approve?
     log_action :approve, @appeal
     ApproveAppealService.new.call(@appeal, current_account)
-    redirect_to disputes_strike_path(@appeal.strike)
+    redirect_to admin_disputes_strike_path(@appeal.strike)
   end
 
   def reject
@@ -22,7 +22,7 @@ class Admin::Disputes::AppealsController < Admin::BaseController
     log_action :reject, @appeal
     @appeal.reject!(current_account)
     UserMailer.appeal_rejected(@appeal.account.user, @appeal).deliver_later
-    redirect_to disputes_strike_path(@appeal.strike)
+    redirect_to admin_disputes_strike_path(@appeal.strike)
   end
 
   private

--- a/spec/controllers/admin/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/admin/disputes/appeals_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Admin::Disputes::AppealsController do
       emails = capture_emails { subject }
 
       expect(response)
-        .to redirect_to(disputes_strike_path(appeal.strike))
+        .to redirect_to(admin_disputes_strike_path(appeal.strike))
 
       expect(target_account.reload)
         .to_not be_suspended
@@ -64,7 +64,7 @@ RSpec.describe Admin::Disputes::AppealsController do
       emails = capture_emails { subject }
 
       expect(response)
-        .to redirect_to(disputes_strike_path(appeal.strike))
+        .to redirect_to(admin_disputes_strike_path(appeal.strike))
 
       expect(emails.size)
         .to eq(1)


### PR DESCRIPTION
Follow-up to #39476