### PR TITLE
Update Renovate to wait 3 days after package release before opening a PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,8 @@
     ':enableVulnerabilityAlertsWithLabel(security)',
   ],
   rebaseWhen: 'conflicted',
-  minimumReleaseAge: '3', // Wait 3 days after the package has been published before upgrading it
+  minimumReleaseAge: '3 days', // Wait 3 days after the package has been published before upgrading it
+  prCreation: 'not-pending',
   // packageRules order is important, they are applied from top to bottom and are merged,
   // meaning the most important ones must be at the bottom, for example grouping rules
   // If we do not want a package to be grouped with others, we need to set its groupName


### PR DESCRIPTION
I thought this was already configured, but we were missing the unit in the config and it did not seem to work correctly.

Also setting `prCreation="not-pending"` as per [the documentation](https://docs.renovatebot.com/configuration-options/#minimumreleaseage) so Renovate only opens the PR once the age check is passed