### PR TITLE
Limit flatware to 15 workers to avoid redis DB limit errors

### DIFF
--- a/bin/flatware
+++ b/bin/flatware
@@ -12,5 +12,11 @@ ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "rubygems"
 require "bundler/setup"
+require "etc"
+
+if ARGV.first == "rspec"
+  # Avoid Redis DB access errors when cores exceed default DB count limit
+  ARGV.push("--workers", [Etc.nprocessors, 15].min)
+end
 
 load Gem.bin_path("flatware", "flatware")


### PR DESCRIPTION
This is sort of trivial, but accomplishes two things:

- In a hypothetical future world in the year 2048 where we have flying cars and GH actions CI runners have 16+ cores, we would currently error out due to the redis default limit naming collision
- When you have many cores locally, you need to run with something like `bin/flatware rspec -w 15` ... this builds that limit into the script itself and you can now just do `bin/flatware rspec` which frankly is more fun

Background on why this is 15 and not 16 is in https://github.com/mastodon/mastodon/pull/34665#issuecomment-2882975611 (reserving DB 0 for actual dev, and using the rest for test).

The check for ARGV/rspec here is because there are other flatware commands where this limit isn't relevant and we dont want to add the worker limit.