### PR TITLE
Redesign: Show menu as sheet on mobile

### DIFF
--- a/app/javascript/mastodon/components/bottom_sheet/index.tsx
+++ b/app/javascript/mastodon/components/bottom_sheet/index.tsx
@@ -1,0 +1,63 @@
+import type { ComponentPropsWithRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
+
+import classNames from 'classnames';
+
+import { useMergedRefs } from '@/mastodon/hooks/useMergedRefs';
+import { useOnClickOutside } from '@/mastodon/hooks/useOnClickOutside';
+import { useScrollSensor } from '@/mastodon/hooks/useScrollSensor';
+
+import classes from './styles.module.scss';
+
+interface BottomSheetProps extends Omit<
+  ComponentPropsWithRef<'dialog'>,
+  'onClose'
+> {
+  onClose: (e: Event) => void;
+}
+
+export const BottomSheet: React.FC<BottomSheetProps> = ({
+  children,
+  className,
+  onClose,
+  ...props
+}) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    dialog.showModal();
+
+    return () => {
+      dialog.requestClose();
+    };
+  }, []);
+
+  useOnClickOutside(contentRef, (e) => {
+    onClose(e);
+  });
+
+  const { sensor, isInViewport } = useScrollSensor({
+    placement: 'bottom',
+    tolerance: 10,
+  });
+
+  return (
+    <dialog
+      {...props}
+      className={classNames(
+        classes.dialog,
+        !isInViewport && classes.withGradient,
+      )}
+      ref={useMergedRefs(props.ref, dialogRef)}
+    >
+      <div ref={contentRef} className={classNames(className, classes.sheet)}>
+        {children}
+      </div>
+      {sensor}
+    </dialog>
+  );
+};

--- a/app/javascript/mastodon/components/bottom_sheet/styles.module.scss
+++ b/app/javascript/mastodon/components/bottom_sheet/styles.module.scss
@@ -37,7 +37,7 @@
   overflow: hidden;
   text-align: start;
 
-  @include mixins.elevation-2;
+  @include mixins.elevation-1;
 
   border-inline: none;
   border-bottom: none;

--- a/app/javascript/mastodon/components/bottom_sheet/styles.module.scss
+++ b/app/javascript/mastodon/components/bottom_sheet/styles.module.scss
@@ -1,0 +1,44 @@
+@use '@/styles/mastodon/mixins';
+
+.dialog {
+  width: 100%;
+  max-width: unset;
+  max-height: 100dvh;
+  margin: initial;
+  margin-top: auto;
+  padding: 0;
+  border: none;
+  background: none;
+  overscroll-behavior: contain;
+
+  &::backdrop {
+    opacity: 0.9;
+    background-color: var(--color-bg-overlay);
+  }
+
+  &::after {
+    @include mixins.scroll-gradient(bottom);
+
+    position: fixed;
+    bottom: 0;
+    opacity: 0;
+    transition: opacity ease 250ms;
+  }
+}
+
+.withGradient::after {
+  opacity: 1;
+}
+
+.sheet {
+  padding: var(--space-md);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  background: var(--color-bg-primary);
+  overflow: hidden;
+  text-align: start;
+
+  @include mixins.elevation-2;
+
+  border-inline: none;
+  border-bottom: none;
+}

--- a/app/javascript/mastodon/components/menu/card.tsx
+++ b/app/javascript/mastodon/components/menu/card.tsx
@@ -1,7 +1,9 @@
 import classNames from 'classnames';
 
+import { useBreakpoint } from '@/mastodon/features/ui/hooks/useBreakpoint';
 import type { PolymorphicProps } from '@/types/polymorphic';
 
+import { BottomSheet } from '../bottom_sheet';
 import { Popover } from '../popover';
 import type { PopoverProps } from '../popover';
 
@@ -65,6 +67,16 @@ export const PopoverMenuCard = <As extends React.ElementType>({
   className,
   ...props
 }: PopoverMenuCardProps<As>) => {
+  const isMobile = useBreakpoint('openable');
+
+  if (isMobile && isOpen) {
+    return (
+      <BottomSheet {...props} onClose={onClose}>
+        {children}
+      </BottomSheet>
+    );
+  }
+
   return (
     <Popover
       isOpen={isOpen}

--- a/app/javascript/mastodon/components/menu/styles.module.scss
+++ b/app/javascript/mastodon/components/menu/styles.module.scss
@@ -1,4 +1,5 @@
 @use '@/styles/mastodon/mixins';
+@use '@/styles/mastodon/variables';
 
 .card {
   @include mixins.elevation-1;
@@ -41,6 +42,7 @@
 
   --cursor: pointer;
 
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   border-radius: var(--radius-sm);
@@ -59,6 +61,10 @@
     border: none;
     width: 100%;
     text-align: start;
+  }
+
+  @media (width < variables.$mobile-menu-breakpoint) {
+    min-height: 48px;
   }
 
   &:hover {


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Fixes WEB-1257

### Changes proposed in this PR:
- Renders the `PopoverMenuCard` component as a bottom sheet, using a new `BottomSheet` component that makes use of the `<dialog>` element and the `.openModal()` API

### Screenshots

<img width="400" height="715" alt="image" src="https://github.com/user-attachments/assets/78afcf9e-6e3d-45de-b259-8da05c317ad6" />

https://github.com/user-attachments/assets/afddcbcd-addf-4394-b00f-4413b29303a7

