### PR TITLE
Fix path not being redirected to deck mode after window resizing

### DIFF
--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -192,10 +192,12 @@ class SwitchingColumnsArea extends PureComponent {
             <Redirect from='/' to={{pathname: rootRedirect, state: {...this.props.location.state, focusTarget: false}}} exact />
 
             {singleColumn ? <Redirect from='/deck' to='/home' exact /> : null}
+            {singleColumn ? <Redirect from='/getting-started' to='/home' exact /> : null}
             {singleColumn && pathName.startsWith('/deck/') ? <Redirect from={pathName} to={{...this.props.location, pathname: pathName.slice(5)}} /> : null}
+            {/* Redirect after e.g. window resize */ }
+            {!singleColumn && !pathName.startsWith('/deck/') && pathName !== '/home' ? <Redirect from={pathName} to={{...this.props.location, pathname: `/deck${pathName}`}} exact /> : null}
             {/* Redirect old bookmarks (without /deck) with home-like routes to the advanced interface */}
             {!singleColumn && pathName === '/home' ? <Redirect from='/home' to='/deck/getting-started' exact /> : null}
-            {pathName === '/getting-started' ? <Redirect from='/getting-started' to={singleColumn ? '/home' : '/deck/getting-started'} exact /> : null}
 
             <WrappedRoute path='/getting-started' component={GettingStarted} content={children} />
             <WrappedRoute path='/keyboard-shortcuts' component={KeyboardShortcuts} content={children} />


### PR DESCRIPTION
Closes #40180

Whenever starting in deck mode, Mastodon will seamlessly switch between deck mode and mobile UI depending on window size.

However, while, when switching to single-column mode, it drops the `/deck` part of the URL, it doesn't re-insert it when switching back to deck mode, potentially causing surprising issues when the window is temporarily resized.

This PR fixes that by re-inserting `/deck` upon switching back to multi-column. A perhaps cleaner alternative to this PR would be to rewrite the URLs depending on the setting only, and not on the current state (e.g. if the advanced interface is enabled, `/deck` would never be removed). This is what #40180 does.