### PR TITLE
Use new PolymorphicProps to silence error around missing ref

### DIFF
--- a/app/javascript/mastodon/components/navigation_focus_target/index.tsx
+++ b/app/javascript/mastodon/components/navigation_focus_target/index.tsx
@@ -8,7 +8,7 @@ import {
 
 import { useLocation } from 'react-router-dom';
 
-import { polymorphicForwardRef } from '@/types/polymorphic';
+import type { PolymorphicProps } from '@/types/polymorphic';
 
 import type { MastodonLocation } from '../router';
 
@@ -129,10 +129,13 @@ interface FocusTargetElementProps extends React.ComponentPropsWithoutRef<'h1'> {
   focusTargetName?: NamedFocusTarget;
 }
 
-export const NavigationFocusTarget = polymorphicForwardRef<
-  'h1',
-  FocusTargetElementProps
->(({ as: Component = 'h1', focusTargetName, children, ...otherProps }) => {
+export const NavigationFocusTarget = <As extends React.ElementType = 'h1'>({
+  as: asComp,
+  focusTargetName,
+  children,
+  ...otherProps
+}: PolymorphicProps<FocusTargetElementProps, As>) => {
+  const Component = asComp ?? 'h1';
   const focusOnNavigation = useFocusOnNavigation(focusTargetName);
 
   return (
@@ -140,4 +143,4 @@ export const NavigationFocusTarget = polymorphicForwardRef<
       {children}
     </Component>
   );
-});
+};


### PR DESCRIPTION
Fixes a minor warning that was complaining about `ref` not being passed into the wrapped function.