### PR TITLE
Fix: Add missing preventDefault to Lists modal

### DIFF
--- a/app/javascript/mastodon/features/list_adder/index.tsx
+++ b/app/javascript/mastodon/features/list_adder/index.tsx
@@ -79,6 +79,8 @@ const NewListItem: React.FC<{
   );
 
   const handleSubmit = useCallback(() => {
+    e.preventDefault();
+
     if (title.trim().length === 0) {
       return;
     }


### PR DESCRIPTION
Was removed in #32881 but because other modals call this still. I've added it back.

app/javascript/mastodon/features/collections/editor/details.tsx

Detected by linter, fix by me.