### PR TITLE
Allow message content to slightly exceed the bounds of the message

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1059,7 +1059,8 @@ body > [data-popover-placement] {
   position: relative;
   overflow-wrap: break-word;
   font-weight: 400;
-  overflow: hidden;
+  overflow: clip;
+  overflow-clip-margin: 1em;
   text-overflow: ellipsis;
   text-autospace: normal;
   font-size: 15px;


### PR DESCRIPTION
This makes it so that custom emoji on the last line of a message are not cut off when being hovered (which makes them grow), while also preventing people from stacking Unicode diacritics way beyond the bounds of their message.
From what I can tell, that's the original reason for this clipping: https://github.com/mastodon/mastodon/issues/79 Specifically, in response to this post: https://mastodon.social/@mnx/15291

Emoji cut off without this change: (found at https://mastodon.catgirl.cloud/@WolvericCatkin@tech.lgbt/114428025595864603 )
<img width="725" height="179" alt="image" src="https://github.com/user-attachments/assets/b488f255-72fa-45ab-a6b2-dd4d70e51e9f" />

The same emoji with this change applied:
<img width="714" height="172" alt="image" src="https://github.com/user-attachments/assets/cba44482-92cb-48eb-8292-805d9b7fc725" />
(Yes, the bottom of this emoji just looks like that. There is nothing missing here)


Here's a potentially problematic message without this change: (a lot of zalgo-text nonsense has been cut off at the top)
<img width="571" height="149" alt="image" src="https://github.com/user-attachments/assets/585e43cf-638f-4b52-ab03-af9ab5e9e9ad" />

And here's the same message with this change applied:
<img width="571" height="149" alt="image" src="https://github.com/user-attachments/assets/b3116414-36c2-44dc-ae39-f78b39c21bfd" />
The text intrudes on the profile picture a little, but it's not like a malicious user can harmfully cover areas that they shouldn't be able to. If somebody is doing whatever this is, they can now have a little fun but nothing more.

Some notes:
My devtools tell me that `overflow-clip-margin` isn't yet supported in Safari. This doesn't cause any problems, it'll just mean that Safari users will have to wait a bit longer for this fix to actually work. There isn't any other CSS to cleanly achieve this effect, but I think the issue here is benign enough to where this isn't a problem.

Also, `overflow-clip-margin` should work with `overflow: hidden` but browser support is even more spotty for that and `overflow: clip` tends to be better anyways. (overall they're basically the same though)