### PR TITLE
Add StoplightRegistry to try to reduce Stoplight build overhead in ActivityPub::DeliveryWorker

### DIFF
--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -79,7 +79,7 @@ class ActivityPub::DeliveryWorker
   end
 
   def stoplight_wrapper
-    Stoplight(
+    StoplightRegistry.fetch(
       @inbox_url,
       cool_off_time: STOPLIGHT_COOL_OFF_TIME,
       threshold: STOPLIGHT_FAILURE_THRESHOLD

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,7 @@ require_relative '../lib/active_record/database_tasks_extensions'
 require_relative '../lib/active_record/batches'
 require_relative '../lib/simple_navigation/item_extensions'
 require_relative '../lib/json-canonicalization/floats_fix'
+require_relative '../lib/stoplight_registry'
 
 Bundler.require(:pam_authentication) if ENV['PAM_ENABLED'] == 'true'
 

--- a/lib/stoplight_registry.rb
+++ b/lib/stoplight_registry.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'concurrent/map'
+
+# Keep track of created lights to avoid recreating them
+# NOTE: In theory, Stoplight v6 will have a registry built
+class StoplightRegistry
+  attr_reader :registry
+
+  def self.current
+    @current ||= new
+  end
+
+  def self.fetch(light, **)
+    current.fetch(light, **)
+  end
+
+  def initialize
+    @registry = Concurrent::Map.new
+  end
+
+  def fetch(light, **)
+    MastodonOTELTracer.in_span('StoplightRegistry#fetch', attributes: { 'stoplight.name' => light }) do
+      registry.compute_if_absent(light) { Stoplight.light(light, **) }
+    end
+  end
+end

--- a/spec/lib/stoplight_registry_spec.rb
+++ b/spec/lib/stoplight_registry_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StoplightRegistry do
+  subject { described_class }
+
+  describe '.fetch' do
+    it 'creates a new light' do
+      name =  "test-#{rand}"
+      light = subject.fetch(name)
+
+      expect(light.name).to eq(name)
+    end
+
+    it 'reuses an existing light' do
+      name =  "test-#{rand}"
+      first = subject.fetch(name)
+      second = subject.fetch(name)
+
+      expect(first).to be(second)
+    end
+  end
+end


### PR DESCRIPTION
Same as https://github.com/mastodon/mastodon/pull/40208 but with `stable-4.7` as base