### PR TITLE
Redesign: Update main layout background colors

### DIFF
--- a/app/javascript/mastodon/features/navigation_panel/redesign/header.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/header.module.scss
@@ -13,22 +13,13 @@
 
   padding: var(--space-xl) var(--space-lg) var(--half-bottom-spacing);
   margin-bottom: var(--half-bottom-spacing);
-  background: var(--color-bg-primary);
+  background: var(--color-bg-blend-solid);
 
   &::after {
-    content: '';
-    position: absolute;
-    top: 100%;
-    inset-inline: 0;
-    height: var(--space-2xl);
-    background: linear-gradient(
-      to bottom,
-      var(--color-bg-primary),
-      transparent
-    );
-    pointer-events: none;
+    @include mixins.scroll-gradient(top, var(--color-bg-blend-solid));
+
     opacity: 0;
-    transition: opacity linear 200ms;
+    transition: opacity ease 250ms;
   }
 
   &[data-stuck='true']::after {

--- a/app/javascript/mastodon/features/navigation_panel/redesign/index.stories.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/index.stories.tsx
@@ -10,7 +10,13 @@ const meta = {
   component: RedesignNavigationPanel,
   render(args) {
     return (
-      <div style={{ width: 320 }}>
+      <div
+        style={{
+          width: 320,
+          height: 600,
+          backgroundColor: 'var(--color-bg-blend-solid)',
+        }}
+      >
         <RedesignNavigationPanel {...args} />
         <div inert aria-hidden='true' className='logo-resources'>
           {/* In our web app, this icon is embedded server-side */}

--- a/app/javascript/mastodon/features/navigation_panel/redesign/styles.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/styles.module.scss
@@ -28,18 +28,13 @@
   margin-top: auto;
   padding: var(--space-xl);
   padding-top: var(--space-2xs);
-  background-color: var(--color-bg-primary);
+  background-color: var(--color-bg-blend-solid);
 
   &::before {
-    content: '';
-    position: absolute;
-    bottom: 100%;
-    inset-inline: 0;
-    height: var(--space-2xl);
-    background: linear-gradient(to top, var(--color-bg-primary), transparent);
-    pointer-events: none;
+    @include mixins.scroll-gradient(bottom, var(--color-bg-blend-solid));
+
     opacity: 0;
-    transition: opacity linear 200ms;
+    transition: opacity ease 250ms;
   }
 
   &[data-stuck='true']::before {

--- a/app/javascript/mastodon/features/ui/components/columns_area/redesign.module.scss
+++ b/app/javascript/mastodon/features/ui/components/columns_area/redesign.module.scss
@@ -56,3 +56,21 @@
     border-inline: 1px solid var(--color-border-primary);
   }
 }
+
+.columnHeader {
+  background: var(--color-bg-blend-solid);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  border-top: 0;
+
+  @media (width >= $no-gap-breakpoint) {
+    border-top: 10px solid var(--color-bg-blend-solid);
+  }
+
+  // Fix bg color for legacy column headers.
+  // Remove when new column headers are in.
+  & :global(.column-header) {
+    background: var(--color-bg-primary);
+  }
+}

--- a/app/javascript/mastodon/features/ui/components/columns_area/redesign.tsx
+++ b/app/javascript/mastodon/features/ui/components/columns_area/redesign.tsx
@@ -68,7 +68,7 @@ export const ColumnsAreaRedesign: React.FC<{
         {isMobile ? <RedesignMobileNavigation /> : <ComposeRedesignButton />}
 
         <main className={classes.main}>
-          <div className='tabs-bar__wrapper'>
+          <div className={classes.columnHeader}>
             <TabsBarPortal />
           </div>
 

--- a/app/javascript/styles/mastodon/_mixins.scss
+++ b/app/javascript/styles/mastodon/_mixins.scss
@@ -120,6 +120,25 @@
 }
 
 /**
+ * Scroll gradient
+ */
+
+@mixin scroll-gradient($position, $background-color: var(--color-bg-primary)) {
+  content: '';
+  position: absolute;
+  @if $position == 'top' {
+    top: 100%;
+  } @else {
+    bottom: 100%;
+  }
+
+  inset-inline: 0;
+  height: calc(var(--space-4xl) * 2);
+  background: linear-gradient(to $position, transparent, $background-color);
+  pointer-events: none;
+}
+
+/**
  * Search input styles
  */
 

--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -14,6 +14,8 @@ html {
 
   &[data-redesign='true'] {
     --font-body: Inter, sans-serif;
+
+    background: var(--color-bg-blend-solid);
   }
 
   --outline-focus-default: 2px solid var(--color-border-brand);
@@ -54,7 +56,6 @@ html.has-modal {
 
 body {
   font-family: var(--font-body);
-  background: var(--color-bg-primary);
   font-size: 13px;
   line-height: 18px;
   font-weight: 400;

--- a/app/javascript/styles/mastodon/tokens/theme/_dark.scss
+++ b/app/javascript/styles/mastodon/tokens/theme/_dark.scss
@@ -40,7 +40,16 @@
   --overlay-strength-secondary: 4%;
   --color-bg-secondary: var(--color-grey-900);
   --color-bg-tertiary: var(--color-grey-800); // legacy
-  --color-bg-blend: #{utils.css-alpha(var(--color-black), 30%)};
+  --color-bg-blend-strength: 30%;
+  --color-bg-blend: #{utils.css-alpha(
+      var(--color-black),
+      var(--color-bg-blend-strength)
+    )};
+  --color-bg-blend-solid: color-mix(
+    in srgb,
+    var(--color-bg-primary),
+    var(--color-black) var(--color-bg-blend-strength)
+  );
   --color-bg-highlight: #{utils.css-alpha(var(--color-text-primary), 5%)};
 
   // Utility

--- a/app/javascript/styles/mastodon/tokens/theme/_light.scss
+++ b/app/javascript/styles/mastodon/tokens/theme/_light.scss
@@ -36,7 +36,16 @@
   --overlay-strength-secondary: 4%;
   --color-bg-secondary: var(--color-grey-50);
   --color-bg-tertiary: var(--color-grey-100); // legacy
-  --color-bg-blend: #{utils.css-alpha(var(--color-text-primary), 4%)};
+  --color-bg-blend-strength: 4%;
+  --color-bg-blend: #{utils.css-alpha(
+      var(--color-grey-950),
+      var(--color-bg-blend-strength)
+    )};
+  --color-bg-blend-solid: color-mix(
+    in srgb,
+    var(--color-bg-primary),
+    var(--color-grey-950) var(--color-bg-blend-strength)
+  );
   --color-bg-highlight: #{utils.css-alpha(var(--color-text-primary), 4%)};
 
   // Utility


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Fixes PRO-503

### Changes proposed in this PR:
- Updates the page background color outside of column content to a light grey (light mode) and black (dark mode)
- Splits a new token `color-bg-blend-strength` out of the the `color-bg-blend` token to create a separate `color-bg-blend-solid` token. (We need this token to be solid, will discuss whether we can just change `color-bg-blend` instead of having a transparent and a solid variant.)
- Increases the size of the navigation's overscroll gradients (to prevent it from becoming invisible at certain scroll positions)
- Moves the scroll gradient's CSS into a mixin

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="1382" height="867" alt="image" src="https://github.com/user-attachments/assets/faa34d8d-5bf0-4797-bc9b-efb15a93935a" /> | <img width="1380" height="869" alt="image" src="https://github.com/user-attachments/assets/8d69ad75-fdb3-4004-9fc9-bb115e5fe1c1" /> |
| <img width="1380" height="871" alt="image" src="https://github.com/user-attachments/assets/05194175-9308-40f1-96b6-8c79f5bb2c80" /> | <img width="1381" height="870" alt="image" src="https://github.com/user-attachments/assets/a6fd9f9f-2ed4-4e28-9b5a-a1e5f8da7162" /> |