### PR TITLE
Redesign: Clarify message meaning

### DIFF
--- a/app/javascript/mastodon/features/compose/redesign/header.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/header.tsx
@@ -39,10 +39,14 @@ const messages = defineMessages({
   messageNew: {
     id: 'compose_form.message.title.new',
     defaultMessage: 'New message',
+    description:
+      'Message refers to a direct message. For languages where this is confusing, "chat" or "direct message" can be used.',
   },
   messageEdit: {
     id: 'compose_form.message.title.edit',
     defaultMessage: 'Edit message',
+    description:
+      'Message refers to a direct message. For languages where this is confusing, "chat" or "direct message" can be used.',
   },
 });
 

--- a/app/javascript/mastodon/features/compose/redesign/index.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/index.tsx
@@ -100,6 +100,7 @@ export const RedesignComposeForm: React.FC<RedesignComposeFormProps> = ({
               <FormattedMessage
                 id='compose.message.notice'
                 defaultMessage='Messages are not end-to-end encrypted'
+                description='Message refers to a direct message. For languages where this is confusing, "chat" or "direct message" can be used.'
               />
             </p>
           )}

--- a/app/javascript/mastodon/features/compose/redesign/textarea.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/textarea.tsx
@@ -33,6 +33,8 @@ const messages = defineMessages({
   messagePlaceholder: {
     id: 'compose.message.placeholder',
     defaultMessage: 'Add your recipients and your message.',
+    description:
+      'Message refers to a direct message. For languages where this is confusing, "chat" or "direct message" can be used.',
   },
 });
 

--- a/app/javascript/mastodon/features/compose/redesign/trigger.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/trigger.tsx
@@ -108,7 +108,11 @@ export const ComposeRedesignButton: React.FC = () => {
           onClick={handleComposerOpen}
           leadingIcon={ChatCircleIcon}
         >
-          <FormattedMessage id='compose.new.message' defaultMessage='Message' />
+          <FormattedMessage
+            id='compose.new.message'
+            defaultMessage='Message'
+            description='Message refers to a direct message. For languages where this is confusing, "chat" or "direct message" can be used.'
+          />
         </DropdownItemButton>
       </DropdownPopover>
     </>

--- a/app/javascript/mastodon/features/compose/redesign/visibility.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/visibility.tsx
@@ -257,6 +257,7 @@ const ComposeVisibilityMenu: React.FC<Record<string, unknown>> = (
         <FormattedMessage
           id='compose.post.to_message'
           defaultMessage='Compose a message instead'
+          description='Message refers to a direct message. For languages where this is confusing, "chat" or "direct message" can be used.'
         />
       </DropdownItemButton>
     </Dropdown>

--- a/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
@@ -91,6 +91,7 @@ export const RedesignNavigationPanel: React.FC<{ siteName?: string }> = ({
               <FormattedMessage
                 id='tabs_bar.messages'
                 defaultMessage='Messages'
+                description='Message refers to a direct message. For languages where this is confusing, "chat" or "direct message" can be used.'
               />
             </NavigationLink>
             <NavigationLink to='/bookmarks' iconComponent={BookmarkSimpleIcon}>


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. A future blog post will provide more information.

Fixes #40139, adding description for translators.