### PR TITLE
Remove `ignored_columns` for 4.3 and earlier

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -64,8 +64,6 @@
 #
 
 class Account < ApplicationRecord
-  self.ignored_columns += %w(devices_url)
-
   BACKGROUND_REFRESH_INTERVAL = 1.week.freeze
   REFRESH_DEADLINE = 6.hours
   STALE_THRESHOLD = 1.day

--- a/app/models/account_relationship_severance_event.rb
+++ b/app/models/account_relationship_severance_event.rb
@@ -14,10 +14,6 @@
 #  relationship_severance_event_id :bigint(8)        not null
 #
 class AccountRelationshipSeveranceEvent < ApplicationRecord
-  self.ignored_columns += %w(
-    relationships_count
-  )
-
   belongs_to :account
   belongs_to :relationship_severance_event
 

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -15,8 +15,6 @@
 #
 
 class CustomFilter < ApplicationRecord
-  self.ignored_columns += %w(whole_word irreversible)
-
   alias_attribute :title, :phrase
   alias_attribute :filter_action, :action
 

--- a/app/models/notification_policy.rb
+++ b/app/models/notification_policy.rb
@@ -17,13 +17,6 @@
 #
 
 class NotificationPolicy < ApplicationRecord
-  self.ignored_columns += %w(
-    filter_not_following
-    filter_not_followers
-    filter_new_accounts
-    filter_private_mentions
-  )
-
   belongs_to :account
 
   has_many :notification_requests, primary_key: :account_id, foreign_key: :account_id, dependent: nil, inverse_of: false

--- a/app/models/notification_request.rb
+++ b/app/models/notification_request.rb
@@ -14,8 +14,6 @@
 #
 
 class NotificationRequest < ApplicationRecord
-  self.ignored_columns += %w(dismissed)
-
   include Paginable
 
   MAX_MEANINGFUL_COUNT = 100

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,11 +43,9 @@
 
 class User < ApplicationRecord
   self.ignored_columns += %w(
-    admin
     encrypted_otp_secret
     encrypted_otp_secret_iv
     encrypted_otp_secret_salt
-    moderator
     skip_sign_in_token
   )
 


### PR DESCRIPTION
Those `ignored_columns` statements are useful for running new code on old database schemas, to provide zero-downtime migration.

However, all of these columns were removed in Mastodon 4.3.0, and we do not support zero-downtime migrations from anything earlier than 4.3.0 (soon to change to 4.7.0 after #40235), so these can be removed.