### PR TITLE
Redesign: Change account menu link to "Edit profile"

### DIFF
--- a/app/javascript/mastodon/features/navigation_panel/redesign/account_card_and_menu.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/account_card_and_menu.tsx
@@ -73,10 +73,10 @@ export const NavigationAccountCardAndMenu: React.FC = () => {
           <FormattedMessage id='tabs_bar.more' defaultMessage='More' />
         </MenuTrigger>
         <MenuList placement='top' offset={8}>
-          <MenuItemLink to={accountBasePath} icon={UserIcon}>
+          <MenuItemLink to='/profile/edit' icon={UserIcon}>
             <FormattedMessage
-              id='navigation_bar.profile'
-              defaultMessage='Profile'
+              id='account.edit_profile'
+              defaultMessage='Edit profile'
             />
           </MenuItemLink>
           <MenuItemLink as='a' href='/settings/preferences' icon={GearIcon}>

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -1003,7 +1003,6 @@
   "navigation_bar.powered_by_mastodon": "powered by {logo}Mastodon",
   "navigation_bar.preferences": "Preferences",
   "navigation_bar.privacy_and_reach": "Privacy and reach",
-  "navigation_bar.profile": "Profile",
   "navigation_bar.search": "Search",
   "navigation_bar.search_trends": "Search / Trending",
   "navigation_bar.sign_out": "Sign out",


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Fixes PRO-498

### Changes proposed in this PR:
- Changes first link in the account menu from "Profile" to "Edit profile"

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="217" height="386" alt="image" src="https://github.com/user-attachments/assets/07982958-8b6a-4b6b-99c5-59e3dd3f8c6f" /> | <img width="224" height="390" alt="image" src="https://github.com/user-attachments/assets/817e9dc2-07fd-43ec-855e-8a66aaaf3f41" /> |