### PR TITLE
Refactor requests_controller dismiss_bulk to use DismissNotificationRequestService

### DIFF
--- a/app/controllers/api/v1/notifications/requests_controller.rb
+++ b/app/controllers/api/v1/notifications/requests_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::Notifications::RequestsController < Api::BaseController
   end
 
   def dismiss_bulk
-    @requests.each(&:destroy!)
+    @requests.each { |request| DismissNotificationRequestService.new.call(request) }
     render_empty
   end
 


### PR DESCRIPTION
This is just following the dismiss pattern in a loop. Looks like this was the correct way but was likely just missed by mistake.

```
  def dismiss
    DismissNotificationRequestService.new.call(@request)
    render_empty
  end
```

Caught by detail.app, fix by me.