### PR TITLE
Fix title tooltip appearing for fullscreen videos

### DIFF
--- a/app/javascript/mastodon/features/video/index.tsx
+++ b/app/javascript/mastodon/features/video/index.tsx
@@ -829,7 +829,7 @@ export const Video: React.FC<{
             role='button'
             tabIndex={0}
             aria-label={alt}
-            title={alt}
+            title={fullscreen ? undefined : alt}
             lang={lang}
             onClick={handleClick}
             onKeyDownCapture={handleVideoKeyDown}


### PR DESCRIPTION
Fixes #38572

### Changes proposed in this PR:
- Removes the `title` attribute from videos when they are in fullscreen, to prevent the system tooltip from appearing when there's no way to move the mouse cursor away from the element
