### PR TITLE
Fix: Pass existing meta object to returned data in simulateModifiedApiResponse 

### DIFF
--- a/app/javascript/mastodon/actions/compose_typed.ts
+++ b/app/javascript/mastodon/actions/compose_typed.ts
@@ -57,12 +57,14 @@ const simulateModifiedApiResponse = (
   media: MediaAttachment,
   params: { description?: string; focus?: string },
 ): SimulatedMediaAttachmentJSON => {
+  const mediaJS = media.toJS();
   const [x, y] = (params.focus ?? '').split(',');
 
   const data = {
-    ...media.toJS(),
+    ...mediaJS,
     ...params,
     meta: {
+      ...mediaJS.meta,
       focus: {
         x: parseFloat(x ?? '0'),
         y: parseFloat(y ?? '0'),

--- a/app/javascript/mastodon/actions/compose_typed.ts
+++ b/app/javascript/mastodon/actions/compose_typed.ts
@@ -64,7 +64,7 @@ const simulateModifiedApiResponse = (
     ...mediaJS,
     ...params,
     meta: {
-      ...mediaJS.meta,
+      ...(mediaJS.meta ?? {}),
       focus: {
         x: parseFloat(x ?? '0'),
         y: parseFloat(y ?? '0'),


### PR DESCRIPTION
Caught by linter. I believe this is correct.