### PR TITLE
Add new `ColumnHeader` component

### DIFF
--- a/app/javascript/mastodon/components/button/redesign.tsx
+++ b/app/javascript/mastodon/components/button/redesign.tsx
@@ -116,7 +116,11 @@ export const Button: React.FC<ButtonProps> = ({
   </BaseButton>
 );
 
-export const IconButton: React.FC<BaseButtonProps & { icon: IconProp }> = ({
+export type IconButtonProps = BaseButtonProps & {
+  icon: IconProp;
+};
+
+export const IconButton: React.FC<IconButtonProps> = ({
   icon,
   className,
   children,

--- a/app/javascript/mastodon/components/column_header/column_header.stories.tsx
+++ b/app/javascript/mastodon/components/column_header/column_header.stories.tsx
@@ -1,0 +1,54 @@
+import { UserPlusIcon, DotsThreeIcon } from '@phosphor-icons/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import type { ColumnHeaderProps } from './index';
+import { ColumnHeader, ColumnHeaderButton } from './index';
+
+const meta = {
+  title: 'Redesign/ColumnHeader',
+  component: ColumnHeader,
+  args: {
+    title: 'Page title',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 600, margin: 'auto', padding: 20 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+    redesign: true,
+  },
+} satisfies Meta<ColumnHeaderProps>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithBackButton: Story = {
+  args: {
+    withBackButton: true,
+  },
+};
+
+export const WithButtons: Story = {
+  args: {
+    withBackButton: true,
+    extraButtons: (
+      <>
+        <ColumnHeaderButton icon={DotsThreeIcon}>Options</ColumnHeaderButton>
+        <ColumnHeaderButton
+          showTextOnDesktop
+          icon={UserPlusIcon}
+          variant='solid'
+        >
+          Follow
+        </ColumnHeaderButton>
+      </>
+    ),
+  },
+};

--- a/app/javascript/mastodon/components/column_header/index.tsx
+++ b/app/javascript/mastodon/components/column_header/index.tsx
@@ -1,0 +1,127 @@
+import { useCallback } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import classNames from 'classnames';
+
+import { ArrowLeftIcon, ListIcon } from '@phosphor-icons/react';
+
+import { openNavigation } from '@/mastodon/actions/navigation';
+import { getColumnSkipLinkId } from '@/mastodon/features/ui/components/skip_links';
+import { useBreakpoint } from '@/mastodon/features/ui/hooks/useBreakpoint';
+import { useAppDispatch } from '@/mastodon/store';
+import { hasReactChildren } from '@/mastodon/utils/has_react_children';
+
+import type { IconButtonProps } from '../button/redesign';
+import { Button, IconButton } from '../button/redesign';
+import { useColumn, useColumnIndexContext } from '../column/context';
+import { NavigationFocusTarget } from '../navigation_focus_target';
+import { useAppHistory } from '../router';
+
+import classes from './styles.module.scss';
+
+export interface ColumnHeaderProps {
+  title: string;
+  withBackButton?: boolean;
+  extraButtons?: React.ReactNode;
+  className?: string;
+}
+
+export const ColumnHeader: React.FC<ColumnHeaderProps> = ({
+  title,
+  withBackButton,
+  extraButtons,
+  className,
+  ...props
+}: ColumnHeaderProps) => {
+  const { scrollTop } = useColumn();
+  const columnIndex = useColumnIndexContext();
+
+  return (
+    <header {...props} className={classNames(className, classes.root)}>
+      {withBackButton ? <BackButton /> : <MobileMenuButton />}
+      <NavigationFocusTarget className={classes.title}>
+        <button
+          type='button'
+          onClick={scrollTop}
+          id={getColumnSkipLinkId(columnIndex)}
+        >
+          {title}
+        </button>
+      </NavigationFocusTarget>
+      {hasReactChildren(extraButtons) && (
+        <div className={classes.rightButtons}>{extraButtons}</div>
+      )}
+    </header>
+  );
+};
+
+type ColumnHeaderButtonProps = IconButtonProps & {
+  showTextOnDesktop?: boolean;
+};
+
+export const ColumnHeaderButton: React.FC<ColumnHeaderButtonProps> = ({
+  showTextOnDesktop,
+  variant = 'ghost',
+  icon,
+  children,
+  ...props
+}) => {
+  const isMobile = useBreakpoint('openable');
+
+  if (showTextOnDesktop && !isMobile) {
+    return (
+      <Button {...props} variant={variant}>
+        {children}
+      </Button>
+    );
+  }
+
+  return (
+    <IconButton icon={icon} variant={variant} {...props}>
+      {children}
+    </IconButton>
+  );
+};
+
+const BackButton: React.FC = () => {
+  const history = useAppHistory();
+
+  const goBack = useCallback(() => {
+    if (history.location.state?.fromMastodon) {
+      history.goBack();
+    } else {
+      history.push('/');
+    }
+  }, [history]);
+
+  return (
+    <div className={classes.leftButton}>
+      <ColumnHeaderButton onClick={goBack} icon={ArrowLeftIcon}>
+        <FormattedMessage id='column_back_button.label' defaultMessage='Back' />
+      </ColumnHeaderButton>
+    </div>
+  );
+};
+
+const MobileMenuButton: React.FC = () => {
+  const dispatch = useAppDispatch();
+
+  const openMobileNavigation = useCallback(() => {
+    dispatch(openNavigation());
+  }, [dispatch]);
+
+  const isMobile = useBreakpoint('openable');
+
+  if (!isMobile) {
+    return null;
+  }
+
+  return (
+    <div className={classes.leftButton}>
+      <ColumnHeaderButton onClick={openMobileNavigation} icon={ListIcon}>
+        <FormattedMessage id='tabs_bar.menu' defaultMessage='Menu' />
+      </ColumnHeaderButton>
+    </div>
+  );
+};

--- a/app/javascript/mastodon/components/column_header/styles.module.scss
+++ b/app/javascript/mastodon/components/column_header/styles.module.scss
@@ -1,0 +1,53 @@
+@use '@/styles/mastodon/mixins';
+
+.root {
+  position: relative;
+  display: grid;
+
+  // Ensure title is centered regardless of side-content
+  grid-template-columns:
+    minmax(min-content, 1fr)
+    minmax(0, auto)
+    minmax(min-content, 1fr);
+  align-items: center;
+  min-height: 40px;
+  padding: var(--space-sm);
+  border-top-left-radius: var(--radius-xl);
+  border-top-right-radius: var(--radius-xl);
+  text-align: center;
+  color: var(--color-text-primary);
+  background: linear-gradient(
+    to bottom,
+    var(--color-bg-primary) 50%,
+    transparent
+  );
+}
+
+.title {
+  @include mixins.type-heading-sm;
+
+  grid-column: 2;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  min-width: 0;
+
+  > button {
+    overflow: hidden;
+    width: 100%;
+    padding: 0;
+    border: none;
+    font: inherit;
+    background: transparent;
+  }
+}
+
+.leftButton {
+  justify-self: start;
+}
+
+.rightButtons {
+  display: flex;
+  align-items: center;
+  justify-self: end;
+}


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Fixes PRO-504

### Changes proposed in this PR:
- Implements a new `ColumnHeader` component, just in Storybook for now (i.e. it's not used in the app yet)

### Screenshots

<img width="686" height="550" alt="image" src="https://github.com/user-attachments/assets/0b281c18-ff01-47d2-9c0a-21501c3c88da" />
