### PR TITLE
Add Elasticsearch request timeout of 10s (can be overridden through `ES_QUERY_TIMEOUT`)

### DIFF
--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -10,6 +10,8 @@ class AccountSearchService < BaseService
   # Min. number of characters to look for non-exact matches
   MIN_QUERY_LENGTH = 3
 
+  ES_QUERY_TIMEOUT = ENV.fetch('ES_QUERY_TIMEOUT', '10s')
+
   class QueryBuilder
     def initialize(query, account, options = {})
       @query = query
@@ -253,7 +255,7 @@ class AccountSearchService < BaseService
       end
     end
 
-    records = elastic_stoplight_wrapper.run { query_builder.build.limit(limit_for_non_exact_results).offset(offset).objects.compact }
+    records = elastic_stoplight_wrapper.run { query_builder.build.limit(limit_for_non_exact_results).timeout(ES_QUERY_TIMEOUT).offset(offset).objects.compact }
 
     ActiveRecord::Associations::Preloader.new(records: records, associations: [:account_stat, { user: :role }]).call
 

--- a/app/services/statuses_search_service.rb
+++ b/app/services/statuses_search_service.rb
@@ -3,6 +3,8 @@
 class StatusesSearchService < BaseService
   include SearchStoplight
 
+  ES_QUERY_TIMEOUT = ENV.fetch('ES_QUERY_TIMEOUT', '10s')
+
   def call(query, account = nil, options = {})
     MastodonOTELTracer.in_span('StatusesSearchService#call') do |span|
       @query   = query&.strip
@@ -28,7 +30,7 @@ class StatusesSearchService < BaseService
 
   def status_search_results
     request             = parsed_query.request
-    results             = elastic_stoplight_wrapper.run { request.collapse(field: :id).order(id: { order: :desc }).limit(@limit).offset(@offset).objects.compact }
+    results             = elastic_stoplight_wrapper.run { request.timeout(ES_QUERY_TIMEOUT).collapse(field: :id).order(id: { order: :desc }).limit(@limit).offset(@offset).objects.compact }
     account_ids         = results.map(&:account_id)
     account_domains     = results.map(&:account_domain)
 


### PR DESCRIPTION
Note that this is what we request of Elasticsearch, and not a timeout on the transport layer (there are ways to set them, but I have not investigated enough to see if we can do it per-request).