### PR TITLE
Redesign: Add "custom feeds" and "followed hashtags" sections to main navigation

### DIFF
--- a/app/javascript/mastodon/components/button/redesign.module.scss
+++ b/app/javascript/mastodon/components/button/redesign.module.scss
@@ -43,6 +43,8 @@
 
 // Override default anchor styles
 a.base {
+  text-decoration: none;
+
   &:focus {
     border-radius: var(--radius-round);
   }

--- a/app/javascript/mastodon/components/button/redesign.tsx
+++ b/app/javascript/mastodon/components/button/redesign.tsx
@@ -3,8 +3,8 @@ import type { ReactNode } from 'react';
 import { useCallback } from 'react';
 
 import classNames from 'classnames';
-import { NavLink } from 'react-router-dom';
-import type { NavLinkProps } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import type { LinkProps } from 'react-router-dom';
 
 import { CircularProgress } from '../circular_progress';
 import type { IconProp } from '../icon';
@@ -30,7 +30,7 @@ type ButtonButtonProps = { as?: 'button' } & ButtonPropsBase<'button'> &
 type ButtonAnchorProps = { as: 'a' } & ButtonPropsBase<'a'> &
   Omit<React.ComponentPropsWithRef<'a'>, 'children'>;
 type ButtonLinkProps = { as: 'link' } & ButtonPropsBase<'a'> &
-  Omit<NavLinkProps, 'children'>;
+  Omit<LinkProps, 'children'>;
 
 type ButtonProps = ButtonButtonProps | ButtonAnchorProps | ButtonLinkProps;
 
@@ -64,7 +64,7 @@ const BaseButton: React.FC<ButtonProps> = ({
 
   let Comp: React.ElementType = asComp;
   if (asComp === 'link') {
-    Comp = NavLink;
+    Comp = Link;
   }
 
   return (

--- a/app/javascript/mastodon/components/button/redesign.tsx
+++ b/app/javascript/mastodon/components/button/redesign.tsx
@@ -3,8 +3,8 @@ import type { ReactNode } from 'react';
 import { useCallback } from 'react';
 
 import classNames from 'classnames';
-import { Link } from 'react-router-dom';
-import type { LinkProps } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
+import type { NavLinkProps } from 'react-router-dom';
 
 import { CircularProgress } from '../circular_progress';
 import type { IconProp } from '../icon';
@@ -30,7 +30,7 @@ type ButtonButtonProps = { as?: 'button' } & ButtonPropsBase<'button'> &
 type ButtonAnchorProps = { as: 'a' } & ButtonPropsBase<'a'> &
   Omit<React.ComponentPropsWithRef<'a'>, 'children'>;
 type ButtonLinkProps = { as: 'link' } & ButtonPropsBase<'a'> &
-  Omit<LinkProps, 'children'>;
+  Omit<NavLinkProps, 'children'>;
 
 type ButtonProps = ButtonButtonProps | ButtonAnchorProps | ButtonLinkProps;
 
@@ -64,7 +64,7 @@ const BaseButton: React.FC<ButtonProps> = ({
 
   let Comp: React.ElementType = asComp;
   if (asComp === 'link') {
-    Comp = Link;
+    Comp = NavLink;
   }
 
   return (

--- a/app/javascript/mastodon/features/navigation_panel/redesign/account_card_and_menu.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/account_card_and_menu.module.scss
@@ -1,5 +1,3 @@
-@use '@/styles/mastodon/mixins';
-
 .root {
   display: flex;
   align-items: center;

--- a/app/javascript/mastodon/features/navigation_panel/redesign/header.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/header.module.scss
@@ -3,6 +3,7 @@
 .root {
   position: sticky;
   top: 0;
+  z-index: 1;
   display: flex;
   align-items: center;
   padding: var(--space-xl) var(--space-lg);

--- a/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
@@ -168,7 +168,7 @@ export const RedesignNavigationPanel: React.FC<{ siteName?: string }> = ({
                   link: '/followed_tags',
                 }}
               >
-                {followedHashtags.slice(0, 5).map((tag) => (
+                {followedHashtags.slice(0, 4).map((tag) => (
                   <NavigationLink key={tag.name} to={`/tags/${tag.name}`}>
                     #{tag.name}
                   </NavigationLink>

--- a/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
@@ -14,6 +14,7 @@ import {
 
 import FediIcon from '@/images/icons/icon_fediverse.svg?react';
 import { fetchLists } from '@/mastodon/actions/lists';
+import { fetchFollowedHashtags } from '@/mastodon/actions/tags_typed';
 import { useIdentity } from '@/mastodon/identity_context';
 import { openNewComposer } from '@/mastodon/reducers/slices/composer';
 import { getOrderedLists } from '@/mastodon/selectors/lists';
@@ -49,6 +50,19 @@ function useCustomFeeds() {
   };
 }
 
+function useFollowedHashtags() {
+  const dispatch = useAppDispatch();
+  const { tags, stale } = useAppSelector((state) => state.followedTags);
+
+  useEffect(() => {
+    if (stale) {
+      void dispatch(fetchFollowedHashtags());
+    }
+  }, [dispatch, stale]);
+
+  return { followedHashtags: tags };
+}
+
 export const RedesignNavigationPanel: React.FC<{ siteName?: string }> = ({
   siteName,
 }) => {
@@ -64,6 +78,7 @@ export const RedesignNavigationPanel: React.FC<{ siteName?: string }> = ({
   }, [dispatch]);
 
   const { customFeeds } = useCustomFeeds();
+  const { followedHashtags } = useFollowedHashtags();
 
   return (
     <nav
@@ -140,6 +155,26 @@ export const RedesignNavigationPanel: React.FC<{ siteName?: string }> = ({
                 </NavigationLink>
               ))}
             </ListSection>
+
+            {followedHashtags.length > 0 && (
+              <ListSection
+                title={{
+                  label: (
+                    <FormattedMessage
+                      id='navigation_bar.followed_tags'
+                      defaultMessage='Followed hashtags'
+                    />
+                  ),
+                  link: '/followed_tags',
+                }}
+              >
+                {followedHashtags.slice(0, 5).map((tag) => (
+                  <NavigationLink key={tag.name} to={`/tags/${tag.name}`}>
+                    #{tag.name}
+                  </NavigationLink>
+                ))}
+              </ListSection>
+            )}
           </ul>
           <footer className={classes.footer}>
             <ul className={classes.footerNav}>

--- a/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
@@ -6,14 +6,17 @@ import {
   PenNibIcon,
   HouseIcon,
   MagnifyingGlassIcon,
+  RssSimpleIcon,
   BellIcon,
   ChatCircleIcon,
   BookmarkSimpleIcon,
 } from '@phosphor-icons/react';
 
 import FediIcon from '@/images/icons/icon_fediverse.svg?react';
+import { fetchLists } from '@/mastodon/actions/lists';
 import { useIdentity } from '@/mastodon/identity_context';
 import { openNewComposer } from '@/mastodon/reducers/slices/composer';
+import { getOrderedLists } from '@/mastodon/selectors/lists';
 import { selectUnreadNotificationGroupsCount } from '@/mastodon/selectors/notifications';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 
@@ -33,6 +36,19 @@ const messages = defineMessages({
   },
 });
 
+function useCustomFeeds() {
+  const dispatch = useAppDispatch();
+  const customFeeds = useAppSelector((state) => getOrderedLists(state));
+
+  useEffect(() => {
+    void dispatch(fetchLists());
+  }, [dispatch]);
+
+  return {
+    customFeeds,
+  };
+}
+
 export const RedesignNavigationPanel: React.FC<{ siteName?: string }> = ({
   siteName,
 }) => {
@@ -46,6 +62,8 @@ export const RedesignNavigationPanel: React.FC<{ siteName?: string }> = ({
   const openComposer = useCallback(() => {
     dispatch(openNewComposer({ type: 'post' }));
   }, [dispatch]);
+
+  const { customFeeds } = useCustomFeeds();
 
   return (
     <nav
@@ -105,8 +123,22 @@ export const RedesignNavigationPanel: React.FC<{ siteName?: string }> = ({
                 ),
                 link: '/lists/new',
               }}
+              emptyMessage={
+                <FormattedMessage
+                  id='tabs_bar.custom_feeds_empty'
+                  defaultMessage='You have no custom feeds yet.'
+                />
+              }
             >
-              List
+              {customFeeds.map((feed) => (
+                <NavigationLink
+                  key={feed.id}
+                  to={`/lists/${feed.id}`}
+                  iconComponent={RssSimpleIcon}
+                >
+                  {feed.title}
+                </NavigationLink>
+              ))}
             </ListSection>
           </ul>
           <footer className={classes.footer}>

--- a/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
@@ -20,6 +20,7 @@ import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 import { NavigationAccountCardAndMenu } from './account_card_and_menu';
 import { NavigationFooterLinks } from './footer_links';
 import { NavigationHeader } from './header';
+import { ListSection } from './list_section';
 import { NavigationLink } from './navigation_link';
 import classes from './styles.module.scss';
 
@@ -75,12 +76,38 @@ export const RedesignNavigationPanel: React.FC<{ siteName?: string }> = ({
                 defaultMessage='Explore'
               />
             </NavigationLink>
-            <NavigationLink to='/public/local' iconComponent={FediIcon}>
+            <NavigationLink
+              withSpaceAfter
+              to='/public/local'
+              iconComponent={FediIcon}
+            >
               <FormattedMessage
                 id='tabs_bar.fediverse_feeds'
                 defaultMessage='Fediverse Feeds'
               />
             </NavigationLink>
+            <ListSection
+              title={{
+                label: (
+                  <FormattedMessage
+                    id='tabs_bar.custom_feeds'
+                    defaultMessage='Custom feeds'
+                  />
+                ),
+                link: '/lists',
+              }}
+              action={{
+                label: (
+                  <FormattedMessage
+                    id='tabs_bar.create_custom_feed'
+                    defaultMessage='Create feed'
+                  />
+                ),
+                link: '/lists/new',
+              }}
+            >
+              List
+            </ListSection>
           </ul>
           <footer className={classes.footer}>
             <ul className={classes.footerNav}>

--- a/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
@@ -120,15 +120,12 @@ export const RedesignNavigationPanel: React.FC<{ siteName?: string }> = ({
               />
             </NavigationLink>
             <ListSection
-              title={{
-                label: (
-                  <FormattedMessage
-                    id='tabs_bar.custom_feeds'
-                    defaultMessage='Custom feeds'
-                  />
-                ),
-                link: '/lists',
-              }}
+              title={
+                <FormattedMessage
+                  id='tabs_bar.custom_feeds'
+                  defaultMessage='Custom feeds'
+                />
+              }
               action={{
                 label: (
                   <FormattedMessage
@@ -158,11 +155,17 @@ export const RedesignNavigationPanel: React.FC<{ siteName?: string }> = ({
 
             {followedHashtags.length > 0 && (
               <ListSection
-                title={{
+                title={
+                  <FormattedMessage
+                    id='navigation_bar.followed_tags'
+                    defaultMessage='Followed hashtags'
+                  />
+                }
+                action={{
                   label: (
                     <FormattedMessage
-                      id='navigation_bar.followed_tags'
-                      defaultMessage='Followed hashtags'
+                      id='navigation_bar.followed_tags_view_all'
+                      defaultMessage='View all'
                     />
                   ),
                   link: '/followed_tags',

--- a/app/javascript/mastodon/features/navigation_panel/redesign/list_section.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/list_section.module.scss
@@ -1,5 +1,11 @@
 @use '@/styles/mastodon/mixins';
 
+.root {
+  &:not(:last-child) {
+    margin-bottom: var(--space-md);
+  }
+}
+
 .titleWrapper {
   display: flex;
   align-items: center;
@@ -13,8 +19,30 @@
   // Ensure text is flush against inline-start edge
   // by subtracting the button's horizontal padding
   margin-inline-start: calc(-1 * (var(--space-2xs) + var(--space-3xs)));
+
+  &[aria-current] {
+    --fg: var(--color-text-primary);
+    --bg: var(--color-bg-highlight);
+
+    // Add a visual selection indicator
+    &::after {
+      content: '';
+      display: block;
+      width: 0.5em;
+      height: 0.5em;
+      border-radius: var(--radius-round);
+      background-color: var(--color-text-primary);
+      margin-inline-start: var(--space-3xs);
+    }
+  }
 }
 
 .action {
   margin-inline-start: auto;
+}
+
+.emptyState {
+  @include mixins.type-label-sm;
+
+  padding-inline: var(--space-xs);
 }

--- a/app/javascript/mastodon/features/navigation_panel/redesign/list_section.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/list_section.module.scss
@@ -14,27 +14,10 @@
 }
 
 .title {
-  --fg: var(--color-text-secondary);
+  @include mixins.type-label-sm;
 
-  // Ensure text is flush against inline-start edge
-  // by subtracting the button's horizontal padding
-  margin-inline-start: calc(-1 * (var(--space-2xs) + var(--space-3xs)));
-
-  &[aria-current] {
-    --fg: var(--color-text-primary);
-    --bg: var(--color-bg-highlight);
-
-    // Add a visual selection indicator
-    &::after {
-      content: '';
-      display: block;
-      width: 0.5em;
-      height: 0.5em;
-      border-radius: var(--radius-round);
-      background-color: var(--color-text-primary);
-      margin-inline-start: var(--space-3xs);
-    }
-  }
+  color: var(--color-text-secondary);
+  cursor: default;
 }
 
 .action {

--- a/app/javascript/mastodon/features/navigation_panel/redesign/list_section.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/list_section.module.scss
@@ -1,0 +1,20 @@
+@use '@/styles/mastodon/mixins';
+
+.titleWrapper {
+  display: flex;
+  align-items: center;
+  padding-inline: var(--space-xs);
+  padding-block: calc(var(--space-xs) - var(--space-3xs));
+}
+
+.title {
+  --fg: var(--color-text-secondary);
+
+  // Ensure text is flush against inline-start edge
+  // by subtracting the button's horizontal padding
+  margin-inline-start: calc(-1 * (var(--space-2xs) + var(--space-3xs)));
+}
+
+.action {
+  margin-inline-start: auto;
+}

--- a/app/javascript/mastodon/features/navigation_panel/redesign/list_section.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/list_section.tsx
@@ -7,10 +7,7 @@ import { hasReactChildren } from '@/mastodon/utils/has_react_children';
 import classes from './list_section.module.scss';
 
 export const ListSection: React.FC<{
-  title: {
-    label: ReactNode;
-    link: MastodonLocationDescriptor;
-  };
+  title: ReactNode;
   action?: {
     label: ReactNode;
     link: MastodonLocationDescriptor;
@@ -23,16 +20,7 @@ export const ListSection: React.FC<{
   return (
     <li className={classes.root}>
       <div className={classes.titleWrapper}>
-        <Button
-          as='link'
-          exact
-          to={title.link}
-          size='xs'
-          variant='ghost'
-          className={classes.title}
-        >
-          {title.label}
-        </Button>
+        <span className={classes.title}>{title}</span>
         {action && (
           <Button
             as='link'

--- a/app/javascript/mastodon/features/navigation_panel/redesign/list_section.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/list_section.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react';
+
+import { Button } from '@/mastodon/components/button/redesign';
+import type { MastodonLocationDescriptor } from '@/mastodon/components/router';
+
+import classes from './list_section.module.scss';
+
+export const ListSection: React.FC<{
+  title: {
+    label: ReactNode;
+    link: MastodonLocationDescriptor;
+  };
+  action?: {
+    label: ReactNode;
+    link: MastodonLocationDescriptor;
+  };
+  children: ReactNode;
+}> = ({ title, action, children }) => {
+  return (
+    <li>
+      <div className={classes.titleWrapper}>
+        <Button
+          as='link'
+          to={title.link}
+          size='xs'
+          variant='ghost'
+          className={classes.title}
+        >
+          {title.label}
+        </Button>
+        {action && (
+          <Button
+            as='link'
+            to={action.link}
+            size='xs'
+            className={classes.action}
+          >
+            {action.label}
+          </Button>
+        )}
+      </div>
+      <ul>{children}</ul>
+    </li>
+  );
+};

--- a/app/javascript/mastodon/features/navigation_panel/redesign/list_section.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/list_section.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 
 import { Button } from '@/mastodon/components/button/redesign';
 import type { MastodonLocationDescriptor } from '@/mastodon/components/router';
+import { hasReactChildren } from '@/mastodon/utils/has_react_children';
 
 import classes from './list_section.module.scss';
 
@@ -15,12 +16,16 @@ export const ListSection: React.FC<{
     link: MastodonLocationDescriptor;
   };
   children: ReactNode;
-}> = ({ title, action, children }) => {
+  emptyMessage?: ReactNode;
+}> = ({ title, action, children, emptyMessage }) => {
+  const hasContent = hasReactChildren(children);
+
   return (
-    <li>
+    <li className={classes.root}>
       <div className={classes.titleWrapper}>
         <Button
           as='link'
+          exact
           to={title.link}
           size='xs'
           variant='ghost'
@@ -39,7 +44,11 @@ export const ListSection: React.FC<{
           </Button>
         )}
       </div>
-      <ul>{children}</ul>
+      {hasContent ? (
+        <ul>{children}</ul>
+      ) : (
+        emptyMessage && <div className={classes.emptyState}>{emptyMessage}</div>
+      )}
     </li>
   );
 };

--- a/app/javascript/mastodon/features/navigation_panel/redesign/navigation_link.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/navigation_link.tsx
@@ -12,7 +12,7 @@ import classes from './navigation_link.module.scss';
 
 type NavigationLinkProps = {
   stacked?: boolean;
-  iconComponent: Icon | React.FC<SVGProps<SVGSVGElement>>;
+  iconComponent?: Icon | React.FC<SVGProps<SVGSVGElement>>;
   badgeCount?: number;
   withSpaceAfter?: boolean;
 } & (
@@ -55,9 +55,11 @@ export const NavigationLink: React.FC<NavigationLinkProps> = ({
         {...otherProps}
         className={classNames(classes.link, stacked && classes.linkStacked)}
       >
-        <span className={classes.icon}>
-          <IconComp size={20} weight={isActive ? 'fill' : undefined} />
-        </span>
+        {IconComp && (
+          <span className={classes.icon}>
+            <IconComp size={20} weight={isActive ? 'fill' : undefined} />
+          </span>
+        )}
         <span className={classes.label}>{children}</span>
         {badgeCount > 0 && (
           <Badge

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -1398,6 +1398,8 @@
   "subscribed_languages.lead": "Only posts in selected languages will appear on your home and list timelines after the change. Select none to receive posts in all languages.",
   "subscribed_languages.save": "Save changes",
   "subscribed_languages.target": "Change subscribed languages for {target}",
+  "tabs_bar.create_custom_feed": "Create feed",
+  "tabs_bar.custom_feeds": "Custom feeds",
   "tabs_bar.explore": "Explore",
   "tabs_bar.fediverse_feeds": "Fediverse Feeds",
   "tabs_bar.home": "Home",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -1400,6 +1400,7 @@
   "subscribed_languages.target": "Change subscribed languages for {target}",
   "tabs_bar.create_custom_feed": "Create feed",
   "tabs_bar.custom_feeds": "Custom feeds",
+  "tabs_bar.custom_feeds_empty": "You have no custom feeds yet.",
   "tabs_bar.explore": "Explore",
   "tabs_bar.fediverse_feeds": "Fediverse Feeds",
   "tabs_bar.home": "Home",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -986,6 +986,7 @@
   "navigation_bar.filters": "Muted words",
   "navigation_bar.follow_requests": "Follow requests",
   "navigation_bar.followed_tags": "Followed hashtags",
+  "navigation_bar.followed_tags_view_all": "View all",
   "navigation_bar.followers_and_following": "Followers & Following",
   "navigation_bar.follows_and_followers": "Follows and followers",
   "navigation_bar.import_export": "Import and export",


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

### Changes proposed in this PR:
- Adds sections for "Custom feeds" (formerly known as "Lists") and "Followed hashtags" to the main navigation
  - "Custom feeds" shows all feeds and an action to create a new one. When empty, a simple empty state is shown
  - "Followed hashtags" is only shown if the user has any followed hashtags. When empty, the section is hidden. Only the first 5 followed hashtags are shown, and there is a "View all" action.

### Screenshots

<img width="306" height="804" alt="image" src="https://github.com/user-attachments/assets/9d52e0ec-5e94-43f5-9d25-e0c2f62ea065" />

<img width="293" height="798" alt="image" src="https://github.com/user-attachments/assets/c3bb84f1-4e83-451f-bf35-72e67b397c29" />
