### PR TITLE
Add multiple timeline update coverage to "markers" API spec

### DIFF
--- a/spec/models/marker_spec.rb
+++ b/spec/models/marker_spec.rb
@@ -3,7 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Marker do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:user) }
+  end
+
   describe 'Validations' do
+    it { is_expected.to validate_presence_of(:timeline) }
     it { is_expected.to validate_inclusion_of(:timeline).in_array(described_class::TIMELINES) }
   end
 end

--- a/spec/requests/api/v1/markers_spec.rb
+++ b/spec/requests/api/v1/markers_spec.rb
@@ -34,31 +34,54 @@ RSpec.describe 'API Markers' do
 
   describe 'POST /api/v1/markers' do
     context 'when no marker exists' do
-      before do
-        post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '69420' } }
-      end
+      subject { post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '69420' } } }
 
       it 'creates a marker', :aggregate_failures do
-        expect(response).to have_http_status(200)
-        expect(response.content_type)
-          .to start_with('application/json')
-        expect(user.markers.first.timeline).to eq 'home'
-        expect(user.markers.first.last_read_id).to eq 69_420
+        expect { subject }
+          .to change { user.markers.count }.by(1)
+        expect(response)
+          .to have_http_status(200)
+        expect(response.media_type)
+          .to eq('application/json')
+        expect(user.markers.first)
+          .to have_attributes(timeline: 'home', last_read_id: 69_420)
+      end
+    end
+
+    context 'with multiple timelines' do
+      subject { post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '69420' }, notifications: { last_read_id: '89345' } } }
+
+      it 'creates a marker', :aggregate_failures do
+        expect { subject }
+          .to change { user.markers.count }.by(2)
+        expect(response)
+          .to have_http_status(200)
+        expect(response.media_type)
+          .to eq('application/json')
+        expect(user.markers.first)
+          .to have_attributes(timeline: 'home', last_read_id: 69_420)
+        expect(user.markers.last)
+          .to have_attributes(timeline: 'notifications', last_read_id: 89_345)
       end
     end
 
     context 'when a marker exists' do
+      subject { post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '70120' } } }
+
       before do
         post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '69420' } }
-        post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '70120' } }
       end
 
       it 'updates a marker', :aggregate_failures do
-        expect(response).to have_http_status(200)
-        expect(response.content_type)
-          .to start_with('application/json')
-        expect(user.markers.first.timeline).to eq 'home'
-        expect(user.markers.first.last_read_id).to eq 70_120
+        expect { subject }
+          .to_not(change { user.markers.count })
+
+        expect(response)
+          .to have_http_status(200)
+        expect(response.media_type)
+          .to eq('application/json')
+        expect(user.markers.first)
+          .to have_attributes(timeline: 'home', last_read_id: 70_120)
       end
     end
 
@@ -71,8 +94,8 @@ RSpec.describe 'API Markers' do
       it 'returns error json' do
         expect(response)
           .to have_http_status(409)
-        expect(response.content_type)
-          .to start_with('application/json')
+        expect(response.media_type)
+          .to eq('application/json')
         expect(response.parsed_body)
           .to include(error: /Conflict during update/)
       end


### PR DESCRIPTION
Extracted from separate branch which had been doing some refactor on `Marker` model. Changes:

- Add missing association and validation checks to marker model spec
- Add missing "multiple update" to markers API for the scenario where separate timelines are sent in one request
- While in that request spec, add misc assertions to other examples, and do some style/naming adjustment to make more consistent with other request specs