### PR TITLE
Change `UpdateAccountSummariesToVersion3` migration to minimize downtime

### DIFF
--- a/db/migrate/20260728145403_update_account_summaries_to_version_3.rb
+++ b/db/migrate/20260728145403_update_account_summaries_to_version_3.rb
@@ -2,11 +2,26 @@
 
 class UpdateAccountSummariesToVersion3 < ActiveRecord::Migration[8.0]
   def up
-    reapplication_global_follow_recommendations_v1 do
-      drop_view :account_summaries, materialized: true
-      create_view :account_summaries, version: 3, materialized: { no_data: true }
-      safety_assured { add_index :account_summaries, :account_id, unique: true }
-    end
+    # First, create a temporary `account_summaries` and populate it.
+    # This is the most expensive part.
+    create_view :tmp_account_summaries,
+                sql_definition: Scenic::Definition.new(:account_summaries, 3).to_sql,
+                materialized: true
+
+    rename_index :account_summaries, :index_account_summaries_on_account_id, :tmp_index_account_summaries_on_account_id
+    safety_assured { add_index :tmp_account_summaries, :account_id, name: :index_account_summaries_on_account_id, unique: true }
+
+    # Then, drop `global_follow_recommendations` and `account_summaries`
+    # Downtime starts here but should hopefuly be pretty short.
+    drop_view :global_follow_recommendations, materialized: true
+    drop_view :account_summaries, materialized: true
+
+    # Then rename `tmp_account_summaries` to `account_summaries`
+    safety_assured { execute('ALTER MATERIALIZED VIEW tmp_account_summaries RENAME TO account_summaries') }
+
+    # Then re-create `global_follow_recommendations`, populating it
+    create_view :global_follow_recommendations, version: 1, materialized: true
+    safety_assured { add_index :global_follow_recommendations, :account_id, unique: true }
   end
 
   def down


### PR DESCRIPTION
This PR rewrites `UpdateAccountSummariesToVersion3` to minimize runtime locking.

This is similar to using [Scenic's `side_by_side: true`](https://github.com/scenic-views/scenic#can-i-update-the-definition-of-a-materialized-view-without-dropping-it) except we cannot use it because the `account_summaries` table is depended on by `global_follow_recommendations`.

The new migration creates a temporary `tmp_account_summaries` view with the contents of the new version of the view, populates it, then drops the two materialized views, renames `tmp_account_summaries` to `account_summaries`, and re-creates `global_follow_recommendations`.

This way, the materialized views are immediately usable after the migration, and populating `tmp_account_summaries` does not block any other query.

Populating `global_follow_recommendations` still blocks queries, but this is orders of magnitude faster than populating `account_summaries` (on mastodon.social, populating `global_follow_recommendations` takes a little over 2 minutes).