### PR TITLE
Fix semitransparent background of picture-in-picture video player

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8739,6 +8739,7 @@ noscript {
   bottom: 20px;
   inset-inline-end: 20px;
   width: 300px;
+  background-color: var(--color-bg-primary);
   box-shadow: var(--dropdown-shadow);
 
   &__footer {


### PR DESCRIPTION
Fixes #38493

### Changes proposed in this PR:
- Fixes background of picture-in-picture video player being partially transparent

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="317" height="598" alt="image" src="https://github.com/user-attachments/assets/73403a9c-daa3-4fcb-b5ff-5dd3bc5baefd" /> | <img width="316" height="588" alt="image" src="https://github.com/user-attachments/assets/9f1d9e41-3039-41bd-b128-ef9d305d13a2" /> |
| <img width="313" height="593" alt="image" src="https://github.com/user-attachments/assets/6a3d3633-c6ba-49d9-b135-77ed70f9a2fc" /> | <img width="312" height="596" alt="image" src="https://github.com/user-attachments/assets/6e403135-27e2-4c55-b1b8-1ebadfaed407" /> |