### PR TITLE
Reduce repeated role and WebAuthn queries in settings navigation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -208,6 +208,8 @@ module ApplicationHelper
   end
 
   def render_initial_state
+    signed_in = user_signed_in?
+    functional = signed_in && current_user.functional?
     state_params = {
       settings: {},
       text: [params[:title], params[:text], params[:url]].compact.join(' '),
@@ -218,15 +220,13 @@ module ApplicationHelper
     permit_visibilities.shift(permit_visibilities.index(default_privacy) + 1) if default_privacy.present?
     state_params[:visibility] = params[:visibility] if permit_visibilities.include? params[:visibility]
 
-    if user_signed_in? && current_user.functional?
+    if functional
       state_params[:settings]          = state_params[:settings].merge(Web::Setting.find_by(user: current_user)&.data || {})
       state_params[:push_subscription] = current_account.user.web_push_subscription(current_session)
       state_params[:current_account]   = current_account
       state_params[:token]             = current_session.token
       state_params[:admin]             = Account.find_local(Setting.site_contact_username.strip.gsub(/\A@/, ''))
-    end
-
-    if user_signed_in? && !current_user.functional?
+    elsif signed_in
       state_params[:disabled_account] = current_account
       state_params[:moved_to_account] = current_account.moved_to_account
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,11 +148,9 @@ class User < ApplicationRecord
   end
 
   def role
-    if role_id.nil?
-      UserRole.everyone
-    else
-      super
-    end
+    return super unless role_id.nil?
+
+    association(:role).target ||= UserRole.everyone
   end
 
   def invited?

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -2,6 +2,7 @@
 
 SimpleNavigation::Configuration.run do |navigation|
   self_destruct = SelfDestructHelper.self_destruct?
+  functional = current_user.functional?
 
   navigation.items do |n|
     n.item :web, safe_join([material_symbol('chevron_left'), t('settings.back')]), root_path
@@ -14,22 +15,22 @@ SimpleNavigation::Configuration.run do |navigation|
            html: { class: SoftwareUpdate.urgent_pending? || SoftwareDeprecation.current&.unsupported? ? 'warning' : nil },
            if: -> { Rails.configuration.x.mastodon.software_update_url.present? && current_user.can?(:view_devops) && SoftwareUpdate.pending? }
 
-    n.item :profile, safe_join([material_symbol('person'), t('settings.profile')]), settings_profile_path, if: -> { current_user.functional? && !self_destruct }, highlights_on: %r{/settings/profile|/settings/featured_tags|/settings/verification}
-    n.item :privacy, safe_join([material_symbol('globe'), t('privacy.title')]), settings_privacy_path, if: -> { current_user.functional? && !self_destruct }, highlights_on: %r{/settings/privacy}
+    n.item :profile, safe_join([material_symbol('person'), t('settings.profile')]), settings_profile_path, if: -> { functional && !self_destruct }, highlights_on: %r{/settings/profile|/settings/featured_tags|/settings/verification}
+    n.item :privacy, safe_join([material_symbol('globe'), t('privacy.title')]), settings_privacy_path, if: -> { functional && !self_destruct }, highlights_on: %r{/settings/privacy}
 
-    n.item :preferences, safe_join([material_symbol('settings'), t('settings.preferences')]), settings_preferences_path, if: -> { current_user.functional? && !self_destruct } do |s|
+    n.item :preferences, safe_join([material_symbol('settings'), t('settings.preferences')]), settings_preferences_path, if: -> { functional && !self_destruct } do |s|
       s.item :appearance, safe_join([material_symbol('computer'), t('settings.appearance')]), settings_preferences_appearance_path
       s.item :posting_defaults, safe_join([material_symbol('edit_square'), t('preferences.posting_defaults')]), settings_preferences_posting_defaults_path
       s.item :notifications, safe_join([material_symbol('mail'), t('settings.notifications')]), settings_preferences_notifications_path
       s.item :other, safe_join([material_symbol('tune'), t('preferences.other')]), settings_preferences_other_path
     end
 
-    n.item :relationships, safe_join([material_symbol('groups'), t('settings.relationships')]), relationships_path, if: -> { current_user.functional? && !self_destruct } do |s|
+    n.item :relationships, safe_join([material_symbol('groups'), t('settings.relationships')]), relationships_path, if: -> { functional && !self_destruct } do |s|
       s.item :current, safe_join([material_symbol('groups'), t('settings.relationships')]), relationships_path
       s.item :severed_relationships, safe_join([material_symbol('link_off'), t('settings.severed_relationships')]), severed_relationships_path
     end
 
-    n.item :filters, safe_join([material_symbol('filter_alt'), t('filters.index.title')]), filters_path, highlights_on: %r{/filters}, if: -> { current_user.functional? && !self_destruct }
+    n.item :filters, safe_join([material_symbol('filter_alt'), t('filters.index.title')]), filters_path, highlights_on: %r{/filters}, if: -> { functional && !self_destruct }
     n.item :statuses_cleanup, safe_join([material_symbol('history'), t('settings.statuses_cleanup')]), statuses_cleanup_path, if: -> { current_user.functional_or_moved? && !self_destruct }
 
     n.item :security, safe_join([material_symbol('account_circle'), t('settings.account')]), edit_user_registration_path do |s|
@@ -39,12 +40,12 @@ SimpleNavigation::Configuration.run do |navigation|
     end
 
     n.item :data, safe_join([material_symbol('cloud_sync'), t('settings.import_and_export')]), settings_export_path do |s|
-      s.item :import, safe_join([material_symbol('cloud_upload'), t('settings.import')]), settings_imports_path, highlights_on: %r{/settings/imports}, if: -> { current_user.functional? && !self_destruct }
+      s.item :import, safe_join([material_symbol('cloud_upload'), t('settings.import')]), settings_imports_path, highlights_on: %r{/settings/imports}, if: -> { functional && !self_destruct }
       s.item :export, safe_join([material_symbol('cloud_download'), t('settings.export')]), settings_export_path
     end
 
-    n.item :user_invites, safe_join([material_symbol('person_add'), t('invites.title')]), invites_path, if: -> { current_user.can?(:invite_users) && current_user.functional? && !self_destruct }
-    n.item :development, safe_join([material_symbol('code'), t('settings.development')]), settings_applications_path, highlights_on: %r{/settings/applications}, if: -> { current_user.functional? && !self_destruct }
+    n.item :user_invites, safe_join([material_symbol('person_add'), t('invites.title')]), invites_path, if: -> { current_user.can?(:invite_users) && functional && !self_destruct }
+    n.item :development, safe_join([material_symbol('code'), t('settings.development')]), settings_applications_path, highlights_on: %r{/settings/applications}, if: -> { functional && !self_destruct }
 
     n.item :trends, safe_join([material_symbol('trending_up'), t('admin.trends.title')]), admin_trends_statuses_path, if: -> { current_user.can?(:manage_taxonomies) && !self_destruct } do |s|
       s.item :statuses, safe_join([material_symbol('chat_bubble'), t('admin.trends.statuses.title')]), admin_trends_statuses_path, highlights_on: %r{/admin/trends/statuses}

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe User do
     it { is_expected.to have_many(:login_activities) }
   end
 
+  describe '#role' do
+    it 'caches the default role in the association when role_id is nil' do
+      user = described_class.new
+      default_role = instance_double(UserRole)
+      allow(UserRole).to receive(:everyone).and_return(default_role)
+
+      2.times { user.role }
+
+      expect(UserRole).to have_received(:everyone).once
+      expect(user.association(:role).target).to be(default_role)
+    end
+  end
+
   describe 'Validations' do
     it { is_expected.to_not allow_value('john@').for(:email) }
 

--- a/spec/requests/settings/exports_spec.rb
+++ b/spec/requests/settings/exports_spec.rb
@@ -3,6 +3,32 @@
 require 'rails_helper'
 
 RSpec.describe 'Settings / Exports' do
+  context 'when signed in' do
+    let(:user) { Fabricate(:user, role: nil) }
+
+    before do
+      user.update_column(:approved, true)
+      sign_in user
+    end
+
+    describe 'GET /settings/export' do
+      it 'does not repeat default-role and WebAuthn queries while rendering the settings layout' do
+        queries = []
+        subscriber = lambda do |_name, _start, _finish, _id, payload|
+          queries << payload[:sql] unless payload[:name] == 'SCHEMA'
+        end
+
+        ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record') do
+          get settings_export_path
+        end
+
+        expect(response).to have_http_status(:success)
+        expect(queries.grep(/FROM "user_roles"/).size).to be <= 1
+        expect(queries.grep(/FROM "webauthn_credentials"/).size).to be <= 3
+      end
+    end
+  end
+
   context 'when not signed in' do
     describe 'GET /settings/export' do
       it 'redirects to sign in page' do


### PR DESCRIPTION
Reduce repeated default-role and WebAuthn checks while rendering authenticated settings pages. The settings navigation calls `current_user.functional?` several times. For users without an explicitly assigned role, each permission check also calls `UserRole.everyone`. These accesses generate repeated Active Record SQL events, even though most are served by Rails’ query cache.

This change: 

 - Reuses the result of `current_user.functional?` within settings navigation.
 - Avoids evaluating the signed-in functional state more than once in render_initial_state.
 - Stores the default role in the user’s association cache when role_id is NULL. 
 - Adds regression coverage for repeated default-role and WebAuthn lookups.
 
## Performance
I profiled an authenticated GET `/settings/export` request in production mode using an approved and  confirmed normal member with

- role_id = NULL
- No WebAuthn credentials
- 10 statuses 

The latest comparison used three warmups and five measured requests per state. 
| Metric | Before mean | After mean | Mean change | Before median | After median |
|---|---:|---:|---:|---:|---:|
| Server duration (ms) | 50.48 | 45.37 | -10.1% | 49.26 | 45.32 |
| SQL duration (ms) | 10.63 | 10.15 | -4.5% | 10.74 | 10.40 |
| Allocated objects | 26319 | 24528 | -6.8% | 26314 | 24525 |
| SQL events | 54 | 26 | -51.9% | 54 | 26 |
| Cached SQL events | 31 | 3 | -90.3% | 31 | 3 |
| Duplicate fingerprints | 31 | 3 | -90.3% | 31 | 3 |
| Default role lookups | 21 | 1 | -95.2% | 21 | 1 |
| WebAuthn lookups | 11 | 3 | -72.7% | 11 | 3 |

The latency result should be treated cautiously because it comes from a small local sample. An earlier production-mode comparison showed effectively neutral latency. Also, most of the removed SQL events were Rails query-cache hits rather than additional database round trips. The main expected benefit is therefore less repeated Active Record work and fewer allocations, not a large reduction in database load. 

Although `/settings/export` was used as the reproducible example, the affected code is shared. The navigation change applies to every page using the authenticated admin layout, while default-role association caching applies wherever the same default-role user instance is checked repeatedly for permissions. The WebAuthn reduction is limited to the changed rendering paths; this does not introduce global memoization of two-factor authentication state. I used `/settings/export` as the reproducible case and have not separately profiled the other affected routes.