### PR TITLE
Fix: Guard against empty changes in tags audit log.

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -37,8 +37,11 @@ module Admin
     private
 
     def log_action_from_change
+      changes = @tag.saved_changes.slice('usable', 'trendable', 'listable').transform_values(&:last)
+      return if changes.empty?
+
       action_log = current_account.action_logs.new(action: 'update', target: @tag)
-      action_log.recorded_changes = @tag.saved_changes.slice('usable', 'trendable', 'listable').transform_values(&:last)
+      action_log.recorded_changes = changes
       action_log.recorded_changes_format = 'tags_format_1.0'
       action_log.save
     end


### PR DESCRIPTION
<img width="861" height="286" alt="image" src="https://github.com/user-attachments/assets/c197d5e3-1f32-46dd-8bc0-6094f43a908b" />

Hitting save twice on a tag causes junk audit log