### PR TITLE
Make some of 4.7 migrations more resilient to being interrupted

### DIFF
--- a/db/migrate/20260629125939_add_index_account_id_local_fragment_to_keypair.rb
+++ b/db/migrate/20260629125939_add_index_account_id_local_fragment_to_keypair.rb
@@ -3,7 +3,13 @@
 class AddIndexAccountIdLocalFragmentToKeypair < ActiveRecord::Migration[8.1]
   disable_ddl_transaction!
 
-  def change
+  def up
     add_index :keypairs, [:account_id, :local_fragment], unique: true, where: 'local_fragment IS NOT NULL', algorithm: :concurrently
+  rescue ActiveRecord::StatementInvalid
+    safety_assured { execute 'REINDEX INDEX CONCURRENTLY index_keypairs_on_account_id_and_local_fragment' }
+  end
+
+  def down
+    remove_index :keypairs, name: :index_keypairs_on_account_id_and_local_fragment
   end
 end

--- a/db/migrate/20260701161457_add_new_index_account_id_local_fragment_to_keypair.rb
+++ b/db/migrate/20260701161457_add_new_index_account_id_local_fragment_to_keypair.rb
@@ -3,7 +3,13 @@
 class AddNewIndexAccountIdLocalFragmentToKeypair < ActiveRecord::Migration[8.1]
   disable_ddl_transaction!
 
-  def change
+  def up
     add_index :keypairs, [:account_id, :local_fragment], unique: true, name: :index_keypairs_on_account_id_and_local_fragment, algorithm: :concurrently
+  rescue ActiveRecord::StatementInvalid
+    safety_assured { execute 'REINDEX INDEX CONCURRENTLY index_keypairs_on_account_id_and_local_fragment' }
+  end
+
+  def down
+    remove_index :keypairs, name: :index_keypairs_on_account_id_and_local_fragment
   end
 end


### PR DESCRIPTION
We had one case of an admin interrupting the migrations when building those indexes, leaving behind invalid indexes. Re-running the migrations would error out because the indexes are already here—just not valid.

This PR makes it so in such a case they are re-validated instead of created.