### PR TITLE
Fix Web UI being inaccessible with URLs ending with `.zip`

### DIFF
--- a/app/controllers/concerns/web_app_controller_concern.rb
+++ b/app/controllers/concerns/web_app_controller_concern.rb
@@ -6,6 +6,7 @@ module WebAppControllerConcern
   included do
     vary_by 'Accept, Accept-Language, Cookie'
 
+    before_action :adjust_format_for_zip_tlds
     before_action :redirect_unauthenticated_to_permalinks!
     before_action :set_referer_header
     before_action :redirect_to_tos_interstitial!
@@ -45,6 +46,14 @@ module WebAppControllerConcern
   end
 
   protected
+
+  # This endpoint will never serve zip files, but may serve paths ending with `.zip` due to the `.zip` TLD.
+  # When that happens from a browser, Rails will unfortunately determine the requested format to be `:zip`
+  # instead of `:html`, so override this.
+  # We don't just override `format` in all cases, because we want to handle `:json` as well.
+  def adjust_format_for_zip_tlds
+    request.format = :html if request.format == :zip
+  end
 
   def redirect_to_tos_interstitial!
     return unless current_user&.require_tos_interstitial?


### PR DESCRIPTION
Fixes #40101

This PR unfortunately hardcodes the solution for the `.zip` TLD, while I would have liked something more generic, but it does not look like Rails allows us to opt out of the logic that causes the issue (see https://github.com/mastodon/mastodon/issues/40101#issuecomment-5264614749)