### PR TITLE
Typo: 20240111033014_create_generated_annual_reports.rb

### DIFF
--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -40,6 +40,7 @@ module Account::Associations
         has_many :statuses
         has_many :keypairs
         has_many :email_subscriptions
+        has_many :generated_annual_reports
 
         has_one :deletion_request, class_name: 'AccountDeletionRequest'
         has_one :follow_recommendation_suppression

--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -28,6 +28,7 @@ class DeleteAccountService < BaseService
     scheduled_statuses
     status_pins
     tag_follows
+    generated_annual_reports
   ).freeze
 
   # The following associations have no important side-effects

--- a/db/migrate/20240111033014_create_generated_annual_reports.rb
+++ b/db/migrate/20240111033014_create_generated_annual_reports.rb
@@ -3,7 +3,7 @@
 class CreateGeneratedAnnualReports < ActiveRecord::Migration[7.1]
   def change
     create_table :generated_annual_reports do |t|
-      t.belongs_to :account, null: false, foreign_key: { on_cascade: :delete }, index: false
+      t.belongs_to :account, null: false, foreign_key: { on_delete: :cascade }, index: false
       t.integer :year, null: false
       t.jsonb :data, null: false
       t.integer :schema_version, null: false


### PR DESCRIPTION
`on_cascade: :delete` doesn't exist  `on_delete: :cascade` does.

@ClearlyClaire as this is touching a migration. I'd imagine we'd need to make a new migration? instead of touching the old one?

Found by linter, fix by me. No LLM