### PR TITLE
Fix `/deck` being removed from path when resizing window

### DIFF
--- a/app/javascript/mastodon/components/router.tsx
+++ b/app/javascript/mastodon/components/router.tsx
@@ -11,8 +11,9 @@ import type {
 } from 'history';
 import { createBrowserHistory } from 'history';
 
-import { layoutFromWindow } from 'mastodon/is_mobile';
 import { isDevelopment } from 'mastodon/utils/environment';
+
+import { forceSingleColumn, hasMultiColumnPath } from '../initial_state';
 
 import type { FocusTarget } from './navigation_focus_target';
 
@@ -63,7 +64,8 @@ function normalizePath(
   }
 
   if (
-    layoutFromWindow() === 'multi-column' &&
+    !forceSingleColumn &&
+    hasMultiColumnPath &&
     location.pathname &&
     !location.pathname.startsWith('/deck')
   ) {

--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -21,7 +21,7 @@ import { Hotkeys } from 'mastodon/components/hotkeys';
 import { HoverCardController } from 'mastodon/components/hover_card_controller';
 import { PictureInPicture } from 'mastodon/features/picture_in_picture';
 import { identityContextPropShape, withIdentity } from 'mastodon/identity_context';
-import { layoutFromWindow } from 'mastodon/is_mobile';
+import { layoutFromWindow, transientSingleColumn } from 'mastodon/is_mobile';
 import { WithRouterPropTypes } from 'mastodon/utils/react_router';
 import { isRedesignEnabled } from '@/mastodon/utils/environment';
 import { checkAnnualReport } from '@/mastodon/reducers/slices/annual_report';
@@ -30,7 +30,7 @@ import { uploadCompose, resetCompose, changeComposeSpoilerness } from '../../act
 import { clearHeight } from '../../actions/height_cache';
 import { fetchServer, fetchServerTranslationLanguages } from '../../actions/server';
 import { expandHomeTimeline } from '../../actions/timelines';
-import { initialState, me, owner, singleUserMode, trendsEnabled, landingPage, localLiveFeedAccess, disableHoverCards, domain } from '../../initial_state';
+import { initialState, forceSingleColumn, me, owner, singleUserMode, trendsEnabled, landingPage, localLiveFeedAccess, disableHoverCards, domain } from '../../initial_state';
 
 import BundleColumnError from './components/bundle_column_error';
 import { NavigationBar } from './components/navigation_bar';
@@ -191,8 +191,8 @@ class SwitchingColumnsArea extends PureComponent {
           <WrappedSwitch>
             <Redirect from='/' to={{pathname: rootRedirect, state: {...this.props.location.state, focusTarget: false}}} exact />
 
-            {singleColumn ? <Redirect from='/deck' to='/home' exact /> : null}
-            {singleColumn && pathName.startsWith('/deck/') ? <Redirect from={pathName} to={{...this.props.location, pathname: pathName.slice(5)}} /> : null}
+            {forceSingleColumn || transientSingleColumn ? <Redirect from='/deck' to='/home' exact /> : null}
+            {(forceSingleColumn || transientSingleColumn) && pathName.startsWith('/deck/') ? <Redirect from={pathName} to={{...this.props.location, pathname: pathName.slice(5)}} /> : null}
             {/* Redirect old bookmarks (without /deck) with home-like routes to the advanced interface */}
             {!singleColumn && pathName === '/home' ? <Redirect from='/home' to='/deck/getting-started' exact /> : null}
             {pathName === '/getting-started' ? <Redirect from='/getting-started' to={singleColumn ? '/home' : '/deck/getting-started'} exact /> : null}

--- a/app/javascript/mastodon/features/ui/util/react_router_helpers.jsx
+++ b/app/javascript/mastodon/features/ui/util/react_router_helpers.jsx
@@ -8,12 +8,13 @@ import StackTrace from 'stacktrace-js';
 import Bundle from '../components/bundle';
 import BundleColumnError from '../components/bundle_column_error';
 import { ColumnLoading } from '../components/column_loading';
+import { forceSingleColumn, hasMultiColumnPath } from '@/mastodon/initial_state';
 
 // Small wrapper to pass multiColumn to the route components
 export const WrappedSwitch = ({ multiColumn, children }) => {
   const  location = useLocation();
 
-  const decklessLocation = multiColumn && location.pathname.startsWith('/deck')
+  const decklessLocation = !forceSingleColumn && hasMultiColumnPath && location.pathname.startsWith('/deck')
     ? {...location, pathname: location.pathname.slice(5)}
     : location;
 


### PR DESCRIPTION
Closes #40178

This PR, which is an alternative to #40178, changes the redirection logic to never strip `/deck` from the path within a session started in deck mode.