### PR TITLE
Remove redundant index `index_keypairs_on_account_id`

### DIFF
--- a/db/migrate/20260812154114_remove_index_keypairs_on_account_id.rb
+++ b/db/migrate/20260812154114_remove_index_keypairs_on_account_id.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveIndexKeypairsOnAccountId < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :keypairs, :account_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_05_130216) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_12_154114) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -728,7 +728,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_05_130216) do
     t.datetime "updated_at", null: false
     t.string "uri"
     t.index ["account_id", "local_fragment"], name: "index_keypairs_on_account_id_and_local_fragment", unique: true
-    t.index ["account_id"], name: "index_keypairs_on_account_id"
     t.index ["uri"], name: "index_keypairs_on_uri", unique: true
   end
 


### PR DESCRIPTION
This was added as this is a foreign key, but it's already covered by the new `index_keypairs_on_account_id_and_local_fragment`.