### PR TITLE
Status redesign: Fixes bug with media modal

### DIFF
--- a/app/javascript/mastodon/components/status/attachments.tsx
+++ b/app/javascript/mastodon/components/status/attachments.tsx
@@ -142,11 +142,16 @@ const MediaAttachments: React.FC<{
       dispatch(
         openModal({
           modalType: 'MEDIA',
-          modalProps: { statusId, media: attachment, index, lang: language },
+          modalProps: {
+            statusId,
+            media: immutableAttachments,
+            index,
+            lang: language,
+          },
         }),
       );
     },
-    [attachment, dispatch, language, statusId],
+    [immutableAttachments, dispatch, language, statusId],
   );
   const handleOpenVideo = useCallback(
     (options: {


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

This fixes an incorrect value passed to the media gallery modal.