### PR TITLE
Redesign: Auto-focus search when opening Explore from new navigation

### DIFF
--- a/app/javascript/mastodon/features/compose/components/search.tsx
+++ b/app/javascript/mastodon/features/compose/components/search.tsx
@@ -19,7 +19,9 @@ import { useHistory } from 'react-router-dom';
 
 import { isFulfilled } from '@reduxjs/toolkit';
 
+import { useFocusOnNavigation } from '@/mastodon/components/navigation_focus_target';
 import { getCollectionPath } from '@/mastodon/features/collections/utils';
+import { useMergedRefs } from '@/mastodon/hooks/useMergedRefs';
 import CancelIcon from '@/material-icons/400-24px/cancel-fill.svg?react';
 import CloseIcon from '@/material-icons/400-24px/close.svg?react';
 import SearchIcon from '@/material-icons/400-24px/search.svg?react';
@@ -105,6 +107,7 @@ export const Search: React.FC<{
   const [expanded, setExpanded] = useState(false);
   const [selectedOption, setSelectedOption] = useState(-1);
   const [quickActions, setQuickActions] = useState<SearchOption[]>([]);
+  const focusOnNavigation = useFocusOnNavigation('search');
 
   const unfocus = useCallback(() => {
     document.querySelector('.ui')?.parentElement?.focus();
@@ -558,7 +561,7 @@ export const Search: React.FC<{
       className={classNames('search', { active: expanded })}
     >
       <input
-        ref={searchInputRef}
+        ref={useMergedRefs(searchInputRef, focusOnNavigation)}
         className='search__input'
         type='text'
         inputMode='search'

--- a/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
@@ -103,7 +103,10 @@ export const RedesignNavigationPanel: React.FC<{ siteName?: string }> = ({
             <NavigationLink to='/home' iconComponent={HouseIcon}>
               <FormattedMessage id='tabs_bar.home' defaultMessage='Home' />
             </NavigationLink>
-            <NavigationLink to='/explore' iconComponent={MagnifyingGlassIcon}>
+            <NavigationLink
+              to={{ pathname: '/explore', state: { focusTarget: 'search' } }}
+              iconComponent={MagnifyingGlassIcon}
+            >
               <FormattedMessage
                 id='tabs_bar.explore'
                 defaultMessage='Explore'


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

### Changes proposed in this PR:
- Sets user focus on the search field when opening the Explore page from the new navigation