### PR TITLE
Refactor `color-bg-blend` token

### DIFF
--- a/app/javascript/mastodon/features/navigation_panel/redesign/header.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/header.module.scss
@@ -13,10 +13,10 @@
 
   padding: var(--space-xl) var(--space-lg) var(--half-bottom-spacing);
   margin-bottom: var(--half-bottom-spacing);
-  background: var(--color-bg-blend-solid);
+  background: var(--color-bg-blend);
 
   &::after {
-    @include mixins.scroll-gradient(top, var(--color-bg-blend-solid));
+    @include mixins.scroll-gradient(top, var(--color-bg-blend));
 
     opacity: 0;
     transition: opacity ease 250ms;

--- a/app/javascript/mastodon/features/navigation_panel/redesign/index.stories.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/index.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
         style={{
           width: 320,
           height: 600,
-          backgroundColor: 'var(--color-bg-blend-solid)',
+          backgroundColor: 'var(--color-bg-blend)',
         }}
       >
         <RedesignNavigationPanel {...args} />

--- a/app/javascript/mastodon/features/navigation_panel/redesign/styles.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/styles.module.scss
@@ -28,10 +28,10 @@
   margin-top: auto;
   padding: var(--space-xl);
   padding-top: var(--space-2xs);
-  background-color: var(--color-bg-blend-solid);
+  background-color: var(--color-bg-blend);
 
   &::before {
-    @include mixins.scroll-gradient(bottom, var(--color-bg-blend-solid));
+    @include mixins.scroll-gradient(bottom, var(--color-bg-blend));
 
     opacity: 0;
     transition: opacity ease 250ms;

--- a/app/javascript/mastodon/features/ui/components/columns_area/redesign.module.scss
+++ b/app/javascript/mastodon/features/ui/components/columns_area/redesign.module.scss
@@ -60,7 +60,7 @@
 
   background: linear-gradient(
     to bottom,
-    var(--color-bg-blend-solid) var(--column-header-gradient-start),
+    var(--color-bg-blend) var(--column-header-gradient-start),
     transparent var(--column-header-gradient-start)
   );
   position: sticky;
@@ -69,7 +69,7 @@
   border-top: 0;
 
   @media (width >= $mobile-menu-breakpoint) {
-    border-top: 10px solid var(--color-bg-blend-solid);
+    border-top: 10px solid var(--color-bg-blend);
   }
 
   // Fix bg color for legacy column headers.

--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -28,7 +28,7 @@ html {
     // Compensate for column header height when scrolling elements into view
     --column-header-height: 74px;
 
-    background: var(--color-bg-blend-solid);
+    background: var(--color-bg-blend);
   }
 
   // Variable for easily inverting directional UI elements,

--- a/app/javascript/styles/mastodon/tokens/theme/_dark.scss
+++ b/app/javascript/styles/mastodon/tokens/theme/_dark.scss
@@ -40,15 +40,10 @@
   --overlay-strength-secondary: 4%;
   --color-bg-secondary: var(--color-grey-900);
   --color-bg-tertiary: var(--color-grey-800); // legacy
-  --color-bg-blend-strength: 30%;
-  --color-bg-blend: #{utils.css-alpha(
-      var(--color-black),
-      var(--color-bg-blend-strength)
-    )};
-  --color-bg-blend-solid: color-mix(
+  --color-bg-blend: color-mix(
     in srgb,
     var(--color-bg-primary),
-    var(--color-black) var(--color-bg-blend-strength)
+    var(--color-black) 30%
   );
   --color-bg-highlight: #{utils.css-alpha(var(--color-text-primary), 5%)};
 

--- a/app/javascript/styles/mastodon/tokens/theme/_light.scss
+++ b/app/javascript/styles/mastodon/tokens/theme/_light.scss
@@ -36,15 +36,10 @@
   --overlay-strength-secondary: 4%;
   --color-bg-secondary: var(--color-grey-50);
   --color-bg-tertiary: var(--color-grey-100); // legacy
-  --color-bg-blend-strength: 4%;
-  --color-bg-blend: #{utils.css-alpha(
-      var(--color-grey-950),
-      var(--color-bg-blend-strength)
-    )};
-  --color-bg-blend-solid: color-mix(
+  --color-bg-blend: color-mix(
     in srgb,
     var(--color-bg-primary),
-    var(--color-grey-950) var(--color-bg-blend-strength)
+    var(--color-grey-950) 4%
   );
   --color-bg-highlight: #{utils.css-alpha(var(--color-text-primary), 4%)};
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Updates the `color-bg-blend` token to always be an opaque color, removing the temporary `color-bg-blend-solid` and `color-bg-blend-strength` tokens