### PR TITLE
Add "options"-related coverage for poll model

### DIFF
--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -23,5 +23,51 @@ RSpec.describe Poll do
     subject { Fabricate.build(:poll) }
 
     it { is_expected.to validate_presence_of(:expires_at) }
+    it { is_expected.to_not allow_value([]).for(:options) }
+  end
+
+  describe 'Callbacks' do
+    describe 'Normalizing options' do
+      context 'when values are missing and padded' do
+        let(:poll) { Fabricate.build :poll }
+
+        before { poll.options = ['One', '', '  Three  '] }
+
+        it 'strips and compacts the array' do
+          expect { poll.valid? }
+            .to change(poll, :options).to(%w(One Three))
+        end
+      end
+    end
+  end
+
+  describe '#loaded_options' do
+    before { poll.options = %w(One Two) }
+
+    context 'with a poll hiding totals' do
+      let(:poll) { Fabricate.build :poll, hide_totals: true }
+
+      it 'returns serialized option values' do
+        expect(poll.loaded_options)
+          .to be_an(Array)
+          .and contain_exactly(
+            be_a(Poll::Option).and(have_attributes(poll:, id: '0', votes_count: nil, title: /One/)),
+            be_a(Poll::Option).and(have_attributes(poll:, id: '1', votes_count: nil, title: /Two/))
+          )
+      end
+    end
+
+    context 'with an expired poll' do
+      let(:poll) { Fabricate.build :poll, expires_at: 5.days.ago }
+
+      it 'returns serialized option values' do
+        expect(poll.loaded_options)
+          .to be_an(Array)
+          .and contain_exactly(
+            be_a(Poll::Option).and(have_attributes(poll:, id: '0', votes_count: 0, title: /One/)),
+            be_a(Poll::Option).and(have_attributes(poll:, id: '1', votes_count: 0, title: /Two/))
+          )
+      end
+    end
   end
 end


### PR DESCRIPTION
Extracted from a branch making a `Poll::Options` concern. I can revive that if desired, but at minimum this gets us some basic missing coverage on poll options feature.