### PR TITLE
Fix description text overflowing on Overview landing page

### DIFF
--- a/app/javascript/mastodon/features/custom_homepage/styles.module.scss
+++ b/app/javascript/mastodon/features/custom_homepage/styles.module.scss
@@ -45,6 +45,7 @@
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
+    line-clamp: 2;
     font-size: 16px;
     line-height: 24px;
     text-overflow: ellipsis;

--- a/app/javascript/mastodon/features/custom_homepage/styles.module.scss
+++ b/app/javascript/mastodon/features/custom_homepage/styles.module.scss
@@ -48,6 +48,7 @@
     font-size: 16px;
     line-height: 24px;
     text-overflow: ellipsis;
+    overflow: hidden;
   }
 }
 

--- a/app/javascript/mastodon/features/custom_homepage/styles.module.scss
+++ b/app/javascript/mastodon/features/custom_homepage/styles.module.scss
@@ -1,3 +1,5 @@
+@use '@/styles/mastodon/mixins';
+
 .page {
   border-radius: 16px;
   border: 1px solid var(--color-border-primary);
@@ -42,14 +44,10 @@
   }
 
   p {
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
-    line-clamp: 2;
+    @include mixins.line-clamp(2);
+
     font-size: 16px;
     line-height: 24px;
-    text-overflow: ellipsis;
-    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
Fixes #40267

### Changes proposed in this PR:
- Fixes the description text overflowing on the Overview landing page
- Resolves a minor stylelint warning

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="389" height="177" alt="image" src="https://github.com/user-attachments/assets/ff9acedf-271f-421f-b416-c44e60240ba5" /> | <img width="390" height="179" alt="image" src="https://github.com/user-attachments/assets/1560cd6c-7ec4-46c9-b1b0-50695d59a95a" /> |