### PR TITLE
Fix email footer spacing around custom footer text

### DIFF
--- a/app/javascript/styles/entrypoints/mailer.scss
+++ b/app/javascript/styles/entrypoints/mailer.scss
@@ -516,7 +516,7 @@ table + p {
     text-decoration: underline;
   }
 
-  &:first-child {
+  &:not(last-child) {
     margin-bottom: 12px;
   }
 }


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/40301

Previously the margin was applied to bottom of first element only, which meant when custom text is present there's no space above it. Change to apply margin to all but the last element, which should skip space "between" paragraphs. Looks better when custom text present, and the same when not.

Before:

<img width="804" height="229" alt="Screenshot 2026-09-09 at 11 24 41" src="https://github.com/user-attachments/assets/af40bded-0989-4d14-be9f-be5a2b44b3c1" />

After:

<img width="779" height="224" alt="Screenshot 2026-09-09 at 11 24 50" src="https://github.com/user-attachments/assets/783d5094-6e15-4dbd-9100-4d38f1d9c1b1" />
