### PR TITLE
Redesign: Make navigation sections collapsible

### DIFF
--- a/app/javascript/mastodon/components/button/redesign.module.scss
+++ b/app/javascript/mastodon/components/button/redesign.module.scss
@@ -59,8 +59,8 @@ a.base {
 
 @mixin active {
   &:active,
-  &[aria-pressed='true'],
-  &[aria-expanded='true'] {
+  &[aria-pressed='true']:not(.noActiveHighlight),
+  &[aria-expanded='true']:not(.noActiveHighlight) {
     @content;
   }
 }

--- a/app/javascript/mastodon/components/button/redesign.tsx
+++ b/app/javascript/mastodon/components/button/redesign.tsx
@@ -24,6 +24,11 @@ interface ButtonPropsBase<As extends 'a' | 'button'> {
     As extends 'button' ? HTMLButtonElement : HTMLAnchorElement
   >;
   loading?: boolean;
+  /**
+   * Prevents visual highlight on the button when `aria-expanded`
+   * or `aria-pressed` are used.
+   */
+  noActiveHighlight?: boolean;
   children: ReactNode;
 }
 
@@ -45,6 +50,7 @@ const BaseButton: React.FC<BaseButtonProps> = ({
   className,
   onClick,
   loading,
+  noActiveHighlight,
   'aria-disabled': ariaDisabled,
   'aria-live': ariaLive,
   ...props
@@ -79,6 +85,7 @@ const BaseButton: React.FC<BaseButtonProps> = ({
         classes[size],
         classes[color],
         classes[variant],
+        noActiveHighlight && classes.noActiveHighlight,
       )}
       onClick={handleClick}
       // Disabled buttons can't have focus, so we don't really

--- a/app/javascript/mastodon/features/navigation_panel/redesign/list_section.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/list_section.module.scss
@@ -20,6 +20,23 @@
   cursor: default;
 }
 
+.toggleButton {
+  // Compensate for the button's outer spacing, subtracting a mystery
+  // pixel that I can't explain, but is needed for proper alignment.
+  --button-padding: calc(var(--space-xs) - 1px);
+
+  margin: calc(-1 * var(--button-padding));
+  margin-inline-end: var(--button-padding);
+
+  svg {
+    transition: rotate 100ms ease-in;
+  }
+
+  &[aria-expanded='false'] svg {
+    rotate: -90deg;
+  }
+}
+
 .action {
   margin-inline-start: auto;
 }

--- a/app/javascript/mastodon/features/navigation_panel/redesign/list_section.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/list_section.tsx
@@ -1,7 +1,12 @@
 import type { ReactNode } from 'react';
 
-import { Button } from '@/mastodon/components/button/redesign';
+import { FormattedMessage } from 'react-intl';
+
+import { CaretDownIcon } from '@phosphor-icons/react';
+
+import { Button, IconButton } from '@/mastodon/components/button/redesign';
 import type { MastodonLocationDescriptor } from '@/mastodon/components/router';
+import { useToggle } from '@/mastodon/hooks/useToggle';
 import { hasReactChildren } from '@/mastodon/utils/has_react_children';
 
 import classes from './list_section.module.scss';
@@ -16,10 +21,28 @@ export const ListSection: React.FC<{
   emptyMessage?: ReactNode;
 }> = ({ title, action, children, emptyMessage }) => {
   const hasContent = hasReactChildren(children);
+  const [isOpen, { onToggle }] = useToggle(true);
 
   return (
     <li className={classes.root}>
       <div className={classes.titleWrapper}>
+        {hasContent && (
+          <IconButton
+            size='sm'
+            variant='ghost'
+            icon={CaretDownIcon}
+            onClick={onToggle}
+            noActiveHighlight
+            aria-expanded={isOpen}
+            className={classes.toggleButton}
+          >
+            <FormattedMessage
+              id='tabs_bar.open_section'
+              defaultMessage='Open {title} menu'
+              values={{ title }}
+            />
+          </IconButton>
+        )}
         <span className={classes.title}>{title}</span>
         {action && (
           <Button
@@ -32,11 +55,11 @@ export const ListSection: React.FC<{
           </Button>
         )}
       </div>
-      {hasContent ? (
-        <ul>{children}</ul>
-      ) : (
-        emptyMessage && <div className={classes.emptyState}>{emptyMessage}</div>
-      )}
+      {hasContent
+        ? isOpen && <ul>{children}</ul>
+        : emptyMessage && (
+            <div className={classes.emptyState}>{emptyMessage}</div>
+          )}
     </li>
   );
 };

--- a/app/javascript/mastodon/features/navigation_panel/redesign/navigation_link.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/navigation_link.module.scss
@@ -18,6 +18,7 @@
   display: flex;
   align-items: center;
   width: 100%;
+  min-height: 40px;
   padding: var(--space-xs);
   column-gap: var(--space-sm);
   border-radius: var(--border-radius);

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -1458,6 +1458,7 @@
   "tabs_bar.menu": "Menu",
   "tabs_bar.messages": "Messages",
   "tabs_bar.notifications": "Notifications",
+  "tabs_bar.open_section": "Open {title} menu",
   "tabs_bar.publish": "New Post",
   "tabs_bar.quick_links": "Quick links",
   "tabs_bar.saved": "Saved",


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Fixes PRO-519

### Changes proposed in this PR:
- Adds a disclosure button next to the titles of navigation sections to make them collapsible
- Adds a `noActiveHighlight` prop to the Button/redesign component to optionally prevent a button from being highlighted when the `aria-expanded` or `aria-pressed` attributes are used
- Slightly increases the minimum height of main navigation items

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="271" height="209" alt="image" src="https://github.com/user-attachments/assets/d675babc-411e-4f89-b2a0-c1799fd37d9e" /> | <img width="268" height="233" alt="image" src="https://github.com/user-attachments/assets/2970fdef-103d-453a-8810-c97005f17ab0" /> |

https://github.com/user-attachments/assets/4c182870-d994-481f-ab8d-5591d35e2444

