### PR TITLE
5.0: Fixes bugs with menu items

### DIFF
--- a/app/javascript/mastodon/components/menu/items.tsx
+++ b/app/javascript/mastodon/components/menu/items.tsx
@@ -87,6 +87,8 @@ const MenuItemBase = <As extends React.ElementType>({
 
   return (
     <Component
+      // If it's a button, set the type by default or it will submit forms.
+      type={AsComp === 'button' ? 'button' : undefined}
       {...props}
       data-menu-item
       className={classNames(
@@ -260,7 +262,13 @@ export const MenuItemCheckbox: React.FC<MenuItemCheckboxProps> = ({
       aria-checked={checked}
       onClick={handleChange}
       trailingContent={
-        <Toggle aria-hidden='true' tabIndex={-1} size='sm' checked={checked} />
+        <Toggle
+          aria-hidden='true'
+          tabIndex={-1}
+          size='sm'
+          checked={checked}
+          readOnly
+        />
       }
     >
       {children}


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Fixes WEB-1235.

This resolves two problems with `MenuItem`s:

First, all `MenuItem`s that are a button do not set the `type` attribute, which means when clicked they trigger a `submit` on the composer. This adds a `type` prop for buttons which can still be overwritten in use.

Second, `MenuItemCheckbox` passes in the `checked` attribute to the `Toggle` component used as display, but does not provide a change handler which throws a warning in React. The fix is to add `readOnly` so it's clear the user cannot toggle them.

