### PR TITLE
Fix follows and followers pages to show "Today" instead of hours

### DIFF
--- a/app/javascript/mastodon/utils/time.test.ts
+++ b/app/javascript/mastodon/utils/time.test.ts
@@ -1,4 +1,13 @@
-import { DAY, HOUR, MINUTE, relativeTimeParts, SECOND } from './time';
+import { createIntl } from 'react-intl';
+
+import {
+  DAY,
+  HOUR,
+  MINUTE,
+  SECOND,
+  relativeTimeParts,
+  formatTime,
+} from './time';
 
 describe('relativeTimeParts', () => {
   const now = Date.now();
@@ -34,5 +43,21 @@ describe('relativeTimeParts', () => {
     [2 * DAY, { value: 2, unit: 'day' }],
   ])('should return correct value and unit for %d ms', (input, expected) => {
     expect(relativeTimeParts(now + input, now)).toMatchObject(expected);
+  });
+});
+
+describe('formatTime with day-only timestamps', () => {
+  const intl = createIntl({ locale: 'en' });
+
+  const now = Date.parse('2026-08-20T22:56:00Z');
+
+  test.concurrent.each([
+    ['2026-08-20', 'today'],
+    ['2026-08-19', '1 day ago'],
+    ['2026-08-17', '3 days ago'],
+  ])('should format the day-only value %s as "%s"', (date, expected) => {
+    expect(
+      formatTime({ timestamp: Date.parse(date), intl, now, noTime: true }),
+    ).toBe(expected);
   });
 });

--- a/app/javascript/mastodon/utils/time.ts
+++ b/app/javascript/mastodon/utils/time.ts
@@ -41,13 +41,13 @@ export function relativeTimeParts(
   return { value: sign * Math.floor(absDelta / DAY), unit: 'day', delta };
 }
 
-export function isToday(ts: number, now = Date.now()): boolean {
+export function isSameUTCDay(ts: number, now = Date.now()): boolean {
   const date = new Date(ts);
   const nowDate = new Date(now);
   return (
-    date.getDate() === nowDate.getDate() &&
-    date.getMonth() === nowDate.getMonth() &&
-    date.getFullYear() === nowDate.getFullYear()
+    date.getUTCDate() === nowDate.getUTCDate() &&
+    date.getUTCMonth() === nowDate.getUTCMonth() &&
+    date.getUTCFullYear() === nowDate.getUTCFullYear()
   );
 }
 
@@ -138,7 +138,7 @@ export function formatTime({
   const { value, unit } = relativeTimeParts(timestamp, now);
 
   // If we're only showing days, show "today" for the current day.
-  if (noTime && isToday(timestamp, now)) {
+  if (noTime && isSameUTCDay(timestamp, now)) {
     return intl.formatMessage(timeMessages.today);
   }
 


### PR DESCRIPTION
Tried fixing #40230
Seems to be a regression caused by the refactor at #38275. 
Since `.getDate()` translates to the browser's local time, if the browser is in a non-UTC timezone then viewing the follows page at for example August 20th 19:00 UTC-4 (`nowDate` == 20) would get compared with `date` that is `2026-08-20T00:00:00Z` translated to local time (because of `.getDate()`) which is August 19th 20:00, failing the check.
So I fixed it by comparing UTC against UTC, and tried adding a regression test!
