### PR TITLE
Fix autosuggestions overstaying their welcome in languages that don't use spaces

### DIFF
--- a/app/javascript/mastodon/components/autosuggest/utils.test.ts
+++ b/app/javascript/mastodon/components/autosuggest/utils.test.ts
@@ -7,6 +7,14 @@ describe('textAtCursorMatchesToken', () => {
       [1, '#hashtag'],
     ],
     [
+      ['@alice', 6, ['@']],
+      [1, '@alice'],
+    ],
+    [
+      ['＠alice', 6, ['＠']],
+      [1, '＠alice'],
+    ],
+    [
       ['#hash tag', 8, ['#']],
       [1, '#hash tag'],
     ],
@@ -24,7 +32,35 @@ describe('textAtCursorMatchesToken', () => {
     ],
     [
       ['#ハッシュ タグ', 7, ['#']],
-      [1, '#ハッシュ タグ'],
+      [null, null],
+    ],
+    [
+      ['@alice reply', 12, ['@']],
+      [1, '@alice reply'],
+    ],
+    [
+      ['@alice 这是我输入的回复内容', 17, ['@']],
+      [null, null],
+    ],
+    [
+      ['@alice これは本文', 12, ['@']],
+      [null, null],
+    ],
+    [
+      ['@alice 이것은답변입니다', 15, ['@']],
+      [null, null],
+    ],
+    [
+      ['@alice　これは本文', 12, ['@']],
+      [null, null],
+    ],
+    [
+      ['@алиса', 6, ['@']],
+      [1, '@алиса'],
+    ],
+    [
+      ['@алиса пример', 13, ['@']],
+      [1, '@алиса пример'],
     ],
   ] as const)(
     'textAtCursorMatchesToken(%s) is %o',

--- a/app/javascript/mastodon/components/autosuggest/utils.ts
+++ b/app/javascript/mastodon/components/autosuggest/utils.ts
@@ -8,7 +8,7 @@ export const textAtCursorMatchesToken = (
   let word: string;
 
   const regex = new RegExp(
-    `[${searchTokens.join('')}${WORD}+-]+(\\s[${WORD}]+)?$`,
+    `[${searchTokens.join('')}${WORD}+-]+(\\s[\\p{Script=Latin}\\p{Script=Cyrillic}\\p{M}]+)?$`,
     'iu',
   );
   const left = str.slice(0, caretPosition).search(regex);

--- a/app/javascript/mastodon/utils/hashtags.ts
+++ b/app/javascript/mastodon/utils/hashtags.ts
@@ -1,5 +1,5 @@
 const HASHTAG_SEPARATORS = '_\\u00b7\\u200c';
-const ALPHA = '\\p{L}\\p{M}';
+export const ALPHA = '\\p{L}\\p{M}';
 export const WORD = '\\p{L}\\p{M}\\p{N}\\p{Pc}';
 
 const buildHashtagPatternRegex = () => {


### PR DESCRIPTION
#39622 made it so you could type up to two words after a `@` symbol to bring up autosuggestions for users based on their first and last name. However, this is a problem for scripts that don't typically use a space: The autosuggestions would persist while the user continues with their sentence, and if Enter is pressed instead of Escape, the autosuggestion replacement would swallow a big chunk of text. This fixes that behaviour by only continuing to show autosuggestions if the second word is written in a script that separates words with spaces, specifically, Latin and Cyrillic (more scripts may fit this criteria, but in this case it's better to err on the side of caution). Credit to #40057 for suggesting some of the new test cases.

____

Fixes #39995, fixes WEB-1227