### PR TITLE
Fix account creation failing on ActiveRecord::Encryption configuration

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -549,6 +549,12 @@ namespace :mastodon do
           require_relative '../../config/environment'
           disable_log_stdout!
 
+          ActiveRecord::Encryption.configure(
+            primary_key: ENV.fetch('ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY'),
+            deterministic_key: ENV.fetch('ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY'),
+            key_derivation_salt: ENV.fetch('ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT')
+          )
+
           username = prompt.ask('Username:') do |q|
             q.required true
             q.default 'admin'


### PR DESCRIPTION
Fixes #40245

I am not sure what would be the correct way to do it, but this works.