### PR TITLE
Composer redesign: Replies

### DIFF
--- a/app/javascript/mastodon/components/status/content.tsx
+++ b/app/javascript/mastodon/components/status/content.tsx
@@ -17,7 +17,7 @@ import { EmojiHTML } from '../emoji/html';
 import { Icon } from '../icon';
 import { Poll } from '../poll';
 
-import { useElementHandledLink } from './handled_link';
+import { useHandlersForStatus } from './hooks';
 
 const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
 
@@ -72,20 +72,7 @@ export const StatusContent: React.FC<{
     [onClick],
   );
 
-  const hrefToMention = useCallback(
-    (href: string) => status?.mentions.find((item) => item.url === href),
-    [status?.mentions],
-  );
-  const hrefToCollectionId = useCallback(
-    (href: string) =>
-      status?.tagged_collections.find((item) => item.url === href)?.id,
-    [status?.tagged_collections],
-  );
-  const htmlHandlers = useElementHandledLink({
-    hashtagAccountId: status?.account,
-    hrefToCollectionId,
-    hrefToMention,
-  });
+  const htmlHandlers = useHandlersForStatus(status);
 
   if (!status) {
     return null;

--- a/app/javascript/mastodon/components/status/hooks.ts
+++ b/app/javascript/mastodon/components/status/hooks.ts
@@ -11,12 +11,16 @@ import { openModal } from '@/mastodon/actions/modal';
 import { toggleStatusSpoilers } from '@/mastodon/actions/statuses';
 import { useExpandedStatus } from '@/mastodon/hooks/useStatus';
 import { useToggle } from '@/mastodon/hooks/useToggle';
-import type { ExpandedStatusShape } from '@/mastodon/models/status';
+import type {
+  ExpandedStatusShape,
+  StatusShape,
+} from '@/mastodon/models/status';
 import { selectStatusFilters } from '@/mastodon/selectors/filters';
 import { useAppSelector, useAppDispatch } from '@/mastodon/store';
 
 import { FOCUS_TARGET } from '../navigation_focus_target';
 
+import { useElementHandledLink } from './handled_link';
 import type { StatusContextType } from './types';
 
 const messages = defineMessages({
@@ -259,4 +263,29 @@ export function useTextForScreenReader({
 
     return values.join(', ');
   }, [intl, isQuote, reblogAcct, status]);
+}
+
+export function useHandlersForStatus(
+  status?: Pick<
+    StatusShape | ExpandedStatusShape,
+    'account' | 'mentions' | 'tagged_collections'
+  > | null,
+) {
+  const hrefToMention = useCallback(
+    (href: string) => status?.mentions.find((item) => item.url === href),
+    [status?.mentions],
+  );
+  const hrefToCollectionId = useCallback(
+    (href: string) =>
+      status?.tagged_collections.find((item) => item.url === href)?.id,
+    [status?.tagged_collections],
+  );
+  return useElementHandledLink({
+    hashtagAccountId:
+      typeof status?.account === 'string'
+        ? status.account
+        : status?.account.acct,
+    hrefToCollectionId,
+    hrefToMention,
+  });
 }

--- a/app/javascript/mastodon/features/compose/redesign/index.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/index.tsx
@@ -31,6 +31,7 @@ import type { OnEmojiPick } from './emoji';
 import { ComposeFooter } from './footer';
 import { ComposeFormHeader } from './header';
 import { LanguageButton } from './language';
+import { ComposeReply } from './reply';
 import {
   selectComposeCanSubmit,
   selectComposeSensitive,
@@ -86,6 +87,8 @@ export const RedesignComposeForm: React.FC<RedesignComposeFormProps> = ({
       className={classNames(className, classes.root)}
     >
       <ComposeFormHeader id={titleId} noMinimize={noMinimize} />
+
+      <ComposeReply />
 
       <div className={classes.toolbar}>
         <div className={classes.flexGrowWrap}>

--- a/app/javascript/mastodon/features/compose/redesign/reply.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/reply.tsx
@@ -1,5 +1,7 @@
+import { Link } from 'react-router-dom';
+
 import { Avatar } from '@/mastodon/components/avatar';
-import { DisplayNameSimple } from '@/mastodon/components/display_name/simple';
+import { LinkedDisplayName } from '@/mastodon/components/display_name';
 import { EmojiHTML } from '@/mastodon/components/emoji/html';
 import { RelativeTimestamp } from '@/mastodon/components/relative_timestamp';
 import { useHandlersForStatus } from '@/mastodon/components/status/hooks';
@@ -23,11 +25,19 @@ export const ComposeReply: React.FC = () => {
   return (
     <blockquote cite={status.uri} className={classes.reply}>
       <cite className={classes.replyAccount}>
-        <Avatar account={status.account} className={classes.replyAvatar} />
-        <DisplayNameSimple account={status.account} />
+        <Avatar
+          account={status.account}
+          className={classes.replyAvatar}
+          withLink
+        />
+        <LinkedDisplayName
+          displayProps={{ account: status.account, variant: 'simple' }}
+        />
         <span className={classes.replyTime}>
           &middot;&nbsp;
-          <RelativeTimestamp timestamp={status.created_at} />
+          <Link to={`/@${status.account.acct}/${status.id}`}>
+            <RelativeTimestamp timestamp={status.created_at} />
+          </Link>
         </span>
       </cite>
 

--- a/app/javascript/mastodon/features/compose/redesign/reply.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/reply.tsx
@@ -1,0 +1,43 @@
+import { Avatar } from '@/mastodon/components/avatar';
+import { DisplayNameSimple } from '@/mastodon/components/display_name/simple';
+import { EmojiHTML } from '@/mastodon/components/emoji/html';
+import { RelativeTimestamp } from '@/mastodon/components/relative_timestamp';
+import { useHandlersForStatus } from '@/mastodon/components/status/hooks';
+import { selectAccountStatus } from '@/mastodon/selectors/statuses';
+import { useAppSelector } from '@/mastodon/store';
+
+import classes from './styles.module.scss';
+
+export const ComposeReply: React.FC = () => {
+  const replyId = useAppSelector(
+    (state) => state.compose.get('in_reply_to') as null | string,
+  );
+  const status = useAppSelector((state) => selectAccountStatus(state, replyId));
+
+  const htmlHandlers = useHandlersForStatus(status);
+
+  if (!status) {
+    return;
+  }
+
+  return (
+    <blockquote cite={status.uri} className={classes.reply}>
+      <cite className={classes.replyAccount}>
+        <Avatar account={status.account} className={classes.replyAvatar} />
+        <DisplayNameSimple account={status.account} />
+        <span className={classes.replyTime}>
+          &middot;&nbsp;
+          <RelativeTimestamp timestamp={status.created_at} />
+        </span>
+      </cite>
+
+      <EmojiHTML
+        htmlString={status.translation?.contentHtml ?? status.contentHtml}
+        extraEmojis={status.emojis}
+        className={classes.replyText}
+        lang={status.translation?.language ?? status.language}
+        {...htmlHandlers}
+      />
+    </blockquote>
+  );
+};

--- a/app/javascript/mastodon/features/compose/redesign/reply.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/reply.tsx
@@ -23,8 +23,8 @@ export const ComposeReply: React.FC = () => {
   }
 
   return (
-    <blockquote cite={status.uri} className={classes.reply}>
-      <cite className={classes.replyAccount}>
+    <figure className={classes.reply}>
+      <figcaption className={classes.replyAccount}>
         <Avatar
           account={status.account}
           className={classes.replyAvatar}
@@ -39,15 +39,17 @@ export const ComposeReply: React.FC = () => {
             <RelativeTimestamp timestamp={status.created_at} />
           </Link>
         </span>
-      </cite>
+      </figcaption>
 
       <EmojiHTML
+        as='blockquote'
+        cite={status.uri}
         htmlString={status.translation?.contentHtml ?? status.contentHtml}
         extraEmojis={status.emojis}
         className={classes.replyText}
         lang={status.translation?.language ?? status.language}
         {...htmlHandlers}
       />
-    </blockquote>
+    </figure>
   );
 };

--- a/app/javascript/mastodon/features/compose/redesign/styles.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/styles.module.scss
@@ -199,10 +199,17 @@
 .replyAccount {
   display: flex;
   margin-bottom: var(--space-2xs);
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 }
 
 .replyAvatar {
   margin-right: var(--space-xs);
+  border-radius: var(--radius-round);
+  overflow: hidden;
 }
 
 .replyTime {
@@ -212,13 +219,17 @@
 .replyText {
   @include mixins.line-clamp(2);
 
-  max-height: round(
-    calc(2 * calc(var(--fs-sm) * var(--lh-tight))),
-    5px
-  ); // 40px at default REM size
+  // 40px at default REM size
+  max-height: round(calc(2 * calc(var(--fs-sm) * var(--lh-tight))), 5px);
 
   a {
     color: var(--color-text-brand);
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
   }
 }
 

--- a/app/javascript/mastodon/features/compose/redesign/styles.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/styles.module.scss
@@ -192,7 +192,7 @@
 .reply {
   @include mixins.type-body-compact;
 
-  border-left: 0.5px solid var(--color-border-primary);
+  border-inline-start: 0.5px solid var(--color-border-primary);
   padding: 0 var(--space-md);
 }
 

--- a/app/javascript/mastodon/features/compose/redesign/styles.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/styles.module.scss
@@ -190,6 +190,8 @@
 // Reply
 
 .reply {
+  @include mixins.type-body-compact;
+
   border-left: 0.5px solid var(--color-border-primary);
   padding: 0 var(--space-md);
 }
@@ -209,6 +211,11 @@
 
 .replyText {
   @include mixins.line-clamp(2);
+
+  max-height: round(
+    calc(2 * calc(var(--fs-sm) * var(--lh-tight))),
+    5px
+  ); // 40px at default REM size
 
   a {
     color: var(--color-text-brand);

--- a/app/javascript/mastodon/features/compose/redesign/styles.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/styles.module.scss
@@ -187,6 +187,34 @@
   }
 }
 
+// Reply
+
+.reply {
+  border-left: 0.5px solid var(--color-border-primary);
+  padding: 0 var(--space-md);
+}
+
+.replyAccount {
+  display: flex;
+  margin-bottom: var(--space-2xs);
+}
+
+.replyAvatar {
+  margin-right: var(--space-xs);
+}
+
+.replyTime {
+  color: var(--color-text-tertiary);
+}
+
+.replyText {
+  @include mixins.line-clamp(2);
+
+  a {
+    color: var(--color-text-brand);
+  }
+}
+
 // Attachments
 
 .mediaSingle {

--- a/app/javascript/mastodon/features/compose/redesign/styles.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/styles.module.scss
@@ -207,7 +207,7 @@
 }
 
 .replyAvatar {
-  margin-right: var(--space-xs);
+  margin-inline-end: var(--space-xs);
   border-radius: var(--radius-round);
   overflow: hidden;
 }

--- a/app/javascript/mastodon/features/compose/redesign/styles.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/styles.module.scss
@@ -190,8 +190,6 @@
 // Reply
 
 .reply {
-  @include mixins.type-body-compact;
-
   border-inline-start: 0.5px solid var(--color-border-primary);
   padding: 0 var(--space-md);
 }
@@ -218,9 +216,10 @@
 
 .replyText {
   @include mixins.line-clamp(2);
+  @include mixins.type-body-compact;
 
-  // 40px at default REM size
-  max-height: round(calc(2 * calc(var(--fs-sm) * var(--lh-tight))), 5px);
+  // Round two lines to the nearest 5px.
+  max-height: round(2lh, 5px);
 
   a {
     color: var(--color-text-brand);

--- a/app/javascript/styles/mastodon/_mixins.scss
+++ b/app/javascript/styles/mastodon/_mixins.scss
@@ -156,3 +156,15 @@
     color: var(--color-text-primary);
   }
 }
+
+/**
+ * Utilities
+ */
+
+@mixin line-clamp($lines) {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: $lines;
+  line-clamp: $lines;
+}


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. A future blog post will provide more information.

Fixes WEB-1197.

This renders replies in the new composer, clamping the text to two lines via a new utility.