### PR TITLE
Update Badge component styles for redesign

### DIFF
--- a/app/javascript/mastodon/components/account_header/badges.tsx
+++ b/app/javascript/mastodon/components/account_header/badges.tsx
@@ -7,6 +7,7 @@ import { fetchRelationships } from '@/mastodon/actions/accounts';
 import { useAccount } from '@/mastodon/hooks/useAccount';
 import type { AccountRole } from '@/mastodon/models/account';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
+import PersonIcon from '@/material-icons/400-24px/person.svg?react';
 
 import {
   AdminBadge,
@@ -57,6 +58,7 @@ export const AccountBadges: FC<{ accountId: string }> = ({ accountId }) => {
     } else {
       badges.push(
         <Badge
+          icon={<PersonIcon />}
           key={role.id}
           label={role.name}
           domain={`(${domain})`}

--- a/app/javascript/mastodon/components/badge/badge.stories.tsx
+++ b/app/javascript/mastodon/components/badge/badge.stories.tsx
@@ -28,6 +28,13 @@ export const Default: Story = {
   },
 };
 
+export const Accent: Story = {
+  args: {
+    label: 'Example',
+    variant: 'accent',
+  },
+};
+
 export const Domain: Story = {
   args: {
     ...Default.args,

--- a/app/javascript/mastodon/components/badge/index.tsx
+++ b/app/javascript/mastodon/components/badge/index.tsx
@@ -11,7 +11,6 @@ import IconVerified from '@/images/icons/icon_verified.svg?react';
 import type { OnAttributeHandler } from '@/mastodon/utils/html';
 import BlockIcon from '@/material-icons/400-24px/block.svg?react';
 import GroupsIcon from '@/material-icons/400-24px/group.svg?react';
-import PersonIcon from '@/material-icons/400-24px/person.svg?react';
 import SmartToyIcon from '@/material-icons/400-24px/smart_toy.svg?react';
 import VolumeOffIcon from '@/material-icons/400-24px/volume_off.svg?react';
 
@@ -28,6 +27,7 @@ interface BadgeProps extends React.ComponentPropsWithoutRef<'div'> {
   variant?:
     | 'default'
     | 'subtle'
+    | 'accent'
     | 'inverted'
     | 'success'
     | 'warning'
@@ -40,7 +40,7 @@ type PresetBadgeProps = Omit<
 >;
 
 export const Badge: FC<BadgeProps> = ({
-  icon = <PersonIcon />,
+  icon,
   variant = 'default',
   label,
   className,

--- a/app/javascript/mastodon/components/badge/index.tsx
+++ b/app/javascript/mastodon/components/badge/index.tsx
@@ -8,6 +8,7 @@ import AdminIcon from '@/images/icons/icon_admin.svg?react';
 import ClockIcon from '@/images/icons/icon_clock.svg?react';
 import FollowerIcon from '@/images/icons/icon_follower.svg?react';
 import IconVerified from '@/images/icons/icon_verified.svg?react';
+import { isRedesignEnabled } from '@/mastodon/utils/environment';
 import type { OnAttributeHandler } from '@/mastodon/utils/html';
 import BlockIcon from '@/material-icons/400-24px/block.svg?react';
 import GroupsIcon from '@/material-icons/400-24px/group.svg?react';
@@ -17,6 +18,7 @@ import VolumeOffIcon from '@/material-icons/400-24px/volume_off.svg?react';
 import { EmojiHTML } from '../emoji/html';
 import { Icon } from '../icon';
 
+import redesignClasses from './redesign.module.scss';
 import classes from './styles.module.scss';
 
 interface BadgeProps extends React.ComponentPropsWithoutRef<'div'> {
@@ -52,6 +54,7 @@ export const Badge: FC<BadgeProps> = ({
     {...otherProps}
     className={classNames(
       classes.badge,
+      isRedesignEnabled() && redesignClasses.badge,
       !icon && classes.badgeWithoutIcon,
       classes[variant],
       className,

--- a/app/javascript/mastodon/components/badge/redesign.module.scss
+++ b/app/javascript/mastodon/components/badge/redesign.module.scss
@@ -1,0 +1,11 @@
+@use '@/styles/mastodon/mixins';
+
+.badge {
+  @include mixins.type-micro;
+
+  line-height: 1.1;
+
+  &:not(.badgeWithoutIcon) {
+    padding-inline: var(--space-3xs) var(--space-2xs);
+  }
+}

--- a/app/javascript/mastodon/components/badge/styles.module.scss
+++ b/app/javascript/mastodon/components/badge/styles.module.scss
@@ -46,6 +46,11 @@
   background-color: var(--color-bg-brand-softest);
 }
 
+.accent {
+  color: var(--color-text-on-brand-base);
+  background-color: var(--color-bg-brand-base);
+}
+
 .feature {
   background-color: var(--color-bg-brand-base);
   color: var(--color-text-on-brand-base);

--- a/app/javascript/mastodon/components/badge/styles.module.scss
+++ b/app/javascript/mastodon/components/badge/styles.module.scss
@@ -17,16 +17,6 @@
     padding-inline-end: var(--space-xs);
   }
 
-  html[data-redesign='true'] & {
-    @include mixins.type-micro;
-
-    line-height: 1.1;
-
-    &:not(.badgeWithoutIcon) {
-      padding-inline: var(--space-3xs) var(--space-2xs);
-    }
-  }
-
   > svg {
     flex-shrink: 0;
     width: auto;

--- a/app/javascript/mastodon/components/badge/styles.module.scss
+++ b/app/javascript/mastodon/components/badge/styles.module.scss
@@ -1,13 +1,31 @@
+@use '@/styles/mastodon/mixins';
+
 .badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  min-width: 1lh;
+  padding: var(--space-2xs);
+  gap: var(--space-2xs);
+  border-radius: var(--radius-xs);
   color: var(--color-text-primary);
   font-size: 13px;
   font-weight: 400;
-  display: inline-flex;
-  max-width: 100%;
-  padding: 4px;
-  gap: 4px;
-  border-radius: 8px;
-  align-items: center;
+
+  &:not(.badgeWithoutIcon) {
+    padding-inline-end: var(--space-xs);
+  }
+
+  html[data-redesign='true'] & {
+    @include mixins.type-micro;
+
+    line-height: 1.1;
+
+    &:not(.badgeWithoutIcon) {
+      padding-inline: var(--space-3xs) var(--space-2xs);
+    }
+  }
 
   > svg {
     flex-shrink: 0;
@@ -20,10 +38,6 @@
   a {
     color: inherit;
     text-decoration: none;
-  }
-
-  &:not(.badgeWithoutIcon) {
-    padding-inline-end: 8px;
   }
 }
 

--- a/app/javascript/styles/mastodon/_mixins.scss
+++ b/app/javascript/styles/mastodon/_mixins.scss
@@ -83,7 +83,7 @@
 }
 
 @mixin type-micro {
-  font-family: var(--font-monospace);
+  font-family: var(--font-body);
   font-size: var(--fs-3xs);
   font-weight: normal;
   line-height: var(--lh-tighter);


### PR DESCRIPTION
### Changes proposed in this PR:
- Adds new `'accent'` variant
- Updates styles of the Badge component to match latest designs (respecting the feature flag for more obvious changes, so there should be minimal change for existing badges)
- Removes default icon from Badge component
- Changes the font of the new "micro" text style to not use a monospace anymore