### PR TITLE
Add counters for which features result in users following each other

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def follow
-    follow  = FollowService.new.call(current_user.account, @account, reblogs: params.key?(:reblogs) ? truthy_param?(:reblogs) : nil, notify: params.key?(:notify) ? truthy_param?(:notify) : nil, languages: params.key?(:languages) ? params[:languages] : nil, with_rate_limit: true)
+    follow  = FollowService.new.call(current_user.account, @account, reblogs: params.key?(:reblogs) ? truthy_param?(:reblogs) : nil, notify: params.key?(:notify) ? truthy_param?(:notify) : nil, languages: params.key?(:languages) ? params[:languages] : nil, with_rate_limit: true, ref: params[:ref])
     options = @account.locked? || current_user.account.silenced? ? {} : { following_map: { @account.id => { reblogs: follow.show_reblogs?, notify: follow.notify?, languages: follow.languages } }, requested_map: { @account.id => false } }
 
     render json: @account, serializer: REST::RelationshipSerializer, relationships: relationships(**options)

--- a/app/javascript/mastodon/actions/accounts.js
+++ b/app/javascript/mastodon/actions/accounts.js
@@ -149,6 +149,7 @@ export function fetchAccountFail(id, error) {
  * @param {Object} options
  * @param {boolean} [options.reblogs]
  * @param {boolean} [options.notify]
+ * @param {string} [options.ref]
  * @returns {function(): void}
  */
 export function followAccount(id, options = { reblogs: true }) {

--- a/app/javascript/mastodon/api/accounts.ts
+++ b/app/javascript/mastodon/api/accounts.ts
@@ -32,7 +32,8 @@ export const apiSubmitAccountNote = (id: string, value: string) =>
 export const apiFollowAccount = (
   id: string,
   params?: {
-    reblogs: boolean;
+    reblogs?: boolean;
+    ref?: string;
   },
 ) =>
   apiRequestPost<ApiRelationshipJSON>(`v1/accounts/${id}/follow`, {

--- a/app/javascript/mastodon/components/account/index.tsx
+++ b/app/javascript/mastodon/components/account/index.tsx
@@ -77,6 +77,7 @@ interface AccountProps {
   extraAccountInfo?: React.ReactNode;
   className?: string;
   children?: React.ReactNode;
+  reference?: string;
 }
 
 export const Account: React.FC<AccountProps> = ({
@@ -91,6 +92,7 @@ export const Account: React.FC<AccountProps> = ({
   extraAccountInfo,
   className,
   children,
+  reference,
 }) => {
   const intl = useIntl();
   const { signedIn } = useIdentity();
@@ -169,7 +171,7 @@ export const Account: React.FC<AccountProps> = ({
                 modalProps: {
                   accountId: id,
                   onConfirm: () => {
-                    apiFollowAccount(id)
+                    apiFollowAccount(id, { ref: reference })
                       .then((relationship) => {
                         dispatch(
                           followAccountSuccess({
@@ -225,6 +227,7 @@ export const Account: React.FC<AccountProps> = ({
     defaultAction,
     isRemote,
     signedIn,
+    reference,
   ]);
 
   if (hidden) {
@@ -269,7 +272,7 @@ export const Account: React.FC<AccountProps> = ({
       />
     );
   } else {
-    button = <FollowButton accountId={id} />;
+    button = <FollowButton accountId={id} reference={reference} />;
   }
 
   let muteTimeRemaining: React.ReactNode;

--- a/app/javascript/mastodon/components/account_header/buttons.tsx
+++ b/app/javascript/mastodon/components/account_header/buttons.tsx
@@ -96,6 +96,7 @@ const AccountButtonsOther: FC<
           accountId={accountId}
           className={classes.followButton}
           labelLength='long'
+          reference='profile'
         />
       )}
       {isFollowing && (

--- a/app/javascript/mastodon/components/account_list_item/index.tsx
+++ b/app/javascript/mastodon/components/account_list_item/index.tsx
@@ -199,6 +199,12 @@ const defaultRenderButton = ({ accountId }: RenderButtonOptions) => (
 
 export const AccountListItemFollowButton: React.FC<{
   accountId: string | undefined;
-}> = ({ accountId }) => (
-  <FollowButton compact labelLength='short' accountId={accountId} />
+  reference?: string;
+}> = ({ accountId, reference }) => (
+  <FollowButton
+    compact
+    labelLength='short'
+    accountId={accountId}
+    reference={reference}
+  />
 );

--- a/app/javascript/mastodon/components/follow_button.tsx
+++ b/app/javascript/mastodon/components/follow_button.tsx
@@ -61,12 +61,14 @@ export const FollowButton: React.FC<{
   labelLength?: 'auto' | 'short' | 'long';
   className?: string;
   withUnmute?: boolean;
+  reference?: string;
 }> = ({
   accountId,
   compact,
   labelLength = 'auto',
   className,
   withUnmute = true,
+  reference,
 }) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
@@ -125,9 +127,17 @@ export const FollowButton: React.FC<{
       );
     } else {
       // @ts-expect-error this action is not typed yet
-      dispatch(followAccount(accountId));
+      dispatch(followAccount(accountId, { ref: reference }));
     }
-  }, [signedIn, relationship, accountId, withUnmute, account, dispatch]);
+  }, [
+    signedIn,
+    relationship,
+    accountId,
+    withUnmute,
+    account,
+    dispatch,
+    reference,
+  ]);
 
   const isNarrow = useBreakpoint('narrow');
   const useShortLabel =

--- a/app/javascript/mastodon/features/collections/detail/accounts_list.tsx
+++ b/app/javascript/mastodon/features/collections/detail/accounts_list.tsx
@@ -143,7 +143,12 @@ export const CollectionAccountsList: React.FC<{
     ({ relationship, accountId }: RenderButtonOptions) => {
       if (!me || !relationship) {
         // Show follow button when logged out (it will trigger the remote interaction modal)
-        return <AccountListItemFollowButton accountId={accountId} />;
+        return (
+          <AccountListItemFollowButton
+            accountId={accountId}
+            reference='collection'
+          />
+        );
       }
 
       // When viewing your own collection, only show the Follow button
@@ -165,7 +170,12 @@ export const CollectionAccountsList: React.FC<{
         );
       }
 
-      return <AccountListItemFollowButton accountId={accountId} />;
+      return (
+        <AccountListItemFollowButton
+          accountId={accountId}
+          reference='collection'
+        />
+      );
     },
     [collectionOwnerId, confirmRevoke],
   );

--- a/app/javascript/mastodon/features/onboarding/follows.tsx
+++ b/app/javascript/mastodon/features/onboarding/follows.tsx
@@ -169,7 +169,13 @@ export const Follows: React.FC<{
         }
       >
         {displayedAccountIds.map((accountId) => (
-          <Account id={accountId} key={accountId} withBio withMenu={false} />
+          <Account
+            id={accountId}
+            key={accountId}
+            withBio
+            withMenu={false}
+            reference='onboarding'
+          />
         ))}
       </ScrollableList>
 

--- a/app/lib/feature_usage_tracker.rb
+++ b/app/lib/feature_usage_tracker.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class FeatureUsageTracker
+  include Redisable
+
+  FEATURES = %i(
+    follow
+  ).freeze
+
+  REF_VALUES = %w(
+    collection
+    onboarding
+    profile
+  ).freeze
+
+  EXPIRE_AFTER = 6.months.seconds
+
+  def self.for(feature)
+    raise ArgumentError unless FEATURES.include?(feature)
+
+    new(feature)
+  end
+
+  def initialize(feature)
+    @feature = feature
+  end
+
+  def increment(ref)
+    ref = nil unless REF_VALUES.include?(ref)
+    key = key_at(Time.now.utc)
+
+    with_redis do |redis|
+      redis.hincrby(key, ref || 'unknown', 1)
+      redis.expire(key, EXPIRE_AFTER)
+    end
+  end
+
+  private
+
+  def key_at(at_time)
+    "activity:feature_usage:#{@feature}:#{at_time.beginning_of_day.to_i}"
+  end
+end

--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -15,6 +15,7 @@ class FollowService < BaseService
   # @option [Boolean] :bypass_locked
   # @option [Boolean] :bypass_limit Allow following past the total follow number
   # @option [Boolean] :with_rate_limit
+  # @option [String] :ref Client-side feature reference
   def call(source_account, target_account, options = {})
     @source_account = source_account
     @target_account = target_account
@@ -30,6 +31,7 @@ class FollowService < BaseService
     end
 
     ActivityTracker.increment('activity:interactions')
+    FeatureUsageTracker.for(:follow).increment(@options[:ref])
 
     # When an account follows someone for the first time, avoid showing
     # an empty home feed while the follow request is being processed


### PR DESCRIPTION
We already increment an anonymous counter when users interact with each other by following, replying, voting in a poll, etc; this adds another anonymous counter that increments each time a feature is used to follow another user, features being things like `onboarding`, `profile`, or `collection`. Currently it's very difficult to see the impact of new features and design changes on activity on the platform, this should help that.

___

Fixes WEB-1230, fixes WEB-1229