### PR TITLE
Composer redesign: Quotes

### DIFF
--- a/app/javascript/mastodon/components/card/styles.module.scss
+++ b/app/javascript/mastodon/components/card/styles.module.scss
@@ -80,10 +80,8 @@ a.root {
 
 // Linked body
 a.body {
-  padding-inline-start: var(--space-sm);
-  padding-inline-end: var(--space-sm);
-  margin-inline-start: calc(-1 * var(--space-sm));
-  margin-inline-end: calc(-1 * var(--space-sm));
+  padding-inline: var(--space-sm);
+  margin-inline: calc(-1 * var(--space-sm));
 
   .root:has(&:hover) {
     background-color: var(--color-bg-highlight);

--- a/app/javascript/mastodon/components/card/styles.module.scss
+++ b/app/javascript/mastodon/components/card/styles.module.scss
@@ -39,7 +39,6 @@ a.root {
 
   color: var(--color-text-secondary);
   display: flex;
-  margin-bottom: var(--space-2xs);
 
   a {
     color: inherit;
@@ -66,6 +65,7 @@ a.root {
 
   overflow-wrap: break-word;
   flex-grow: 1;
+  margin-block-start: var(--space-xs);
 
   a {
     color: var(--color-text-brand);
@@ -80,9 +80,10 @@ a.root {
 
 // Linked body
 a.body {
-  padding: 0 var(--space-sm) var(--space-sm);
-  margin: calc(-1 * var(--space-sm));
-  margin-top: 0;
+  padding-inline-start: var(--space-sm);
+  padding-inline-end: var(--space-sm);
+  margin-inline-start: calc(-1 * var(--space-sm));
+  margin-inline-end: calc(-1 * var(--space-sm));
 
   .root:has(&:hover) {
     background-color: var(--color-bg-highlight);

--- a/app/javascript/mastodon/components/emoji/html.tsx
+++ b/app/javascript/mastodon/components/emoji/html.tsx
@@ -6,38 +6,50 @@ import type {
   OnElementHandler,
 } from '@/mastodon/utils/html';
 import { htmlStringToComponents } from '@/mastodon/utils/html';
-import { polymorphicForwardRef } from '@/types/polymorphic';
+import type { PolymorphicProps } from '@/types/polymorphic';
 
 import { AnimateEmojiProvider, CustomEmojiProvider } from './context';
 import { textToEmojis } from './index';
 
-export interface EmojiHTMLProps {
+export interface EmojiHTMLProps<
+  Arg extends Record<string, unknown> = Record<string, unknown>,
+> {
   htmlString: string;
   extraEmojis?: CustomEmojiMapArg;
   className?: string;
-  onElement?: OnElementHandler;
-  onAttribute?: OnAttributeHandler;
+  onElement?: OnElementHandler<Arg>;
+  onAttribute?: OnAttributeHandler<Arg>;
+  extraArgs?: Arg;
 }
 
-export const EmojiHTML = polymorphicForwardRef<'div', EmojiHTMLProps>(
-  ({ extraEmojis, htmlString, onElement, onAttribute, ...props }, ref) => {
-    const contents = useMemo(
-      () =>
-        htmlStringToComponents(htmlString, {
-          onText: textToEmojis,
-          onElement,
-          onAttribute,
-        }),
-      [htmlString, onAttribute, onElement],
-    );
+export const EmojiHTML = <
+  As extends React.ElementType = 'div',
+  Arg extends Record<string, unknown> = Record<string, unknown>,
+>({
+  extraEmojis,
+  htmlString,
+  onElement,
+  onAttribute,
+  extraArgs,
+  ref,
+  ...props
+}: PolymorphicProps<EmojiHTMLProps<Arg>, As>) => {
+  const contents = useMemo(
+    () =>
+      htmlStringToComponents(htmlString, {
+        onText: textToEmojis,
+        onElement,
+        onAttribute,
+        extraArgs,
+      }),
+    [extraArgs, htmlString, onAttribute, onElement],
+  );
 
-    return (
-      <CustomEmojiProvider emojis={extraEmojis}>
-        <AnimateEmojiProvider {...props} ref={ref}>
-          {contents}
-        </AnimateEmojiProvider>
-      </CustomEmojiProvider>
-    );
-  },
-);
-EmojiHTML.displayName = 'EmojiHTML';
+  return (
+    <CustomEmojiProvider emojis={extraEmojis}>
+      <AnimateEmojiProvider {...props} ref={ref}>
+        {contents}
+      </AnimateEmojiProvider>
+    </CustomEmojiProvider>
+  );
+};

--- a/app/javascript/mastodon/components/icon.tsx
+++ b/app/javascript/mastodon/components/icon.tsx
@@ -1,5 +1,7 @@
 import classNames from 'classnames';
 
+import type { IconWeight } from '@phosphor-icons/react';
+
 import CheckBoxOutlineBlankIcon from '@/material-icons/400-24px/check_box_outline_blank.svg?react';
 import { isProduction } from 'mastodon/utils/environment';
 
@@ -14,6 +16,7 @@ interface Props extends React.SVGProps<SVGSVGElement> {
   id?: string;
   icon: IconProp;
   noFill?: boolean;
+  weight?: IconWeight;
 }
 
 export const Icon: React.FC<Props> = ({

--- a/app/javascript/mastodon/features/compose/redesign/attachments.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/attachments.module.scss
@@ -202,10 +202,22 @@
 }
 
 .quoteVideoDuration {
+  @include mixins.type-label-md;
+
   display: flex;
   gap: var(--space-2xs);
   align-items: center;
   position: absolute;
   bottom: var(--space-xs);
   left: var(--space-xs);
+  padding: var(--space-2xs) var(--space-3xs);
+  background: var(--color-bg-highlight);
+  border-radius: var(--radius-xs);
+  color: var(--color-text-primary);
+
+  svg {
+    width: 16px;
+    height: 16px;
+    opacity: 0.7;
+  }
 }

--- a/app/javascript/mastodon/features/compose/redesign/attachments.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/attachments.module.scss
@@ -193,7 +193,7 @@
   }
 
   strong {
-    font-weight: 600;
+    font-weight: bold;
   }
 }
 
@@ -222,8 +222,8 @@
   gap: var(--space-2xs);
   align-items: center;
   position: absolute;
-  bottom: var(--space-xs);
-  left: var(--space-xs);
+  inset-block-end: var(--space-xs);
+  inset-inline-start: var(--space-xs);
   padding: var(--space-2xs) var(--space-3xs);
   background: var(--color-bg-highlight);
   border-radius: var(--radius-xs);

--- a/app/javascript/mastodon/features/compose/redesign/attachments.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/attachments.module.scss
@@ -6,6 +6,7 @@
   min-width: 120px;
   max-width: min(100%, 400px);
   max-height: var(--max-media-height-large);
+  aspect-ratio: var(--aspect);
 }
 
 .mediaGrid {
@@ -185,4 +186,25 @@
   border-radius: var(--radius-sm);
   margin: var(--space-2xs) 0;
   padding: var(--space-xs);
+}
+
+.quoteMedia {
+  margin-top: var(--space-2xs);
+
+  &.mediaGrid {
+    height: 260px;
+  }
+
+  .mediaUpload {
+    max-height: 260px;
+    border-radius: var(--radius-xs);
+  }
+}
+
+.quoteVideoDuration {
+  display: flex;
+  align-items: center;
+  position: absolute;
+  bottom: var(--space-xs);
+  left: var(--space-xs);
 }

--- a/app/javascript/mastodon/features/compose/redesign/attachments.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/attachments.module.scss
@@ -203,6 +203,7 @@
 
 .quoteVideoDuration {
   display: flex;
+  gap: var(--space-2xs);
   align-items: center;
   position: absolute;
   bottom: var(--space-xs);

--- a/app/javascript/mastodon/features/compose/redesign/attachments.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/attachments.module.scss
@@ -197,6 +197,11 @@
   }
 }
 
+.quoteReply {
+  color: var(--color-text-tertiary);
+  margin-bottom: var(--space-xs);
+}
+
 .quoteMedia {
   margin-top: var(--space-2xs);
 

--- a/app/javascript/mastodon/features/compose/redesign/attachments.module.scss
+++ b/app/javascript/mastodon/features/compose/redesign/attachments.module.scss
@@ -169,11 +169,6 @@
 
 // Quotes
 
-.quoteBody {
-  color: inherit;
-  text-decoration: none;
-}
-
 // If hovering over an account link, underline all account links.
 .quoteTitle:has(.quoteAccountLink:hover) {
   .quoteAccountLink {
@@ -186,6 +181,20 @@
   border-radius: var(--radius-sm);
   margin: var(--space-2xs) 0;
   padding: var(--space-xs);
+}
+
+.quoteBody {
+  color: inherit;
+  text-decoration: none;
+
+  // If a body only has an empty div (such as when quoting just a link), just hide it.
+  &:has(> div:only-child:empty) {
+    display: none;
+  }
+
+  strong {
+    font-weight: 600;
+  }
 }
 
 .quoteMedia {

--- a/app/javascript/mastodon/features/compose/redesign/poll.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/poll.tsx
@@ -113,7 +113,10 @@ export const ComposePoll: React.FC = () => {
     useCallback(
       (event) => {
         dispatch(
-          changePollSettings(Number.parseInt(event.target.value), multiple),
+          changePollSettings(
+            Number.parseInt(event.target.value) / 1000,
+            multiple,
+          ),
         );
       },
       [dispatch, multiple],
@@ -189,7 +192,7 @@ export const ComposePoll: React.FC = () => {
             {pollDurationOptions.map((duration) => {
               const { message, multiplier } = durationToMessage(duration);
               return (
-                <option key={duration} value={duration}>
+                <option key={duration} value={duration / 1000}>
                   {intl.formatMessage(message, {
                     number: duration / multiplier,
                   })}

--- a/app/javascript/mastodon/features/compose/redesign/quote.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/quote.tsx
@@ -18,6 +18,7 @@ import type {
 import { Avatar } from '@/mastodon/components/avatar';
 import { Card, CardBody, CardTitle } from '@/mastodon/components/card';
 import { LinkedDisplayName } from '@/mastodon/components/display_name';
+import { DisplayNameSimple } from '@/mastodon/components/display_name/simple';
 import { EmojiHTML } from '@/mastodon/components/emoji/html';
 import { Icon } from '@/mastodon/components/icon';
 import { RelativeTimestamp } from '@/mastodon/components/relative_timestamp';
@@ -26,6 +27,7 @@ import type {
   MediaAttachmentShape,
   AccountStatusShape,
 } from '@/mastodon/models/status';
+import { selectPlainAccount } from '@/mastodon/selectors/accounts';
 import { selectAccountStatus } from '@/mastodon/selectors/statuses';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 import type { OnElementHandler } from '@/mastodon/utils/html';
@@ -119,6 +121,9 @@ const ComposeQuoteBody: React.FC<{
   const sensitive = status.sensitive;
 
   const poll = useAppSelector((state) => state.polls[status.poll ?? '']);
+  const inReplyToAccount = useAppSelector((state) =>
+    selectPlainAccount(state, status.in_reply_to_account_id),
+  );
 
   if (status.spoilerHtml) {
     return (
@@ -139,8 +144,31 @@ const ComposeQuoteBody: React.FC<{
     );
   }
 
+  // Show reply or thread text.
+  let reply: React.ReactNode = null;
+  if (status.in_reply_to_account_id === status.account.id) {
+    reply = (
+      <FormattedMessage
+        id='status.continued_thread'
+        defaultMessage='Continued thread'
+      />
+    );
+  } else if (inReplyToAccount) {
+    reply = (
+      <FormattedMessage
+        id='status.replied_to'
+        defaultMessage='Replied to {name}'
+        values={{
+          name: <DisplayNameSimple account={inReplyToAccount} />,
+        }}
+      />
+    );
+  }
+
   return (
     <>
+      {!!reply && <p className={classes.quoteReply}>{reply}</p>}
+
       <EmojiHTML
         htmlString={status.translation?.contentHtml ?? status.contentHtml}
         extraEmojis={status.emojis}

--- a/app/javascript/mastodon/features/compose/redesign/quote.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/quote.tsx
@@ -93,9 +93,8 @@ export const ComposeQuote: React.FC<{ id: string }> = ({ id }) => {
 };
 
 const ComposeQuoteBody: React.FC<{
-  sensitive?: boolean;
   status: AccountStatusShape;
-}> = ({ sensitive, status }) => {
+}> = ({ status }) => {
   const attachments = status.media_attachments;
   const mainAttachment = attachments.find(
     (
@@ -130,6 +129,7 @@ const ComposeQuoteBody: React.FC<{
 
     return formatter.format({ hours, minutes, seconds });
   }, [mainAttachment?.meta.original.duration]);
+  const sensitive = status.sensitive;
 
   return (
     <>
@@ -141,7 +141,10 @@ const ComposeQuoteBody: React.FC<{
       />
 
       {mainAttachment?.type === 'audio' && (
-        <div className={classes.quoteSpoiler}>
+        <div
+          className={classNames(classes.quoteMedia, classes.quoteSpoiler)}
+          aria-label={mainAttachment.description}
+        >
           <FormattedMessage
             id='compose.quote.audio'
             defaultMessage='Audio file {duration}'
@@ -154,7 +157,11 @@ const ComposeQuoteBody: React.FC<{
 
       {mainAttachment?.type === 'video' && (
         <div className={classNames(classes.quoteMedia, classes.mediaSingle)}>
-          <ComposeImage attachment={mainAttachment} sensitive={sensitive}>
+          <ComposeImage
+            attachment={mainAttachment}
+            sensitive={sensitive}
+            aria-label={mainAttachment.description}
+          >
             <div className={classes.quoteVideoDuration}>
               <Icon icon={PlayIcon} weight='fill' />
 
@@ -178,6 +185,7 @@ const ComposeQuoteBody: React.FC<{
               attachment={attachment}
               sensitive={sensitive}
               key={attachment.id}
+              aria-label={attachment.description}
             />
           ))}
         </div>

--- a/app/javascript/mastodon/features/compose/redesign/quote.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/quote.tsx
@@ -21,6 +21,7 @@ import { LinkedDisplayName } from '@/mastodon/components/display_name';
 import { EmojiHTML } from '@/mastodon/components/emoji/html';
 import { Icon } from '@/mastodon/components/icon';
 import { RelativeTimestamp } from '@/mastodon/components/relative_timestamp';
+import { domain } from '@/mastodon/initial_state';
 import type {
   MediaAttachmentShape,
   AccountStatusShape,
@@ -70,27 +71,10 @@ export const ComposeQuote: React.FC<{ id: string }> = ({ id }) => {
       </CardTitle>
 
       <CardBody className={classes.quoteBody} as={Link} to={statusTo}>
-        {!status.spoilerHtml ? (
-          <ComposeQuoteBody status={status} />
-        ) : (
-          <div className={classes.quoteSpoiler}>
-            <FormattedMessage
-              id='compose.quote.spoiler'
-              defaultMessage='Content:'
-              description='Comes before user-provided spoiler description'
-            />
-            &nbsp;
-            <EmojiHTML
-              as='span'
-              htmlString={status.translation?.spoilerHtml ?? status.spoilerHtml}
-              lang={status.translation?.language ?? status.language}
-              extraEmojis={status.emojis}
-            />
-          </div>
-        )}
+        <ComposeQuoteBody status={status} />
       </CardBody>
 
-      <ComposeQuoteLink status={status} />
+      {!status.spoilerHtml && <ComposeQuoteLink status={status} />}
     </Card>
   );
 };
@@ -134,6 +118,25 @@ const ComposeQuoteBody: React.FC<{
   }, [mainAttachment?.meta.original.duration]);
   const sensitive = status.sensitive;
 
+  if (status.spoilerHtml) {
+    return (
+      <div className={classes.quoteSpoiler}>
+        <FormattedMessage
+          id='compose.quote.spoiler'
+          defaultMessage='Content:'
+          description='Comes before user-provided spoiler description'
+        />
+        &nbsp;
+        <EmojiHTML
+          as='span'
+          htmlString={status.translation?.spoilerHtml ?? status.spoilerHtml}
+          lang={status.translation?.language ?? status.language}
+          extraEmojis={status.emojis}
+        />
+      </div>
+    );
+  }
+
   return (
     <>
       <EmojiHTML
@@ -141,6 +144,7 @@ const ComposeQuoteBody: React.FC<{
         extraEmojis={status.emojis}
         lang={status.translation?.language ?? status.language}
         onElement={onStatusLinks}
+        extraArgs={status}
       />
 
       {mainAttachment?.type === 'audio' && (
@@ -204,22 +208,59 @@ const ComposeQuoteLink: React.FC<{ status: AccountStatusShape }> = ({
     selectAccountStatus(state, status.quote?.quoted_status),
   );
 
-  if (!quotedPost || status.spoilerHtml) {
-    return null;
-  }
+  let link: React.ReactNode = null;
 
-  return (
-    <CardBody>
+  if (quotedPost) {
+    link = (
       <Link to={`/@${quotedPost.account.acct}/${quotedPost.id}`}>
         {quotedPost.uri}
       </Link>
-    </CardBody>
-  );
+    );
+  }
+
+  if (status.card) {
+    if (new URL(status.card.url).host === domain) {
+      link = <Link to={status.card.url}>{status.card.url}</Link>;
+    } else {
+      link = (
+        <a href={status.card.url} target='_blank' rel='noopener'>
+          {status.card.url}
+        </a>
+      );
+    }
+  }
+
+  const collection = status.tagged_collections[0];
+  if (collection) {
+    link = <Link to={`/collections/${collection.id}`}>{collection.url}</Link>;
+  }
+
+  if (!link) {
+    return null;
+  }
+
+  return <CardBody>{link}</CardBody>;
 };
 
-const onStatusLinks: OnElementHandler = (element, { key }, children) => {
-  if (element instanceof HTMLAnchorElement) {
-    return <span key={key as string}>{children}</span>;
+const onStatusLinks: OnElementHandler<AccountStatusShape> = (
+  element,
+  { key, href },
+  children,
+  status,
+) => {
+  // If this is a paragraph with just a link and it matches the card, don't add it.
+  if (
+    element instanceof HTMLParagraphElement &&
+    element.children.length === 1 &&
+    element.firstChild instanceof HTMLAnchorElement &&
+    element.firstChild.href === status.card?.url
+  ) {
+    return null;
+  } else if (element instanceof HTMLAnchorElement) {
+    if (href === status.card?.url) {
+      return null;
+    }
+    return <strong key={key as string}>{children}</strong>;
   }
   return undefined;
 };

--- a/app/javascript/mastodon/features/compose/redesign/quote.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/quote.tsx
@@ -69,7 +69,7 @@ export const ComposeQuote: React.FC<{ id: string }> = ({ id }) => {
       </CardTitle>
 
       <CardBody className={classes.quoteBody} as={Link} to={statusTo}>
-        {!status.spoiler_text ? (
+        {!status.spoilerHtml ? (
           <ComposeQuoteBody status={status} />
         ) : (
           <div className={classes.quoteSpoiler}>
@@ -79,7 +79,12 @@ export const ComposeQuote: React.FC<{ id: string }> = ({ id }) => {
               description='Comes before user-provided spoiler description'
             />
             &nbsp;
-            {status.spoiler_text}
+            <EmojiHTML
+              as='span'
+              htmlString={status.translation?.spoilerHtml ?? status.spoilerHtml}
+              lang={status.translation?.language ?? status.language}
+              extraEmojis={status.emojis}
+            />
           </div>
         )}
       </CardBody>

--- a/app/javascript/mastodon/features/compose/redesign/quote.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/quote.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { useCallback, useMemo } from 'react';
 
 import { FormattedMessage } from 'react-intl';
@@ -88,6 +89,8 @@ export const ComposeQuote: React.FC<{ id: string }> = ({ id }) => {
           </div>
         )}
       </CardBody>
+
+      <ComposeQuoteLink status={status} />
     </Card>
   );
 };
@@ -191,6 +194,26 @@ const ComposeQuoteBody: React.FC<{
         </div>
       )}
     </>
+  );
+};
+
+const ComposeQuoteLink: React.FC<{ status: AccountStatusShape }> = ({
+  status,
+}) => {
+  const quotedPost = useAppSelector((state) =>
+    selectAccountStatus(state, status.quote?.quoted_status),
+  );
+
+  if (!quotedPost || status.spoilerHtml) {
+    return null;
+  }
+
+  return (
+    <CardBody>
+      <Link to={`/@${quotedPost.account.acct}/${quotedPost.id}`}>
+        {quotedPost.uri}
+      </Link>
+    </CardBody>
   );
 };
 

--- a/app/javascript/mastodon/features/compose/redesign/quote.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/quote.tsx
@@ -1,5 +1,4 @@
-import type React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -108,6 +107,24 @@ const ComposeQuoteBody: React.FC<{
       ApiImageAttachmentJSON | ApiGifvAttachmentJSON
     > => attachment.type === 'gifv' || attachment.type === 'image',
   );
+  const duration = useMemo(() => {
+    const duration = mainAttachment?.meta.original.duration;
+    if (!duration) {
+      return '';
+    }
+    const locale = document.documentElement.lang;
+    const formatter = new Intl.DurationFormat(locale, {
+      style: 'digital',
+      hoursDisplay: 'auto',
+    });
+
+    const totalSeconds = Math.floor(duration);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    return formatter.format({ hours, minutes, seconds });
+  }, [mainAttachment?.meta.original.duration]);
 
   return (
     <>
@@ -117,45 +134,49 @@ const ComposeQuoteBody: React.FC<{
         lang={status.translation?.language ?? status.language}
         onElement={onStatusLinks}
       />
+
       {mainAttachment?.type === 'audio' && (
         <div className={classes.quoteSpoiler}>
           <FormattedMessage
             id='compose.quote.audio'
-            defaultMessage='Audio file ({duration})'
-            values={{ duration: mainAttachment.meta.original.duration }}
+            defaultMessage='Audio file {duration}'
+            values={{
+              duration: `(${duration})`,
+            }}
           />
         </div>
       )}
+
       {mainAttachment?.type === 'video' && (
         <div className={classNames(classes.quoteMedia, classes.mediaSingle)}>
           <ComposeImage attachment={mainAttachment} sensitive={sensitive}>
             <div className={classes.quoteVideoDuration}>
               <Icon icon={PlayIcon} weight='fill' />
 
-              {mainAttachment.meta.original.duration}
+              {duration}
             </div>
           </ComposeImage>
         </div>
       )}
-      {imageAttachments.length > 0 ||
-        (mainAttachment?.type === 'video' && (
-          <div
-            className={classNames(
-              classes.quoteMedia,
-              imageAttachments.length === 1 && classes.mediaSingle,
-              imageAttachments.length > 1 && classes.mediaGrid,
-            )}
-            data-number={imageAttachments.length}
-          >
-            {imageAttachments.map((attachment) => (
-              <ComposeImage
-                attachment={attachment}
-                sensitive={sensitive}
-                key={attachment.id}
-              />
-            ))}
-          </div>
-        ))}
+
+      {imageAttachments.length > 0 && (
+        <div
+          className={classNames(
+            classes.quoteMedia,
+            imageAttachments.length === 1 && classes.mediaSingle,
+            imageAttachments.length > 1 && classes.mediaGrid,
+          )}
+          data-number={imageAttachments.length}
+        >
+          {imageAttachments.map((attachment) => (
+            <ComposeImage
+              attachment={attachment}
+              sensitive={sensitive}
+              key={attachment.id}
+            />
+          ))}
+        </div>
+      )}
     </>
   );
 };

--- a/app/javascript/mastodon/features/compose/redesign/quote.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/quote.tsx
@@ -118,6 +118,8 @@ const ComposeQuoteBody: React.FC<{
   }, [mainAttachment?.meta.original.duration]);
   const sensitive = status.sensitive;
 
+  const poll = useAppSelector((state) => state.polls[status.poll ?? '']);
+
   if (status.spoilerHtml) {
     return (
       <div className={classes.quoteSpoiler}>
@@ -146,6 +148,20 @@ const ComposeQuoteBody: React.FC<{
         onElement={onStatusLinks}
         extraArgs={status}
       />
+
+      {poll && (
+        <div className={classes.quoteSpoiler}>
+          <FormattedMessage
+            id='compose.quote.poll'
+            defaultMessage='Poll {sep} {isOpen, select, open {Accepting responses} other {Closed}}'
+            values={{
+              isOpen: poll.expired ? 'closed' : 'open',
+              // eslint-disable-next-line no-restricted-syntax
+              sep: <>&bull;</>,
+            }}
+          />
+        </div>
+      )}
 
       {mainAttachment?.type === 'audio' && (
         <div

--- a/app/javascript/mastodon/features/compose/redesign/quote.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/quote.tsx
@@ -3,21 +3,34 @@ import { useCallback } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
+import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 
+import { PlayIcon } from '@phosphor-icons/react';
+
 import { quoteComposeCancel } from '@/mastodon/actions/compose_typed';
+import type {
+  ApiAudioAttachmentJSON,
+  ApiGifvAttachmentJSON,
+  ApiImageAttachmentJSON,
+  ApiVideoAttachmentJSON,
+} from '@/mastodon/api_types/media_attachments';
 import { Avatar } from '@/mastodon/components/avatar';
-import { Blurhash } from '@/mastodon/components/blurhash';
 import { Card, CardBody, CardTitle } from '@/mastodon/components/card';
 import { LinkedDisplayName } from '@/mastodon/components/display_name';
 import { EmojiHTML } from '@/mastodon/components/emoji/html';
+import { Icon } from '@/mastodon/components/icon';
 import { RelativeTimestamp } from '@/mastodon/components/relative_timestamp';
-import type { AccountStatusShape } from '@/mastodon/models/status';
+import type {
+  MediaAttachmentShape,
+  AccountStatusShape,
+} from '@/mastodon/models/status';
 import { selectAccountStatus } from '@/mastodon/selectors/statuses';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 import type { OnElementHandler } from '@/mastodon/utils/html';
 
 import classes from './attachments.module.scss';
+import { ComposeImage } from './upload';
 
 export const ComposeQuote: React.FC<{ id: string }> = ({ id }) => {
   const status = useAppSelector((state) => selectAccountStatus(state, id));
@@ -31,20 +44,10 @@ export const ComposeQuote: React.FC<{ id: string }> = ({ id }) => {
     return null;
   }
 
-  let imageEle: React.ReactNode = null;
-  const image = status.media_attachments.find(({ type }) => type !== 'unknown');
-  if (image) {
-    imageEle = !status.sensitive ? (
-      <img src={image.preview_url} alt={image.description} />
-    ) : (
-      <Blurhash hash={image.blurhash} width={120} />
-    );
-  }
-
   const statusTo = `/@${status.account.acct}/${status.id}`;
 
   return (
-    <Card image={imageEle} onDelete={handleDelete}>
+    <Card onDelete={handleDelete}>
       <CardTitle
         className={classes.quoteTitle}
         image={
@@ -86,15 +89,74 @@ export const ComposeQuote: React.FC<{ id: string }> = ({ id }) => {
 };
 
 const ComposeQuoteBody: React.FC<{
+  sensitive?: boolean;
   status: AccountStatusShape;
-}> = ({ status }) => {
+}> = ({ sensitive, status }) => {
+  const attachments = status.media_attachments;
+  const mainAttachment = attachments.find(
+    (
+      attachment,
+    ): attachment is
+      | MediaAttachmentShape<ApiAudioAttachmentJSON>
+      | MediaAttachmentShape<ApiVideoAttachmentJSON> =>
+      attachment.type === 'audio' || attachment.type === 'video',
+  );
+  const imageAttachments = attachments.filter(
+    (
+      attachment,
+    ): attachment is MediaAttachmentShape<
+      ApiImageAttachmentJSON | ApiGifvAttachmentJSON
+    > => attachment.type === 'gifv' || attachment.type === 'image',
+  );
+
   return (
-    <EmojiHTML
-      htmlString={status.translation?.contentHtml ?? status.contentHtml}
-      extraEmojis={status.emojis}
-      lang={status.translation?.language ?? status.language}
-      onElement={onStatusLinks}
-    />
+    <>
+      <EmojiHTML
+        htmlString={status.translation?.contentHtml ?? status.contentHtml}
+        extraEmojis={status.emojis}
+        lang={status.translation?.language ?? status.language}
+        onElement={onStatusLinks}
+      />
+      {mainAttachment?.type === 'audio' && (
+        <div className={classes.quoteSpoiler}>
+          <FormattedMessage
+            id='compose.quote.audio'
+            defaultMessage='Audio file ({duration})'
+            values={{ duration: mainAttachment.meta.original.duration }}
+          />
+        </div>
+      )}
+      {mainAttachment?.type === 'video' && (
+        <div className={classNames(classes.quoteMedia, classes.mediaSingle)}>
+          <ComposeImage attachment={mainAttachment} sensitive={sensitive}>
+            <div className={classes.quoteVideoDuration}>
+              <Icon icon={PlayIcon} weight='fill' />
+
+              {mainAttachment.meta.original.duration}
+            </div>
+          </ComposeImage>
+        </div>
+      )}
+      {imageAttachments.length > 0 ||
+        (mainAttachment?.type === 'video' && (
+          <div
+            className={classNames(
+              classes.quoteMedia,
+              imageAttachments.length === 1 && classes.mediaSingle,
+              imageAttachments.length > 1 && classes.mediaGrid,
+            )}
+            data-number={imageAttachments.length}
+          >
+            {imageAttachments.map((attachment) => (
+              <ComposeImage
+                attachment={attachment}
+                sensitive={sensitive}
+                key={attachment.id}
+              />
+            ))}
+          </div>
+        ))}
+    </>
   );
 };
 

--- a/app/javascript/mastodon/features/compose/redesign/upload.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/upload.tsx
@@ -9,7 +9,12 @@ import { DotsThreeIcon, TrashIcon } from '@phosphor-icons/react';
 
 import { undoUploadCompose } from '@/mastodon/actions/compose';
 import { openModal } from '@/mastodon/actions/modal';
-import type { ApiAudioAttachmentJSON } from '@/mastodon/api_types/media_attachments';
+import type {
+  ApiAudioAttachmentJSON,
+  ApiGifvAttachmentJSON,
+  ApiImageAttachmentJSON,
+  ApiVideoAttachmentJSON,
+} from '@/mastodon/api_types/media_attachments';
 import { Blurhash } from '@/mastodon/components/blurhash';
 import { IconButton } from '@/mastodon/components/button/redesign';
 import {
@@ -19,6 +24,7 @@ import {
   MenuItemDivider,
   MenuList,
 } from '@/mastodon/components/menu';
+import type { MediaAttachmentShape } from '@/mastodon/models/status';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 
 import classes from './attachments.module.scss';
@@ -43,28 +49,11 @@ export const ComposeUpload: React.FC<{
     return <ComposeAudioUpload attachment={attachment} />;
   }
 
-  let x = 50;
-  let y = 50;
-  const focusX = attachment.meta.focus?.x;
-  const focusY = attachment.meta.focus?.y;
-  if (focusX && focusY) {
-    x = (focusX / 2 + 0.5) * 100;
-    y = (focusY / -2 + 0.5) * 100;
-  }
-
   return (
-    <div
-      className={classNames(classes.mediaUpload, className)}
-      style={{
-        backgroundImage:
-          !sensitive && attachment.preview_url
-            ? `url(${attachment.preview_url})`
-            : undefined,
-        backgroundPosition: `${x}% ${y}%`,
-        aspectRatio: single
-          ? `${attachment.meta.original.width} / ${attachment.meta.original.height}`
-          : undefined,
-      }}
+    <ComposeImage
+      attachment={attachment}
+      className={className}
+      sensitive={sensitive}
       data-color-scheme='dark'
     >
       {sensitive && attachment.blurhash && (
@@ -93,6 +82,54 @@ export const ComposeUpload: React.FC<{
           <FormattedMessage id='compose.upload.alt' defaultMessage='Alt' />
         </span>
       )}
+    </ComposeImage>
+  );
+};
+
+type ComposeImageAttachmentJSON =
+  | ApiImageAttachmentJSON
+  | ApiGifvAttachmentJSON
+  | ApiVideoAttachmentJSON;
+
+export const ComposeImage: React.FC<
+  {
+    attachment:
+      | ComposeImageAttachmentJSON
+      | MediaAttachmentShape<ComposeImageAttachmentJSON>;
+    children?: React.ReactNode;
+    sensitive?: boolean;
+  } & React.ComponentPropsWithRef<'div'>
+> = ({ attachment, children, sensitive, className, style, ...props }) => {
+  let x = 50;
+  let y = 50;
+  const focusX = attachment.meta.focus?.x;
+  const focusY = attachment.meta.focus?.y;
+  if (focusX && focusY) {
+    x = (focusX / 2 + 0.5) * 100;
+    y = (focusY / -2 + 0.5) * 100;
+  }
+
+  const imgStyle = {
+    backgroundImage:
+      !sensitive && attachment.preview_url
+        ? `url(${attachment.preview_url})`
+        : undefined,
+    backgroundPosition: `${x}% ${y}%`,
+    '--aspect': `${attachment.meta.original.width} / ${attachment.meta.original.height}`,
+    ...style,
+  };
+
+  return (
+    <div
+      {...props}
+      className={classNames(classes.mediaUpload, className)}
+      style={imgStyle}
+    >
+      {sensitive && attachment.blurhash && (
+        <Blurhash hash={attachment.blurhash} className={classes.blurHash} />
+      )}
+
+      {children}
     </div>
   );
 };

--- a/app/javascript/mastodon/features/compose/redesign/upload.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/upload.tsx
@@ -54,7 +54,6 @@ export const ComposeUpload: React.FC<{
       attachment={attachment}
       className={className}
       sensitive={sensitive}
-      data-color-scheme='dark'
     >
       {sensitive && attachment.blurhash && (
         <Blurhash hash={attachment.blurhash} className={classes.blurHash} />
@@ -124,6 +123,7 @@ export const ComposeImage: React.FC<
       {...props}
       className={classNames(classes.mediaUpload, className)}
       style={imgStyle}
+      data-color-scheme='dark'
     >
       {sensitive && attachment.blurhash && (
         <Blurhash hash={attachment.blurhash} className={classes.blurHash} />

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -528,6 +528,7 @@
   "compose.published.open": "Open",
   "compose.quotable": "Allow others to quote",
   "compose.quote.audio": "Audio file {duration}",
+  "compose.quote.poll": "Poll {sep} {isOpen, select, open {Accepting responses} other {Closed}}",
   "compose.quote.spoiler": "Content:",
   "compose.rearrange_modal.cancel": "Cancel",
   "compose.rearrange_modal.drag_cancel": "Dragging was cancelled. Attachment index {item, number} was dropped.",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -527,7 +527,7 @@
   "compose.published.body": "Post published.",
   "compose.published.open": "Open",
   "compose.quotable": "Allow others to quote",
-  "compose.quote.audio": "Audio file ({duration})",
+  "compose.quote.audio": "Audio file {duration}",
   "compose.quote.spoiler": "Content:",
   "compose.rearrange_modal.cancel": "Cancel",
   "compose.rearrange_modal.drag_cancel": "Dragging was cancelled. Attachment index {item, number} was dropped.",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -527,6 +527,7 @@
   "compose.published.body": "Post published.",
   "compose.published.open": "Open",
   "compose.quotable": "Allow others to quote",
+  "compose.quote.audio": "Audio file ({duration})",
   "compose.quote.spoiler": "Content:",
   "compose.rearrange_modal.cancel": "Cancel",
   "compose.rearrange_modal.drag_cancel": "Dragging was cancelled. Attachment index {item, number} was dropped.",


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Fixes WEB-1198.

This renders quotes inside the composer, with all their various permutations. In general quotes are non-interactive, with clicks opening the quoted post. The exception is 

| Caption | Screenshot |
| - | - |
| Link | <img width="982" height="216" alt="Screenshot 2026-09-02 at 16 26 38" src="https://github.com/user-attachments/assets/72b2d01a-acea-4105-9405-7db21744659d" /> |
| Reply | <img width="982" height="228" alt="Screenshot 2026-09-02 at 16 58 48" src="https://github.com/user-attachments/assets/a418fcb3-a585-4d95-8d50-680d61e1e35d" /> |
| Thread | <img width="982" height="228" alt="Screenshot 2026-09-02 at 16 59 21" src="https://github.com/user-attachments/assets/c58db3bb-de5e-4bf7-9b21-afc83ef11613" /> |
| Content warning | <img width="982" height="240" alt="Screenshot 2026-09-02 at 16 29 03" src="https://github.com/user-attachments/assets/23ffbf6a-e82e-4c1b-9c26-043cdae21f64" /> |
| Mentions | <img width="982" height="230" alt="Screenshot 2026-09-02 at 16 33 45" src="https://github.com/user-attachments/assets/20ab2bd2-aedf-434d-91fc-4c857edc768b" /> |
| Image | <img width="982" height="686" alt="Screenshot 2026-09-02 at 16 30 38" src="https://github.com/user-attachments/assets/cda5a8cf-4606-4efd-b905-d390b0aef87e" /> |
| Video | <img width="982" height="678" alt="Screenshot 2026-09-02 at 17 03 42" src="https://github.com/user-attachments/assets/1957563f-a265-4b92-820e-bfe7c46c48cf" /> |
| Audio | <img width="982" height="276" alt="Screenshot 2026-09-02 at 17 04 15" src="https://github.com/user-attachments/assets/5016a40d-4d8e-468f-a5c6-aec9e89a08f6" /> |
| Sensitive media | <img width="982" height="724" alt="Screenshot 2026-09-02 at 16 41 49" src="https://github.com/user-attachments/assets/d5e3cf7a-197b-42b8-be67-98f661b5953f" /> |
| Open poll | <img width="982" height="276" alt="Screenshot 2026-09-02 at 16 28 07" src="https://github.com/user-attachments/assets/fd2e277d-a34d-4b37-adf6-119b5d3c408f" /> |
| Closed poll | <img width="982" height="276" alt="Screenshot 2026-09-02 at 16 28 40" src="https://github.com/user-attachments/assets/ceaacc40-2552-412b-bed6-3283b7a74b02" /> |
| Collections | <img width="982" height="228" alt="Screenshot 2026-09-02 at 16 42 37" src="https://github.com/user-attachments/assets/d815f42f-c02f-45a7-9bee-b7a4f7274373" /> |
| Quoting a quote | <img width="982" height="228" alt="Screenshot 2026-09-02 at 16 43 19" src="https://github.com/user-attachments/assets/1675f9d6-db6f-4def-b2ea-b2bdc652aa7c" /> |
