### PR TITLE
Fix typo in embedded quote handling code

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -413,7 +413,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def fetch_and_verify_quote
     return if @quote.nil?
 
-    embedded_quote = safe_prefetched_embed(@account, @status_parser.quoted_object, @json['context'])
+    embedded_quote = safe_prefetched_embed(@account, @status_parser.quoted_object, @json['@context'])
     ActivityPub::VerifyQuoteService.new.call(@quote, @quote_approval_uri, fetchable_quoted_uri: @quote_uri, prefetched_quoted_object: embedded_quote, request_id: @options[:request_id], depth: @options[:depth])
   rescue Mastodon::RecursionLimitExceededError, Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
     ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(PROCESSING_DELAY), @quote.id, @quote_uri, { 'request_id' => @options[:request_id], 'approval_uri' => @quote_approval_uri })

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -384,7 +384,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
   end
 
   def fetch_and_verify_quote!(quote, approval_uri, quote_uri)
-    embedded_quote = safe_prefetched_embed(@account, @status_parser.quoted_object, @activity_json['context'])
+    embedded_quote = safe_prefetched_embed(@account, @status_parser.quoted_object, @activity_json['@context'])
     ActivityPub::VerifyQuoteService.new.call(quote, approval_uri, fetchable_quoted_uri: quote_uri, prefetched_quoted_object: embedded_quote, request_id: @request_id)
   rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
     ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(PROCESSING_DELAY), quote.id, quote_uri, { 'request_id' => @request_id, 'approval_uri' => approval_uri })


### PR DESCRIPTION
Follow up to #34584

Change `@json['context']` to `@json['@context']`

Matching examples
app/services/activitypub/verify_quote_service.rb:88 
app/lib/activitypub/activity/quote_request.rb:49

Found by linter, fix by me. no LLM.