### PR TITLE
Extract `visibility_scope` method to re-use existing scopes in `AccountStatusesFilter`

### DIFF
--- a/app/lib/account_statuses_filter.rb
+++ b/app/lib/account_statuses_filter.rb
@@ -49,15 +49,23 @@ class AccountStatusesFilter
     scope = account.statuses
 
     if exclude_direct?
-      scope = scope.where(visibility: follower? ? %i(public unlisted private) : %i(public unlisted))
+      scope = visibility_scope(scope)
     else
       scope = account.statuses.left_outer_joins(:mentions)
-      scope.merge!(scope.where(visibility: follower? ? %i(public unlisted private) : %i(public unlisted)).or(scope.where(mentions: { account_id: current_account.id })).group(Status.arel_table[:id]))
+      scope.merge!(visibility_scope(scope).or(scope.where(mentions: { account_id: current_account.id })).group(Status.arel_table[:id]))
     end
 
     scope.merge!(filtered_reblogs_scope) if reblogs_may_occur?
 
     scope
+  end
+
+  def visibility_scope(scope)
+    if follower?
+      scope.list_eligible_visibility
+    else
+      scope.distributable_visibility
+    end
   end
 
   def filtered_reblogs_scope


### PR DESCRIPTION
Basically two changes in the same area:

- Extract method to DRY up the repeated call to build the scope
- Use the pre-existing well named scopes from `Status::Visibility` which wrap the enum list options, instead of repeating the value list in this filter class