### PR TITLE
Fix image preview too dark in alt text editor dialog

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8259,6 +8259,10 @@ noscript {
   justify-content: center;
   align-items: center;
 
+  img {
+    user-select: none;
+  }
+
   &.dragging {
     cursor: grabbing;
   }
@@ -8270,7 +8274,7 @@ noscript {
     transform: translate(-50%, -50%);
     border: 2px solid var(--color-text-on-media);
     border-radius: 50%;
-    box-shadow: 0 0 0 9999em var(--color-shadow-primary);
+    box-shadow: 0 0 0 9999em rgb(from black r g b / 25%);
     pointer-events: none;
   }
 }


### PR DESCRIPTION
Fixes #40035

### Changes proposed in this PR:
- Fixes the focal point overlay in the alt text editor dialog being too dark. It's now set to a theme-independent black overlay with 25% opacity.
- Prevents the image from being selected when dragging the focal point selector

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="616" height="544" alt="image" src="https://github.com/user-attachments/assets/ffe07575-b10f-4165-b461-250e6f6bf3f9" /> | <img width="614" height="543" alt="image" src="https://github.com/user-attachments/assets/3bb79c3f-642f-4aed-acc6-427d69e4af81" /> |
| <img width="616" height="547" alt="image" src="https://github.com/user-attachments/assets/d9326af7-b1de-4fe5-8c2f-64ba3a98c091" /> | <img width="611" height="545" alt="image" src="https://github.com/user-attachments/assets/d828f46d-8a62-4dd7-8386-a70487cd624b" /> |