### PR TITLE
Fix: publish deleted media to timeline using ordered_media_attachment_ids column data

### DIFF
--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -87,7 +87,7 @@ class BatchedRemoveStatusService < BaseService
     pipeline.publish('timeline:public', payload)
     pipeline.publish(status.local? ? 'timeline:public:local' : 'timeline:public:remote', payload)
 
-    if status.media_attachments.any?
+    if status.ordered_media_attachment_ids.present?
       pipeline.publish('timeline:public:media', payload)
       pipeline.publish(status.local? ? 'timeline:public:local:media' : 'timeline:public:remote:media', payload)
     end


### PR DESCRIPTION
Apparently media_attachments is null by the time that check is completed.

@ClearlyClaire This was reported by tools... but I am not 100% confidence about it so please close if it's junk

Found by static code analysis. fix by myself. LLM likely in tooling.