### PR TITLE
Fix autosuggestions replacing reply text

### DIFF
--- a/app/javascript/mastodon/components/autosuggest/utils.test.ts
+++ b/app/javascript/mastodon/components/autosuggest/utils.test.ts
@@ -7,8 +7,16 @@ describe('textAtCursorMatchesToken', () => {
       [1, '#hashtag'],
     ],
     [
+      ['@alice', 6, ['@']],
+      [1, '@alice'],
+    ],
+    [
+      ['＠alice', 6, ['＠']],
+      [1, '＠alice'],
+    ],
+    [
       ['#hash tag', 8, ['#']],
-      [1, '#hash tag'],
+      [null, null],
     ],
     [
       [':+1', 2, [':']],
@@ -24,7 +32,27 @@ describe('textAtCursorMatchesToken', () => {
     ],
     [
       ['#ハッシュ タグ', 7, ['#']],
-      [1, '#ハッシュ タグ'],
+      [null, null],
+    ],
+    [
+      ['@alice reply', 12, ['@']],
+      [null, null],
+    ],
+    [
+      ['@alice 这是我输入的回复内容', 17, ['@']],
+      [null, null],
+    ],
+    [
+      ['@alice これは本文', 12, ['@']],
+      [null, null],
+    ],
+    [
+      ['@alice 이것은답변입니다', 15, ['@']],
+      [null, null],
+    ],
+    [
+      ['@alice　これは本文', 12, ['@']],
+      [null, null],
     ],
   ] as const)(
     'textAtCursorMatchesToken(%s) is %o',

--- a/app/javascript/mastodon/components/autosuggest/utils.ts
+++ b/app/javascript/mastodon/components/autosuggest/utils.ts
@@ -7,10 +7,7 @@ export const textAtCursorMatchesToken = (
 ) => {
   let word: string;
 
-  const regex = new RegExp(
-    `[${searchTokens.join('')}${WORD}+-]+(\\s[${WORD}]+)?$`,
-    'iu',
-  );
+  const regex = new RegExp(`[${searchTokens.join('')}${WORD}+-]+$`, 'iu');
   const left = str.slice(0, caretPosition).search(regex);
   const right = str.slice(caretPosition).search(/\s/);
 


### PR DESCRIPTION
## Summary

- Stop autosuggestion tokens at whitespace.
- Prevent text after automatically inserted reply mentions from being treated as an account search query.
- Add regression coverage for Latin, Chinese, Japanese, Korean, and full-width whitespace.

## Rationale

#39622 allowed autosuggestions to include a second whitespace-separated word so account display-name searches could be narrowed. The composer cannot distinguish that search syntax from ordinary text after a completed reply mention, however. For languages that commonly continue without another space, the suggestion menu remains open and Enter can replace the authored reply text.

This deliberately removes multi-word display-name search from the composer. Single-token account, hashtag, and emoji suggestions remain unchanged. Preventing user-authored text from being replaced takes precedence over the narrower multi-word lookup convenience.

Fixes #39995

## Testing

- yarn format:check
- yarn lint:js --no-cache --max-warnings 0
- yarn typecheck
- yarn test:js run (27 test files, 4,050 tests)