### PR TITLE
vite-rb: Use Struct instead of Hash for manifest entries

### DIFF
--- a/lib/vite/manifest.rb
+++ b/lib/vite/manifest.rb
@@ -31,7 +31,8 @@ module Vite
       end
     end
 
-    Entry = Struct.new(:file, :integrity, :import_ids, :stylesheet_ids)
+    Entrypoint = Struct.new(:file, :integrity, :import_ids, :stylesheet_ids)
+    Asset = Struct.new(:file, :integrity)
 
     attr_reader :config, :entries, :pool, :logger
 
@@ -106,7 +107,7 @@ module Vite
         import_ids, stylesheet_ids = resolve_relations(json, raw)
 
         @virtual[raw['name']] = key
-        @entries[key] = Entry.new(
+        @entries[key] = Entrypoint.new(
           raw['file'],
           raw['integrity'],
           import_ids,
@@ -117,7 +118,7 @@ module Vite
       logger.debug { "loading manifest file: #{config.manifest_assets_path}" }
       assets = JSON.load_file(config.manifest_assets_path)
       assets.each do |key, raw|
-        @entries[key] = Entry.new(
+        @entries[key] = Asset.new(
           raw['file'],
           raw['integrity']
         )
@@ -175,7 +176,7 @@ module Vite
       id, deps = @lookup[file] || []
 
       if id.nil?
-        @pool << Entry.new(file, integrity)
+        @pool << Asset.new(file, integrity)
         id = @pool.size - 1 # last ID
         deps = yield if block_given?
         @lookup[file] = [id, deps]

--- a/lib/vite/manifest.rb
+++ b/lib/vite/manifest.rb
@@ -31,6 +31,8 @@ module Vite
       end
     end
 
+    Entry = Struct.new(:file, :integrity, :import_ids, :stylesheet_ids)
+
     attr_reader :config, :entries, :pool, :logger
 
     def initialize(config:, logger:)
@@ -104,21 +106,21 @@ module Vite
         import_ids, stylesheet_ids = resolve_relations(json, raw)
 
         @virtual[raw['name']] = key
-        @entries[key] = {
-          file: raw['file'],
-          integrity: raw['integrity'],
-          import_ids: import_ids,
-          stylesheet_ids: stylesheet_ids,
-        }
+        @entries[key] = Entry.new(
+          raw['file'],
+          raw['integrity'],
+          import_ids,
+          stylesheet_ids
+        )
       end
 
       logger.debug { "loading manifest file: #{config.manifest_assets_path}" }
       assets = JSON.load_file(config.manifest_assets_path)
       assets.each do |key, raw|
-        @entries[key] = {
-          file: raw['file'],
-          integrity: raw['integrity'],
-        }
+        @entries[key] = Entry.new(
+          raw['file'],
+          raw['integrity']
+        )
       end
     ensure
       @lookup = {}
@@ -173,7 +175,7 @@ module Vite
       id, deps = @lookup[file] || []
 
       if id.nil?
-        @pool << { file:, integrity: }
+        @pool << Entry.new(file, integrity)
         id = @pool.size - 1 # last ID
         deps = yield if block_given?
         @lookup[file] = [id, deps]


### PR DESCRIPTION
This actually makes load times a bit faster and reduces some memory usage.

My own measurements in dev console:

Memory before:
```ruby
report = MemoryProfiler.report { Vite.manifest.reload; GC.start }
report.pretty_print
#=> Total allocated: 245728 bytes (1581 objects)
#=> Total retained:  245728 bytes (1581 objects)
```

Memory after:
```ruby
report = MemoryProfiler.report { Vite.manifest.reload; GC.start }
report.pretty_print
#=> Total allocated: 225144 bytes (1928 objects)
#=> Total retained:  225144 bytes (1928 objects)
```

Time before:
```ruby
Benchmark.measure { Vite.manifest.reload }.real
#=> 0.012134000000514789
```

Time after:
```ruby
Benchmark.measure { Vite.manifest.reload }.real
#=> 0.005042000000685221
```

It's not a huge gain but we also get the benefits of using more structured data that will fail if we try to access a field that doesn't exists instead of silently return `nil`.
