### PR TITLE
Add coverage for approve/reject actions in Form::AccountBatch

### DIFF
--- a/spec/models/form/account_batch_spec.rb
+++ b/spec/models/form/account_batch_spec.rb
@@ -107,8 +107,13 @@ RSpec.describe Form::AccountBatch do
 
     context 'when action is "unknown"' do
       let(:action) { 'unknown' }
+      let(:account_ids) { [account.id] }
+      let(:account) { Fabricate :account }
 
-      it { is_expected.to be_nil }
+      it 'does not change the supplied accounts' do
+        expect { subject }
+          .to_not(change { account.reload.updated_at })
+      end
     end
   end
 end


### PR DESCRIPTION
Missing coverage extracted from separate refactor branch which was shuffling around the various `Form::...` classes.

The `select_all_matching` is called in a before block which may not be obvious from this diff alone, and so needs a value.