### PR TITLE
Remove reference to tmp/cache/vite/last-build*.json file in test-ruby workflow

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Archive asset artifacts
         run: |
-          tar --exclude={"*.br","*.gz"} -zcf artifacts.tar.gz public/assets public/packs* tmp/cache/vite/last-build*.json
+          tar --exclude={"*.br","*.gz"} -zcf artifacts.tar.gz public/assets public/packs*
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: matrix.mode == 'test'


### PR DESCRIPTION
This file is an artifact from `vite_rails` and since we've removed the gem we don't generate it anymore.