### PR TITLE
Composer redesign: Restrict width and fix autosuggest scroll

### DIFF
--- a/app/javascript/mastodon/components/autosuggest/hooks.tsx
+++ b/app/javascript/mastodon/components/autosuggest/hooks.tsx
@@ -201,6 +201,7 @@ export function useAutosuggestFloatingMenu({
   return {
     mirror,
     getToken,
+    onUpdate,
     ...autosuggestProps,
 
     sourceProps: {

--- a/app/javascript/mastodon/components/autosuggest/hooks.tsx
+++ b/app/javascript/mastodon/components/autosuggest/hooks.tsx
@@ -116,7 +116,6 @@ export function useAutosuggestMenu({
       'aria-autocomplete': 'list',
       'aria-expanded': suggestions.length > 0,
       'aria-haspopup': 'listbox',
-      role: 'combobox',
     } satisfies SourceProps,
   };
 }

--- a/app/javascript/mastodon/components/autosuggest/hooks.tsx
+++ b/app/javascript/mastodon/components/autosuggest/hooks.tsx
@@ -114,6 +114,9 @@ export function useAutosuggestMenu({
 
     sourceProps: {
       'aria-autocomplete': 'list',
+      'aria-expanded': suggestions.length > 0,
+      'aria-haspopup': 'listbox',
+      role: 'combobox',
     } satisfies SourceProps,
   };
 }

--- a/app/javascript/mastodon/components/autosuggest/hooks.tsx
+++ b/app/javascript/mastodon/components/autosuggest/hooks.tsx
@@ -2,7 +2,6 @@ import { useCallback, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 
-import type { Simplify } from 'type-fest';
 import { useThrottledCallback } from 'use-debounce';
 
 import { getAllMenuItems } from '../menu';
@@ -30,26 +29,12 @@ type SourceProps = React.DetailedHTMLProps<
   AutosuggestSourceElements
 >;
 
-interface UseAutosuggestReturn {
-  onTextChange: React.ChangeEventHandler<AutosuggestSourceElements>;
-  focus: (event?: React.SyntheticEvent) => void;
-  getToken: () => { token: string | null; startPosition: number };
-
-  mirror?: React.JSX.Element;
-
-  suggestProps: Simplify<Omit<AutosuggestMenuProps, 'children'>>;
-
-  sourceProps: Simplify<
-    Pick<SourceProps, 'onSelect' | 'onScroll' | 'aria-autocomplete'>
-  >;
-}
-
 export function useAutosuggestMenu({
   suggestions,
   onSelect,
   onFetch,
   onClear,
-}: UseAutosuggestMenuOptions): UseAutosuggestReturn {
+}: UseAutosuggestMenuOptions) {
   const lastTokenRef = useRef<string | null>(null); // The last suggestion token encountered.
   const tokenStartRef = useRef(0); // Character location of the token start.
   const listRef = useRef<HTMLDivElement>(null);
@@ -144,7 +129,7 @@ export function useAutosuggestFloatingMenu({
   sourceRef,
   className,
   ...suggestOptions
-}: UseAutosuggestFloatingMenuOptions): UseAutosuggestReturn {
+}: UseAutosuggestFloatingMenuOptions) {
   const [mirrorElement, setMirrorElement] = useState<HTMLElement | null>(null); // Reference to the mirror element.
   const [selectedText, setSelectedText] = useState(text ?? ''); // The actual selected text inside the mirror.
   const updatePopover = useRef<() => void>(null); // Reference to the popover update callback.

--- a/app/javascript/mastodon/components/autosuggest/hooks.tsx
+++ b/app/javascript/mastodon/components/autosuggest/hooks.tsx
@@ -146,12 +146,19 @@ export function useAutosuggestFloatingMenu({
     updatePopover.current?.();
 
     if (source && mirrorElement) {
-      // Set top to scroll offset so bottom edge looks right.
-      mirrorElement.style.setProperty('top', `${-1 * source.scrollTop}px`);
+      // Set top to scroll offset so the mirror matches the current line location.
+      const lineOffset =
+        mirrorElement.scrollHeight - mirrorElement.clientHeight;
+      mirrorElement.style.setProperty(
+        'top',
+        `${lineOffset - source.scrollTop}px`,
+      );
 
-      const { height } = source.getBoundingClientRect();
-      const offset = mirrorElement.offsetHeight - source.scrollTop;
-      if (offset < 0 || offset > height) {
+      // Get the wrapper and mirror element bounds to check if the new location is out of sight...
+      const wrapper = mirrorElement.parentElement?.getBoundingClientRect();
+      const { bottom, top } = mirrorElement.getBoundingClientRect();
+      if (wrapper && (bottom <= wrapper.top || top >= wrapper.bottom)) {
+        // And clear the results if so.
         onClear?.();
       }
     }

--- a/app/javascript/mastodon/components/autosuggest/hooks.tsx
+++ b/app/javascript/mastodon/components/autosuggest/hooks.tsx
@@ -182,7 +182,7 @@ export function useAutosuggestFloatingMenu({
 
   const onScroll = useThrottledCallback(onUpdate, 0);
   const updatePopoverCb = useCallback((update: () => void) => {
-    updatePopover.current = () => update;
+    updatePopover.current = update;
   }, []);
 
   const mirror = (

--- a/app/javascript/mastodon/components/autosuggest/styles.module.scss
+++ b/app/javascript/mastodon/components/autosuggest/styles.module.scss
@@ -7,6 +7,8 @@
   top: 0;
   left: 0;
   right: 0;
+  height: 1lh;
+  overflow: hidden;
 }
 
 .textAreaMirror {

--- a/app/javascript/mastodon/features/compose/redesign/index.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/index.tsx
@@ -120,8 +120,7 @@ export const RedesignComposeForm: React.FC<RedesignComposeFormProps> = ({
         autoFocus={autoFocus}
         onSubmit={onSubmit}
       >
-        {' '}
-        <ComposeAttachments className={classes.attachments} />{' '}
+        <ComposeAttachments className={classes.attachments} />
       </ComposeTextarea>
 
       <ComposeHints />

--- a/app/javascript/mastodon/features/compose/redesign/index.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/index.tsx
@@ -15,7 +15,6 @@ import {
 import { ToggleButton } from '@/mastodon/components/button/redesign';
 import { TextInputField } from '@/mastodon/components/form_fields/redesign';
 import { Icon } from '@/mastodon/components/icon';
-import { useScrollSensor } from '@/mastodon/hooks/useScrollSensor';
 import {
   focusComposerTextarea,
   getComposerTextarea,
@@ -68,11 +67,6 @@ export const RedesignComposeForm: React.FC<RedesignComposeFormProps> = ({
   const intl = useIntl();
   const titleId = useId();
 
-  const { sensor, isInViewport } = useScrollSensor({
-    placement: 'bottom',
-    tolerance: 10,
-  });
-
   return (
     <form
       role='dialog'
@@ -121,17 +115,14 @@ export const RedesignComposeForm: React.FC<RedesignComposeFormProps> = ({
         />
       )}
 
-      <div data-scroll-down={!isInViewport} className={classes.editorWrapper}>
-        <ComposeTextarea
-          // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus={autoFocus}
-          onSubmit={onSubmit}
-        />
-
-        <ComposeAttachments className={classes.attachments} />
-
-        {sensor}
-      </div>
+      <ComposeTextarea
+        // eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus={autoFocus}
+        onSubmit={onSubmit}
+      >
+        {' '}
+        <ComposeAttachments className={classes.attachments} />{' '}
+      </ComposeTextarea>
 
       <ComposeHints />
 

--- a/app/javascript/mastodon/features/compose/redesign/styles.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/styles.module.scss
@@ -79,7 +79,7 @@
   }
 }
 
-.editorWrapper {
+.textareaWrapper {
   --fade-size: var(--space-xl);
 
   overflow-y: auto;
@@ -112,14 +112,6 @@
   }
 }
 
-.textareaWrapper {
-  flex-grow: 1;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
 .textarea,
 .textareaMirror {
   @include mixins.type-body-lg;
@@ -129,12 +121,14 @@
 
 .textarea {
   flex-grow: 1;
+  flex-shrink: 0;
   border-radius: var(--radius-xs);
   transition: border 200ms;
   cursor: text;
   border: none;
   width: 100%;
   outline: none;
+  background: none;
 
   &:focus {
     outline: 2px solid var(--color-border-brand);

--- a/app/javascript/mastodon/features/compose/redesign/styles.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/styles.module.scss
@@ -155,6 +155,9 @@ textarea.textarea {
 }
 
 .attachments {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
   margin-top: var(--space-md);
 }
 

--- a/app/javascript/mastodon/features/compose/redesign/textarea.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/textarea.tsx
@@ -204,6 +204,7 @@ export const ComposeTextarea: React.FC<ComposeTextareaProps> = ({
       {mirror}
 
       <AutosuggestMenu {...suggestProps} maxWidth={280} />
+
       {children}
 
       {sensor}

--- a/app/javascript/mastodon/features/compose/redesign/textarea.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/textarea.tsx
@@ -16,6 +16,7 @@ import { useAutosuggestFloatingMenu } from '@/mastodon/components/autosuggest/ho
 import { AutosuggestMenu } from '@/mastodon/components/autosuggest/list';
 import { TextArea } from '@/mastodon/components/form_fields';
 import { normalizeKey } from '@/mastodon/components/hotkeys/utils';
+import { useScrollSensor } from '@/mastodon/hooks/useScrollSensor';
 import {
   COMPOSER_TEXTAREA_ID,
   focusComposerTextarea,
@@ -66,6 +67,7 @@ export const ComposeTextarea: React.FC<ComposeTextareaProps> = ({
   onSubmit,
   className,
   disabled,
+  children,
   ...props
 }) => {
   const intl = useIntl();
@@ -156,8 +158,13 @@ export const ComposeTextarea: React.FC<ComposeTextareaProps> = ({
     [dispatch],
   );
 
+  const { sensor, isInViewport } = useScrollSensor({
+    placement: 'bottom',
+    tolerance: 10,
+  });
+
   return (
-    <div className={classes.textareaWrapper}>
+    <div className={classes.textareaWrapper} data-scroll-down={!isInViewport}>
       <TextArea
         {...props}
         dir='auto'
@@ -182,6 +189,8 @@ export const ComposeTextarea: React.FC<ComposeTextareaProps> = ({
       {mirror}
 
       <AutosuggestMenu {...suggestProps} maxWidth={280} />
+
+      {sensor}
     </div>
   );
 };

--- a/app/javascript/mastodon/features/compose/redesign/textarea.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/textarea.tsx
@@ -1,8 +1,11 @@
+import type React from 'react';
 import { useCallback, useRef } from 'react';
 
 import { defineMessages, useIntl } from 'react-intl';
 
 import classNames from 'classnames';
+
+import type { TextareaAutosizeProps } from 'react-textarea-autosize';
 
 import {
   changeCompose,
@@ -44,7 +47,7 @@ const messages = defineMessages({
 });
 
 type ComposeTextareaProps = Omit<
-  React.ComponentPropsWithoutRef<'textarea'>,
+  TextareaAutosizeProps,
   | 'placeholder'
   | 'onFocus'
   | 'onBlur'
@@ -102,16 +105,23 @@ export const ComposeTextarea: React.FC<ComposeTextareaProps> = ({
   const suggestions = useAppSelector(selectSuggestions);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
-  const { onTextChange, focus, mirror, sourceProps, suggestProps } =
-    useAutosuggestFloatingMenu({
-      suggestions,
-      text,
-      className: classes.textareaMirror,
-      sourceRef: textAreaRef,
-      onSelect: onSuggestion,
-      onFetch: onSuggestionFetch,
-      onClear: onSuggestionClear,
-    });
+  const {
+    onTextChange,
+    focus,
+    mirror,
+    sourceProps: fullSourceProps,
+    suggestProps,
+  } = useAutosuggestFloatingMenu({
+    suggestions,
+    text,
+    className: classes.textareaMirror,
+    sourceRef: textAreaRef,
+    onSelect: onSuggestion,
+    onFetch: onSuggestionFetch,
+    onClear: onSuggestionClear,
+  });
+
+  const { onScroll, ...sourceProps } = fullSourceProps;
 
   // Update the composer text and trigger suggestions.
   const onChange: React.ChangeEventHandler<HTMLTextAreaElement> = useCallback(
@@ -164,12 +174,17 @@ export const ComposeTextarea: React.FC<ComposeTextareaProps> = ({
   });
 
   return (
-    <div className={classes.textareaWrapper} data-scroll-down={!isInViewport}>
+    <div
+      className={classes.textareaWrapper}
+      data-scroll-down={!isInViewport}
+      onScrollCapture={onScroll} // Requires capture so it fires before TextArea.
+    >
       <TextArea
         {...props}
         dir='auto'
         id={COMPOSER_TEXTAREA_ID}
         className={classNames(className, classes.textarea)}
+        autoSize
         ref={textAreaRef}
         value={text}
         lang={lang}
@@ -189,6 +204,7 @@ export const ComposeTextarea: React.FC<ComposeTextareaProps> = ({
       {mirror}
 
       <AutosuggestMenu {...suggestProps} maxWidth={280} />
+      {children}
 
       {sensor}
     </div>

--- a/app/javascript/mastodon/features/compose/redesign/trigger.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/trigger.module.scss
@@ -17,7 +17,8 @@
 }
 
 .composer {
-  width: min(560px, calc(100vw - var(--space-md) * 2));
+  width: calc(100vw - var(--space-md) * 2);
+  max-width: 500px;
   min-height: 520px;
   max-height: 80vh;
 }

--- a/app/javascript/mastodon/hooks/useScrollSensor/styles.module.scss
+++ b/app/javascript/mastodon/hooks/useScrollSensor/styles.module.scss
@@ -1,6 +1,7 @@
 .sensor {
   height: 1px;
   pointer-events: none;
+  flex-shrink: 0;
 
   &[data-placement='top'] {
     position: absolute;

--- a/app/javascript/mastodon/reducers/slices/composer.ts
+++ b/app/javascript/mastodon/reducers/slices/composer.ts
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 import {
   changeCompose,
+  clearComposeSuggestions,
   directCompose,
   replyComposeById,
   resetCompose,
@@ -73,7 +74,17 @@ const composerSlice = createSlice({
 });
 
 export const composer = composerSlice.reducer;
-export const { minimizeComposerToggle } = composerSlice.actions;
+
+export const minimizeComposerToggle = createAppThunk(
+  (_arg, { dispatch, getState }) => {
+    dispatch(composerSlice.actions.minimizeComposerToggle());
+
+    const displayState = getState().composer.displayState;
+    if (displayState !== 'showing') {
+      dispatch(clearComposeSuggestions());
+    }
+  },
+);
 
 export const selectComposerIsChanged = createAppSelector(
   [
@@ -148,6 +159,7 @@ export const openNewComposer = createAppThunk(
 export const resetComposer = createAppThunk((_arg, { dispatch }) => {
   dispatch(composerSlice.actions.hideComposer());
   dispatch(resetCompose());
+  dispatch(clearComposeSuggestions());
 });
 
 export const closeComposer = createAppThunk((_arg, { getState, dispatch }) => {


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Fixes WEB-1238.

This makes the composer narrower, and fixes some style bugs and scroll issues from #40276.