### PR TITLE
Composer redesign: Make the composer cover the viewport

### DIFF
--- a/app/javascript/mastodon/features/compose/redesign/trigger.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/trigger.module.scss
@@ -21,10 +21,8 @@
   top: env(safe-area-inset-top);
 
   // Set from the visualViewport API.
-  height: var(--viewport-height, 80vh);
-  max-height: 80vh;
-  transition: height 200ms;
-  box-shadow: 0 2px var(--color-border-strong);
+  height: var(--viewport-height, 100vh);
+  max-height: 100vh;
 
   @media (width >= #{variables.$mobile-menu-breakpoint}) {
     top: auto;


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Follow-up to #40346 to make the viewport cover the navigation buttons on mobile.