### PR TITLE
Redesign: Always show search field on Explore page

### DIFF
--- a/app/javascript/mastodon/features/explore/index.tsx
+++ b/app/javascript/mastodon/features/explore/index.tsx
@@ -1,11 +1,13 @@
 import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
 
+import classNames from 'classnames';
 import { NavLink, Switch, Route } from 'react-router-dom';
 
 import { Helmet } from '@unhead/react/helmet';
 
 import { Column } from '@/mastodon/components/column';
 import { ColumnHeader } from '@/mastodon/components/column/header';
+import { isRedesignEnabled } from '@/mastodon/utils/environment';
 import TrendingUpIcon from '@/material-icons/400-24px/trending_up.svg?react';
 import { SymbolLogo } from 'mastodon/components/logo';
 import { Search } from 'mastodon/features/compose/components/search';
@@ -13,6 +15,7 @@ import { useBreakpoint } from 'mastodon/features/ui/hooks/useBreakpoint';
 import { useIdentity } from 'mastodon/identity_context';
 
 import Links from './links';
+import redesignClasses from './redesign.module.scss';
 import Statuses from './statuses';
 import Suggestions from './suggestions';
 import Tags from './tags';
@@ -39,7 +42,12 @@ const Explore: React.FC<{ multiColumn: boolean }> = ({ multiColumn }) => {
         scrollTopOnClick
       />
 
-      <div className='explore__search-header'>
+      <div
+        className={classNames(
+          'explore__search-header',
+          isRedesignEnabled() && redesignClasses.searchHeader,
+        )}
+      >
         <Search singleColumn />
       </div>
 

--- a/app/javascript/mastodon/features/explore/redesign.module.scss
+++ b/app/javascript/mastodon/features/explore/redesign.module.scss
@@ -1,0 +1,3 @@
+.searchHeader {
+  display: flex !important;
+}


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

### Changes proposed in this PR:
- Ensures that a search field is accessible on the Explore page while the main navigation redesign is underway

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="892" height="278" alt="image" src="https://github.com/user-attachments/assets/1177ebac-2dfd-40f5-bc52-959b84a089a8" /> | <img width="900" height="275" alt="image" src="https://github.com/user-attachments/assets/33a4549c-0d06-4b9a-80d8-8dc8ce97ae6a" /> |