### PR TITLE
Renovate: `Fix minimumReleaseAge`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,7 @@
   ],
   rebaseWhen: 'conflicted',
   minimumReleaseAge: '3 days', // Wait 3 days after the package has been published before upgrading it
-  prCreation: 'not-pending',
+  minimumReleaseAgeBehaviour: 'timestamp-optional',
   // packageRules order is important, they are applied from top to bottom and are merged,
   // meaning the most important ones must be at the bottom, for example grouping rules
   // If we do not want a package to be grouped with others, we need to set its groupName


### PR DESCRIPTION
- set `minimumReleaseAgeBehaviour: timestamp-optional` Without this, package managers without a release timestamp (like some docker registries) will never get valid updates

- remove `prCreation: 'not-pending',` This is preventing the creation of new PRs for updates. It is no longer recommended to set it since Renovate 42.19.9, and the new behaviour should match what we want

See https://docs.renovatebot.com/key-concepts/minimum-release-age/#what-happens-if-the-datasource-andor-registry-does-not-provide-a-release-timestamp-when-using-minimumreleaseage