### PR TITLE
Composer redesign: Fixes height for image

### DIFF
--- a/app/javascript/mastodon/features/compose/redesign/upload.tsx
+++ b/app/javascript/mastodon/features/compose/redesign/upload.tsx
@@ -47,7 +47,7 @@ export const ComposeUpload: React.FC<{
   return (
     <StatusImage
       attachment={attachment}
-      className={className}
+      className={classNames(className, classes.mediaUpload)}
       sensitive={sensitive}
     >
       {sensitive && attachment.blurhash && (


### PR DESCRIPTION
This fixes a regression from #40429 where the height on single image attachments was missing.