### PR TITLE
Fix: Disconnect websocket streams from users when mark_deleted is triggered.

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -326,6 +326,10 @@ class Account < ApplicationRecord
       create_deletion_request!
       update!(requested_deletion_at: date)
     end
+
+    # This terminates all connections for the given account with the streaming
+    # server:
+    redis.publish("timeline:system:#{id}", { event: :kill }.to_json) if local?
   end
 
   def memorialize!


### PR DESCRIPTION
Stolen from suspensions 
https://github.com/mastodon/mastodon/blob/7d1cca8359fc48f0a0624701829e1540a2087142/app/models/concerns/account/suspensions.rb#L43-L45
