### PR TITLE
Redesign: Update column headers on profile pages

### DIFF
--- a/app/javascript/mastodon/components/column_header/index.tsx
+++ b/app/javascript/mastodon/components/column_header/index.tsx
@@ -25,7 +25,7 @@ import classes from './styles.module.scss';
 export { ColumnSettingsMenu } from './column_settings_menu';
 
 export interface ColumnHeaderProps {
-  title: string;
+  title: React.ReactNode;
   // Set to auto to display the back button based on
   // the `fromMastodon` location state
   withBackButton?: boolean | 'auto';

--- a/app/javascript/mastodon/components/column_header/styles.module.scss
+++ b/app/javascript/mastodon/components/column_header/styles.module.scss
@@ -4,7 +4,7 @@
 .root {
   // Make bottom half of column header transparent to make the
   // overlay gradient on the `.layout` class work
-  --column-header-gradient-start: 55%;
+  --column-header-gradient-start: calc(100% - var(--space-sm));
 
   background: linear-gradient(
     to bottom,

--- a/app/javascript/mastodon/features/account_edit/components/column.tsx
+++ b/app/javascript/mastodon/features/account_edit/components/column.tsx
@@ -4,12 +4,18 @@ import { FormattedMessage } from 'react-intl';
 
 import { Link } from 'react-router-dom';
 
+import { CheckIcon } from '@phosphor-icons/react';
 import { Helmet } from '@unhead/react/helmet';
 
 import { Column } from '@/mastodon/components/column';
-import { ColumnHeader } from '@/mastodon/components/column/header';
+import { ColumnHeader as LegacyColumnHeader } from '@/mastodon/components/column/header';
+import {
+  ColumnHeader,
+  ColumnHeaderButton,
+} from '@/mastodon/components/column_header';
 import { LoadingIndicator } from '@/mastodon/components/loading_indicator';
 import { BundleColumnError } from '@/mastodon/features/ui/components/bundle_column_error';
+import { isRedesignEnabled } from '@/mastodon/utils/environment';
 
 import { useColumnsContext } from '../../ui/util/columns_context';
 import classes from '../styles.module.scss';
@@ -40,19 +46,40 @@ export const AccountEditColumn: FC<{
   return (
     <>
       <Column bindToDocument={!multiColumn}>
-        <ColumnHeader
-          title={title}
-          className={classes.columnHeader}
-          showBackButton
-          extraButton={
-            <Link to={to} className='button'>
-              <FormattedMessage
-                id='account_edit.column_button'
-                defaultMessage='Done'
-              />
-            </Link>
-          }
-        />
+        {isRedesignEnabled() ? (
+          <ColumnHeader
+            withBackButton
+            title={title}
+            extraButtons={
+              <ColumnHeaderButton
+                showTextOnDesktop
+                variant='solid'
+                as='link'
+                to={to}
+                icon={CheckIcon}
+              >
+                <FormattedMessage
+                  id='account_edit.column_button'
+                  defaultMessage='Done'
+                />
+              </ColumnHeaderButton>
+            }
+          />
+        ) : (
+          <LegacyColumnHeader
+            title={title}
+            className={classes.columnHeader}
+            showBackButton
+            extraButton={
+              <Link to={to} className='button'>
+                <FormattedMessage
+                  id='account_edit.column_button'
+                  defaultMessage='Done'
+                />
+              </Link>
+            }
+          />
+        )}
 
         <div className='scrollable'>{children}</div>
       </Column>

--- a/app/javascript/mastodon/features/account_timeline/index.tsx
+++ b/app/javascript/mastodon/features/account_timeline/index.tsx
@@ -15,18 +15,23 @@ import {
 import { AccountHeader } from '@/mastodon/components/account_header';
 import { Column } from '@/mastodon/components/column';
 import { ColumnBackButton } from '@/mastodon/components/column/back_button';
+import { ColumnHeader } from '@/mastodon/components/column_header';
+import { DisplayNameSimple } from '@/mastodon/components/display_name/simple';
 import { LimitedAccountHint } from '@/mastodon/components/limited_account_hint';
 import { LoadingIndicator } from '@/mastodon/components/loading_indicator';
 import { RemoteHint } from '@/mastodon/components/remote_hint';
 import StatusList from '@/mastodon/components/status_list';
 import { BundleColumnError } from '@/mastodon/features/ui/components/bundle_column_error';
+import { useAccount } from '@/mastodon/hooks/useAccount';
 import {
   useAccountId,
   useCurrentAccountId,
 } from '@/mastodon/hooks/useAccountId';
 import { useAccountVisibility } from '@/mastodon/hooks/useAccountVisibility';
+import type { Account } from '@/mastodon/models/account';
 import { selectTimelineByKey } from '@/mastodon/selectors/timelines';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
+import { isRedesignEnabled } from '@/mastodon/utils/environment';
 
 import { FeaturedTags } from './components/featured_tags';
 import { AccountFilters } from './components/filters';
@@ -45,13 +50,14 @@ const emptyList = ImmutableList<string>();
 const AccountTimeline: FC<{ multiColumn: boolean }> = ({ multiColumn }) => {
   const accountId = useAccountId();
   const accountContext = useAccountContextValue(accountId);
+  const account = useAccount(accountId);
 
   // Null means accountId does not exist (e.g. invalid acct). Undefined means loading.
   if (accountId === null) {
     return <BundleColumnError multiColumn={multiColumn} errorType='routing' />;
   }
 
-  if (!accountId) {
+  if (!accountId || !account) {
     return (
       <Column bindToDocument={!multiColumn}>
         <LoadingIndicator />
@@ -63,7 +69,7 @@ const AccountTimeline: FC<{ multiColumn: boolean }> = ({ multiColumn }) => {
   return (
     <AccountTimelineContext.Provider value={accountContext}>
       <InnerTimeline
-        accountId={accountId}
+        account={account}
         key={accountId}
         multiColumn={multiColumn}
       />
@@ -71,10 +77,11 @@ const AccountTimeline: FC<{ multiColumn: boolean }> = ({ multiColumn }) => {
   );
 };
 
-const InnerTimeline: FC<{ accountId: string; multiColumn: boolean }> = ({
-  accountId,
+const InnerTimeline: FC<{ account: Account; multiColumn: boolean }> = ({
+  account,
   multiColumn,
 }) => {
+  const accountId = account.id;
   const { tagged } = useParams<{ tagged?: string }>();
   const { boosts, replies } = useAccountContext();
   const key = timelineKey({
@@ -112,7 +119,14 @@ const InnerTimeline: FC<{ accountId: string; multiColumn: boolean }> = ({
 
   return (
     <Column bindToDocument={!multiColumn}>
-      <ColumnBackButton />
+      {isRedesignEnabled() ? (
+        <ColumnHeader
+          withBackButton
+          title={<DisplayNameSimple account={account} />}
+        />
+      ) : (
+        <ColumnBackButton />
+      )}
 
       <StatusList
         alwaysPrepend


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Related to PRO-515

### Changes proposed in this PR:
- Updates profile page & profile editor column header to new design
  (The profile page header will be tweaked further, this is just an initial pass to line up the design)
- Changes the size of the column header overscroll gradient

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="961" height="394" alt="image" src="https://github.com/user-attachments/assets/6273c3f0-9e19-4eae-b2b4-590da5743d7b" /> | <img width="964" height="413" alt="image" src="https://github.com/user-attachments/assets/744865d5-c571-43bc-84a7-f0220786b0f0" /> |