### PR TITLE
Add information about trends and follow recommendation blocks in admin/accounts show page

### DIFF
--- a/app/controllers/admin/follow_recommendations/suppressions_controller.rb
+++ b/app/controllers/admin/follow_recommendations/suppressions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Admin::FollowRecommendations::SuppressionsController < Admin::BaseController
+  def create
+    authorize :follow_recommendation, :suppress?
+
+    form = Form::AccountBatch.new(current_account:, action: 'suppress_follow_recommendation', account_ids: [account_id])
+    form.save
+
+    redirect_to admin_account_path(account_id)
+  end
+
+  def destroy
+    authorize :follow_recommendation, :unsuppress?
+
+    form = Form::AccountBatch.new(current_account:, action: 'unsuppress_follow_recommendation', account_ids: [account_id])
+    form.save
+
+    redirect_to admin_account_path(account_id)
+  end
+
+  private
+
+  def account_id
+    params[:account_id]
+  end
+end

--- a/app/controllers/admin/trends/approvals_controller.rb
+++ b/app/controllers/admin/trends/approvals_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Admin::Trends::ApprovalsController < Admin::BaseController
+  def create
+    authorize account, :review?
+    account.update(trendable: true, reviewed_at: Time.now.utc)
+
+    redirect_to admin_account_path(account.id)
+  end
+
+  def destroy
+    authorize account, :review?
+    account.update(trendable: false, reviewed_at: Time.now.utc)
+
+    redirect_to admin_account_path(account.id)
+  end
+
+  private
+
+  def account
+    @account ||= Account.find(params[:account_id])
+  end
+end

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -31,6 +31,27 @@
           = render 'admin/accounts/local_account', account: @account
         - else
           = render 'admin/accounts/remote_account', account: @account, domain_block: @domain_block
+        %tr
+          %th= t('admin.accounts.discoverable.title')
+          %td= @account.discoverable? ? t('admin.accounts.discoverable.enabled') : t('admin.accounts.discoverable.disabled')
+          %td
+        %tr
+          %th= t('admin.accounts.trends.title')
+          %td= @account.trendable? ? t('admin.accounts.trends.allowed') : t('admin.accounts.trends.disallowed')
+          %td
+            - if can?(:review, @account)
+              - if @account.trendable?
+                = table_link_to 'close', t('admin.accounts.trends.disallow'), admin_account_trends_approval_path(@account.id), method: :delete, data: { confirm: t('admin.accounts.are_you_sure') }
+              - else
+                = table_link_to 'check', t('admin.accounts.trends.allow'), admin_account_trends_approval_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }
+        %tr
+          %th= t('admin.accounts.follow_recommendations.title')
+          %td= @account.follow_recommendation_suppression ? t('admin.accounts.follow_recommendations.suppressed') : t('admin.accounts.follow_recommendations.allowed')
+          %td
+            - if can?(:unsuppress, :follow_recommendation) && @account.follow_recommendation_suppression
+              = table_link_to 'check', t('admin.accounts.follow_recommendations.unsuppress'), admin_account_follow_recommendations_suppression_path(@account.id), method: :delete, data: { confirm: t('admin.accounts.are_you_sure') }
+            - elsif can?(:suppress, :follow_recommendation)
+              = table_link_to 'close', t('admin.accounts.follow_recommendations.suppress'), admin_account_follow_recommendations_suppression_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }
 
   = render 'admin/accounts/buttons', account: @account, deletion_request: @deletion_request
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,6 +68,10 @@ en:
       deletion_reversible_hint_html: This account is pending deletion, and the data will be fully removed on %{date}.
       demote: Demote
       destroyed_msg: "%{username}'s data is now queued to be deleted imminently"
+      discoverable:
+        disabled: Author has not opted-in to being discoverable
+        enabled: Author has opted-in to being discoverable
+        title: Discoverable
       disable: Freeze
       disable_sign_in_token_auth: Disable email token authentication
       disable_two_factor_authentication: Disable 2FA
@@ -82,6 +86,12 @@ en:
       enabled: Enabled
       enabled_msg: Successfully unfroze %{username}'s account
       followers: Followers
+      follow_recommendations:
+        allowed: Allowed
+        suppress: Suppress any follow recommendation
+        suppressed: Suppressed
+        title: Follow recommendations
+        unsuppress: Restore any follow recommendation
       follows: Follows
       header: Header
       inbox_url: Inbox URL
@@ -165,6 +175,12 @@ en:
       suspension_irreversible: The data of this account has been irreversibly deleted. You can unsuspend the account to make it usable but it will not recover any data it previously had.
       suspension_reversible_hint_html: The account has been suspended, and the data will be fully removed on %{date}. Until then, the account can be restored without any ill effects. If you wish to remove all of the account's data immediately, you can do so below.
       title: Accounts
+      trends:
+        allow: Allow
+        allowed: Allowed
+        disallowed: Disallowed
+        disallow: Disallow
+        title: Treding posts
       unblock_email: Unblock email address
       unblocked_email_msg: Successfully unblocked %{username}'s email address
       unconfirmed_email: Unconfirmed email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,14 +68,14 @@ en:
       deletion_reversible_hint_html: This account is pending deletion, and the data will be fully removed on %{date}.
       demote: Demote
       destroyed_msg: "%{username}'s data is now queued to be deleted imminently"
-      discoverable:
-        disabled: Author has not opted-in to being discoverable
-        enabled: Author has opted-in to being discoverable
-        title: Discoverable
       disable: Freeze
       disable_sign_in_token_auth: Disable email token authentication
       disable_two_factor_authentication: Disable 2FA
       disabled: Frozen
+      discoverable:
+        disabled: Author has not opted-in to being discoverable
+        enabled: Author has opted-in to being discoverable
+        title: Discoverable
       display_name: Display name
       domain: Domain
       edit: Edit
@@ -85,13 +85,13 @@ en:
       enable_sign_in_token_auth: Enable email token authentication
       enabled: Enabled
       enabled_msg: Successfully unfroze %{username}'s account
-      followers: Followers
       follow_recommendations:
         allowed: Allowed
         suppress: Suppress any follow recommendation
         suppressed: Suppressed
         title: Follow recommendations
         unsuppress: Restore any follow recommendation
+      followers: Followers
       follows: Follows
       header: Header
       inbox_url: Inbox URL
@@ -178,8 +178,8 @@ en:
       trends:
         allow: Allow
         allowed: Allowed
-        disallowed: Disallowed
         disallow: Disallow
+        disallowed: Disallowed
         title: Treding posts
       unblock_email: Unblock email address
       unblocked_email_msg: Successfully unblocked %{username}'s email address

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -174,6 +174,14 @@ namespace :admin do
         post :resend
       end
     end
+
+    namespace :trends do
+      resource :approval, only: [:create, :destroy]
+    end
+
+    namespace :follow_recommendations do
+      resource :suppression, only: [:create, :destroy]
+    end
   end
 
   resources :users, only: [] do

--- a/spec/requests/admin/follow_recommendations/suppressions_spec.rb
+++ b/spec/requests/admin/follow_recommendations/suppressions_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin FollowRecommendations Suppressions' do
+  before { sign_in Fabricate(:admin_user) }
+
+  describe 'POST /admin/accounts/:account_id/follow_recommendations/suppression' do
+    let(:account) { Fabricate(:account) }
+
+    it 'suppress account from follow recommendations' do
+      post admin_account_follow_recommendations_suppression_path(account.id)
+
+      expect(response)
+        .to redirect_to(admin_account_path(account.id))
+      expect(account.reload.follow_recommendation_suppression)
+        .to_not be_nil
+    end
+  end
+
+  describe 'DELETE /admin/accounts/:account_id/follow_recommendations/suppression' do
+    before { FollowRecommendationSuppression.create(account:) }
+
+    let(:account) { Fabricate(:account) }
+
+    it 'allows account in follow recommendations' do
+      delete admin_account_follow_recommendations_suppression_path(account.id)
+
+      expect(response)
+        .to redirect_to(admin_account_path(account.id))
+      expect(account.reload.follow_recommendation_suppression)
+        .to be_nil
+    end
+  end
+end

--- a/spec/requests/admin/trends/approvals_spec.rb
+++ b/spec/requests/admin/trends/approvals_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Trends Approvals' do
+  before { sign_in Fabricate(:admin_user) }
+
+  describe 'POST /admin/accounts/:account_id/trends/approval' do
+    let(:account) { Fabricate(:account, trendable: false) }
+
+    it 'approves account to appear in trends' do
+      post admin_account_trends_approval_path(account.id)
+
+      expect(response)
+        .to redirect_to(admin_account_path(account.id))
+      expect(account.reload)
+        .to be_trendable
+    end
+  end
+
+  describe 'DELETE /admin/accounts/:account_id/trends/approval' do
+    let(:account) { Fabricate(:account, trendable: true) }
+
+    it 'rejects account from showing in trends' do
+      delete admin_account_trends_approval_path(account.id)
+
+      expect(response)
+        .to redirect_to(admin_account_path(account.id))
+      expect(account.reload)
+        .to_not be_trendable
+    end
+  end
+end


### PR DESCRIPTION
This PR adds information about the trends and follow recommendation status of an account in the admin area. This way an admin or moderator can check accounts they know and disallow them from being recommended for trends and accounts to follow, or the other way around.

Fixes WEB-1030