### PR TITLE
Status redesign: Link cards

### DIFF
--- a/app/javascript/mastodon/components/card/index.tsx
+++ b/app/javascript/mastodon/components/card/index.tsx
@@ -107,6 +107,7 @@ type CardBodyProps<As extends React.ElementType> = PolymorphicProps<
   {
     children: React.ReactNode;
     className?: string;
+    description?: boolean;
     noClamp?: boolean;
   },
   As
@@ -116,6 +117,7 @@ export const CardBody = <As extends React.ElementType>({
   as: asComp,
   children,
   className,
+  description,
   noClamp,
   ...props
 }: CardBodyProps<As>) => {
@@ -123,7 +125,12 @@ export const CardBody = <As extends React.ElementType>({
   return (
     <Comp
       {...props}
-      className={classNames(className, classes.body, !noClamp && classes.clamp)}
+      className={classNames(
+        className,
+        classes.body,
+        !noClamp && classes.clamp,
+        description && classes.description,
+      )}
     >
       {children}
     </Comp>

--- a/app/javascript/mastodon/components/card/index.tsx
+++ b/app/javascript/mastodon/components/card/index.tsx
@@ -107,17 +107,17 @@ type CardBodyProps<As extends React.ElementType> = PolymorphicProps<
   {
     children: React.ReactNode;
     className?: string;
-    description?: boolean;
+    isDescription?: boolean;
     noClamp?: boolean;
   },
   As
 >;
 
-export const CardBody = <As extends React.ElementType>({
+export const CardBody = <As extends React.ElementType = 'div'>({
   as: asComp,
   children,
   className,
-  description,
+  isDescription,
   noClamp,
   ...props
 }: CardBodyProps<As>) => {
@@ -129,7 +129,7 @@ export const CardBody = <As extends React.ElementType>({
         className,
         classes.body,
         !noClamp && classes.clamp,
-        description && classes.description,
+        isDescription && classes.description,
       )}
     >
       {children}

--- a/app/javascript/mastodon/components/card/styles.module.scss
+++ b/app/javascript/mastodon/components/card/styles.module.scss
@@ -21,6 +21,9 @@
 
 // Handle cases where the root is a link
 a.root {
+  color: inherit;
+  text-decoration: none;
+
   &:hover {
     text-decoration: none;
   }
@@ -60,7 +63,7 @@ a.root {
 }
 
 .body {
-  @include mixins.type-body-compact;
+  @include mixins.type-label-lg;
 
   overflow-wrap: break-word;
   flex-grow: 1;
@@ -84,10 +87,16 @@ a.root {
 a.body {
   padding-inline: var(--space-sm);
   margin-inline: calc(-1 * var(--space-sm));
+  color: inherit;
+  text-decoration: none;
 
   .root:has(&:hover) {
     background-color: var(--color-bg-highlight);
   }
+}
+
+.description {
+  @include mixins.type-body-compact;
 }
 
 .image {

--- a/app/javascript/mastodon/components/status/attachments.tsx
+++ b/app/javascript/mastodon/components/status/attachments.tsx
@@ -4,7 +4,7 @@ import { openModal } from '@/mastodon/actions/modal';
 import type { DeployPictureInPictureCallback } from '@/mastodon/actions/picture_in_picture';
 import { deployPictureInPicture } from '@/mastodon/actions/picture_in_picture';
 import { CollectionPreviewCard } from '@/mastodon/features/collections/components/collection_preview_card';
-import Card from '@/mastodon/features/status/components/card';
+import MediaCard from '@/mastodon/features/status/components/card';
 import { useExpandedStatus } from '@/mastodon/hooks/useStatus';
 import { useToggle } from '@/mastodon/hooks/useToggle';
 import { displayMedia } from '@/mastodon/initial_state';
@@ -18,7 +18,9 @@ import { selectPictureInPicture } from '@/mastodon/selectors/statuses';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 import { compareUrls } from '@/mastodon/utils/compare_urls';
 
+import { Card, CardBody, CardTitle } from '../card';
 import { PictureInPicturePlaceholder } from '../picture_in_picture_placeholder';
+import { RelativeTimestamp } from '../relative_timestamp';
 
 import { StatusQuote } from './quote';
 
@@ -58,12 +60,29 @@ export const StatusAttachments: React.FC<{
     ? status.tagged_collections.find(({ url }) => compareUrls(url, card.url))
     : status.tagged_collections[0];
   if (card && !collection) {
+    if (card.type === 'video') {
+      return (
+        <MediaCard
+          key={`${status.id}-${status.edited_at}`}
+          card={card}
+          sensitive={status.sensitive}
+        />
+      );
+    }
+
     return (
-      <Card
-        key={`${status.id}-${status.edited_at}`}
-        card={card}
-        sensitive={status.sensitive}
-      />
+      <Card as='a' href={card.url} target='_blank' rel='noopener'>
+        <CardTitle
+          afterContent={
+            card.published_at && (
+              <RelativeTimestamp timestamp={card.published_at} />
+            )
+          }
+        >
+          {card.title}
+        </CardTitle>
+        {card.description && <CardBody>{card.description}</CardBody>}
+      </Card>
     );
   }
 

--- a/app/javascript/mastodon/components/status/attachments.tsx
+++ b/app/javascript/mastodon/components/status/attachments.tsx
@@ -279,6 +279,7 @@ const LinkCard: React.FC<{ card: CardShape; status: ExpandedStatusShape }> = ({
   card,
   status,
 }) => {
+  // Use the old card if we have authors as the new design doesn't have attribution yet.
   if (card.type === 'video' || card.authors.length > 0) {
     return (
       <div>

--- a/app/javascript/mastodon/components/status/attachments.tsx
+++ b/app/javascript/mastodon/components/status/attachments.tsx
@@ -9,6 +9,8 @@ import { useExpandedStatus } from '@/mastodon/hooks/useStatus';
 import { useToggle } from '@/mastodon/hooks/useToggle';
 import { displayMedia } from '@/mastodon/initial_state';
 import type {
+  CardShape,
+  ExpandedStatusShape,
   MediaAttachment,
   MediaAttachmentShape,
 } from '@/mastodon/models/status';
@@ -60,30 +62,7 @@ export const StatusAttachments: React.FC<{
     ? status.tagged_collections.find(({ url }) => compareUrls(url, card.url))
     : status.tagged_collections[0];
   if (card && !collection) {
-    if (card.type === 'video') {
-      return (
-        <MediaCard
-          key={`${status.id}-${status.edited_at}`}
-          card={card}
-          sensitive={status.sensitive}
-        />
-      );
-    }
-
-    return (
-      <Card as='a' href={card.url} target='_blank' rel='noopener'>
-        <CardTitle
-          afterContent={
-            card.published_at && (
-              <RelativeTimestamp timestamp={card.published_at} />
-            )
-          }
-        >
-          {card.title}
-        </CardTitle>
-        {card.description && <CardBody>{card.description}</CardBody>}
-      </Card>
-    );
+    return <LinkCard card={card} status={status} />;
   }
 
   if (collection) {
@@ -293,5 +272,57 @@ const MediaAttachments: React.FC<{
         matchedFilters={mediaFilters}
       />
     </Suspense>
+  );
+};
+
+const LinkCard: React.FC<{ card: CardShape; status: ExpandedStatusShape }> = ({
+  card,
+  status,
+}) => {
+  if (card.type === 'video' || card.authors.length > 0) {
+    return (
+      <div>
+        <MediaCard
+          key={`${status.id}-${status.edited_at}`}
+          card={card}
+          sensitive={status.sensitive}
+        />
+      </div>
+    );
+  }
+
+  const providerUrl = new URL(card.provider_url || card.url);
+
+  const cardLinkProps = {
+    as: 'a',
+    href: card.url,
+    target: '_blank',
+    rel: 'noopener',
+  } as const;
+
+  return (
+    <Card>
+      <CardTitle
+        afterContent={
+          card.published_at && (
+            <RelativeTimestamp timestamp={card.published_at} />
+          )
+        }
+      >
+        <a
+          href={`${providerUrl.protocol}//${providerUrl.host}`}
+          target='_blank'
+          rel='noopener'
+        >
+          {card.author_name || card.provider_name || providerUrl.host}
+        </a>
+      </CardTitle>
+      <CardBody {...cardLinkProps}>{card.title}</CardBody>
+      {card.description && (
+        <CardBody {...cardLinkProps} description>
+          {card.description}
+        </CardBody>
+      )}
+    </Card>
   );
 };

--- a/app/javascript/mastodon/components/status/attachments.tsx
+++ b/app/javascript/mastodon/components/status/attachments.tsx
@@ -320,7 +320,7 @@ const LinkCard: React.FC<{ card: CardShape; status: ExpandedStatusShape }> = ({
       </CardTitle>
       <CardBody {...cardLinkProps}>{card.title}</CardBody>
       {card.description && (
-        <CardBody {...cardLinkProps} description>
+        <CardBody {...cardLinkProps} isDescription>
           {card.description}
         </CardBody>
       )}


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Uses the new Card component for link embeds, falling back to the old style for video or attributions as those aren't ready yet.

<img width="500" alt="Screenshot 2026-09-08 at 16 55 06" src="https://github.com/user-attachments/assets/e493275e-74c6-4f77-8ff3-0c1c9ac4b51d" />
