### PR TITLE
Feature: Append local or remote to moderation notifications

### DIFF
--- a/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
@@ -47,14 +47,10 @@ export const NotificationAdminReport: React.FC<{
 
   const values = {
     name: <DisplayName account={account} variant='simple' />,
-    target: (
-      <>
-        <DisplayName account={targetAccount} variant='simple' /> (
-        {isLocal ? 'local' : 'remote'})
-      </>
-    ),
+    target: <DisplayName account={targetAccount} variant='simple' />,
     category: intl.formatMessage(messages[report.category]),
     count: report.status_ids.length,
+    isLocal: {isLocal ? 'local' : 'remote'},
   };
 
   let message;
@@ -64,7 +60,7 @@ export const NotificationAdminReport: React.FC<{
       message = (
         <FormattedMessage
           id='notification.admin.report_account_other'
-          defaultMessage='{name} reported {count, plural, one {one post} other {# posts}} from {target}'
+          defaultMessage='{name} reported {count, plural, one {one post} other {# posts}} from {target} ({isLocal})' 
           values={values}
         />
       );
@@ -72,7 +68,7 @@ export const NotificationAdminReport: React.FC<{
       message = (
         <FormattedMessage
           id='notification.admin.report_account'
-          defaultMessage='{name} reported {count, plural, one {one post} other {# posts}} from {target} for {category}'
+          defaultMessage='{name} reported {count, plural, one {one post} other {# posts}} from {target} for {category} ({isLocal})'
           values={values}
         />
       );
@@ -82,7 +78,7 @@ export const NotificationAdminReport: React.FC<{
       message = (
         <FormattedMessage
           id='notification.admin.report_statuses_other'
-          defaultMessage='{name} reported {target}'
+          defaultMessage='{name} reported {target}  ({isLocal})'
           values={values}
         />
       );
@@ -90,7 +86,7 @@ export const NotificationAdminReport: React.FC<{
       message = (
         <FormattedMessage
           id='notification.admin.report_statuses'
-          defaultMessage='{name} reported {target} for {category}'
+          defaultMessage='{name} reported {target} for {category}  ({isLocal})'
           values={values}
         />
       );

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
@@ -50,7 +50,7 @@ export const NotificationAdminReport: React.FC<{
     target: <DisplayName account={targetAccount} variant='simple' />,
     category: intl.formatMessage(messages[report.category]),
     count: report.status_ids.length,
-    isLocal: isLocal ? 'local' : 'remote',
+    isLocal: isLocal ? 'Local' : 'Remote',
   };
 
   let message;

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
@@ -78,7 +78,7 @@ export const NotificationAdminReport: React.FC<{
       message = (
         <FormattedMessage
           id='notification.admin.report_statuses_other'
-          defaultMessage='{name} reported {target}  ({isLocal})'
+          defaultMessage='{name} reported {target} ({isLocal})'
           values={values}
         />
       );
@@ -86,7 +86,7 @@ export const NotificationAdminReport: React.FC<{
       message = (
         <FormattedMessage
           id='notification.admin.report_statuses'
-          defaultMessage='{name} reported {target} for {category}  ({isLocal})'
+          defaultMessage='{name} reported {target} for {category} ({isLocal})'
           values={values}
         />
       );

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
@@ -50,7 +50,7 @@ export const NotificationAdminReport: React.FC<{
     target: <DisplayName account={targetAccount} variant='simple' />,
     category: intl.formatMessage(messages[report.category]),
     count: report.status_ids.length,
-    isLocal: {isLocal ? 'local' : 'remote'},
+    isLocal: {isLocal ? 'local' : 'remote'}
   };
 
   let message;

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
@@ -68,7 +68,7 @@ export const NotificationAdminReport: React.FC<{
       message = (
         <FormattedMessage
           id='notification.admin.report_account'
-          defaultMessage='{name} reported {count, plural, one {one post} other {# posts}} from {target} for {category} ({isLocal})'
+          defaultMessage='{name} reported {count, plural, one {one post} other {# posts}} from {target} ({isLocal}) for {category}'
           values={values}
         />
       );
@@ -86,7 +86,7 @@ export const NotificationAdminReport: React.FC<{
       message = (
         <FormattedMessage
           id='notification.admin.report_statuses'
-          defaultMessage='{name} reported {target} for {category} ({isLocal})'
+          defaultMessage='{name} reported {target} ({isLocal}) for {category}'
           values={values}
         />
       );

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
@@ -60,7 +60,7 @@ export const NotificationAdminReport: React.FC<{
       message = (
         <FormattedMessage
           id='notification.admin.report_account_other'
-          defaultMessage='{name} reported {count, plural, one {one post} other {# posts}} from {target} ({isLocal})' 
+          defaultMessage='{name} reported {count, plural, one {one post} other {# posts}} from {target} ({isLocal})'
           values={values}
         />
       );

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
@@ -43,9 +43,16 @@ export const NotificationAdminReport: React.FC<{
 
   if (!account || !targetAccount) return null;
 
+  const isLocal = !targetAccount.acct.includes('@');
+
   const values = {
     name: <DisplayName account={account} variant='simple' />,
-    target: <DisplayName account={targetAccount} variant='simple' />,
+    target: (
+      <>
+        <DisplayName account={targetAccount} variant='simple' /> (
+        {isLocal ? 'local' : 'remote'})
+      </>
+    ),
     category: intl.formatMessage(messages[report.category]),
     count: report.status_ids.length,
   };

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
@@ -50,7 +50,7 @@ export const NotificationAdminReport: React.FC<{
     target: <DisplayName account={targetAccount} variant='simple' />,
     category: intl.formatMessage(messages[report.category]),
     count: report.status_ids.length,
-    isLocal: {isLocal ? 'local' : 'remote'}
+    isLocal: isLocal ? 'local' : 'remote',
   };
 
   let message;


### PR DESCRIPTION
Preview:
<img width="403" height="76" alt="image" src="https://github.com/user-attachments/assets/28422573-32a6-4fb0-8da8-5ea9efa2fded" />
<img width="399" height="113" alt="image" src="https://github.com/user-attachments/assets/80dc92c1-333a-4d55-ab71-6aa94e4251d5" />


This allows me to respond with additional urgency to reports about local users if required.

AI Disclosure: My own dumb brain.
