### PR TITLE
Remove `Account#private_key`

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -64,7 +64,7 @@
 #
 
 class Account < ApplicationRecord
-  self.ignored_columns += %w(devices_url)
+  self.ignored_columns += %w(devices_url private_key)
 
   BACKGROUND_REFRESH_INTERVAL = 1.week.freeze
   REFRESH_DEADLINE = 6.hours
@@ -537,7 +537,7 @@ class Account < ApplicationRecord
   before_destroy :clean_feed_manager
 
   def ensure_keys!
-    return unless local? && private_key.blank? && public_key.blank? && keypairs.empty?
+    return unless local? && public_key.blank? && keypairs.empty?
 
     generate_keys
     save!
@@ -557,7 +557,7 @@ class Account < ApplicationRecord
   end
 
   def generate_keys
-    return unless local? && private_key.blank? && public_key.blank? && keypairs.empty?
+    return unless local? && public_key.blank? && keypairs.empty?
 
     keypair = OpenSSL::PKey::RSA.new(2048)
     keypairs << keypairs.build(local_fragment: "#rsa-#{SecureRandom.hex(8)}", type: :rsa, public_key: keypair.public_key.to_pem, private_key: keypair.to_pem)

--- a/app/models/keypair.rb
+++ b/app/models/keypair.rb
@@ -108,7 +108,7 @@ class Keypair < ApplicationRecord
       account:,
       uri: uri.presence || ActivityPub::TagManager.instance.key_uri_for(account),
       public_key: account.public_key,
-      private_key: account.private_key,
+      private_key: nil,
       type: :rsa
     )
   end

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -191,7 +191,6 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.protocol          = :activitypub
     @account.username          = @username
     @account.domain            = @domain
-    @account.private_key       = nil
     @account.suspended_at      = domain_block.created_at if auto_suspend?
     @account.suspension_origin = :local if auto_suspend?
     @account.silenced_at       = domain_block.created_at if auto_silence?

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -606,7 +606,7 @@ module Mastodon::CLI
       old_key = account.keypair
       new_key = OpenSSL::PKey::RSA.new(2048)
 
-      account.update(private_key: nil, public_key: '', keypairs: [account.keypairs.build(local_fragment: '#main-key', type: :rsa, public_key: new_key.public_key.to_pem, private_key: new_key.to_pem)])
+      account.update(public_key: '', keypairs: [account.keypairs.build(local_fragment: '#main-key', type: :rsa, public_key: new_key.public_key.to_pem, private_key: new_key.to_pem)])
 
       ActivityPub::UpdateDistributionWorker.perform_in(
         delay,

--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -7,7 +7,6 @@ Fabricator(:account) do
   username              { sequence(:username) { |i| "#{Faker::Internet.user_name(separators: %w(_))}#{i}" } }
   last_webfingered_at   { Time.now.utc }
   public_key            { |attrs| attrs[:legacy_keypair] ? SigningKeysHelpers::PUBLIC_RSA_TEST_KEY : '' }
-  private_key           { |attrs| attrs[:legacy_keypair] && attrs[:domain].nil? ? SigningKeysHelpers::PRIVATE_RSA_TEST_KEY : nil }
   suspended_at          { |attrs| attrs[:suspended] ? Time.now.utc : nil }
   silenced_at           { |attrs| attrs[:silenced] ? Time.now.utc : nil }
   requested_deletion_at { |attrs| attrs[:requested_deletion] ? Time.now.utc : nil }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -733,7 +733,6 @@ RSpec.describe Account do
     it 'generates keys' do
       account = described_class.create!(domain: nil, username: 'user_without_keys')
 
-      expect(account.private_key).to be_nil
       expect(account.public_key).to eq ''
 
       expect(account.keypair.keypair)

--- a/spec/requests/signature_verification_spec.rb
+++ b/spec/requests/signature_verification_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'signature verification concern' do
 
   context 'with an HTTP Signature (draft version)' do
     context 'with a known account' do
-      let!(:actor) { Fabricate(:account, username: 'bob', domain: 'remote.domain', uri: 'https://remote.domain/users/bob', private_key: nil, public_key: actor_keypair.public_key.to_pem, protocol: :activitypub) }
+      let!(:actor) { Fabricate(:account, username: 'bob', domain: 'remote.domain', uri: 'https://remote.domain/users/bob', public_key: actor_keypair.public_key.to_pem, protocol: :activitypub) }
 
       let(:actor_json) do
         {
@@ -136,7 +136,7 @@ RSpec.describe 'signature verification concern' do
 
         context 'when the key material has changed' do
           # Let the user be known with the default test keys
-          let!(:actor) { Fabricate(:account, username: 'bob', domain: 'remote.domain', uri: 'https://remote.domain/users/bob', private_key: nil, protocol: :activitypub) }
+          let!(:actor) { Fabricate(:account, username: 'bob', domain: 'remote.domain', uri: 'https://remote.domain/users/bob', protocol: :activitypub) }
 
           # Needed to update the keypair
           before { stub_key_requests }
@@ -427,7 +427,7 @@ RSpec.describe 'signature verification concern' do
 
   context 'with an HTTP Message Signature (final RFC version)' do
     context 'with a known account' do
-      let!(:actor) { Fabricate(:account, domain: 'remote.domain', uri: 'https://remote.domain/users/bob', private_key: nil, public_key: actor_keypair.public_key.to_pem) }
+      let!(:actor) { Fabricate(:account, domain: 'remote.domain', uri: 'https://remote.domain/users/bob', public_key: actor_keypair.public_key.to_pem) }
 
       context 'with a valid signature on a GET request' do
         let(:signature_input) do

--- a/spec/services/activitypub/process_activity_service_spec.rb
+++ b/spec/services/activitypub/process_activity_service_spec.rb
@@ -168,7 +168,6 @@ RSpec.describe ActivityPub::ProcessActivityService do
                     username: 'bob',
                     domain: 'example.com',
                     uri: 'https://example.com/users/bob',
-                    private_key: nil,
                     public_key: <<~TEXT)
                       -----BEGIN PUBLIC KEY-----
                       MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuuYyoyfsRkYnXRotMsId


### PR DESCRIPTION
Opened as a draft because we need to add a database migration, most probably depend on #40235, and there is no urgency.

4.7.0 moved private keys to the `keypairs` table.

We can't get rid of `public_key` quite yet because we can't move remote account's public keys in there ourselves, as this requires knowing their identifier, which we did not store. We should delete that in a few versions, most likely not before a while after 4.5.0 (which did not store keys in `keypairs`) support gets dropped.