### PR TITLE
Status redesign: Actions menu and interactions

### DIFF
--- a/app/javascript/mastodon/actions/interactions_typed.ts
+++ b/app/javascript/mastodon/actions/interactions_typed.ts
@@ -42,6 +42,7 @@ import {
 
 export type StatusInteractionIntent =
   | 'bookmark'
+  | 'copy'
   | 'delete'
   | 'editQuotePolicy'
   | 'edit'
@@ -60,6 +61,10 @@ export type StatusInteractionIntent =
   | 'translate';
 
 const messages = defineMessages({
+  copied: {
+    id: 'status.copied',
+    defaultMessage: 'Copied post link to clipboard',
+  },
   noEdits: {
     id: 'status.cannot_edit',
     defaultMessage: 'You are not allowed to edit this post',
@@ -136,6 +141,13 @@ export const statusInteraction = createAppThunk(
         } else {
           dispatch(bookmark(statusImmutable));
         }
+        return;
+      case 'copy':
+        void navigator.clipboard
+          .writeText(status.url ?? status.uri)
+          .then(() => {
+            dispatch(showAlert({ message: messages.copied }));
+          });
         return;
       case 'delete':
         if (!deleteModal) {

--- a/app/javascript/mastodon/actions/interactions_typed.ts
+++ b/app/javascript/mastodon/actions/interactions_typed.ts
@@ -18,8 +18,8 @@ import { deleteModal } from '../initial_state';
 import { selectStatusInteractions } from '../selectors/statuses';
 
 import { showAlert, showGenericAlert } from './alerts';
-import { replyCompose } from './compose';
-import { quoteComposeById } from './compose_typed';
+import { replyCompose, replyComposeById } from './compose';
+import { changeComposeVisibility, quoteComposeById } from './compose_typed';
 import { importFetchedStatus, importFetchedStatuses } from './importer';
 import {
   bookmark,
@@ -54,6 +54,7 @@ export type StatusInteractionIntent =
   | 'reblog'
   | 'redraft'
   | 'reply'
+  | 'replyPrivately'
   | 'report'
   | 'revokeQuote'
   | 'translate';
@@ -240,6 +241,9 @@ export const statusInteraction = createAppThunk(
       case 'reply':
         dispatch(replyCompose(statusImmutable));
         return;
+      case 'replyPrivately':
+        dispatch(replyPrivately(statusId));
+        return;
       case 'report':
         dispatch(
           openModal({
@@ -269,6 +273,13 @@ export const statusInteraction = createAppThunk(
           dispatch(translateStatus(statusId));
         }
     }
+  },
+);
+
+export const replyPrivately = createAppThunk(
+  (statusId: string, { dispatch }) => {
+    dispatch(replyComposeById(statusId));
+    dispatch(changeComposeVisibility('direct'));
   },
 );
 

--- a/app/javascript/mastodon/actions/interactions_typed.ts
+++ b/app/javascript/mastodon/actions/interactions_typed.ts
@@ -18,7 +18,7 @@ import { deleteModal } from '../initial_state';
 import { selectStatusInteractions } from '../selectors/statuses';
 
 import { showAlert, showGenericAlert } from './alerts';
-import { replyCompose, replyComposeById } from './compose';
+import { replyComposeById } from './compose';
 import { changeComposeVisibility, quoteComposeById } from './compose_typed';
 import { importFetchedStatus, importFetchedStatuses } from './importer';
 import {
@@ -239,7 +239,7 @@ export const statusInteraction = createAppThunk(
         }
         return;
       case 'reply':
-        dispatch(replyCompose(statusImmutable));
+        dispatch(replyComposeById(statusId));
         return;
       case 'replyPrivately':
         dispatch(replyPrivately(statusId));

--- a/app/javascript/mastodon/actions/interactions_typed.ts
+++ b/app/javascript/mastodon/actions/interactions_typed.ts
@@ -19,7 +19,7 @@ import { selectStatusInteractions } from '../selectors/statuses';
 
 import { showAlert, showGenericAlert } from './alerts';
 import { replyComposeById } from './compose';
-import { changeComposeVisibility, quoteComposeById } from './compose_typed';
+import { quoteComposeById } from './compose_typed';
 import { importFetchedStatus, importFetchedStatuses } from './importer';
 import {
   bookmark,
@@ -55,7 +55,6 @@ export type StatusInteractionIntent =
   | 'reblog'
   | 'redraft'
   | 'reply'
-  | 'replyPrivately'
   | 'report'
   | 'revokeQuote'
   | 'translate';
@@ -253,9 +252,6 @@ export const statusInteraction = createAppThunk(
       case 'reply':
         dispatch(replyComposeById(statusId));
         return;
-      case 'replyPrivately':
-        dispatch(replyPrivately(statusId));
-        return;
       case 'report':
         dispatch(
           openModal({
@@ -285,13 +281,6 @@ export const statusInteraction = createAppThunk(
           dispatch(translateStatus(statusId));
         }
     }
-  },
-);
-
-export const replyPrivately = createAppThunk(
-  (statusId: string, { dispatch }) => {
-    dispatch(replyComposeById(statusId));
-    dispatch(changeComposeVisibility('direct'));
   },
 );
 

--- a/app/javascript/mastodon/components/button/redesign.module.scss
+++ b/app/javascript/mastodon/components/button/redesign.module.scss
@@ -178,6 +178,10 @@ a.base {
 
 // Toggle buttons
 .toggle {
+  &:hover {
+    background-color: var(--bg-hover);
+  }
+
   &.solid {
     @include active {
       --bg: var(--color-bg-brand-base);

--- a/app/javascript/mastodon/components/button/redesign.module.scss
+++ b/app/javascript/mastodon/components/button/redesign.module.scss
@@ -176,6 +176,30 @@ a.base {
   }
 }
 
+// Toggle buttons
+.toggle {
+  &.solid {
+    @include active {
+      --bg: var(--color-bg-brand-base);
+      --fg: var(--color-text-on-brand-base);
+    }
+  }
+
+  &.tonal {
+    @include active {
+      --bg: rgb(from var(--color-bg-brand-base) r g b / 10%);
+      --fg: var(--color-text-brand);
+    }
+  }
+
+  &.ghost {
+    @include active {
+      --bg: transparent;
+      --fg: var(--color-text-brand);
+    }
+  }
+}
+
 // Helper classes
 
 .icon,
@@ -196,22 +220,4 @@ a.base {
 
 .loading {
   color: inherit;
-}
-
-// Toggle tonal buttons by default show the neutral color, but when pressed show the brand color.
-.toggle {
-  &.tonal {
-    @include active {
-      --bg: rgb(from var(--color-bg-brand-base) r g b / 10%);
-      --fg: var(--color-text-brand);
-    }
-  }
-
-  &.solid,
-  &.ghost {
-    @include active {
-      --bg: var(--color-bg-brand-base);
-      --fg: var(--color-text-on-brand-base);
-    }
-  }
 }

--- a/app/javascript/mastodon/components/button/redesign.stories.tsx
+++ b/app/javascript/mastodon/components/button/redesign.stories.tsx
@@ -6,7 +6,7 @@ import ChatIcon from '@/material-icons/400-24px/chat.svg?react';
 import DownloadIcon from '@/material-icons/400-24px/download.svg?react';
 import HeadphonesIcon from '@/material-icons/400-24px/headphones.svg?react';
 
-import { Button, IconButton, ToggleButton } from './redesign';
+import { Button, IconButton, ToggleButton, ToggleIconButton } from './redesign';
 
 const iconArgType = {
   control: 'select',
@@ -107,5 +107,19 @@ export const Toggle: Story = {
   render(args) {
     const [active, { onToggle }] = useToggle();
     return <ToggleButton {...args} active={active} onClick={onToggle} />;
+  },
+};
+
+export const ToggleIcon: Story = {
+  render(args) {
+    const [active, { onToggle }] = useToggle();
+    return (
+      <ToggleIconButton
+        {...args}
+        active={active}
+        onClick={onToggle}
+        icon={args.leadingIcon ?? ChatIcon}
+      />
+    );
   },
 };

--- a/app/javascript/mastodon/components/button/redesign.tsx
+++ b/app/javascript/mastodon/components/button/redesign.tsx
@@ -176,3 +176,15 @@ export const ToggleButton: React.FC<ButtonProps & { active?: boolean }> = ({
     className={classNames(className, classes.toggle)}
   />
 );
+
+export const ToggleIconButton: React.FC<
+  IconButtonProps & { active?: boolean }
+> = ({ active, className, ...props }) => (
+  <IconButton
+    aria-pressed={active}
+    {...props}
+    // Toggle buttons always have neutral until pressed.
+    color='neutral'
+    className={classNames(className, classes.toggle)}
+  />
+);

--- a/app/javascript/mastodon/components/menu/index.tsx
+++ b/app/javascript/mastodon/components/menu/index.tsx
@@ -266,7 +266,7 @@ export type MenuListProps<As extends React.ElementType> = Omit<
   'isOpen' | 'onClose' | 'reference' | 'popoverElement'
 >;
 
-export const MenuList = <As extends React.ElementType>({
+export const MenuList = <As extends React.ElementType = 'div'>({
   children,
   ...props
 }: MenuListProps<As>) => {

--- a/app/javascript/mastodon/components/status/action_bar.tsx
+++ b/app/javascript/mastodon/components/status/action_bar.tsx
@@ -351,14 +351,28 @@ const StatusReblogButton: React.FC<{
           icon={ArrowsClockwiseIcon}
           disabled={boostState.disabled}
         >
-          {intl.formatMessage(boostState.title)}
+          <p>
+            {intl.formatMessage(boostState.title)}
+            {boostState.meta && (
+              <span className={classes.actionDescription}>
+                {intl.formatMessage(boostState.meta)}
+              </span>
+            )}
+          </p>
         </MenuItem>
         <MenuItem
           onClick={onQuote}
           icon={QuotesFilledIcon}
           disabled={quoteState.disabled}
         >
-          {intl.formatMessage(quoteState.title)}
+          <p>
+            {intl.formatMessage(quoteState.title)}
+            {quoteState.meta && (
+              <span className={classes.actionDescription}>
+                {intl.formatMessage(quoteState.meta)}
+              </span>
+            )}
+          </p>
         </MenuItem>
       </MenuList>
     </Menu>

--- a/app/javascript/mastodon/components/status/action_bar.tsx
+++ b/app/javascript/mastodon/components/status/action_bar.tsx
@@ -57,12 +57,11 @@ import { Dropdown } from '../dropdown_menu';
 import { RemoveQuoteHint } from '../status_action_bar/remove_quote_hint';
 
 import { quoteItemState } from './boost_button_utils';
+import { useStatusContext } from './hooks';
 import classes from './styles.module.scss';
-import type { StatusContextType } from './types';
 
 interface StatusActionBarProps {
   statusId: string;
-  contextType?: StatusContextType;
   withDismiss?: boolean;
   withCounters?: boolean;
   scrollKey?: string;
@@ -137,7 +136,6 @@ const messages = defineMessages({
 
 export const StatusActionBar: React.FC<StatusActionBarProps> = ({
   statusId,
-  contextType,
   withDismiss,
   withCounters,
   scrollKey,
@@ -148,6 +146,7 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
       state.statuses.getIn([status?.quote?.quoted_status, 'account']) ?? null,
   );
   const currentAccountId = useCurrentAccountId();
+  const { contextType } = useStatusContext();
   const statusUrl = status?.url ?? status?.uri;
 
   // Actions
@@ -270,7 +269,6 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
           <StatusActionMenu
             dismissQuoteHint={dismissQuoteHint}
             status={status}
-            contextType={contextType}
             withDismiss={withDismiss}
             scrollKey={scrollKey}
           />
@@ -283,11 +281,11 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
 const StatusActionMenu: React.FC<{
   dismissQuoteHint: () => void;
   status: StatusShape;
-  contextType?: StatusContextType;
   scrollKey?: string;
   withDismiss?: boolean;
-}> = ({ status, dismissQuoteHint, contextType, scrollKey, withDismiss }) => {
+}> = ({ status, dismissQuoteHint, scrollKey, withDismiss }) => {
   const account = useAppSelector((state) => state.accounts.get(status.account));
+  const { contextType } = useStatusContext();
   const { permissions } = useIdentity();
   const relationship = useRelationship(account?.id);
   const intl = useIntl();

--- a/app/javascript/mastodon/components/status/action_bar.tsx
+++ b/app/javascript/mastodon/components/status/action_bar.tsx
@@ -63,6 +63,7 @@ import {
   Menu,
   MenuItem,
   MenuItemDivider,
+  MenuItemLink,
   MenuList,
   MenuTrigger,
 } from '../menu';
@@ -180,9 +181,9 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
         url: statusUrl,
       });
     } else {
-      void nav.clipboard.writeText(statusUrl);
+      dispatch(statusInteraction({ statusId, intent: 'copy', contextType }));
     }
-  }, [statusUrl]);
+  }, [contextType, dispatch, statusId, statusUrl]);
   const handleBookmarkClick = useCallback(() => {
     dispatch(statusInteraction({ statusId, intent: 'bookmark', contextType }));
   }, [contextType, dispatch, statusId]);
@@ -447,20 +448,42 @@ const StatusActionMenu: React.FC<{
         <FormattedMessage id='status.more' defaultMessage='More' />
       </MenuTrigger>
 
-      <MenuList placement='top-end'>
-        {menu.map((item, index) =>
-          item ? (
-            <MenuItem key={index} disabled={item.disabled} icon={item.icon}>
-              {item.text}
-            </MenuItem>
-          ) : (
-            <MenuItemDivider key={index} />
-          ),
-        )}
+      <MenuList placement='top-end' container={document.body}>
+        {menu.map((item, index) => (
+          <StatusActionItem key={index} item={item} />
+        ))}
         <StatusActionLoader onMount={onOpen} />
       </MenuList>
     </Menu>
   );
+};
+
+const StatusActionItem: React.FC<{ item: DropdownItem }> = ({ item }) => {
+  if (!item) {
+    return <MenuItemDivider />;
+  }
+
+  const commonProps = {
+    icon: item.icon,
+    disabled: item.disabled,
+    className: classNames(item.dangerous && classes.actionDangerous),
+    children: item.description ? (
+      <p>
+        {item.text}
+        <span className={classes.actionDescription}>{item.description}</span>
+      </p>
+    ) : (
+      item.text
+    ),
+  } as const;
+
+  if ('to' in item) {
+    return <MenuItemLink {...commonProps} to={item.to} as='link' />;
+  } else if ('href' in item) {
+    return <MenuItemLink {...commonProps} href={item.href} as='a' />;
+  }
+
+  return <MenuItem {...commonProps} onClick={item.action} />;
 };
 
 const StatusActionLoader = ({ onMount }: { onMount: () => void }) => {
@@ -515,9 +538,7 @@ function getMenuItems({
 
   menu.push({
     text: intl.formatMessage(messages.copy),
-    action: () => {
-      void navigator.clipboard.writeText(statusUrl);
-    },
+    action: onStatusInteraction('copy'),
   });
 
   if (isPublic && 'share' in navigator) {

--- a/app/javascript/mastodon/components/status/action_bar.tsx
+++ b/app/javascript/mastodon/components/status/action_bar.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
@@ -59,8 +59,13 @@ import {
   ToggleButton,
   ToggleIconButton,
 } from '../button/redesign';
-import { Dropdown } from '../dropdown_menu';
-import { Menu, MenuItem, MenuList, MenuTrigger } from '../menu';
+import {
+  Menu,
+  MenuItem,
+  MenuItemDivider,
+  MenuList,
+  MenuTrigger,
+} from '../menu';
 import { RemoveQuoteHint } from '../status_action_bar/remove_quote_hint';
 
 import { boostItemState, quoteItemState } from './boost_button_utils';
@@ -71,7 +76,6 @@ interface StatusActionBarProps {
   statusId: string;
   withDismiss?: boolean;
   withCounters?: boolean;
-  scrollKey?: string;
 }
 
 const messages = defineMessages({
@@ -145,7 +149,6 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
   statusId,
   withDismiss,
   withCounters,
-  scrollKey,
 }) => {
   const status = useStatus(statusId);
   const quotedAccountId = useAppSelector(
@@ -286,7 +289,6 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
             dismissQuoteHint={dismissQuoteHint}
             status={status}
             withDismiss={withDismiss}
-            scrollKey={scrollKey}
           />
         )}
       </RemoveQuoteHint>
@@ -342,7 +344,7 @@ const StatusReblogButton: React.FC<{
         {children}
       </MenuTrigger>
 
-      <MenuList placement='bottom' maxWidth={180}>
+      <MenuList placement='bottom' maxWidth={180} container={document.body}>
         <MenuItem
           onClick={onReblog}
           icon={ArrowsClockwiseIcon}
@@ -369,9 +371,8 @@ const QuotesFilledIcon = (props: React.SVGProps<SVGSVGElement>) => (
 const StatusActionMenu: React.FC<{
   dismissQuoteHint: () => void;
   status: StatusShape;
-  scrollKey?: string;
   withDismiss?: boolean;
-}> = ({ status, dismissQuoteHint, scrollKey, withDismiss }) => {
+}> = ({ status, dismissQuoteHint, withDismiss }) => {
   const account = useAppSelector((state) => state.accounts.get(status.account));
   const { contextType } = useStatusContext();
   const { permissions } = useIdentity();
@@ -423,7 +424,7 @@ const StatusActionMenu: React.FC<{
       dispatch,
     ],
   );
-  const handleOpen = useCallback(() => {
+  const onOpen = useCallback(() => {
     // Replicates needsStatusRefresh of the Dropdown component.
     if (quickBoosting && !status.quote_approval) {
       dispatch(
@@ -436,12 +437,37 @@ const StatusActionMenu: React.FC<{
   }, [dismissQuoteHint, dispatch, status.id, status.quote_approval]);
 
   return (
-    <Dropdown scrollKey={scrollKey} items={menu} onOpen={handleOpen}>
-      <IconButton size='sm' variant='ghost' icon={DotsThreeIcon}>
+    <Menu>
+      <MenuTrigger
+        as={IconButton}
+        size='sm'
+        variant='ghost'
+        icon={DotsThreeIcon}
+      >
         <FormattedMessage id='status.more' defaultMessage='More' />
-      </IconButton>
-    </Dropdown>
+      </MenuTrigger>
+
+      <MenuList placement='top-end'>
+        {menu.map((item, index) =>
+          item ? (
+            <MenuItem key={index} disabled={item.disabled} icon={item.icon}>
+              {item.text}
+            </MenuItem>
+          ) : (
+            <MenuItemDivider key={index} />
+          ),
+        )}
+        <StatusActionLoader onMount={onOpen} />
+      </MenuList>
+    </Menu>
   );
+};
+
+const StatusActionLoader = ({ onMount }: { onMount: () => void }) => {
+  useEffect(() => {
+    onMount();
+  }, [onMount]);
+  return null;
 };
 
 interface MenuItemsParams {

--- a/app/javascript/mastodon/components/status/action_bar.tsx
+++ b/app/javascript/mastodon/components/status/action_bar.tsx
@@ -11,6 +11,7 @@ import {
   ChatCircleTextIcon,
   DotsThreeIcon,
   HeartIcon,
+  QuotesIcon,
   ShareFatIcon,
 } from '@phosphor-icons/react';
 
@@ -34,7 +35,7 @@ import { useStatus } from '@/mastodon/hooks/useStatus';
 import { useIdentity } from '@/mastodon/identity_context';
 import { quickBoosting } from '@/mastodon/initial_state';
 import type { Account } from '@/mastodon/models/account';
-import type { MenuItem } from '@/mastodon/models/dropdown_menu';
+import type { MenuItem as DropdownItem } from '@/mastodon/models/dropdown_menu';
 import type { Relationship } from '@/mastodon/models/relationship';
 import type { StatusShape } from '@/mastodon/models/status';
 import {
@@ -54,9 +55,10 @@ import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 
 import { Button, IconButton, ToggleButton } from '../button/redesign';
 import { Dropdown } from '../dropdown_menu';
+import { Menu, MenuItem, MenuList, MenuTrigger } from '../menu';
 import { RemoveQuoteHint } from '../status_action_bar/remove_quote_hint';
 
-import { quoteItemState } from './boost_button_utils';
+import { boostItemState, quoteItemState } from './boost_button_utils';
 import { useStatusContext } from './hooks';
 import classes from './styles.module.scss';
 
@@ -154,9 +156,6 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
   const handleReplyClick = useCallback(() => {
     dispatch(statusInteraction({ statusId, intent: 'reply' }));
   }, [dispatch, statusId]);
-  const handleBoostClick = useCallback(() => {
-    dispatch(statusInteraction({ statusId, intent: 'reblog' }));
-  }, [dispatch, statusId]);
   const handleShareClick = useCallback(() => {
     if (!statusUrl) {
       return;
@@ -224,15 +223,9 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
         {withCounters && status.replies_count}
       </Button>
 
-      <ToggleButton
-        size='sm'
-        variant='ghost'
-        active={status.reblogged}
-        leadingIcon={ArrowsClockwiseIcon}
-        onClick={handleBoostClick}
-      >
+      <StatusReblogButton statusId={statusId}>
         {withCounters && status.reblogs_count}
-      </ToggleButton>
+      </StatusReblogButton>
 
       <ToggleButton
         size='sm'
@@ -289,6 +282,78 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
     </div>
   );
 };
+
+const StatusReblogButton: React.FC<{
+  statusId: string;
+  children: React.ReactNode;
+}> = ({ statusId, children }) => {
+  const conditions = useAppSelector((state) =>
+    selectStatusConditions(state, statusId),
+  );
+  const { isBoosted } = conditions;
+
+  const boostState = boostItemState(conditions);
+  const quoteState = quoteItemState(conditions);
+  const intl = useIntl();
+
+  const dispatch = useAppDispatch();
+  const onReblog = useCallback(() => {
+    dispatch(statusInteraction({ statusId, intent: 'reblog' }));
+  }, [dispatch, statusId]);
+  const onQuote = useCallback(() => {
+    dispatch(statusInteraction({ statusId, intent: 'quote' }));
+  }, [dispatch, statusId]);
+
+  if (quickBoosting) {
+    return (
+      <ToggleButton
+        size='sm'
+        variant='ghost'
+        active={isBoosted}
+        leadingIcon={ArrowsClockwiseIcon}
+        onClick={onReblog}
+        disabled={boostState.disabled}
+      >
+        {children}
+      </ToggleButton>
+    );
+  }
+
+  return (
+    <Menu>
+      <MenuTrigger
+        as={ToggleButton}
+        size='sm'
+        variant='ghost'
+        active={isBoosted}
+        leadingIcon={ArrowsClockwiseIcon}
+      >
+        {children}
+      </MenuTrigger>
+
+      <MenuList placement='bottom' maxWidth={180}>
+        <MenuItem
+          onClick={onReblog}
+          icon={ArrowsClockwiseIcon}
+          disabled={boostState.disabled}
+        >
+          {intl.formatMessage(boostState.title)}
+        </MenuItem>
+        <MenuItem
+          onClick={onQuote}
+          icon={QuotesFilledIcon}
+          disabled={quoteState.disabled}
+        >
+          {intl.formatMessage(quoteState.title)}
+        </MenuItem>
+      </MenuList>
+    </Menu>
+  );
+};
+
+const QuotesFilledIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <QuotesIcon {...props} weight='fill' />
+);
 
 const StatusActionMenu: React.FC<{
   dismissQuoteHint: () => void;
@@ -393,7 +458,7 @@ function getMenuItems({
   relationship,
   dispatch,
 }: MenuItemsParams) {
-  const menu: MenuItem[] = [];
+  const menu: DropdownItem[] = [];
 
   const statusId = status.id;
   const statusUrl = status.url ?? status.uri;

--- a/app/javascript/mastodon/components/status/action_bar.tsx
+++ b/app/javascript/mastodon/components/status/action_bar.tsx
@@ -53,7 +53,12 @@ import {
 import type { AppDispatch } from '@/mastodon/store';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 
-import { Button, IconButton, ToggleButton } from '../button/redesign';
+import {
+  Button,
+  IconButton,
+  ToggleButton,
+  ToggleIconButton,
+} from '../button/redesign';
 import { Dropdown } from '../dropdown_menu';
 import { Menu, MenuItem, MenuList, MenuTrigger } from '../menu';
 import { RemoveQuoteHint } from '../status_action_bar/remove_quote_hint';
@@ -190,6 +195,15 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
       ),
     [status?.favourited],
   );
+  const bookmarkIcon = useCallback(
+    (props: React.SVGProps<SVGSVGElement>) =>
+      status?.bookmarked ? (
+        <BookmarkSimpleIcon {...props} weight='fill' />
+      ) : (
+        <BookmarkSimpleIcon {...props} />
+      ),
+    [status?.bookmarked],
+  );
 
   if (!status) {
     return null;
@@ -245,11 +259,13 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
         </IconButton>
       )}
 
-      <IconButton
+      <ToggleIconButton
         size='sm'
         variant='ghost'
-        icon={BookmarkSimpleIcon}
+        active={status.bookmarked}
+        icon={bookmarkIcon}
         onClick={handleBookmarkClick}
+        aria-pressed={status.bookmarked}
       >
         {!status.bookmarked ? (
           <FormattedMessage id='status.bookmark' defaultMessage='Bookmark' />
@@ -259,7 +275,7 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
             defaultMessage='Remove bookmark'
           />
         )}
-      </IconButton>
+      </ToggleIconButton>
 
       <RemoveQuoteHint
         className='status__action-bar__button-wrapper'

--- a/app/javascript/mastodon/components/status/action_bar.tsx
+++ b/app/javascript/mastodon/components/status/action_bar.tsx
@@ -154,8 +154,11 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
   // Actions
   const dispatch = useAppDispatch();
   const handleReplyClick = useCallback(() => {
-    dispatch(statusInteraction({ statusId, intent: 'reply' }));
-  }, [dispatch, statusId]);
+    dispatch(statusInteraction({ statusId, intent: 'reply', contextType }));
+  }, [contextType, dispatch, statusId]);
+  const handleFavouriteClick = useCallback(() => {
+    dispatch(statusInteraction({ statusId, intent: 'favourite', contextType }));
+  }, [contextType, dispatch, statusId]);
   const handleShareClick = useCallback(() => {
     if (!statusUrl) {
       return;
@@ -172,12 +175,9 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
       void nav.clipboard.writeText(statusUrl);
     }
   }, [statusUrl]);
-  const handleFavouriteClick = useCallback(() => {
-    dispatch(statusInteraction({ statusId, intent: 'favourite' }));
-  }, [dispatch, statusId]);
   const handleBookmarkClick = useCallback(() => {
-    dispatch(statusInteraction({ statusId, intent: 'bookmark' }));
-  }, [dispatch, statusId]);
+    dispatch(statusInteraction({ statusId, intent: 'bookmark', contextType }));
+  }, [contextType, dispatch, statusId]);
 
   const intl = useIntl();
 
@@ -197,11 +197,6 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
 
   const isPublic =
     status.visibility === 'public' || status.visibility === 'unlisted';
-  const isReply =
-    !status.in_reply_to_id || status.in_reply_to_account_id === status.account;
-  const replyTitle = isReply
-    ? intl.formatMessage(messages.reply)
-    : intl.formatMessage(messages.replyAll);
 
   const favouriteTitle = intl.formatMessage(
     status.favourited ? messages.removeFavourite : messages.favourite,
@@ -216,7 +211,7 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
       <Button
         size='sm'
         variant='ghost'
-        title={replyTitle}
+        title={intl.formatMessage(messages.replyAll)}
         leadingIcon={ChatCircleTextIcon}
         onClick={handleReplyClick}
       >

--- a/app/javascript/mastodon/components/status/action_bar.tsx
+++ b/app/javascript/mastodon/components/status/action_bar.tsx
@@ -52,7 +52,7 @@ import {
 import type { AppDispatch } from '@/mastodon/store';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 
-import { Button, IconButton } from '../button/redesign';
+import { Button, IconButton, ToggleButton } from '../button/redesign';
 import { Dropdown } from '../dropdown_menu';
 import { RemoveQuoteHint } from '../status_action_bar/remove_quote_hint';
 
@@ -182,6 +182,16 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
 
   const intl = useIntl();
 
+  const favouriteIcon = useCallback(
+    (props: React.SVGProps<SVGSVGElement>) =>
+      status?.favourited ? (
+        <HeartIcon {...props} weight='fill' />
+      ) : (
+        <HeartIcon {...props} />
+      ),
+    [status?.favourited],
+  );
+
   if (!status) {
     return null;
   }
@@ -214,25 +224,27 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
         {withCounters && status.replies_count}
       </Button>
 
-      <Button
+      <ToggleButton
         size='sm'
         variant='ghost'
+        active={status.reblogged}
         leadingIcon={ArrowsClockwiseIcon}
         onClick={handleBoostClick}
       >
         {withCounters && status.reblogs_count}
-      </Button>
+      </ToggleButton>
 
-      <Button
+      <ToggleButton
         size='sm'
         variant='ghost'
+        active={status.favourited}
         title={favouriteTitle}
-        leadingIcon={HeartIcon}
+        leadingIcon={favouriteIcon}
         onClick={handleFavouriteClick}
         className={classes.actionsButtonGap}
       >
         {withCounters && status.favourites_count}
-      </Button>
+      </ToggleButton>
 
       {isPublic && (
         <IconButton

--- a/app/javascript/mastodon/components/status/attachments.stories.tsx
+++ b/app/javascript/mastodon/components/status/attachments.stories.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/testing/factories';
 
 import { StatusAttachments } from './attachments';
+import { StatusContext } from './hooks';
 import type { AttachmentArgs } from './testing';
 import { attachmentArgTypes, attachmentFactory } from './testing';
 
@@ -26,9 +27,9 @@ const meta = {
   title: 'Components/Status/StatusAttachments',
   render() {
     return (
-      <div style={{ width: 'min(600px, 80vw)' }}>
-        <StatusAttachments statusId='1' contextType='home' />
-      </div>
+      <StatusContext.Provider value={{}}>
+        <StatusAttachments statusId='1' />
+      </StatusContext.Provider>
     );
   },
   args: {
@@ -138,6 +139,13 @@ const meta = {
       };
     },
   },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 'min(600px, 80vw)' }}>
+        <Story />
+      </div>
+    ),
+  ],
 } as Meta<StatusAttachmentsStoryProps>;
 
 export default meta;

--- a/app/javascript/mastodon/components/status/attachments.tsx
+++ b/app/javascript/mastodon/components/status/attachments.tsx
@@ -24,12 +24,12 @@ import { Card, CardBody, CardTitle } from '../card';
 import { PictureInPicturePlaceholder } from '../picture_in_picture_placeholder';
 import { RelativeTimestamp } from '../relative_timestamp';
 
+import { useStatusContext } from './hooks';
 import { StatusQuote } from './quote';
 
 export const StatusAttachments: React.FC<{
   statusId: string;
-  contextType?: string;
-}> = ({ statusId, contextType }) => {
+}> = ({ statusId }) => {
   const status = useExpandedStatus(statusId);
 
   if (!status) {
@@ -42,7 +42,6 @@ export const StatusAttachments: React.FC<{
       <MediaAttachments
         statusId={statusId}
         accountId={status.account.id}
-        contextType={contextType}
         sensitive={status.sensitive}
         language={status.translation?.language ?? status.language}
         attachment={attachment}
@@ -98,7 +97,6 @@ const Video = lazy(() => import('@/mastodon/features/video'));
 const MediaAttachments: React.FC<{
   statusId: string;
   accountId: string;
-  contextType?: string;
   sensitive: boolean;
   language: string;
   attachment: MediaAttachmentShape;
@@ -107,7 +105,6 @@ const MediaAttachments: React.FC<{
 }> = ({
   statusId,
   accountId,
-  contextType,
   sensitive,
   language,
   attachment,
@@ -122,6 +119,7 @@ const MediaAttachments: React.FC<{
       'media_attachments',
     ]) as Immutable.List<MediaAttachment>;
   });
+  const { contextType } = useStatusContext();
   const mediaFilters = useAppSelector((state) =>
     selectMediaFilters(state, { statusId, contextType }),
   );

--- a/app/javascript/mastodon/components/status/content.tsx
+++ b/app/javascript/mastodon/components/status/content.tsx
@@ -90,7 +90,6 @@ export const StatusContent: React.FC<
       ref={onRef}
     >
       <EmojiHTML
-        {...props}
         className={classes.contentText}
         ref={onRef}
         lang={language}

--- a/app/javascript/mastodon/components/status/hooks.ts
+++ b/app/javascript/mastodon/components/status/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { createContext, use, useCallback, useMemo } from 'react';
 
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -22,6 +22,15 @@ import { FOCUS_TARGET } from '../navigation_focus_target';
 
 import { useElementHandledLink } from './handled_link';
 import type { StatusContextType } from './types';
+
+export const StatusContext = createContext<{
+  id?: string | null;
+  contextType?: StatusContextType;
+}>({});
+
+export function useStatusContext() {
+  return use(StatusContext);
+}
 
 const messages = defineMessages({
   quote_noun: {

--- a/app/javascript/mastodon/components/status/status.tsx
+++ b/app/javascript/mastodon/components/status/status.tsx
@@ -18,7 +18,11 @@ import { StatusActionBar } from './action_bar';
 import { StatusAttachments } from './attachments';
 import { StatusContent } from './content';
 import type { StatusHandlers } from './hooks';
-import { useStatusHandlers, useTextForScreenReader } from './hooks';
+import {
+  StatusContext,
+  useStatusHandlers,
+  useTextForScreenReader,
+} from './hooks';
 import { StatusMeta } from './meta';
 import { StatusPrepend } from './prepend';
 import { StatusRedesignHeader } from './redesign/header';
@@ -140,94 +144,95 @@ export const StatusRedesign: React.FC<StatusRedesignProps> = ({
     (showActions && !isQuotedPost);
 
   return (
-    <StatusHotkeys
-      {...hotkeysProps}
-      className={classNames(
-        classes.root,
-        variant === 'thread' && classes.variantThread,
-        variant === 'page' && classes.variantPage,
-        isQuotedPost && classes.isQuote,
-      )}
-      data-featured={featured ? 'true' : null}
-      aria-label={screenReaderText}
-      data-nosnippet={status.account.noindex || undefined}
-    >
-      {!skipPrepend && (
-        <StatusPrepend
-          status={actualStatus}
-          isReblog={!!parent}
-          showThread={showThread}
-        />
-      )}
+    <StatusContext.Provider value={{ id, contextType }}>
+      <StatusHotkeys
+        {...hotkeysProps}
+        className={classNames(
+          classes.root,
+          variant === 'thread' && classes.variantThread,
+          variant === 'page' && classes.variantPage,
+          isQuotedPost && classes.isQuote,
+        )}
+        data-featured={featured ? 'true' : null}
+        aria-label={screenReaderText}
+        data-nosnippet={status.account.noindex || undefined}
+      >
+        {!skipPrepend && (
+          <StatusPrepend
+            status={actualStatus}
+            isReblog={!!parent}
+            showThread={showThread}
+          />
+        )}
 
-      <StatusRedesignHeader status={status} className={classes.header}>
-        {headerContents}
-      </StatusRedesignHeader>
+        <StatusRedesignHeader status={status} className={classes.header}>
+          {headerContents}
+        </StatusRedesignHeader>
 
-      {matchedFilters.length > 0 && (
-        <FilterWarning
-          title={matchedFilters.map((filter) => filter.title).join(', ')}
-          expanded={showDespiteFilter}
-          onClick={onFilterToggle}
-        />
-      )}
+        {matchedFilters.length > 0 && (
+          <FilterWarning
+            title={matchedFilters.map((filter) => filter.title).join(', ')}
+            expanded={showDespiteFilter}
+            onClick={onFilterToggle}
+          />
+        )}
 
-      {(matchedFilters.length === 0 || showDespiteFilter) && (
-        <ContentWarning
-          statusId={status.id}
-          expanded={expanded}
-          onClick={onExpandedToggle}
-        />
-      )}
+        {(matchedFilters.length === 0 || showDespiteFilter) && (
+          <ContentWarning
+            statusId={status.id}
+            expanded={expanded}
+            onClick={onExpandedToggle}
+          />
+        )}
 
-      {expanded && (
-        <StatusContent
-          status={status}
-          statusContent={statusContent}
-          onReadMore={handlers.onOpen}
-          onTranslate={onTranslate}
-          collapsible
-        >
-          {!!status.poll && (
-            <Poll
-              pollId={status.poll}
-              statusUrl={status.uri}
-              accountId={status.account.id}
-              lang={status.translation?.language ?? status.language}
-            />
-          )}
+        {expanded && (
+          <StatusContent
+            status={status}
+            statusContent={statusContent}
+            onReadMore={handlers.onOpen}
+            onTranslate={onTranslate}
+            collapsible
+          >
+            {!!status.poll && (
+              <Poll
+                pollId={status.poll}
+                statusUrl={status.uri}
+                accountId={status.account.id}
+                lang={status.translation?.language ?? status.language}
+              />
+            )}
 
-          <StatusAttachments statusId={status.id} contextType={contextType} />
+            <StatusAttachments statusId={status.id} />
 
-          {children}
-        </StatusContent>
-      )}
+            {children}
+          </StatusContent>
+        )}
 
-      {showFooter && (
-        <footer className={classes.footer}>
-          {expanded && hashtagsInBar.length > 0 && (
-            <HashtagBar
-              hashtags={hashtagsInBar}
-              accountId={status.account.id}
-            />
-          )}
+        {showFooter && (
+          <footer className={classes.footer}>
+            {expanded && hashtagsInBar.length > 0 && (
+              <HashtagBar
+                hashtags={hashtagsInBar}
+                accountId={status.account.id}
+              />
+            )}
 
-          {variant === 'page' && (
-            <StatusMeta status={status} className={classes.meta} />
-          )}
+            {variant === 'page' && (
+              <StatusMeta status={status} className={classes.meta} />
+            )}
 
-          {showActions && !isQuotedPost && (
-            <StatusActionBar
-              scrollKey={scrollKey}
-              statusId={status.id}
-              contextType={contextType}
-              withDismiss={withDismiss}
-              withCounters={withCounters}
-            />
-          )}
-        </footer>
-      )}
-    </StatusHotkeys>
+            {showActions && !isQuotedPost && (
+              <StatusActionBar
+                scrollKey={scrollKey}
+                statusId={status.id}
+                withDismiss={withDismiss}
+                withCounters={withCounters}
+              />
+            )}
+          </footer>
+        )}
+      </StatusHotkeys>
+    </StatusContext.Provider>
   );
 };
 

--- a/app/javascript/mastodon/components/status/status.tsx
+++ b/app/javascript/mastodon/components/status/status.tsx
@@ -71,7 +71,7 @@ export const StatusRedesign: React.FC<StatusRedesignProps> = ({
   showActions = true,
   scrollKey,
   children,
-  withCounters,
+  withCounters = true,
   withDismiss,
   onOpen,
   showThread,

--- a/app/javascript/mastodon/components/status/status.tsx
+++ b/app/javascript/mastodon/components/status/status.tsx
@@ -69,7 +69,6 @@ export const StatusRedesign: React.FC<StatusRedesignProps> = ({
   isQuotedPost,
   hidden,
   showActions = true,
-  scrollKey,
   children,
   withCounters = true,
   withDismiss,
@@ -223,7 +222,6 @@ export const StatusRedesign: React.FC<StatusRedesignProps> = ({
 
             {showActions && !isQuotedPost && (
               <StatusActionBar
-                scrollKey={scrollKey}
                 statusId={status.id}
                 withDismiss={withDismiss}
                 withCounters={withCounters}

--- a/app/javascript/mastodon/components/status/styles.module.scss
+++ b/app/javascript/mastodon/components/status/styles.module.scss
@@ -111,7 +111,7 @@
 .actions {
   display: flex;
 
-  button:not(:hover, :active, [aria-pressed='true']) {
+  > button:not(:hover, :active, [aria-pressed='true'], [aria-expanded='true']) {
     opacity: 0.7;
   }
 }

--- a/app/javascript/mastodon/components/status/styles.module.scss
+++ b/app/javascript/mastodon/components/status/styles.module.scss
@@ -111,7 +111,7 @@
 .actions {
   display: flex;
 
-  button:not(:hover, :active) {
+  button:not(:hover, :active, [aria-pressed='true']) {
     opacity: 0.7;
   }
 }

--- a/app/javascript/mastodon/components/status/styles.module.scss
+++ b/app/javascript/mastodon/components/status/styles.module.scss
@@ -120,6 +120,21 @@
   margin-inline-end: auto;
 }
 
+.actionDescription {
+  @include mixins.type-label-sm;
+
+  display: block;
+  color: var(--color-text-tertiary);
+
+  [data-menu-item='true'][aria-disabled='true'] & {
+    color: inherit;
+  }
+}
+
+.actionDangerous {
+  color: var(--color-text-error);
+}
+
 .buttonAlign {
   margin-inline-start: calc(-1 * var(--space-sm));
 }

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -1367,6 +1367,7 @@
   "status.context.retry": "Retry",
   "status.context.show": "Show",
   "status.continued_thread": "Continued thread",
+  "status.copied": "Copied post link to clipboard",
   "status.copy": "Copy link to post",
   "status.delete": "Delete",
   "status.delete.success": "Post deleted",

--- a/app/javascript/mastodon/selectors/statuses.ts
+++ b/app/javascript/mastodon/selectors/statuses.ts
@@ -172,6 +172,7 @@ export const selectStatusInteractions = createAppSelector(
       Partial<typeof conditionals> & { allowed: boolean }
     > = {
       bookmark: addAllowed({ isLoggedIn }),
+      copy: addAllowed({}),
       delete: addAllowed({ isMine }),
       edit: addAllowed({ isMine }),
       editQuotePolicy: addAllowed({ isMine, isPublic }),

--- a/app/javascript/mastodon/selectors/statuses.ts
+++ b/app/javascript/mastodon/selectors/statuses.ts
@@ -184,6 +184,7 @@ export const selectStatusInteractions = createAppSelector(
       reblog: addAllowed({ isLoggedIn }),
       redraft: addAllowed({ isMine }),
       reply: addAllowed({ isLoggedIn }),
+      replyPrivately: addAllowed({ isLoggedIn }),
       report: addAllowed({ isLoggedIn, isNotMine }),
       revokeQuote: addAllowed({ isQuoted, isNotMine }),
       translate: addAllowed({ isLoggedIn }),

--- a/app/javascript/mastodon/selectors/statuses.ts
+++ b/app/javascript/mastodon/selectors/statuses.ts
@@ -185,7 +185,6 @@ export const selectStatusInteractions = createAppSelector(
       reblog: addAllowed({ isLoggedIn }),
       redraft: addAllowed({ isMine }),
       reply: addAllowed({ isLoggedIn }),
-      replyPrivately: addAllowed({ isLoggedIn }),
       report: addAllowed({ isLoggedIn, isNotMine }),
       revokeQuote: addAllowed({ isQuoted, isNotMine }),
       translate: addAllowed({ isLoggedIn }),


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Wires up the new actions bar to new components and displays counters by default.

| Caption | Screenshot |
| - | - |
| New action buttons | <img width="1190" height="296" alt="Screenshot 2026-09-09 at 18 09 48" src="https://github.com/user-attachments/assets/81d7b288-1816-4285-a3f0-fd65be0566a3" /> |
| Boost menu | <img width="460" height="292" alt="Screenshot 2026-09-09 at 18 09 18" src="https://github.com/user-attachments/assets/36bc1e8f-d0cf-44f0-9378-0249f561b0be" /> |
| Boost menu disabled | <img width="456" height="436" alt="Screenshot 2026-09-09 at 18 08 55" src="https://github.com/user-attachments/assets/6089d3a1-cf53-4bd6-b3c8-233e028f02e2" /> |
| Action menu | <img  height="400" alt="Screenshot 2026-09-09 at 18 09 32" src="https://github.com/user-attachments/assets/4ba6b47f-6531-4456-b17f-cfa4f2644716" /> |

