### PR TITLE
Change follow recommendation materialized views to manually-maintained tables

### DIFF
--- a/app/models/account_summary.rb
+++ b/app/models/account_summary.rb
@@ -5,18 +5,71 @@
 # Table name: account_summaries
 #
 #  language   :string
-#  sensitive  :boolean
-#  account_id :bigint(8)        primary key
+#  sensitive  :boolean          default(FALSE), not null
+#  account_id :bigint(8)        not null, primary key
 #
 
 class AccountSummary < ApplicationRecord
-  include DatabaseViewRecord
-
   self.primary_key = :account_id
 
+  # Accounts who haven't posted in this long won't be updated
+  MAX_STATUS_AGE = 1.week
+
+  belongs_to :account
   has_many :follow_recommendation_suppressions, primary_key: :account_id, foreign_key: :account_id, inverse_of: false, dependent: nil
 
   scope :safe, -> { where(sensitive: false) }
   scope :localized, ->(locale) { in_order_of(:language, [locale], filter: false) }
   scope :filtered, -> { where.missing(:follow_recommendation_suppressions) }
+
+  def self.refresh
+    return unless connection.table_exists?(table_name)
+
+    scope = Account.where(suspended_at: nil, requested_deletion_at: nil, silenced_at: nil, moved_to_account_id: nil, discoverable: true, locked: false)
+
+    # Delete any record that is ineligible
+    joins(:account).merge(scope.invert_where).in_batches.delete_all
+
+    # Unless the table is not populated yet, only update accounts who have recently posted
+    scope = scope.joins(:account_stat).where(account_stat: { last_status_at: MAX_STATUS_AGE.ago... }) if exists?
+
+    ids_type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array.new(ActiveModel::Type::BigInteger.new)
+
+    # Update the data in batches
+    scope.in_batches do |accounts|
+      connection.exec_insert(<<~SQL.squish, nil, [ActiveRecord::Relation::QueryAttribute.new('accounts.id', accounts.ids, ids_type)])
+        INSERT INTO account_summaries (account_id, language, sensitive)
+          SELECT
+            accounts.id AS account_id,
+            mode() WITHIN GROUP (ORDER BY language ASC) AS language,
+            mode() WITHIN GROUP (ORDER BY sensitive ASC) AS sensitive
+          FROM accounts
+          CROSS JOIN LATERAL (
+            SELECT
+              s.language,
+              s.sensitive
+            FROM (
+              SELECT
+                statuses.language,
+                statuses.sensitive,
+                statuses.reblog_of_id
+              FROM statuses
+              WHERE statuses.account_id = accounts.id
+                AND statuses.deleted_at IS NULL
+              ORDER BY statuses.id DESC
+              LIMIT 1000
+            ) s
+            WHERE s.reblog_of_id IS NULL
+            LIMIT 20
+          ) t0
+          WHERE accounts.id = ANY($1)
+          GROUP BY accounts.id
+        ON CONFLICT (account_id) DO UPDATE SET language = EXCLUDED.language, sensitive = EXCLUDED.sensitive
+      SQL
+    end
+  end
+
+  def self.readonly?
+    true
+  end
 end

--- a/app/models/follow_recommendation.rb
+++ b/app/models/follow_recommendation.rb
@@ -4,14 +4,13 @@
 #
 # Table name: global_follow_recommendations
 #
-#  rank       :decimal(, )
-#  reason     :text             is an Array
-#  account_id :bigint(8)        primary key
+#  rank       :decimal(, )      not null
+#  reason     :string           not null, is an Array
+#  stale      :boolean          default(FALSE), not null
+#  account_id :bigint(8)        not null, primary key
 #
 
 class FollowRecommendation < ApplicationRecord
-  include DatabaseViewRecord
-
   self.primary_key = :account_id
   self.table_name = :global_follow_recommendations
 
@@ -20,4 +19,55 @@ class FollowRecommendation < ApplicationRecord
 
   scope :unsupressed, -> { where.not(FollowRecommendationSuppression.where(FollowRecommendationSuppression.arel_table[:account_id].eq(arel_table[:account_id])).select(1).arel.exists) }
   scope :localized, ->(locale) { unsupressed.joins(:account_summary).merge(AccountSummary.localized(locale)) }
+
+  def self.refresh
+    return unless connection.table_exists?(table_name)
+
+    # TODO: somehow improve performances
+
+    in_batches.update_all(stale: true)
+
+    connection.execute(<<~SQL.squish)
+      INSERT INTO global_follow_recommendations (account_id, rank, reason)
+        SELECT
+          account_id,
+          sum(rank) AS rank,
+          array_agg(reason) AS reason
+        FROM (
+          SELECT
+            account_summaries.account_id AS account_id,
+            count(follows.id) / (1.0 + count(follows.id)) AS rank,
+            'most_followed' AS reason
+          FROM follows
+          INNER JOIN account_summaries ON account_summaries.account_id = follows.target_account_id
+          INNER JOIN users ON users.account_id = follows.account_id
+          WHERE users.current_sign_in_at >= (now() - interval '30 days')
+            AND account_summaries.sensitive = 'f'
+            AND NOT EXISTS (SELECT 1 FROM follow_recommendation_suppressions WHERE follow_recommendation_suppressions.account_id = follows.target_account_id)
+          GROUP BY account_summaries.account_id
+          HAVING count(follows.id) >= 5
+          UNION ALL
+          SELECT account_summaries.account_id AS account_id,
+                sum(status_stats.reblogs_count + status_stats.favourites_count) / (1.0 + sum(status_stats.reblogs_count + status_stats.favourites_count)) AS rank,
+                'most_interactions' AS reason
+          FROM status_stats
+          INNER JOIN statuses ON statuses.id = status_stats.status_id
+          INNER JOIN account_summaries ON account_summaries.account_id = statuses.account_id
+          WHERE statuses.id >= ((date_part('epoch', now() - interval '30 days') * 1000)::bigint << 16)
+            AND account_summaries.sensitive = 'f'
+            AND NOT EXISTS (SELECT 1 FROM follow_recommendation_suppressions WHERE follow_recommendation_suppressions.account_id = statuses.account_id)
+          GROUP BY account_summaries.account_id
+          HAVING sum(status_stats.reblogs_count + status_stats.favourites_count) >= 5
+        ) t0
+        GROUP BY account_id
+        ORDER BY rank DESC
+      ON CONFLICT (account_id) DO UPDATE SET rank = EXCLUDED.rank, reason = EXCLUDED.reason, stale = 'f'
+    SQL
+
+    where(stale: true).in_batches.delete_all
+  end
+
+  def self.readonly?
+    true
+  end
 end

--- a/db/post_migrate/20260804081821_convert_materialized_views_to_tables.rb
+++ b/db/post_migrate/20260804081821_convert_materialized_views_to_tables.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class ConvertMaterializedViewsToTables < ActiveRecord::Migration[8.1]
+  def up
+    # Prepare replacement of `account_summaries`
+    rename_index :account_summaries, :index_account_summaries_on_account_id, :tmp_index_account_summaries_on_account_id
+    rename_index :account_summaries, :idx_on_account_id_language_sensitive_250461e1eb, :tmp_idx_on_account_id_language_sensitive_250461e1eb
+
+    # Create replacement table for `account_summaries`
+    create_table :tmp_account_summaries, primary_key: :account_id do |t| # rubocop:disable Rails/CreateTableWithTimestamps
+      t.string :language
+      t.boolean :sensitive, default: false, null: false
+    end
+
+    safety_assured do # The table is empty, so blocking is minimal
+      add_foreign_key :tmp_account_summaries, :accounts, on_delete: :cascade
+      add_index :tmp_account_summaries, [:account_id, :language, :sensitive], name: :idx_on_account_id_language_sensitive_250461e1eb
+    end
+
+    # Create replacement table for `global_follow_recommendations`
+    rename_index :global_follow_recommendations, :index_global_follow_recommendations_on_account_id, :tmp_index_global_follow_recommendations_on_account_id
+
+    create_table :tmp_global_follow_recommendations, primary_key: :account_id do |t| # rubocop:disable Rails/CreateTableWithTimestamps
+      t.decimal :rank, null: false
+      t.string :reason, array: true, null: false
+      t.boolean :stale, null: false, default: false
+    end
+
+    safety_assured do # The table is empty, so blocking is minimal
+      add_foreign_key :tmp_global_follow_recommendations, :accounts, on_delete: :cascade
+      add_index :tmp_global_follow_recommendations, :rank, name: :index_global_follow_recommendations_on_rank
+    end
+
+    # Fill the tables
+    safety_assured do
+      execute 'INSERT INTO tmp_account_summaries SELECT account_summaries.* FROM account_summaries INNER JOIN accounts ON accounts.id = account_summaries.account_id' if Scenic.database.populated?('account_summaries')
+      execute 'INSERT INTO tmp_global_follow_recommendations SELECT global_follow_recommendations.* FROM global_follow_recommendations INNER JOIN accounts ON accounts.id = global_follow_recommendations.account_id' if Scenic.database.populated?('global_follow_recommendations')
+    end
+
+    # Drop and rename
+    drop_view :global_follow_recommendations, materialized: true
+    safety_assured { rename_table :tmp_global_follow_recommendations, :global_follow_recommendations }
+
+    drop_view :account_summaries, materialized: true
+    safety_assured { rename_table :tmp_account_summaries, :account_summaries }
+  end
+
+  def down
+    drop_table :account_summaries
+    create_view :account_summaries, version: 3, materialized: true
+    add_index :account_summaries, :account_id, unique: true
+    add_index :account_summaries, [:account_id, :language, :sensitive]
+
+    drop_table :global_follow_recommendations
+    create_view :global_follow_recommendations, version: 1, materialized: true
+    add_index :global_follow_recommendations, :account_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_03_172525) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_04_081821) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -128,6 +128,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_172525) do
     t.integer "min_status_age", default: 1209600, null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_account_statuses_cleanup_policies_on_account_id"
+  end
+
+  create_table "account_summaries", primary_key: "account_id", force: :cascade do |t|
+    t.string "language"
+    t.boolean "sensitive", default: false, null: false
+    t.index ["account_id", "language", "sensitive"], name: "idx_on_account_id_language_sensitive_250461e1eb"
   end
 
   create_table "account_warning_presets", force: :cascade do |t|
@@ -658,6 +664,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_172525) do
     t.datetime "viewed_at"
     t.integer "year", null: false
     t.index ["account_id", "year"], name: "index_generated_annual_reports_on_account_id_and_year", unique: true
+  end
+
+  create_table "global_follow_recommendations", primary_key: "account_id", force: :cascade do |t|
+    t.decimal "rank", null: false
+    t.string "reason", null: false, array: true
+    t.boolean "stale", default: false, null: false
+    t.index ["rank"], name: "index_global_follow_recommendations_on_rank"
   end
 
   create_table "identities", force: :cascade do |t|
@@ -1484,6 +1497,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_172525) do
   add_foreign_key "account_relationship_severance_events", "relationship_severance_events", on_delete: :cascade
   add_foreign_key "account_stats", "accounts", on_delete: :cascade
   add_foreign_key "account_statuses_cleanup_policies", "accounts", on_delete: :cascade
+  add_foreign_key "account_summaries", "accounts", on_delete: :cascade
   add_foreign_key "account_warnings", "accounts", column: "target_account_id", on_delete: :cascade
   add_foreign_key "account_warnings", "accounts", on_delete: :nullify
   add_foreign_key "account_warnings", "reports", on_delete: :cascade
@@ -1538,6 +1552,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_172525) do
   add_foreign_key "follows", "accounts", column: "target_account_id", name: "fk_745ca29eac", on_delete: :cascade
   add_foreign_key "follows", "accounts", name: "fk_32ed1b5560", on_delete: :cascade
   add_foreign_key "generated_annual_reports", "accounts"
+  add_foreign_key "global_follow_recommendations", "accounts", on_delete: :cascade
   add_foreign_key "identities", "users", name: "fk_bea040f377", on_delete: :cascade
   add_foreign_key "instance_moderation_notes", "accounts", on_delete: :cascade
   add_foreign_key "invites", "users", on_delete: :cascade
@@ -1621,56 +1636,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_172525) do
   add_foreign_key "web_push_subscriptions", "users", on_delete: :cascade
   add_foreign_key "web_settings", "users", name: "fk_11910667b2", on_delete: :cascade
   add_foreign_key "webauthn_credentials", "users", on_delete: :cascade
-
-  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
-      SELECT accounts.id AS account_id,
-      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
-      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
-     FROM (accounts
-       CROSS JOIN LATERAL ( SELECT statuses.account_id,
-              statuses.language,
-              statuses.sensitive
-             FROM statuses
-            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
-            ORDER BY statuses.id DESC
-           LIMIT 20) t0)
-    WHERE ((accounts.suspended_at IS NULL) AND (accounts.requested_deletion_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
-    GROUP BY accounts.id;
-  SQL
-  add_index "account_summaries", ["account_id", "language", "sensitive"], name: "idx_on_account_id_language_sensitive_250461e1eb"
-  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
-
-  create_view "global_follow_recommendations", materialized: true, sql_definition: <<-SQL
-      SELECT account_id,
-      sum(rank) AS rank,
-      array_agg(reason) AS reason
-     FROM ( SELECT account_summaries.account_id,
-              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
-              'most_followed'::text AS reason
-             FROM ((follows
-               JOIN account_summaries ON ((account_summaries.account_id = follows.target_account_id)))
-               JOIN users ON ((users.account_id = follows.account_id)))
-            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (account_summaries.sensitive = false) AND (NOT (EXISTS ( SELECT 1
-                     FROM follow_recommendation_suppressions
-                    WHERE (follow_recommendation_suppressions.account_id = follows.target_account_id)))))
-            GROUP BY account_summaries.account_id
-           HAVING (count(follows.id) >= 5)
-          UNION ALL
-           SELECT account_summaries.account_id,
-              (sum((status_stats.reblogs_count + status_stats.favourites_count)) / (1.0 + sum((status_stats.reblogs_count + status_stats.favourites_count)))) AS rank,
-              'most_interactions'::text AS reason
-             FROM ((status_stats
-               JOIN statuses ON ((statuses.id = status_stats.status_id)))
-               JOIN account_summaries ON ((account_summaries.account_id = statuses.account_id)))
-            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (account_summaries.sensitive = false) AND (NOT (EXISTS ( SELECT 1
-                     FROM follow_recommendation_suppressions
-                    WHERE (follow_recommendation_suppressions.account_id = statuses.account_id)))))
-            GROUP BY account_summaries.account_id
-           HAVING (sum((status_stats.reblogs_count + status_stats.favourites_count)) >= (5)::numeric)) t0
-    GROUP BY account_id
-    ORDER BY (sum(rank)) DESC;
-  SQL
-  add_index "global_follow_recommendations", ["account_id"], name: "index_global_follow_recommendations_on_account_id", unique: true
 
   create_view "instances", materialized: true, sql_definition: <<-SQL
       WITH domain_counts(domain, accounts_count) AS (


### PR DESCRIPTION
This replaces the two materialized views with tables, making future database migrations easier.

To do so, it creates two new tables, `tmp_account_summaries` and `tmp_global_follow_recommendations`, and populates them from the materialized views (if populated), then drops the views and renames the tables.

`AccountSummary.refresh` and `FollowRecommendation.refresh` are re-implemented.

`FollowRecommendation.refresh` is a pretty straightforward port of the old cold, with an extra column to decide which columns to clear afterwards. It should have roughly on-par, slightly worse performance than before. I have no obvious idea how to improve it.

`AccountSummary.refresh` is more complicated. It does two scans of `accounts`:
- one to delete irrelevant entries
- one to insert or update new ones

Those changes are made in batches, which will make the whole thing noticeably slower than the previous implementation, but without blocking any table for long. The algorithm is also changed to do partial updates, only updating eligible accounts who have posted in a week or less when the table is already populated. This allows skipping a *lot* of records, making the overall query a lot faster.