### PR TITLE
Fix Elasticsearch error when updating mappings for indices without analyzers (#39672)

### DIFF
--- a/lib/chewy/index_extensions.rb
+++ b/lib/chewy/index_extensions.rb
@@ -15,7 +15,8 @@ module Chewy
 
     def update_specification
       client.indices.close index: index_name
-      client.indices.put_settings index: index_name, body: { settings: { analysis: settings_hash[:settings][:analysis] } }
+      analysis_settings = settings_hash[:settings][:analysis]
+      client.indices.put_settings index: index_name, body: { settings: { analysis: analysis_settings } } if analysis_settings
       client.indices.put_mapping index: index_name, body: root.mappings_hash
       client.indices.open index: index_name
     end

--- a/spec/lib/chewy/index_extensions_spec.rb
+++ b/spec/lib/chewy/index_extensions_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Chewy::IndexExtensions do
+  describe '.update_specification' do
+    let(:indices) { Chewy.client.indices }
+
+    before do
+      allow(indices).to receive_messages(close: nil, put_settings: nil, put_mapping: nil, open: nil)
+    end
+
+    context 'when the index does not define analysis settings' do
+      it 'updates mappings without sending analysis settings' do
+        InstancesIndex.update_specification
+
+        expect(indices).to have_received(:close).with(index: InstancesIndex.index_name)
+        expect(indices).to_not have_received(:put_settings)
+        expect(indices).to have_received(:put_mapping).with(index: InstancesIndex.index_name, body: InstancesIndex.root.mappings_hash)
+        expect(indices).to have_received(:open).with(index: InstancesIndex.index_name)
+      end
+    end
+
+    context 'when the index defines analysis settings' do
+      it 'updates analysis settings and mappings' do
+        AccountsIndex.update_specification
+
+        expect(indices).to have_received(:close).with(index: AccountsIndex.index_name)
+        expect(indices).to have_received(:put_settings).with(
+          index: AccountsIndex.index_name,
+          body: { settings: { analysis: AccountsIndex.settings_hash[:settings][:analysis] } }
+        )
+        expect(indices).to have_received(:put_mapping).with(index: AccountsIndex.index_name, body: AccountsIndex.root.mappings_hash)
+        expect(indices).to have_received(:open).with(index: AccountsIndex.index_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Skip sending analyzer settings when updating Elasticsearch index mappings if the index does not define any, so tootctl search deploy --only-mapping no longer fails on Elasticsearch 7/8. 

closes #39672 