### PR TITLE
Redesign: Add "New" button to Messages column header

### DIFF
--- a/app/javascript/mastodon/features/direct_timeline/index.tsx
+++ b/app/javascript/mastodon/features/direct_timeline/index.tsx
@@ -2,15 +2,18 @@ import { useCallback, useEffect } from 'react';
 
 import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
 
+import { PlusIcon } from '@phosphor-icons/react';
 import { Helmet } from '@unhead/react/helmet';
 
 import { Column } from '@/mastodon/components/column';
 import { ColumnHeader as LegacyColumnHeader } from '@/mastodon/components/column/header';
 import {
   ColumnHeader,
+  ColumnHeaderButton,
   ColumnSettingsMenu,
 } from '@/mastodon/components/column_header';
 import { MultiColumnMenuItems } from '@/mastodon/components/column_header/multicolumn_settings';
+import { openNewComposer } from '@/mastodon/reducers/slices/composer';
 import { useAppDispatch } from '@/mastodon/store';
 import { isRedesignEnabled } from '@/mastodon/utils/environment';
 import AlternateEmailIcon from '@/material-icons/400-24px/alternate_email.svg?react';
@@ -38,6 +41,10 @@ const DirectTimeline: React.FC<ColumnBase> = ({ columnId, multiColumn }) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
   const pinned = !!columnId;
+
+  const composeNewMessage = useCallback(() => {
+    dispatch(openNewComposer({ type: 'message' }));
+  }, [dispatch]);
 
   const handlePin = useCallback(() => {
     if (columnId) {
@@ -76,17 +83,27 @@ const DirectTimeline: React.FC<ColumnBase> = ({ columnId, multiColumn }) => {
           title={intl.formatMessage(messages.title_redesign)}
           withBackButton={multiColumn && !pinned && 'auto'}
           extraButtons={
-            multiColumn && (
-              <ColumnSettingsMenu
-                labelPrefix={intl.formatMessage(messages.title_redesign)}
+            <>
+              <ColumnHeaderButton
+                showTextOnDesktop
+                variant='solid'
+                icon={PlusIcon}
+                onClick={composeNewMessage}
               >
-                <MultiColumnMenuItems
-                  onPin={handlePin}
-                  onMove={handleMove}
-                  pinned={pinned}
-                />
-              </ColumnSettingsMenu>
-            )
+                <FormattedMessage id='messages.new' defaultMessage='New' />
+              </ColumnHeaderButton>
+              {multiColumn && (
+                <ColumnSettingsMenu
+                  labelPrefix={intl.formatMessage(messages.title_redesign)}
+                >
+                  <MultiColumnMenuItems
+                    onPin={handlePin}
+                    onMove={handleMove}
+                    pinned={pinned}
+                  />
+                </ColumnSettingsMenu>
+              )}
+            </>
           }
         />
       ) : (

--- a/app/javascript/mastodon/features/navigation_panel/redesign/mobile_nav.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/mobile_nav.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -9,14 +9,12 @@ import {
   ChatCircleIcon,
   HouseIcon,
   MagnifyingGlassIcon,
-  HamburgerIcon,
 } from '@phosphor-icons/react';
 import { animated, useSpring } from '@react-spring/web';
 import { useDrag } from '@use-gesture/react';
 
 import { closeNavigation, openNavigation } from '@/mastodon/actions/navigation';
 import { Avatar } from '@/mastodon/components/avatar';
-import { IconButton } from '@/mastodon/components/button/redesign';
 import { FOCUS_TARGET } from '@/mastodon/components/navigation_focus_target';
 import { ComposeRedesignButton } from '@/mastodon/features/compose/redesign/trigger';
 import { useAccount } from '@/mastodon/hooks/useAccount';
@@ -29,18 +27,12 @@ import classes from './mobile_nav.module.scss';
 import { MobileNavLink } from './navigation_link';
 
 export const RedesignMobileNavigation: React.FC = () => {
-  const dispatch = useAppDispatch();
-
   const { accountId, signedIn } = useIdentity();
   const account = useAccount(accountId);
 
   const notificationsCount = useAppSelector(
     selectUnreadNotificationGroupsCount,
   );
-
-  const handleOpenNavigation = useCallback(() => {
-    dispatch(openNavigation());
-  }, [dispatch]);
 
   if (!signedIn) {
     return null;
@@ -89,13 +81,6 @@ export const RedesignMobileNavigation: React.FC = () => {
           </MobileNavLink>
         </ul>
         <ComposeRedesignButton inline />
-        <IconButton // Silly placeholder – will be replaced with button in column header
-          icon={HamburgerIcon}
-          variant='solid'
-          onClick={handleOpenNavigation}
-        >
-          Menu
-        </IconButton>
       </nav>
       <SlideOutNavigation />
     </>

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -975,6 +975,7 @@
   "load_pending": "{count, plural, one {# new item} other {# new items}}",
   "loading_indicator.label": "Loading…",
   "media_gallery.hide": "Hide",
+  "messages.new": "New",
   "moved_to_account_banner.text": "Your account {disabledAccount} is currently disabled because you moved to {movedToAccount}.",
   "mute_modal.hide_from_notifications": "Hide from notifications",
   "mute_modal.hide_options": "Hide options",


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

### Changes proposed in this PR:
- Adds "New" button to the Messages column header
- Removes placeholder menu button from mobile 🍔❌ There are now enough functional column headers with menu buttons in place.

### Screenshots

<img width="619" height="422" alt="image" src="https://github.com/user-attachments/assets/70829c17-30ce-4ac1-b372-b72cf002e4ee" />

<img width="345" height="678" alt="image" src="https://github.com/user-attachments/assets/c5ec0d2a-3405-4b06-86c3-0caa497d4c99" />
