### PR TITLE
Mark requested deletion time nil on accounts CLI reattach

### DIFF
--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -100,7 +100,8 @@ module Mastodon::CLI
       end
 
       account.suspended_at = nil
-      user.account         = account
+      account.requested_deletion_at = nil
+      user.account = account
 
       if user.save
         if options[:confirmed]

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -194,6 +194,20 @@ RSpec.describe Mastodon::CLI::Accounts do
 
           it_behaves_like 'a new user with given email address and username'
         end
+
+        context "when account's user is not present and account was previously deleted" do
+          let(:options) { { email: 'tootctl@example.com', reattach: true } }
+
+          before do
+            Fabricate(:account, username: 'tootctl_username', user: nil, requested_deletion_at: 10.days.ago)
+          end
+
+          it 'removes requested deletion timestamp' do
+            expect { subject }
+              .to output_results('OK')
+              .and change { Account.find_local('tootctl_username').requested_deletion_at }.to(nil)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/40363

I think this is safe, and seems consistent with the line above (resetting `suspended_at` during a "reattach").