### PR TITLE
5.0: Adds CaretIcon component

### DIFF
--- a/app/javascript/mastodon/components/button/redesign.module.scss
+++ b/app/javascript/mastodon/components/button/redesign.module.scss
@@ -184,6 +184,11 @@ a.base {
   height: var(--fs-xl);
 }
 
+.iconCustom {
+  width: inherit;
+  height: inherit;
+}
+
 .iconOnly {
   aspect-ratio: 1;
   padding: 0;

--- a/app/javascript/mastodon/components/button/redesign.tsx
+++ b/app/javascript/mastodon/components/button/redesign.tsx
@@ -6,6 +6,8 @@ import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 import type { LinkProps } from 'react-router-dom';
 
+import { CaretDownIcon } from '@phosphor-icons/react';
+
 import { CircularProgress } from '../circular_progress';
 import type { IconProp } from '../icon';
 import { Icon } from '../icon';
@@ -128,6 +130,17 @@ export const IconButton: React.FC<BaseButtonProps & { icon: IconProp }> = ({
     )}
     <span className='sr-only'>{children}</span>
   </BaseButton>
+);
+
+export const CaretIcon = (
+  props: React.SVGProps<SVGSVGElement> & { title?: string },
+) => (
+  <CaretDownIcon
+    {...props}
+    className={classNames(props.className, classes.iconCustom)}
+    weight='fill'
+    size={12}
+  />
 );
 
 const LoadingIcon: React.FC = () => (

--- a/app/javascript/mastodon/features/compose/redesign/language.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/language.tsx
@@ -3,9 +3,10 @@ import { useCallback } from 'react';
 
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
-import { CaretDownIcon, MagnifyingGlassIcon } from '@phosphor-icons/react';
+import { MagnifyingGlassIcon } from '@phosphor-icons/react';
 
 import { changeComposeLanguage } from '@/mastodon/actions/compose';
+import { CaretIcon } from '@/mastodon/components/button/redesign';
 import { TextInput } from '@/mastodon/components/form_fields/redesign';
 import {
   Menu,
@@ -32,7 +33,7 @@ export const LanguageButton: React.FC = () => {
 
   return (
     <Menu>
-      <MenuTrigger size='sm' trailingIcon={CaretDownIcon}>
+      <MenuTrigger size='sm' trailingIcon={CaretIcon}>
         {langCode.toLocaleUpperCase()}
       </MenuTrigger>
 

--- a/app/javascript/mastodon/features/compose/redesign/visibility.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/visibility.tsx
@@ -4,7 +4,6 @@ import { useCallback } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import {
-  CaretDownIcon,
   ChatCircleIcon,
   MagnifyingGlassIcon,
   NewspaperIcon,
@@ -18,6 +17,7 @@ import {
 import { openModal } from '@/mastodon/actions/modal';
 import type { ApiQuotePolicy } from '@/mastodon/api_types/quotes';
 import type { StatusVisibility } from '@/mastodon/api_types/statuses';
+import { CaretIcon } from '@/mastodon/components/button/redesign';
 import { DisplayNameSimple } from '@/mastodon/components/display_name/simple';
 import {
   Menu,
@@ -47,7 +47,7 @@ export const ComposeVisibility: React.FC<{ className?: string }> = ({
         description='Before button that indicates who a post is for (Public, Followers, mentioned people)'
       />
       <Menu>
-        <MenuTrigger size='sm' trailingIcon={CaretDownIcon}>
+        <MenuTrigger size='sm' trailingIcon={CaretIcon}>
           <ComposeVisibilityButtonText privacy={privacy} />
         </MenuTrigger>
 


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Fixes WEB-1239.

This replaces the previous caret icons with the filled variant that is a bit smaller.