### PR TITLE
Redesign: Update notifications column header

### DIFF
--- a/app/javascript/mastodon/components/modal_shell/redesign.module.scss
+++ b/app/javascript/mastodon/components/modal_shell/redesign.module.scss
@@ -18,8 +18,22 @@
   @include mixins.elevation-2;
 }
 
+.titleWrapper {
+  display: flex;
+  align-items: start;
+  gap: var(--space-md);
+}
+
 .title {
   @include mixins.type-heading-sm;
+
+  flex: 1 1 auto;
+}
+
+.closeButton {
+  // Prevent close button from increasing spacing around title
+  margin-block: calc(-1 * var(--space-xs));
+  margin-inline-end: calc(-1 * var(--space-xs));
 }
 
 .actions {

--- a/app/javascript/mastodon/components/modal_shell/redesign.tsx
+++ b/app/javascript/mastodon/components/modal_shell/redesign.tsx
@@ -1,9 +1,14 @@
 import type React from 'react';
 
+import { FormattedMessage } from 'react-intl';
+
 import classNames from 'classnames';
+
+import { XIcon } from '@phosphor-icons/react';
 
 import type { PolymorphicProps } from '@/types/polymorphic';
 
+import { IconButton } from '../button/redesign';
 import type { NamedFocusTarget } from '../navigation_focus_target';
 import { NavigationFocusTarget } from '../navigation_focus_target';
 
@@ -47,31 +52,54 @@ export const ModalShell = <As extends React.ElementType>({
 
 type HeadingLevels = 1 | 2 | 3 | 4 | 5 | 6;
 
-type ModalTitleProps = { children: React.ReactNode; level?: HeadingLevels } & (
+type ModalTitleProps = {
+  children: React.ReactNode;
+  level?: HeadingLevels;
+  onClose?: () => void;
+} & (
   | { noFocus: true }
   | { noFocus?: false; focusTargetName?: NamedFocusTarget }
 );
 
 export const ModalTitle: React.FC<
   ModalTitleProps & React.ComponentPropsWithRef<`h${HeadingLevels}`>
-> = ({ level = 1, children, className, noFocus, ...props }) => {
+> = ({ level = 1, children, className, onClose, noFocus, ...props }) => {
   const Header = `h${level}` as const;
-  if (!noFocus) {
-    return (
-      <NavigationFocusTarget
-        as={Header}
-        {...props}
-        className={classNames(className, classes.title)}
-      >
+  let title = (
+    <NavigationFocusTarget
+      as={Header}
+      {...props}
+      className={classNames(className, classes.title)}
+    >
+      {children}
+    </NavigationFocusTarget>
+  );
+
+  if (noFocus) {
+    title = (
+      <Header {...props} className={classNames(className, classes.title)}>
         {children}
-      </NavigationFocusTarget>
+      </Header>
     );
   }
-  return (
-    <Header {...props} className={classNames(className, classes.title)}>
-      {children}
-    </Header>
-  );
+
+  if (onClose) {
+    return (
+      <header className={classes.titleWrapper}>
+        {title}
+        <IconButton
+          variant='ghost'
+          icon={XIcon}
+          onClick={onClose}
+          className={classes.closeButton}
+        >
+          <FormattedMessage id='lightbox.close' defaultMessage='Close' />
+        </IconButton>
+      </header>
+    );
+  }
+
+  return title;
 };
 
 export const ModalActions = <As extends React.ElementType>({

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_settings_modal.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_settings_modal.tsx
@@ -1,0 +1,44 @@
+import { useCallback } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import { closeModal } from '@/mastodon/actions/modal';
+import { Button } from '@/mastodon/components/button/redesign';
+import {
+  ModalActions,
+  ModalShell,
+  ModalTitle,
+} from '@/mastodon/components/modal_shell/redesign';
+import { useAppDispatch } from '@/mastodon/store';
+
+import NotificationSettings from '../../notifications/containers/column_settings_container';
+
+const NotificationSettingsModal: React.FC = () => {
+  const dispatch = useAppDispatch();
+
+  const handleCloseModal = useCallback(() => {
+    void dispatch(
+      closeModal({ modalType: 'NOTIFICATION_SETTINGS', ignoreFocus: false }),
+    );
+  }, [dispatch]);
+
+  return (
+    <ModalShell>
+      <ModalTitle onClose={handleCloseModal}>
+        <FormattedMessage
+          id='notifications.settings'
+          defaultMessage='Notification Settings'
+        />
+      </ModalTitle>
+      <NotificationSettings />
+      <ModalActions>
+        <Button variant='solid' onClick={handleCloseModal}>
+          <FormattedMessage id='alt_text_modal.done' defaultMessage='Done' />
+        </Button>
+      </ModalActions>
+    </ModalShell>
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default NotificationSettingsModal;

--- a/app/javascript/mastodon/features/notifications_v2/index.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
+import { GearIcon } from '@phosphor-icons/react';
 import { Helmet } from '@unhead/react/helmet';
 import { isEqual } from 'lodash';
 import { useDebouncedCallback } from 'use-debounce';
@@ -12,10 +13,18 @@ import {
   moveColumn,
 } from '@/mastodon/actions/columns';
 import { submitMarkers } from '@/mastodon/actions/markers';
+import { openModal } from '@/mastodon/actions/modal';
 import { Column } from '@/mastodon/components/column';
-import { ColumnHeader } from '@/mastodon/components/column/header';
+import { ColumnHeader as LegacyColumnHeader } from '@/mastodon/components/column/header';
+import {
+  ColumnHeader,
+  ColumnHeaderButton,
+  ColumnSettingsMenu,
+} from '@/mastodon/components/column_header';
+import { MultiColumnMenuItems } from '@/mastodon/components/column_header/multicolumn_settings';
 import { LoadGap } from '@/mastodon/components/load_gap';
 import ScrollableList from '@/mastodon/components/scrollable_list';
+import { isRedesignEnabled } from '@/mastodon/utils/environment';
 import DoneAllIcon from '@/material-icons/400-24px/done_all.svg?react';
 import NotificationsIcon from '@/material-icons/400-24px/notifications-fill.svg?react';
 import {
@@ -165,6 +174,15 @@ export const Notifications: React.FC<{
     void dispatch(submitMarkers({ immediate: true }));
   }, [dispatch]);
 
+  const openSettingsModal = useCallback(() => {
+    dispatch(
+      openModal({
+        modalType: 'NOTIFICATION_SETTINGS',
+        modalProps: {},
+      }),
+    );
+  }, [dispatch]);
+
   const pinned = !!columnId;
   const emptyMessage = (
     <FormattedMessage
@@ -254,20 +272,49 @@ export const Notifications: React.FC<{
       bindToDocument={!multiColumn}
       label={intl.formatMessage(messages.title)}
     >
-      <ColumnHeader
-        icon='bell'
-        iconComponent={NotificationsIcon}
-        active={isUnread}
-        title={intl.formatMessage(messages.title)}
-        onPin={handlePin}
-        onMove={handleMove}
-        pinned={pinned}
-        multiColumn={multiColumn}
-        extraButton={extraButton}
-        scrollTopOnClick
-      >
-        <ColumnSettingsContainer />
-      </ColumnHeader>
+      {isRedesignEnabled() ? (
+        <ColumnHeader
+          title={intl.formatMessage(messages.title)}
+          withUnreadMarker={isUnread}
+          withBackButton={multiColumn && !pinned && 'auto'}
+          extraButtons={
+            <>
+              <ColumnHeaderButton icon={GearIcon} onClick={openSettingsModal}>
+                <FormattedMessage
+                  id='notifications.settings'
+                  defaultMessage='Notification Settings'
+                />
+              </ColumnHeaderButton>
+              {multiColumn && (
+                <ColumnSettingsMenu
+                  labelPrefix={intl.formatMessage(messages.title)}
+                >
+                  <MultiColumnMenuItems
+                    pinned={pinned}
+                    onPin={handlePin}
+                    onMove={handleMove}
+                  />
+                </ColumnSettingsMenu>
+              )}
+            </>
+          }
+        />
+      ) : (
+        <LegacyColumnHeader
+          icon='bell'
+          iconComponent={NotificationsIcon}
+          active={isUnread}
+          title={intl.formatMessage(messages.title)}
+          onPin={handlePin}
+          onMove={handleMove}
+          pinned={pinned}
+          multiColumn={multiColumn}
+          extraButton={extraButton}
+          scrollTopOnClick
+        >
+          <ColumnSettingsContainer />
+        </LegacyColumnHeader>
+      )}
 
       {filterBar}
 

--- a/app/javascript/mastodon/features/ui/components/modal_root.jsx
+++ b/app/javascript/mastodon/features/ui/components/modal_root.jsx
@@ -109,6 +109,7 @@ export const MODAL_COMPONENTS = {
   'COMPOSER_DRAFT_DELETE': () => import('@/mastodon/features/compose/redesign/modal_cancel'),
   'COMPOSER_REARRANGE': () => import('@/mastodon/features/compose/redesign/modal_rearrange'),
   'COMPOSER_SWITCH_TO_POST': () => import('@/mastodon/features/compose/redesign/modal_switch'),
+  'NOTIFICATION_SETTINGS': () => import('@/mastodon/features/notifications_v2/components/notification_settings_modal'),
 };
 
 /** @arg {keyof import('@/mastodon/features/account_edit/modals')} type */

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -1144,6 +1144,7 @@
   "notifications.policy.filter_private_mentions_hint": "Filtered unless it's in reply to your own mention or if you follow the sender",
   "notifications.policy.filter_private_mentions_title": "Unsolicited private mentions",
   "notifications.policy.title": "Manage notifications from…",
+  "notifications.settings": "Notification Settings",
   "notifications_permission_banner.enable": "Enable desktop notifications",
   "notifications_permission_banner.how_to_control": "To receive notifications when Mastodon isn't open, enable desktop notifications. You can control precisely which types of interactions generate desktop notifications through the {icon} button above once they're enabled.",
   "notifications_permission_banner.title": "Never miss a thing",

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6079,16 +6079,23 @@ a.status-card {
   height: 100%;
   max-width: 100vw;
   max-height: 100vh;
+  padding: var(--space-lg);
   box-sizing: border-box;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  align-content: space-around;
   z-index: 9999;
   pointer-events: none;
   user-select: none;
   overscroll-behavior: none;
+  overflow-y: auto;
+
+  @media screen and (width <= $mobile-breakpoint) {
+    padding-bottom: 0;
+    padding-inline: var(--space-xs);
+  }
+
+  > * {
+    margin: auto;
+  }
 }
 
 .modal-root__modal {
@@ -6098,10 +6105,10 @@ a.status-card {
   max-width: 100vw;
 
   @media screen and (width <= $mobile-breakpoint) {
-    margin-top: auto;
+    margin-bottom: initial;
 
     &.video-modal {
-      margin-top: 0;
+      margin-bottom: auto;
     }
   }
 }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5123,6 +5123,14 @@ a.status-card {
     }
   }
 
+  [data-redesign='true'] & section {
+    padding-inline: 0;
+
+    &:first-child {
+      padding-top: 0;
+    }
+  }
+
   h3 {
     font-size: 16px;
     line-height: 24px;


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

### Changes proposed in this PR:
- Updates the notifications page column header to the new design
- Moves the Notification settings into a modal
- Changes modal root layout to use a more robust method for centering content, preventing cut-off content and allowing long modals to be scrolled
- Adds a new `onClose` prop to the `ModalTitle` component to optionally display a close button in the corner of the modal

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="913" height="841" alt="image" src="https://github.com/user-attachments/assets/bbd0755f-574d-4e5d-90cc-4abd4dc10654" /> | <img width="917" height="841" alt="image" src="https://github.com/user-attachments/assets/346a3aeb-dc20-4168-8acf-1de1bfc1aa70" /> |
| <img width="908" height="694" alt="image" src="https://github.com/user-attachments/assets/c7f5ccd0-4339-4b57-9079-64cc77102f36" /> | <img width="651" height="605" alt="image" src="https://github.com/user-attachments/assets/b4715d67-4dad-43f3-81be-a2f7fd5ad514" /> |
| - | <img width="652" height="248" alt="image" src="https://github.com/user-attachments/assets/dc5915c6-9ae6-4b8a-9d68-c1d4ea892f7d" /> |
| - | <img width="378" height="226" alt="image" src="https://github.com/user-attachments/assets/aecb3ec3-ba65-4722-9627-d453d5d413b7" /> |