### PR TITLE
Fix `DeleteAccountService#purge_favourites!` only invalidating deprecated cache keys

### DIFF
--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -194,7 +194,7 @@ class DeleteAccountService < BaseService
       ids = favourites.pluck(:status_id)
       StatusStat.where(status_id: ids).update_all('favourites_count = GREATEST(0, favourites_count - 1)')
       Chewy.strategy.current.update(StatusesIndex, ids) if Chewy.enabled?
-      Rails.cache.delete_multi(ids.map { |id| "statuses/#{id}" })
+      Rails.cache.delete_multi(ids.flat_map { |id| ["v3:statuses/#{id}", "statuses/show:v3:statuses/#{id}"] })
       favourites.delete_all
     end
   end


### PR DESCRIPTION
`"statuses/{id}"` instead of `"v3:statuses/{id}"`

New keys taken from 
https://github.com/mastodon/mastodon/blob/b625f21ceab87556c990344d586a231b6c4559e3/app/models/quote.rb#L91-L94

Found by linter, fix by myself. No LLM