### PR TITLE
Fix search cleanup scanning

### DIFF
--- a/app/lib/importer/base_importer.rb
+++ b/app/lib/importer/base_importer.rb
@@ -46,7 +46,7 @@ class Importer::BaseImporter
 
   # Remove documents from the index that no longer exist in the database
   def clean_up!
-    index.scroll_batches do |documents|
+    index.track_total_hits(true).scroll_batches(batch_size: @batch_size) do |documents|
       primary_key = index.adapter.target.primary_key
       raise ActiveRecord::UnknownPrimaryKey, index.adapter.target if primary_key.nil?
 

--- a/spec/lib/importer/base_importer_spec.rb
+++ b/spec/lib/importer/base_importer_spec.rb
@@ -3,12 +3,30 @@
 require 'rails_helper'
 
 RSpec.describe Importer::BaseImporter do
-  describe 'import!' do
-    let(:pool) { Concurrent::FixedThreadPool.new(5) }
-    let(:importer) { described_class.new(batch_size: 123, executor: pool) }
+  let(:pool) { Concurrent::FixedThreadPool.new(5) }
+  let(:importer) { described_class.new(batch_size: 123, executor: pool) }
 
+  describe 'import!' do
     it 'raises an error' do
       expect { importer.import! }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe 'clean_up!' do
+    let(:tracked_index) { spy }
+    let(:index) { spy }
+
+    before do
+      allow(importer).to receive(:index).and_return(index)
+      allow(index).to receive(:track_total_hits).with(true).and_return(tracked_index)
+      allow(tracked_index).to receive(:scroll_batches)
+    end
+
+    it 'scrolls every document with the configured batch size' do
+      importer.clean_up!
+
+      expect(index).to have_received(:track_total_hits).with(true)
+      expect(tracked_index).to have_received(:scroll_batches).with(batch_size: 123)
     end
   end
 end


### PR DESCRIPTION
Summary
- make search cleanup use track_total_hits(true) so Elasticsearch indices over 10k documents are fully scanned
- pass the configured importer batch size into scroll_batches, so tootctl search deploy --batch-size also applies during cleaning

Issue
Fixes #40018.

Testing
- git diff --check

I could not run the focused RSpec spec locally because the system Ruby/Bundler on this machine cannot satisfy the Bundler version locked by the repo: Could not find bundler 4.0.16. A plain ruby -c is also not useful here because the system Ruby is 2.6 and the repo already uses newer Ruby syntax such as argument forwarding.