### PR TITLE
Status redesign: Adds status feature flag

### DIFF
--- a/app/javascript/mastodon/components/status_quoted.tsx
+++ b/app/javascript/mastodon/components/status_quoted.tsx
@@ -27,7 +27,7 @@ import { getAccountHidden } from 'mastodon/selectors/accounts';
 import type { RootState } from 'mastodon/store';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
-import { isRedesignEnabled } from '../utils/environment';
+import { isRedesignStatusEnabled } from '../utils/environment';
 
 import { Button } from './button';
 import { IconButton } from './icon_button';
@@ -396,7 +396,7 @@ export const StatusQuoteManager = (props: StatusQuoteManagerProps) => {
   });
   const quote = status?.get('quote') as QuoteMap | undefined;
 
-  if (isRedesignEnabled()) {
+  if (isRedesignStatusEnabled()) {
     return (
       <Suspense fallback={<LoadingIndicator />}>
         <LazyStatusRedesign {...props} />

--- a/app/javascript/mastodon/features/compose/components/compose_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/compose_form.jsx
@@ -32,7 +32,6 @@ import { UploadForm } from './upload_form';
 import { Warning } from './warning';
 import { ComposeQuotedStatus } from './quoted_post';
 import { VisibilityButton } from './visibility_button';
-import { isRedesignEnabled } from '@/mastodon/utils/environment';
 
 const allowedAroundShortCode = '><\u0085\u0020\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029\u0009\u000a\u000b\u000c\u000d';
 
@@ -188,9 +187,6 @@ class ComposeForm extends ImmutablePureComponent {
   }
 
   componentDidUpdate (prevProps) {
-    if (isRedesignEnabled()) {
-      return;
-    }
     this._updateFocusAndSelection(prevProps);
   }
 

--- a/app/javascript/mastodon/utils/environment.ts
+++ b/app/javascript/mastodon/utils/environment.ts
@@ -18,7 +18,7 @@ export function isServerFeatureEnabled(feature: ServerFeatures) {
   return initialState?.features.includes(feature) ?? false;
 }
 
-type ClientFeatures = 'redesign';
+type ClientFeatures = 'redesign' | 'redesign-status';
 
 export function isClientFeatureEnabled(feature: ClientFeatures) {
   try {
@@ -34,4 +34,8 @@ export function isClientFeatureEnabled(feature: ClientFeatures) {
 /* Checks if the 5.0 redesign features are enabled or not. */
 export function isRedesignEnabled() {
   return isClientFeatureEnabled('redesign');
+}
+
+export function isRedesignStatusEnabled() {
+  return isRedesignEnabled() && isClientFeatureEnabled('redesign-status');
 }


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

This adds a specific client feature flag for statuses, to use the old one until the new status has been finished and tested but not block testing of the rest of the redesign.