### PR TITLE
Explicitly stop supporting pre-4.7 zero-downtime migrations

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -66,9 +66,9 @@ namespace :db do
     abort 'This version of Mastodon requires PostgreSQL 14.0 or newer. Please update PostgreSQL before updating Mastodon.' if pg_version < 140_000
 
     schema_version = ActiveRecord::Migrator.current_version
-    abort <<~MESSAGE if ENV['SKIP_POST_DEPLOYMENT_MIGRATIONS'] && schema_version < 2024_10_07_071624
-      Zero-downtime migrations from Mastodon versions earlier than 4.3.0 are not supported.
-      Please update to Mastodon 4.3.x first or upgrade by stopping all services and running migrations without `SKIP_POST_DEPLOYMENT_MIGRATIONS`.
+    abort <<~MESSAGE if ENV['SKIP_POST_DEPLOYMENT_MIGRATIONS'] && schema_version < 2026_08_12_154114
+      Zero-downtime migrations from Mastodon versions earlier than 4.7.0 are not supported.
+      Please update to Mastodon 4.7.x first or upgrade by stopping all services and running migrations without `SKIP_POST_DEPLOYMENT_MIGRATIONS`.
     MESSAGE
   end
 


### PR DESCRIPTION
Opened as a draft because we don't have a reason to enforce this *yet*.

But opening the PR anyway as we will very likely have migrations that cannot be properly applied before existing post-deployment migrations.