### PR TITLE
Fix email blocks domain filter not being kept through pagination

### DIFF
--- a/app/controllers/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/admin/email_domain_blocks_controller.rb
@@ -59,7 +59,7 @@ module Admin
 
     def filter_by_domain
       scope = EmailDomainBlock.parents.includes(:children).order(id: :desc)
-      scope.merge!(EmailDomainBlock.matches_domain(params[:domain])) if params[:domain].present?
+      scope.merge!(EmailDomainBlock.matches_domain(params[:by_domain])) if params[:by_domain].present?
       scope
     end
 

--- a/app/views/admin/email_domain_blocks/index.html.haml
+++ b/app/views/admin/email_domain_blocks/index.html.haml
@@ -7,8 +7,8 @@
 = form_with url: admin_email_domain_blocks_path, method: :get, class: :simple_form do |f|
   .fields-group
     .input.string.optional
-      = f.text_field :domain,
-                     value: params[:domain],
+      = f.text_field :by_domain,
+                     value: params[:by_domain],
                      class: 'string optional',
                      placeholder: t('admin.email_domain_blocks.domain')
 
@@ -20,7 +20,7 @@
 
 = form_with model: @form, url: batch_admin_email_domain_blocks_path do |f|
   = hidden_field_tag :page, params[:page] || 1
-  = hidden_field_tag :domain, params[:domain] if params[:domain].present?
+  = hidden_field_tag :by_domain, params[:by_domain] if params[:by_domain].present?
 
   .batch-table
     .batch-table__toolbar

--- a/spec/system/admin/email_domain_blocks_spec.rb
+++ b/spec/system/admin/email_domain_blocks_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'Admin::EmailDomainBlocks' do
     end
 
     it 'filters by domain' do
-      fill_in 'domain', with: 'example.com'
+      fill_in 'by_domain', with: 'example.com'
       click_on I18n.t('admin.email_domain_blocks.search')
 
       expect(page).to have_text('example.com')
@@ -106,7 +106,7 @@ RSpec.describe 'Admin::EmailDomainBlocks' do
     end
 
     it 'shows empty page when no such domains are blocked' do
-      fill_in 'domain', with: 'mydomain.com'
+      fill_in 'by_domain', with: 'mydomain.com'
       click_on I18n.t('admin.email_domain_blocks.search')
 
       expect(page).to have_no_text('mydomain.com')
@@ -114,7 +114,7 @@ RSpec.describe 'Admin::EmailDomainBlocks' do
     end
 
     it 'returns to the list when resetting the search' do
-      fill_in 'domain', with: 'example.com'
+      fill_in 'by_domain', with: 'example.com'
       click_on I18n.t('admin.email_domain_blocks.search')
       click_on I18n.t('admin.email_domain_blocks.reset')
 


### PR DESCRIPTION
For some reason, `domain` gets removed from the pagination parameters, so rename it to `by_domain`.