### PR TITLE
Redesign: Tweaks and fixes for collapsible navigation sections in new navigation

### DIFF
--- a/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
@@ -70,6 +70,8 @@ function useFollowedHashtags() {
   return { followedHashtags: tags };
 }
 
+const MAX_HASHTAG_COUNT = 5;
+
 export const RedesignNavigationPanel: React.FC<{
   siteName?: string;
   /**
@@ -195,17 +197,19 @@ export const RedesignNavigationPanel: React.FC<{
                   />
                 }
               >
-                {followedHashtags.slice(0, 4).map((tag) => (
+                {followedHashtags.slice(0, MAX_HASHTAG_COUNT).map((tag) => (
                   <NavigationLink key={tag.name} to={`/tags/${tag.name}`}>
                     #{tag.name}
                   </NavigationLink>
                 ))}
-                <NavigationLink key='view-all' to='/followed_tags'>
-                  <FormattedMessage
-                    id='tabs_bar.followed_tags_view_all'
-                    defaultMessage='View all'
-                  />
-                </NavigationLink>
+                {followedHashtags.length > MAX_HASHTAG_COUNT && (
+                  <NavigationLink key='view-all' to='/followed_tags'>
+                    <FormattedMessage
+                      id='tabs_bar.followed_tags_view_all'
+                      defaultMessage='View all'
+                    />
+                  </NavigationLink>
+                )}
               </ListSection>
             )}
           </ul>

--- a/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/index.tsx
@@ -151,6 +151,7 @@ export const RedesignNavigationPanel: React.FC<{
               />
             </NavigationLink>
             <ListSection
+              id='custom-feeds'
               title={
                 <FormattedMessage
                   id='tabs_bar.custom_feeds'
@@ -186,6 +187,7 @@ export const RedesignNavigationPanel: React.FC<{
 
             {followedHashtags.length > 0 && (
               <ListSection
+                id='followed-hashtags'
                 title={
                   <FormattedMessage
                     id='tabs_bar.followed_hashtags'

--- a/app/javascript/mastodon/features/navigation_panel/redesign/list_section.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/list_section.module.scss
@@ -21,8 +21,7 @@
 }
 
 .toggleButton {
-  // Compensate for the button's outer spacing, subtracting a mystery
-  // pixel that I can't explain, but is needed for proper alignment.
+  // Compensate for the button's outer spacing
   --button-padding: calc(var(--space-xs) - var(--space-3xs));
 
   margin: calc(-1 * var(--button-padding));

--- a/app/javascript/mastodon/features/navigation_panel/redesign/list_section.module.scss
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/list_section.module.scss
@@ -23,7 +23,7 @@
 .toggleButton {
   // Compensate for the button's outer spacing, subtracting a mystery
   // pixel that I can't explain, but is needed for proper alignment.
-  --button-padding: calc(var(--space-xs) - 1px);
+  --button-padding: calc(var(--space-xs) - var(--space-3xs));
 
   margin: calc(-1 * var(--button-padding));
   margin-inline-end: var(--button-padding);

--- a/app/javascript/mastodon/features/navigation_panel/redesign/list_section.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/list_section.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import type { ReactNode } from 'react';
 
 import { FormattedMessage } from 'react-intl';
@@ -6,7 +7,8 @@ import { CaretDownIcon } from '@phosphor-icons/react';
 
 import { Button, IconButton } from '@/mastodon/components/button/redesign';
 import type { MastodonLocationDescriptor } from '@/mastodon/components/router';
-import { useToggle } from '@/mastodon/hooks/useToggle';
+import { useStorageState } from '@/mastodon/hooks/useStorage';
+import { useIdentity } from '@/mastodon/identity_context';
 import { hasReactChildren } from '@/mastodon/utils/has_react_children';
 
 import classes from './list_section.module.scss';
@@ -17,11 +19,26 @@ export const ListSection: React.FC<{
     label: ReactNode;
     link: MastodonLocationDescriptor;
   };
+  /**
+   * Unique identifier of this section, used for storing the
+   * open/close state of the section in localStorage
+   */
+  id: string;
   children: ReactNode;
   emptyMessage?: ReactNode;
-}> = ({ title, action, children, emptyMessage }) => {
+}> = ({ title, action, id, children, emptyMessage }) => {
   const hasContent = hasReactChildren(children);
-  const [isOpen, { onToggle }] = useToggle(true);
+
+  const { accountId } = useIdentity();
+  const storageKey = `ListSection-${id}-toggle-state-${accountId}`;
+  const [isOpen, setIsOpen] = useStorageState<boolean>(storageKey, true);
+  const toggleIsOpen = useCallback(() => {
+    if (isOpen) {
+      setIsOpen(false);
+    } else {
+      setIsOpen(true);
+    }
+  }, [isOpen, setIsOpen]);
 
   return (
     <li className={classes.root}>
@@ -31,7 +48,7 @@ export const ListSection: React.FC<{
             size='sm'
             variant='ghost'
             icon={CaretDownIcon}
-            onClick={onToggle}
+            onClick={toggleIsOpen}
             noActiveHighlight
             aria-expanded={isOpen}
             className={classes.toggleButton}

--- a/app/javascript/mastodon/features/navigation_panel/redesign/list_section.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/redesign/list_section.tsx
@@ -33,11 +33,7 @@ export const ListSection: React.FC<{
   const storageKey = `ListSection-${id}-toggle-state-${accountId}`;
   const [isOpen, setIsOpen] = useStorageState<boolean>(storageKey, true);
   const toggleIsOpen = useCallback(() => {
-    if (isOpen) {
-      setIsOpen(false);
-    } else {
-      setIsOpen(true);
-    }
+    setIsOpen(!isOpen);
   }, [isOpen, setIsOpen]);
 
   return (


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Fixes WEB-1266

### Changes proposed in this PR:
- Only show "View all" link in the Followed Hashtags panel when there are more than 5 hashtags
- Stores the opened state of collapsible navigation sections in local storage, ensuring that it's scoped to the current user's account
- Fixes a minor alignment issue of the collapse button's caret icon (it was off by 1 pixel horizontally)
