### PR TITLE
Add `has_federated` flag to accounts to keep track of accounts which have actually federated

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -32,6 +32,9 @@ class AccountsController < ApplicationController
 
       format.json do
         expires_in 3.minutes, public: !(authorized_fetch_mode? && signed_request_account.present?)
+
+        @account.update!(has_federated: true) unless @account.has_federated?
+
         render_with_cache json: @account, content_type: 'application/activity+json', serializer: ActivityPub::ActorSerializer, adapter: ActivityPub::Adapter
       end
     end

--- a/app/controllers/activitypub/base_controller.rb
+++ b/app/controllers/activitypub/base_controller.rb
@@ -7,8 +7,13 @@ class ActivityPub::BaseController < Api::BaseController
   skip_before_action :require_authenticated_user!
   skip_before_action :require_not_suspended!
   skip_around_action :set_locale
+  before_action :set_federated
 
   private
+
+  def set_federated
+    @account.update!(has_federated: true) if @account.present? && !@account.has_federated?
+  end
 
   def skip_temporary_suspension_response?
     false

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -24,6 +24,7 @@
 #  fields                        :jsonb
 #  followers_url                 :string           default(""), not null
 #  following_url                 :string           default(""), not null
+#  has_federated                 :boolean          default(TRUE), not null
 #  header_content_type           :string
 #  header_description            :string           default(""), not null
 #  header_file_name              :string
@@ -534,6 +535,7 @@ class Account < ApplicationRecord
 
   before_validation :prepare_contents, if: :local?
   before_create :generate_keys
+  before_create :set_federated, if: :local?
   before_destroy :clean_feed_manager
 
   def ensure_keys!
@@ -561,6 +563,10 @@ class Account < ApplicationRecord
 
     keypair = OpenSSL::PKey::RSA.new(2048)
     keypairs << keypairs.build(local_fragment: "#rsa-#{SecureRandom.hex(8)}", type: :rsa, public_key: keypair.public_key.to_pem, private_key: keypair.to_pem)
+  end
+
+  def set_federated
+    self.has_federated = false
   end
 
   def normalize_domain

--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -328,7 +328,7 @@ class DeleteAccountService < BaseService
   end
 
   def skip_activitypub?
-    @options[:skip_activitypub]
+    @options[:skip_activitypub] || !@account.has_federated?
   end
 
   def relationship_severance_event

--- a/app/workers/scheduler/self_destruct_scheduler.rb
+++ b/app/workers/scheduler/self_destruct_scheduler.rb
@@ -54,13 +54,15 @@ class Scheduler::SelfDestructScheduler
   end
 
   def delete_account!(account)
-    json = ActivityPub::LinkedDataSignature
-      .new(deletion_payload(account))
-      .sign!(account)
-      .to_json
+    if account.has_federated?
+      json = ActivityPub::LinkedDataSignature
+        .new(deletion_payload(account))
+        .sign!(account)
+        .to_json
 
-    ActivityPub::DeliveryWorker.push_bulk(inboxes, limit: 1_000) do |inbox_url|
-      [json, account.id, inbox_url]
+      ActivityPub::DeliveryWorker.push_bulk(inboxes, limit: 1_000) do |inbox_url|
+        [json, account.id, inbox_url]
+      end
     end
 
     # Do not call `Account#mark_deleted!` because we don't want to issue a deletion request

--- a/db/migrate/20260821130820_add_has_federated_to_accounts.rb
+++ b/db/migrate/20260821130820_add_has_federated_to_accounts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHasFederatedToAccounts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :accounts, :has_federated, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_12_154114) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_21_130820) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -178,6 +178,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_12_154114) do
     t.jsonb "fields"
     t.string "followers_url", default: "", null: false
     t.string "following_url", default: "", null: false
+    t.boolean "has_federated", default: true, null: false
     t.string "header_content_type"
     t.string "header_description", default: "", null: false
     t.string "header_file_name"


### PR DESCRIPTION
This is a simpler alternative to #22273.

It appears that a little over a fourth of mastodon.social accounts that get deleted within 2 weeks have not actually federated at all, so sending deletion notices for them is pure waste.

This PR adds a `has_federated` boolean to accounts, set to `false` on creation of local accounts, and set to `true` the first time a federation endpoint is hit.

Compared to #22273, this does not require maintaining bloom filters nor does it require any change to the federation logic. However, unlike bloom filters, it won't help at all for accounts that have had any federation at all.