### PR TITLE
Redesign: Display follow button in column header on profile page

### DIFF
--- a/app/javascript/mastodon/components/account_header/buttons.tsx
+++ b/app/javascript/mastodon/components/account_header/buttons.tsx
@@ -8,6 +8,7 @@ import { useAccount } from '@/mastodon/hooks/useAccount';
 import { useFollowReference } from '@/mastodon/hooks/useFollowReference';
 import { getAccountHidden } from '@/mastodon/selectors/accounts';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
+import { isRedesignEnabled } from '@/mastodon/utils/environment';
 import NotificationsIcon from '@/material-icons/400-24px/notifications.svg?react';
 import NotificationsActiveIcon from '@/material-icons/400-24px/notifications_active-fill.svg?react';
 import ShareIcon from '@/material-icons/400-24px/share.svg?react';
@@ -94,7 +95,7 @@ const AccountButtonsOther: FC<
 
   return (
     <>
-      {!isMovedAndUnfollowedAccount && (
+      {!isMovedAndUnfollowedAccount && !isRedesignEnabled() && (
         <FollowButton
           accountId={accountId}
           className={classes.followButton}

--- a/app/javascript/mastodon/components/account_header/buttons.tsx
+++ b/app/javascript/mastodon/components/account_header/buttons.tsx
@@ -8,6 +8,7 @@ import { useAccount } from '@/mastodon/hooks/useAccount';
 import { useFollowReference } from '@/mastodon/hooks/useFollowReference';
 import { getAccountHidden } from '@/mastodon/selectors/accounts';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
+import { isRedesignEnabled } from '@/mastodon/utils/environment';
 import NotificationsIcon from '@/material-icons/400-24px/notifications.svg?react';
 import NotificationsActiveIcon from '@/material-icons/400-24px/notifications_active-fill.svg?react';
 import ShareIcon from '@/material-icons/400-24px/share.svg?react';
@@ -96,6 +97,7 @@ const AccountButtonsOther: FC<
     <>
       {!isMovedAndUnfollowedAccount && (
         <FollowButton
+          compact={isRedesignEnabled()}
           accountId={accountId}
           className={classes.followButton}
           withUnmute={false}

--- a/app/javascript/mastodon/components/account_header/buttons.tsx
+++ b/app/javascript/mastodon/components/account_header/buttons.tsx
@@ -8,7 +8,6 @@ import { useAccount } from '@/mastodon/hooks/useAccount';
 import { useFollowReference } from '@/mastodon/hooks/useFollowReference';
 import { getAccountHidden } from '@/mastodon/selectors/accounts';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
-import { isRedesignEnabled } from '@/mastodon/utils/environment';
 import NotificationsIcon from '@/material-icons/400-24px/notifications.svg?react';
 import NotificationsActiveIcon from '@/material-icons/400-24px/notifications_active-fill.svg?react';
 import ShareIcon from '@/material-icons/400-24px/share.svg?react';
@@ -95,10 +94,11 @@ const AccountButtonsOther: FC<
 
   return (
     <>
-      {!isMovedAndUnfollowedAccount && !isRedesignEnabled() && (
+      {!isMovedAndUnfollowedAccount && (
         <FollowButton
           accountId={accountId}
           className={classes.followButton}
+          withUnmute={false}
           labelLength='long'
           reference={reference}
         />

--- a/app/javascript/mastodon/components/account_header/buttons.tsx
+++ b/app/javascript/mastodon/components/account_header/buttons.tsx
@@ -3,10 +3,9 @@ import type { FC } from 'react';
 
 import { defineMessages, useIntl } from 'react-intl';
 
-import { useLocation } from 'react-router-dom';
-
 import { followAccount } from '@/mastodon/actions/accounts';
 import { useAccount } from '@/mastodon/hooks/useAccount';
+import { useFollowReference } from '@/mastodon/hooks/useFollowReference';
 import { getAccountHidden } from '@/mastodon/selectors/accounts';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 import NotificationsIcon from '@/material-icons/400-24px/notifications.svg?react';
@@ -83,10 +82,8 @@ const AccountButtonsOther: FC<
       });
     }
   }, [accountUrl]);
-  const { state } = useLocation<{
-    reference?: string;
-  } | null>();
-  const reference = state?.reference ?? 'profile';
+
+  const reference = useFollowReference('profile');
 
   if (!account) {
     return null;

--- a/app/javascript/mastodon/components/button/redesign.tsx
+++ b/app/javascript/mastodon/components/button/redesign.tsx
@@ -100,7 +100,7 @@ const BaseButton: React.FC<BaseButtonProps> = ({
   );
 };
 
-type ButtonProps = BaseButtonProps & {
+export type ButtonProps = BaseButtonProps & {
   leadingIcon?: IconProp;
   trailingIcon?: IconProp;
 };

--- a/app/javascript/mastodon/components/follow_button.tsx
+++ b/app/javascript/mastodon/components/follow_button.tsx
@@ -18,6 +18,11 @@ import { me } from 'mastodon/initial_state';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
 import { useBreakpoint } from '../features/ui/hooks/useBreakpoint';
+import { isRedesignEnabled } from '../utils/environment';
+
+import { Button as RedesignButton } from './button/redesign';
+import type { ButtonProps as RedesignButtonProps } from './button/redesign';
+import type { MastodonLocationDescriptor } from './router';
 
 const longMessages = defineMessages({
   unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },
@@ -55,21 +60,29 @@ const shortMessages = {
   }),
 };
 
-export const FollowButton: React.FC<{
+interface FollowButtonOptions {
   accountId?: string;
-  compact?: boolean;
   labelLength?: 'auto' | 'short' | 'long';
-  className?: string;
   withUnmute?: boolean;
   reference?: string;
-}> = ({
+}
+
+interface FollowButtonReturn {
+  label: React.ReactNode;
+  onClick: (() => void) | undefined;
+  link: MastodonLocationDescriptor | undefined;
+  disabled: boolean;
+  following: boolean;
+  secondary: boolean;
+  hidden: boolean;
+}
+
+function useFollowButton({
   accountId,
-  compact,
   labelLength = 'auto',
-  className,
   withUnmute = true,
   reference,
-}) => {
+}: FollowButtonOptions): FollowButtonReturn {
   const intl = useIntl();
   const dispatch = useAppDispatch();
   const { signedIn } = useIdentity();
@@ -79,7 +92,9 @@ export const FollowButton: React.FC<{
   const relationship = useAppSelector((state) =>
     accountId ? state.relationships.get(accountId) : undefined,
   );
-  const following = relationship?.following || relationship?.requested;
+  const following = relationship?.following || relationship?.requested || false;
+  const secondary = following || relationship?.blocking || false;
+  const link = accountId === me ? '/profile/edit' : undefined;
 
   useEffect(() => {
     if (accountId && signedIn) {
@@ -87,7 +102,7 @@ export const FollowButton: React.FC<{
     }
   }, [dispatch, accountId, signedIn]);
 
-  const handleClick = useCallback(() => {
+  const onClick = useCallback(() => {
     if (!signedIn) {
       dispatch(
         openModal({
@@ -148,7 +163,7 @@ export const FollowButton: React.FC<{
     ? messages.followRequest
     : messages.follow;
 
-  let label;
+  let label: React.ReactNode;
   let disabled =
     relationship?.blocked_by || account?.suspended || !!account?.moved;
 
@@ -176,7 +191,30 @@ export const FollowButton: React.FC<{
     label = intl.formatMessage(followMessage);
   }
 
-  if (accountId === me) {
+  const isMovedAndUnfollowedAccount =
+    (account?.moved && !relationship?.following) || false;
+
+  return {
+    onClick,
+    link,
+    label,
+    disabled,
+    following,
+    secondary,
+    hidden: isMovedAndUnfollowedAccount,
+  };
+}
+
+const FollowButtonLegacy: React.FC<
+  FollowButtonOptions & {
+    compact?: boolean;
+    className?: string;
+  }
+> = ({ compact, className, ...props }) => {
+  const { onClick, link, label, disabled, following, secondary } =
+    useFollowButton(props);
+
+  if (link) {
     const buttonClasses = classNames(className, 'button button-secondary', {
       'button--compact': compact,
     });
@@ -190,13 +228,62 @@ export const FollowButton: React.FC<{
 
   return (
     <Button
-      onClick={handleClick}
+      onClick={onClick}
       disabled={disabled}
-      secondary={following || relationship?.blocking}
+      secondary={secondary}
       compact={compact}
       className={classNames(className, { 'button--destructive': following })}
     >
       {label}
     </Button>
   );
+};
+
+const FollowButtonRedesign: React.FC<
+  FollowButtonOptions &
+    Pick<RedesignButtonProps, 'size' | 'color' | 'className'>
+> = ({ accountId, labelLength, withUnmute, reference, ...buttonProps }) => {
+  const { onClick, link, label, disabled, secondary, hidden } = useFollowButton(
+    {
+      accountId,
+      labelLength,
+      withUnmute,
+      reference,
+    },
+  );
+
+  if (hidden) {
+    return null;
+  }
+
+  if (link) {
+    return (
+      <RedesignButton {...buttonProps} as='link' to='/profile/edit'>
+        {label}
+      </RedesignButton>
+    );
+  }
+
+  return (
+    <RedesignButton
+      {...buttonProps}
+      onClick={onClick}
+      disabled={disabled}
+      variant={secondary ? 'tonal' : 'solid'}
+    >
+      {label}
+    </RedesignButton>
+  );
+};
+
+export const FollowButton: React.FC<
+  FollowButtonOptions & {
+    compact?: boolean;
+    className?: string;
+  }
+> = ({ compact, ...props }) => {
+  if (isRedesignEnabled()) {
+    return <FollowButtonRedesign {...props} size={compact ? 'sm' : 'md'} />;
+  }
+  return <FollowButtonLegacy compact={compact} {...props} />;
 };

--- a/app/javascript/mastodon/components/follow_button.tsx
+++ b/app/javascript/mastodon/components/follow_button.tsx
@@ -5,6 +5,14 @@ import { useIntl, defineMessages } from 'react-intl';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 
+import {
+  ArrowCounterClockwiseIcon,
+  PencilSimpleIcon,
+  SpeakerHighIcon,
+  UserMinusIcon,
+  UserPlusIcon,
+} from '@phosphor-icons/react';
+
 import { useIdentity } from '@/mastodon/identity_context';
 import {
   fetchRelationships,
@@ -22,6 +30,7 @@ import { isRedesignEnabled } from '../utils/environment';
 
 import { Button as RedesignButton } from './button/redesign';
 import type { ButtonProps as RedesignButtonProps } from './button/redesign';
+import type { IconProp } from './icon';
 import type { MastodonLocationDescriptor } from './router';
 
 const longMessages = defineMessages({
@@ -69,6 +78,7 @@ interface FollowButtonOptions {
 
 interface FollowButtonReturn {
   label: React.ReactNode;
+  icon: IconProp;
   onClick: (() => void) | undefined;
   link: MastodonLocationDescriptor | undefined;
   disabled: boolean;
@@ -77,7 +87,7 @@ interface FollowButtonReturn {
   hidden: boolean;
 }
 
-function useFollowButton({
+export function useFollowButton({
   accountId,
   labelLength = 'auto',
   withUnmute = true,
@@ -164,6 +174,7 @@ function useFollowButton({
     : messages.follow;
 
   let label: React.ReactNode;
+  let icon = UserPlusIcon;
   let disabled =
     relationship?.blocked_by || account?.suspended || !!account?.moved;
 
@@ -171,19 +182,24 @@ function useFollowButton({
     label = intl.formatMessage(followMessage);
   } else if (accountId === me) {
     label = intl.formatMessage(messages.editProfile);
+    icon = PencilSimpleIcon;
   } else if (!relationship) {
     label = <LoadingIndicator />;
   } else if (relationship.muting && withUnmute) {
     label = intl.formatMessage(messages.unmute);
+    icon = SpeakerHighIcon;
     disabled = false;
   } else if (relationship.following) {
     label = intl.formatMessage(messages.unfollow);
+    icon = UserMinusIcon;
     disabled = false;
   } else if (relationship.blocking) {
     label = intl.formatMessage(messages.unblock);
+    icon = ArrowCounterClockwiseIcon;
     disabled = false;
   } else if (relationship.requested) {
     label = intl.formatMessage(messages.followRequestCancel);
+    icon = UserMinusIcon;
     disabled = false;
   } else if (relationship.followed_by && !account?.locked) {
     label = intl.formatMessage(messages.followBack);
@@ -198,6 +214,7 @@ function useFollowButton({
     onClick,
     link,
     label,
+    icon,
     disabled,
     following,
     secondary,
@@ -258,7 +275,7 @@ const FollowButtonRedesign: React.FC<
 
   if (link) {
     return (
-      <RedesignButton {...buttonProps} as='link' to='/profile/edit'>
+      <RedesignButton as='link' to={link} {...buttonProps}>
         {label}
       </RedesignButton>
     );

--- a/app/javascript/mastodon/components/follow_button.tsx
+++ b/app/javascript/mastodon/components/follow_button.tsx
@@ -5,14 +5,6 @@ import { useIntl, defineMessages } from 'react-intl';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 
-import {
-  ArrowCounterClockwiseIcon,
-  PencilSimpleIcon,
-  SpeakerHighIcon,
-  UserMinusIcon,
-  UserPlusIcon,
-} from '@phosphor-icons/react';
-
 import { useIdentity } from '@/mastodon/identity_context';
 import {
   fetchRelationships,
@@ -30,7 +22,6 @@ import { isRedesignEnabled } from '../utils/environment';
 
 import { Button as RedesignButton } from './button/redesign';
 import type { ButtonProps as RedesignButtonProps } from './button/redesign';
-import type { IconProp } from './icon';
 import type { MastodonLocationDescriptor } from './router';
 
 const longMessages = defineMessages({
@@ -78,7 +69,6 @@ interface FollowButtonOptions {
 
 interface FollowButtonReturn {
   label: React.ReactNode;
-  icon: IconProp;
   onClick: (() => void) | undefined;
   link: MastodonLocationDescriptor | undefined;
   disabled: boolean;
@@ -174,7 +164,6 @@ export function useFollowButton({
     : messages.follow;
 
   let label: React.ReactNode;
-  let icon = UserPlusIcon;
   let disabled =
     relationship?.blocked_by || account?.suspended || !!account?.moved;
 
@@ -182,24 +171,19 @@ export function useFollowButton({
     label = intl.formatMessage(followMessage);
   } else if (accountId === me) {
     label = intl.formatMessage(messages.editProfile);
-    icon = PencilSimpleIcon;
   } else if (!relationship) {
     label = <LoadingIndicator />;
   } else if (relationship.muting && withUnmute) {
     label = intl.formatMessage(messages.unmute);
-    icon = SpeakerHighIcon;
     disabled = false;
   } else if (relationship.following) {
     label = intl.formatMessage(messages.unfollow);
-    icon = UserMinusIcon;
     disabled = false;
   } else if (relationship.blocking) {
     label = intl.formatMessage(messages.unblock);
-    icon = ArrowCounterClockwiseIcon;
     disabled = false;
   } else if (relationship.requested) {
     label = intl.formatMessage(messages.followRequestCancel);
-    icon = UserMinusIcon;
     disabled = false;
   } else if (relationship.followed_by && !account?.locked) {
     label = intl.formatMessage(messages.followBack);
@@ -214,7 +198,6 @@ export function useFollowButton({
     onClick,
     link,
     label,
-    icon,
     disabled,
     following,
     secondary,

--- a/app/javascript/mastodon/features/account_timeline/index.tsx
+++ b/app/javascript/mastodon/features/account_timeline/index.tsx
@@ -15,8 +15,12 @@ import {
 import { AccountHeader } from '@/mastodon/components/account_header';
 import { Column } from '@/mastodon/components/column';
 import { ColumnBackButton } from '@/mastodon/components/column/back_button';
-import { ColumnHeader } from '@/mastodon/components/column_header';
+import {
+  ColumnHeader,
+  ColumnHeaderButton,
+} from '@/mastodon/components/column_header';
 import { DisplayNameSimple } from '@/mastodon/components/display_name/simple';
+import { useFollowButton } from '@/mastodon/components/follow_button';
 import { LimitedAccountHint } from '@/mastodon/components/limited_account_hint';
 import { LoadingIndicator } from '@/mastodon/components/loading_indicator';
 import { RemoteHint } from '@/mastodon/components/remote_hint';
@@ -28,6 +32,7 @@ import {
   useCurrentAccountId,
 } from '@/mastodon/hooks/useAccountId';
 import { useAccountVisibility } from '@/mastodon/hooks/useAccountVisibility';
+import { useFollowReference } from '@/mastodon/hooks/useFollowReference';
 import type { Account } from '@/mastodon/models/account';
 import { selectTimelineByKey } from '@/mastodon/selectors/timelines';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
@@ -123,6 +128,7 @@ const InnerTimeline: FC<{ account: Account; multiColumn: boolean }> = ({
         <ColumnHeader
           withBackButton
           title={<DisplayNameSimple account={account} />}
+          extraButtons={<ColumnHeaderFollowButton accountId={accountId} />}
         />
       ) : (
         <ColumnBackButton />
@@ -148,6 +154,42 @@ const InnerTimeline: FC<{ account: Account; multiColumn: boolean }> = ({
         statusProps={{ headerRenderFn: renderPinnedStatusHeader }}
       />
     </Column>
+  );
+};
+
+const ColumnHeaderFollowButton: FC<{ accountId: string }> = ({ accountId }) => {
+  const reference = useFollowReference('profile');
+  const { onClick, link, label, icon, disabled, secondary, hidden } =
+    useFollowButton({ accountId, labelLength: 'long', reference });
+
+  if (hidden) {
+    return null;
+  }
+
+  if (link) {
+    return (
+      <ColumnHeaderButton
+        showTextOnDesktop
+        as='link'
+        variant='solid'
+        to={link}
+        icon={icon}
+      >
+        {label}
+      </ColumnHeaderButton>
+    );
+  }
+
+  return (
+    <ColumnHeaderButton
+      showTextOnDesktop
+      onClick={onClick}
+      disabled={disabled}
+      variant={secondary ? 'tonal' : 'solid'}
+      icon={icon}
+    >
+      {label}
+    </ColumnHeaderButton>
   );
 };
 

--- a/app/javascript/mastodon/features/account_timeline/index.tsx
+++ b/app/javascript/mastodon/features/account_timeline/index.tsx
@@ -15,12 +15,8 @@ import {
 import { AccountHeader } from '@/mastodon/components/account_header';
 import { Column } from '@/mastodon/components/column';
 import { ColumnBackButton } from '@/mastodon/components/column/back_button';
-import {
-  ColumnHeader,
-  ColumnHeaderButton,
-} from '@/mastodon/components/column_header';
+import { ColumnHeader } from '@/mastodon/components/column_header';
 import { DisplayNameSimple } from '@/mastodon/components/display_name/simple';
-import { useFollowButton } from '@/mastodon/components/follow_button';
 import { LimitedAccountHint } from '@/mastodon/components/limited_account_hint';
 import { LoadingIndicator } from '@/mastodon/components/loading_indicator';
 import { RemoteHint } from '@/mastodon/components/remote_hint';
@@ -32,7 +28,6 @@ import {
   useCurrentAccountId,
 } from '@/mastodon/hooks/useAccountId';
 import { useAccountVisibility } from '@/mastodon/hooks/useAccountVisibility';
-import { useFollowReference } from '@/mastodon/hooks/useFollowReference';
 import type { Account } from '@/mastodon/models/account';
 import { selectTimelineByKey } from '@/mastodon/selectors/timelines';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
@@ -128,7 +123,6 @@ const InnerTimeline: FC<{ account: Account; multiColumn: boolean }> = ({
         <ColumnHeader
           withBackButton
           title={<DisplayNameSimple account={account} />}
-          extraButtons={<ColumnHeaderFollowButton accountId={accountId} />}
         />
       ) : (
         <ColumnBackButton />
@@ -154,47 +148,6 @@ const InnerTimeline: FC<{ account: Account; multiColumn: boolean }> = ({
         statusProps={{ headerRenderFn: renderPinnedStatusHeader }}
       />
     </Column>
-  );
-};
-
-const ColumnHeaderFollowButton: FC<{ accountId: string }> = ({ accountId }) => {
-  const reference = useFollowReference('profile');
-  const { onClick, link, label, icon, disabled, secondary, hidden } =
-    useFollowButton({
-      accountId,
-      withUnmute: false,
-      labelLength: 'long',
-      reference,
-    });
-
-  if (hidden) {
-    return null;
-  }
-
-  if (link) {
-    return (
-      <ColumnHeaderButton
-        showTextOnDesktop
-        as='link'
-        variant='solid'
-        to={link}
-        icon={icon}
-      >
-        {label}
-      </ColumnHeaderButton>
-    );
-  }
-
-  return (
-    <ColumnHeaderButton
-      showTextOnDesktop
-      onClick={onClick}
-      disabled={disabled}
-      variant={secondary ? 'tonal' : 'solid'}
-      icon={icon}
-    >
-      {label}
-    </ColumnHeaderButton>
   );
 };
 

--- a/app/javascript/mastodon/features/account_timeline/index.tsx
+++ b/app/javascript/mastodon/features/account_timeline/index.tsx
@@ -160,7 +160,12 @@ const InnerTimeline: FC<{ account: Account; multiColumn: boolean }> = ({
 const ColumnHeaderFollowButton: FC<{ accountId: string }> = ({ accountId }) => {
   const reference = useFollowReference('profile');
   const { onClick, link, label, icon, disabled, secondary, hidden } =
-    useFollowButton({ accountId, labelLength: 'long', reference });
+    useFollowButton({
+      accountId,
+      withUnmute: false,
+      labelLength: 'long',
+      reference,
+    });
 
   if (hidden) {
     return null;

--- a/app/javascript/mastodon/hooks/useFollowReference.ts
+++ b/app/javascript/mastodon/hooks/useFollowReference.ts
@@ -1,0 +1,9 @@
+import { useLocation } from 'react-router-dom';
+
+import type { LocationState } from '../components/router';
+
+export function useFollowReference(fallbackReference: string) {
+  const { state } = useLocation<LocationState>();
+
+  return state?.reference ?? fallbackReference;
+}

--- a/app/javascript/mastodon/hooks/useFollowReference.ts
+++ b/app/javascript/mastodon/hooks/useFollowReference.ts
@@ -2,6 +2,14 @@ import { useLocation } from 'react-router-dom';
 
 import type { LocationState } from '../components/router';
 
+/**
+ * Gets the current `reference` state from location state if present,
+ * otherwise returns the passed-in fallback reference.
+ *
+ * `reference` is a string that we use to anonymously & locally track
+ * where a follow is coming from, helping us understand which UI features
+ * people actually use to discover people.
+ */
 export function useFollowReference(fallbackReference: string) {
   const { state } = useLocation<LocationState>();
 


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Related to PRO-515

### Changes proposed in this PR:
- Factors `FollowButton` logic out into a `useFollowButton` hook
- Makes `FollowButton` component use the new `Button` component when feature flag is on
- Disables "unmute" state in FollowButton on the profile page
- ~~Adds follow button to the profile page's column header, removing it from the main page~~
- Adds `hooks/useFollowReference` to easily get the `reference` state from the current location and define a fallback

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="615" height="325" alt="image" src="https://github.com/user-attachments/assets/c9112e22-2949-435f-9580-ebe88501dced" /> | <img width="611" height="324" alt="image" src="https://github.com/user-attachments/assets/1ac0cab2-56db-4e94-a910-b1efa5530f5f" /> |
| <img width="614" height="354" alt="image" src="https://github.com/user-attachments/assets/e1a02535-227b-4d9e-af5d-d65e7a16e800" /> | <img width="616" height="353" alt="image" src="https://github.com/user-attachments/assets/f905d966-589c-48ed-a0ee-a8c009d8ef8b" /> |
| <img width="615" height="366" alt="image" src="https://github.com/user-attachments/assets/9f4956bb-8a20-45e5-9622-2c96343ac15d" /> | <img width="612" height="358" alt="image" src="https://github.com/user-attachments/assets/4c6ec9b0-2537-4ef3-88ce-270d075dd00d" /> |