### PR TITLE
Redesign: Add admin/moderation links, fix relationships link

### DIFF
--- a/app/javascript/mastodon/components/menu/items.tsx
+++ b/app/javascript/mastodon/components/menu/items.tsx
@@ -164,6 +164,13 @@ export const MenuItemLink: React.FC<MenuItemLinkProps> = ({
 
   const Wrapper = type === 'actions' ? Fragment : 'li';
   const asElement = (as ?? 'link') === 'link' ? NavLink : 'a';
+  const externalLinkProps =
+    as === 'a'
+      ? {
+          target: '_blank',
+          rel: 'noopener',
+        }
+      : undefined;
 
   return (
     <Wrapper>
@@ -171,6 +178,7 @@ export const MenuItemLink: React.FC<MenuItemLinkProps> = ({
         as={asElement}
         role={type === 'actions' ? 'menuitem' : undefined}
         onKeyDown={handleSpacebarPress}
+        {...externalLinkProps}
         {...props}
       >
         {children}

--- a/app/javascript/mastodon/features/navigation_panel/redesign/account_card_and_menu.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/account_card_and_menu.module.scss
@@ -9,6 +9,7 @@
 
   & > :global(.account) {
     flex-grow: 1;
+    overflow: hidden;
 
     --account-outer-spacing: 0;
     --avatar-border-radius: var(--radius-round);

--- a/app/javascript/mastodon/features/navigation_panel/redesign/account_card_and_menu.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/account_card_and_menu.tsx
@@ -97,10 +97,7 @@ export const NavigationAccountCardAndMenu: React.FC = () => {
 
           <MenuItemDivider />
 
-          <MenuItemLink
-            to={`${accountBasePath}/followers`}
-            icon={UsersThreeIcon}
-          >
+          <MenuItemLink as='a' href='/relationships' icon={UsersThreeIcon}>
             <FormattedMessage
               id='navigation_bar.followers_and_following'
               defaultMessage='Followers & Following'

--- a/app/javascript/mastodon/features/navigation_panel/redesign/account_card_and_menu.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/account_card_and_menu.tsx
@@ -10,6 +10,8 @@ import {
   HeartIcon,
   UsersThreeIcon,
   ProhibitIcon,
+  GavelIcon,
+  ShieldStarIcon,
   SignOutIcon,
 } from '@phosphor-icons/react';
 
@@ -26,13 +28,17 @@ import {
 } from '@/mastodon/components/menu';
 import { useAccount } from '@/mastodon/hooks/useAccount';
 import { useIdentity } from '@/mastodon/identity_context';
+import {
+  canManageReports,
+  canViewAdminDashboard,
+} from '@/mastodon/permissions';
 import { useAppDispatch } from '@/mastodon/store';
 
 import classes from './account_card_and_menu.module.scss';
 
 export const NavigationAccountCardAndMenu: React.FC = () => {
   const dispatch = useAppDispatch();
-  const { accountId } = useIdentity();
+  const { accountId, permissions } = useIdentity();
   const account = useAccount(accountId);
 
   const confirmLogout = useCallback(() => {
@@ -42,6 +48,9 @@ export const NavigationAccountCardAndMenu: React.FC = () => {
   if (!accountId) {
     return null;
   }
+
+  const isManager = canManageReports(permissions);
+  const isAdmin = canViewAdminDashboard(permissions);
 
   const accountBasePath = `/@${account?.acct}`;
 
@@ -110,6 +119,34 @@ export const NavigationAccountCardAndMenu: React.FC = () => {
               defaultMessage='Blocked accounts'
             />
           </MenuItemLink>
+
+          {(isManager || isAdmin) && (
+            <>
+              <MenuItemDivider />
+
+              {isAdmin && (
+                <MenuItemLink as='a' href='/admin/dashboard' icon={GavelIcon}>
+                  <FormattedMessage
+                    id='navigation_bar.administration'
+                    defaultMessage='Administration'
+                  />
+                </MenuItemLink>
+              )}
+
+              {isManager && (
+                <MenuItemLink
+                  as='a'
+                  href='/admin/reports'
+                  icon={ShieldStarIcon}
+                >
+                  <FormattedMessage
+                    id='navigation_bar.moderation'
+                    defaultMessage='Moderation'
+                  />
+                </MenuItemLink>
+              )}
+            </>
+          )}
 
           <MenuItemDivider />
 


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

### Changes proposed in this PR:
- Adds new "Administration" & "Moderation" links to the account menu
- Fixes "Followers & Following" link
- Fixes account card overflow for long usernames
- Adds `rel='noopener'` and `target='_blank'` to externally linking menu items

### Screenshots

<img width="336" height="449" alt="image" src="https://github.com/user-attachments/assets/d3f25746-2106-4907-a326-11043dfa877f" />
