### PR TITLE
Add `reference` to `MastodonLocationState`

### DIFF
--- a/app/javascript/mastodon/components/router.tsx
+++ b/app/javascript/mastodon/components/router.tsx
@@ -26,6 +26,8 @@ interface MastodonLocationState {
   // Prevent the rightmost column in advanced UI from scrolling
   // into view on location changes
   preventMultiColumnAutoScroll?: string;
+  // Used to track where a follow is coming from
+  reference?: string;
 }
 
 export type LocationState = MastodonLocationState | null | undefined;


### PR DESCRIPTION
Follow-up to #40340

We don't *need* this type right now, because we pass it through the more generic JS code, but it makes sense to record that in the type of Mastodon's location states.

Stumbled on that when porting #40340 to glitch-soc, which uses a different component for most of those links, which uses the more specific `useAppHistory`.