### PR TITLE
Fixed admin reports API performing per report status serialization

### DIFF
--- a/app/controllers/api/v1/admin/reports_controller.rb
+++ b/app/controllers/api/v1/admin/reports_controller.rb
@@ -25,7 +25,13 @@ class Api::V1::Admin::ReportsController < Api::BaseController
 
   def index
     authorize :report, :index?
-    render json: @reports, each_serializer: REST::Admin::ReportSerializer
+
+    statuses = report_statuses
+    render json: @reports,
+           each_serializer: REST::Admin::ReportSerializer,
+           report_statuses: records_by_report(statuses, :status_ids),
+           report_rules: records_by_report(report_rules, :rule_ids),
+           relationships: StatusRelationshipsPresenter.new(statuses, current_account.id)
   end
 
   def show
@@ -80,6 +86,21 @@ class Api::V1::Admin::ReportsController < Api::BaseController
 
   def filtered_reports
     ReportFilter.new(filter_params).results
+  end
+
+  def report_statuses
+    Status.with_discarded.where(id: @reports.flat_map { |report| Array(report.status_ids) }).with_includes.to_a
+  end
+
+  def report_rules
+    Rule.with_discarded.where(id: @reports.flat_map { |report| Array(report.rule_ids) }).includes(:translations).to_a
+  end
+
+  def records_by_report(records, ids_method)
+    @reports.to_h do |report|
+      record_ids = Array(report.public_send(ids_method))
+      [report.id, records.select { |record| record_ids.include?(record.id) }]
+    end
   end
 
   def report_params

--- a/app/serializers/rest/admin/report_serializer.rb
+++ b/app/serializers/rest/admin/report_serializer.rb
@@ -17,6 +17,10 @@ class REST::Admin::ReportSerializer < ActiveModel::Serializer
   end
 
   def statuses
-    object.statuses.with_includes
+    instance_options[:report_statuses]&.fetch(object.id) { object.statuses.with_includes } || object.statuses.with_includes
+  end
+
+  def rules
+    instance_options[:report_rules]&.fetch(object.id) { object.rules } || object.rules
   end
 end

--- a/spec/requests/api/v1/admin/reports_spec.rb
+++ b/spec/requests/api/v1/admin/reports_spec.rb
@@ -120,6 +120,26 @@ RSpec.describe 'Reports' do
           expect(response.parsed_body.size).to eq(1)
         end
       end
+
+      it 'loads report statuses, rules, and status relationships in batches' do
+        rule = Fabricate(:rule)
+        3.times do
+          statuses = Fabricate.times(2, :status, account: spammer)
+          Fabricate(:report, category: :violation, target_account: spammer, status_ids: statuses.map(&:id), rule_ids: [rule.id])
+        end
+
+        queries = []
+        subscriber = lambda do |_name, _start, _finish, _id, payload|
+          queries << payload[:sql] unless payload[:name] == 'SCHEMA'
+        end
+
+        ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record') { subject }
+
+        expect(response).to have_http_status(:success)
+        expect(queries.grep(/SELECT "statuses"\.\* FROM "statuses" WHERE "statuses"\."id" IN/).size).to eq(1)
+        expect(queries.grep(/SELECT "rules"\.\* FROM "rules" WHERE/).size).to eq(1)
+        expect(queries.grep(/FROM "favourites" WHERE "favourites"\."status_id" IN/).size).to eq(1)
+      end
     end
   end
 

--- a/spec/requests/api/v1/admin/reports_spec.rb
+++ b/spec/requests/api/v1/admin/reports_spec.rb
@@ -121,24 +121,19 @@ RSpec.describe 'Reports' do
         end
       end
 
-      it 'loads report statuses, rules, and status relationships in batches' do
+      it 'loads report statuses, rules, and status relationships in batches', :aggregate_failures do
         rule = Fabricate(:rule)
         3.times do
           statuses = Fabricate.times(2, :status, account: spammer)
           Fabricate(:report, category: :violation, target_account: spammer, status_ids: statuses.map(&:id), rule_ids: [rule.id])
         end
 
-        queries = []
-        subscriber = lambda do |_name, _start, _finish, _id, payload|
-          queries << payload[:sql] unless payload[:name] == 'SCHEMA'
-        end
-
-        ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record') { subject }
+        notifications = capture_notifications('sql.active_record') { subject }
 
         expect(response).to have_http_status(:success)
-        expect(queries.grep(/SELECT "statuses"\.\* FROM "statuses" WHERE "statuses"\."id" IN/).size).to eq(1)
-        expect(queries.grep(/SELECT "rules"\.\* FROM "rules" WHERE/).size).to eq(1)
-        expect(queries.grep(/FROM "favourites" WHERE "favourites"\."status_id" IN/).size).to eq(1)
+        expect(notifications.count { |event| event.payload[:name] == 'Status Load' && event.payload[:sql].start_with?('SELECT "statuses".*') }).to eq(1)
+        expect(notifications.count { |event| event.payload[:name] == 'Rule Load' }).to eq(1)
+        expect(notifications.count { |event| event.payload[:name] == 'Favourite Load' }).to eq(1)
       end
     end
   end


### PR DESCRIPTION
Fix admin reports API performing per report status serialization causing hundreds of duplicate queries on one page. Because the controller loaded the report page with only report-account associations preloaded and ` REST::Admin::ReportSerializer#statuses` called `object.statuses.with_includes` once per report. Each status was then rendered through `REST::StatusSerializer`, which independently checked relationships such as favourites, reblogs, bookmarks, conversation mutes, and filters. Consequently, a page triggered the same status-association queries repeatedly instead of batching them across the collection.

## Changes:

- In the controller, The index action now prepares shared serialization data for the entire page and those collections are passed into the serializer
- The serializer now uses the controller-provided status and rule collections (`instance_options[:report_statuses]` and `instance_options[:report_rules]`)

## Performance

I profiled authenticated `GET https://localhost:3000/api/v1/admin/reports?resolved=false&limit=40` request in production mode. 
Data: 40 unresolved reports, distinct local reporter/target accounts, two statuses and one shared rule per report
Measurements: 5 total before and 5 total after; every response validated for report/status/rule counts.

| Metric | Before mean | After mean | Mean change | Before median | After median |
|---|---:|---:|---:|---:|---:|
| Server duration (ms) | 1613.42 | 463.35 | -71.3% | 1563.70 | 454.43 |
| SQL duration (ms) | 551.01 | 21.19 | -96.2% | 539.87 | 20.78 |
| Allocated objects | 882746 | 362740 | -58.9% | 882734 | 362745 |
| SQL events | 1652 | 270 | -83.7% | 1652 | 270 |
| Cached SQL events | 358 | 241 | -32.7% | 358 | 241 |
| Duplicate fingerprints | 1624 | 242 | -85.1% | 1624 | 242 |
| Status queries | 160 | 2 | -98.8% | 160 | 2 |
| Relationship queries | 240 | 3 | -98.8% | 240 | 3 |

This values are observed in my local setup.