### PR TITLE
Add link to homepage to 404 error page

### DIFF
--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -191,6 +191,7 @@ body {
         font-size: 20px;
         line-height: 28px;
         font-weight: 400;
+        margin-bottom: var(--space-md);
       }
     }
   }

--- a/app/views/layouts/error.html.haml
+++ b/app/views/layouts/error.html.haml
@@ -12,8 +12,9 @@
     = theme_style_tags Setting.default_settings['theme']
     = vite_typescript_tag 'error.ts', crossorigin: 'anonymous'
   %body.error
-    .dialog
+    %main.dialog
       .dialog__illustration
         %img{ alt: Setting.default_settings['site_title'], src: '/oops.png' }/
       .dialog__message
         %h1= yield :content
+        %a{ class: 'button button-secondary', href: '/' }= t('errors.go_home')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1596,6 +1596,7 @@ en:
       content: We're sorry, but something went wrong on our end.
       title: This page is not correct
     '503': The page could not be served due to a temporary server failure.
+    go_home: Go home
     noscript_html: To use the Mastodon web application, please enable JavaScript. Alternatively, try one of the <a href="%{apps_path}">native apps</a> for Mastodon for your platform.
   existing_username_validator:
     not_found: could not find a local user with that username


### PR DESCRIPTION
### Changes proposed in this PR:
- Adds a link to the homepage to the 404 error page

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="494" height="496" alt="image" src="https://github.com/user-attachments/assets/6f572f11-fecc-46f8-afc9-791eca08d985" /> | <img width="532" height="491" alt="image" src="https://github.com/user-attachments/assets/1b8ee09f-beb5-4c55-bc9e-6687642f28e5" /> |