### PR TITLE
Fix incorrect attribute being read while processing Collection items

### DIFF
--- a/app/services/activitypub/process_featured_item_service.rb
+++ b/app/services/activitypub/process_featured_item_service.rb
@@ -70,7 +70,7 @@ class ActivityPub::ProcessFeaturedItemService
     return false if Account.exists?(uri: @actor_uri)
 
     object_json = fetch_resource(@actor_uri, true, raise_on_error: :temporary)
-    object_json.nil? || (as_array(object_json['fetch']) & ActivityPub::FetchRemoteActorService::SUPPORTED_TYPES).empty?
+    object_json.nil? || (as_array(object_json['type']) & ActivityPub::FetchRemoteActorService::SUPPORTED_TYPES).empty?
   end
 
   def verify_authorization!


### PR DESCRIPTION
Follow up to #39834 

I think the original was correct because this is the only fetch in the entire codebase.

<img width="938" height="244" alt="image" src="https://github.com/user-attachments/assets/0a66d06d-ebc6-4175-a7f5-6fb9ea48733d" />

found by linter, fix by me. no LLM