### PR TITLE
Redesign: Add app icon to navigation header

### DIFF
--- a/app/javascript/mastodon/api_types/instance.ts
+++ b/app/javascript/mastodon/api_types/instance.ts
@@ -56,6 +56,7 @@ export interface ApiInstanceJSON {
     description: string;
     versions?: Record<string, string>;
   };
+  icon: { src: string; size: string }[];
   contact: {
     email: string | null;
     account: ApiAccountJSON | null;

--- a/app/javascript/mastodon/features/navigation_panel/redesign/account_card_and_menu.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/account_card_and_menu.module.scss
@@ -16,4 +16,9 @@
     --account-handle-color: var(--color-text-secondary);
     --account-handle-size: var(--fs-2xs);
   }
+
+  & :global(.display-name) {
+    // Allow display name to wrap instead of truncating with ellipsis
+    white-space: normal;
+  }
 }

--- a/app/javascript/mastodon/features/navigation_panel/redesign/footer_links.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/footer_links.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  gap: var(--space-xs);
   margin-top: var(--space-xl);
 
   @include mixins.type-label-sm;

--- a/app/javascript/mastodon/features/navigation_panel/redesign/header.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/header.module.scss
@@ -15,11 +15,14 @@
 }
 
 .siteNameLink {
+  --app-icon-size: 40px;
+
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  column-gap: var(--space-xs);
+  min-width: 0;
   color: inherit;
   text-decoration: none;
-  overflow-wrap: anywhere;
   outline-offset: var(--space-3xs);
 
   &:hover {
@@ -27,13 +30,30 @@
   }
 }
 
+.content {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.appIcon {
+  align-self: center;
+  width: var(--app-icon-size);
+  aspect-ratio: 1;
+}
+
 .serverName {
   @include mixins.type-heading-sm;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .poweredBy {
   @include mixins.type-label-sm;
 
+  grid-column: 2;
   color: var(--color-text-tertiary);
 
   svg {

--- a/app/javascript/mastodon/features/navigation_panel/redesign/header.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/header.tsx
@@ -6,15 +6,15 @@ import { Link } from 'react-router-dom';
 
 import { IconLogo } from '@/mastodon/components/logo';
 import { domain, title } from '@/mastodon/initial_state';
+import { useAppSelector } from '@/mastodon/store';
 
 import classes from './header.module.scss';
 
 export const NavigationHeader: React.FC<{ siteName?: string }> = ({
   siteName,
 }) => {
-  const appIconUrl = document
-    .querySelector('link[rel="apple-touch-icon"][sizes="120x120"]')
-    ?.getAttribute('href');
+  const { item: server } = useAppSelector((state) => state.server.server);
+  const appIconUrl = server?.icon[3]?.src;
 
   return (
     <header className={classes.root}>

--- a/app/javascript/mastodon/features/navigation_panel/redesign/header.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/header.tsx
@@ -5,25 +5,36 @@ import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 
 import { IconLogo } from '@/mastodon/components/logo';
-import { domain } from '@/mastodon/initial_state';
+import { domain, title } from '@/mastodon/initial_state';
 
 import classes from './header.module.scss';
 
 export const NavigationHeader: React.FC<{ siteName?: string }> = ({
-  siteName = domain,
+  siteName,
 }) => {
+  const appIconUrl = document
+    .querySelector('link[rel="apple-touch-icon"][sizes="120x120"]')
+    ?.getAttribute('href');
+
   return (
     <header className={classes.root}>
       <Link to='/' className={classes.siteNameLink}>
-        <span className={classes.serverName}>{siteName}</span>
-        <span className={classes.poweredBy}>
-          <FormattedMessage
-            id='navigation_bar.powered_by_mastodon'
-            defaultMessage='powered by {logo}Mastodon'
-            values={{
-              logo: <IconLogo role='presentation' />,
-            }}
-          />
+        {appIconUrl && (
+          <img src={appIconUrl} alt='' className={classes.appIcon} />
+        )}
+        <span className={classes.content}>
+          <span className={classes.serverName}>
+            {siteName ?? title ?? domain}
+          </span>
+          <span className={classes.poweredBy}>
+            <FormattedMessage
+              id='navigation_bar.powered_by_mastodon'
+              defaultMessage='powered by {logo}Mastodon'
+              values={{
+                logo: <IconLogo role='presentation' />,
+              }}
+            />
+          </span>
         </span>
       </Link>
     </header>

--- a/app/javascript/mastodon/features/navigation_panel/redesign/header.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/header.tsx
@@ -5,22 +5,18 @@ import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 
 import { IconLogo } from '@/mastodon/components/logo';
-import { domain, title } from '@/mastodon/initial_state';
-import { useAppSelector } from '@/mastodon/store';
+import { customAppIcon, domain, title } from '@/mastodon/initial_state';
 
 import classes from './header.module.scss';
 
 export const NavigationHeader: React.FC<{ siteName?: string }> = ({
   siteName,
 }) => {
-  const { item: server } = useAppSelector((state) => state.server.server);
-  const appIconUrl = server?.icon[3]?.src;
-
   return (
     <header className={classes.root}>
       <Link to='/' className={classes.siteNameLink}>
-        {appIconUrl && (
-          <img src={appIconUrl} alt='' className={classes.appIcon} />
+        {customAppIcon && (
+          <img src={customAppIcon} alt='' className={classes.appIcon} />
         )}
         <span className={classes.content}>
           <span className={classes.serverName}>

--- a/app/javascript/mastodon/initial_state.ts
+++ b/app/javascript/mastodon/initial_state.ts
@@ -43,6 +43,7 @@ interface InitialStateMeta {
   local_topic_feed_access: 'public' | 'authenticated';
   remote_topic_feed_access: 'public' | 'authenticated' | 'disabled';
   title: string;
+  custom_app_icon: string | null;
   show_trends: boolean;
   landing_page: 'about' | 'trends' | 'local_feed';
   use_blurhash: boolean;
@@ -142,6 +143,7 @@ export const remoteLiveFeedAccess = getMeta('remote_live_feed_access');
 export const localTopicFeedAccess = getMeta('local_topic_feed_access');
 export const remoteTopicFeedAccess = getMeta('remote_topic_feed_access');
 export const title = getMeta('title');
+export const customAppIcon = getMeta('custom_app_icon');
 export const landingPage = getMeta('landing_page');
 export const useBlurhash = getMeta('use_blurhash');
 export const usePendingItems = getMeta('use_pending_items');

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class InitialStateSerializer < ActiveModel::Serializer
+  include InstanceHelper
   include RoutingHelper
 
   attributes :meta, :compose, :accounts,
@@ -124,6 +125,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       status_page_url: Setting.status_page_url,
       streaming_api_base_url: Rails.configuration.x.streaming_api_base_url,
       title: instance_presenter.title,
+      custom_app_icon: app_icon_path(120),
       landing_page: Setting.landing_page,
       trends_enabled: Setting.trends,
       version: instance_presenter.version,


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).


Fixes WEB-1086
Fixes PRO-499

### Changes proposed in this PR:
- Adds new field `custom_app_icon: string | null` to the initial app's `meta` state. It contains a path to the app icon at size 120x120, but only if a custom app icon has been uploaded. (I.e. there is no fallback to the default Mastodon icon.)
- Uses this field to display the app icon in the header of the new navigation
- Renders the server name in the header instead of the domain (if available)
- Allows the current account's display name to wrap if it's too long to fit into the account card at the bottom of the sidebar
- Adds some spacing if there's text wrapping in the navigation's link footer

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="351" height="209" alt="image" src="https://github.com/user-attachments/assets/b37bae7b-eae2-464c-9e29-22b14008831e" /> | <img width="353" height="209" alt="image" src="https://github.com/user-attachments/assets/b1465416-956a-4812-a47f-0cae7f80e5fb" /> |
| <img width="332" height="193" alt="image" src="https://github.com/user-attachments/assets/b49a1c57-9d6d-4c23-b502-fee1aa08ed31" /> | <img width="341" height="221" alt="image" src="https://github.com/user-attachments/assets/2eba005d-a548-4410-81d5-d5ae54b8da48" /> | 