### PR TITLE
Change design of "New collection" button in "Add to collection" dialog

### DIFF
--- a/app/javascript/mastodon/features/collection_adder/index.tsx
+++ b/app/javascript/mastodon/features/collection_adder/index.tsx
@@ -174,12 +174,17 @@ export const CollectionAdder: React.FC<{
                 />
               }
             >
-              <NewCollectionButton onClick={handleNewCollection} />
+              <NewCollectionButton compact onClick={handleNewCollection} />
             </EmptyState>
           ) : (
             <>
               <div className={classes.newCollection}>
-                <NewCollectionButton onClick={handleNewCollection} />
+                <NewCollectionButton secondary onClick={handleNewCollection}>
+                  <FormattedMessage
+                    id='collections.create_new_collection'
+                    defaultMessage='Create new collection'
+                  />
+                </NewCollectionButton>
               </div>
               {collections.map((item) => (
                 <ListItem key={item.id} collection={item} account={account} />

--- a/app/javascript/mastodon/features/collection_adder/styles.module.scss
+++ b/app/javascript/mastodon/features/collection_adder/styles.module.scss
@@ -1,5 +1,3 @@
 .newCollection {
-  display: flex;
-  justify-content: center;
-  padding-block: 16px;
+  padding: 16px;
 }

--- a/app/javascript/mastodon/features/collections/overview/created_by_account.tsx
+++ b/app/javascript/mastodon/features/collections/overview/created_by_account.tsx
@@ -1,7 +1,9 @@
+import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
+import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 
 import AddIcon from '@/material-icons/400-24px/add.svg?react';
@@ -26,16 +28,23 @@ import {
 } from '../editor';
 import classes from '../styles.module.scss';
 
-export const NewCollectionButton: React.FC<{ onClick?: () => void }> = ({
-  onClick,
-}) => (
+export const NewCollectionButton: React.FC<{
+  compact?: boolean;
+  secondary?: boolean;
+  onClick?: () => void;
+  children?: ReactNode;
+}> = ({ compact, secondary, onClick, children }) => (
   <Link
     to='/collections/new'
-    className='button button--compact'
+    className={classNames(
+      'button',
+      compact && 'button--compact',
+      secondary && 'button-secondary',
+    )}
     onClick={onClick}
   >
     <Icon id='plus' icon={AddIcon} />
-    <FormattedMessage {...editorMessages.newCollection} />
+    {children ?? <FormattedMessage {...editorMessages.newCollection} />}
   </Link>
 );
 
@@ -103,7 +112,7 @@ export const CollectionsCreatedByAccount: React.FC = () => {
             />
           }
         >
-          <NewCollectionButton />
+          <NewCollectionButton compact />
         </EmptyState>
       );
     } else {
@@ -135,7 +144,7 @@ export const CollectionsCreatedByAccount: React.FC = () => {
             }}
           />
         </h2>
-        {showCreateButton && <NewCollectionButton />}
+        {showCreateButton && <NewCollectionButton compact />}
       </div>
       <ItemList>
         {isOwnCollectionPage && !canCreateMoreCollections && (

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -395,6 +395,7 @@
   "collections.create.basic_details_title": "Basic details",
   "collections.create.steps": "Step {step}/{total}",
   "collections.create_collection": "Create collection",
+  "collections.create_new_collection": "Create new collection",
   "collections.delete_collection": "Delete collection",
   "collections.description_length_hint": "100 characters limit",
   "collections.detail.author_added_you_on_date": "{author} added you on {date}",


### PR DESCRIPTION
Related to #39874

### Changes proposed in this PR:
- Updates design and wording of the "New collection" button introduced to the "Add to collection" dialog in #39897

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="615" height="544" alt="image" src="https://github.com/user-attachments/assets/86bfa2d5-11ec-425c-bb79-2c841fa7ea67" /> | <img width="605" height="545" alt="image" src="https://github.com/user-attachments/assets/ee48a993-6f57-48fd-ad74-bc9f8dac040a" /> |