### PR TITLE
Fix mobile navigation scrolling to top while opening

### DIFF
--- a/app/javascript/mastodon/features/navigation_panel/index.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/index.tsx
@@ -468,7 +468,7 @@ export const CollapsibleNavigationPanel: React.FC = () => {
         x({ value }: { value: number }) {
           if (value === 0) {
             dispatch(openNavigation());
-          } else if (isLtrDir ? value > 0 : value < 0) {
+          } else if (value === OPEN_MENU_OFFSET) {
             dispatch(closeNavigation());
           }
         },
@@ -508,6 +508,7 @@ export const CollapsibleNavigationPanel: React.FC = () => {
     },
     {
       from: () => [x.get(), 0],
+      axis: 'x',
       filterTaps: true,
       bounds: isLtrDir ? { left: 0 } : { right: 0 },
       rubberband: true,


### PR DESCRIPTION
Fix to In the mobile layout, scrolling almost immediately after opening the menu was recognized as a kind of close gesture, causing the menu to jump back to the top of the scroll.

Only dispatch `closeNavigation()` when the spring rests exactly at `OPEN_MENU_OFFSET`, so a partial drag no longer counts as closed.

Both are RTL-safe, since `OPEN_MENU_OFFSET` already accounts for the document direction.