### PR TITLE
Status redesign: Translation button

### DIFF
--- a/app/javascript/mastodon/components/status/action_bar.tsx
+++ b/app/javascript/mastodon/components/status/action_bar.tsx
@@ -3,8 +3,6 @@ import { useCallback, useMemo } from 'react';
 
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
-import classNames from 'classnames';
-
 import {
   ArrowsClockwiseIcon,
   BookmarkSimpleIcon,
@@ -214,9 +212,10 @@ export const StatusActionBar: React.FC<StatusActionBarProps> = ({
     isQuotingMe && contextType === 'notifications';
 
   return (
-    <div className={classNames(classes.actions, classes.buttonAlign)}>
+    <div className={classes.actions}>
       <Button
         size='sm'
+        clipPadding
         variant='ghost'
         title={intl.formatMessage(messages.replyAll)}
         leadingIcon={ChatCircleTextIcon}

--- a/app/javascript/mastodon/components/status/content.stories.tsx
+++ b/app/javascript/mastodon/components/status/content.stories.tsx
@@ -29,6 +29,7 @@ const meta = {
         spoilerHtml: '',
         language: args.translatedTo,
         detected_source_language: 'en',
+        isLoading: false,
       } satisfies StatusTranslation;
     }
 

--- a/app/javascript/mastodon/components/status/content.tsx
+++ b/app/javascript/mastodon/components/status/content.tsx
@@ -1,20 +1,16 @@
 import type React from 'react';
 import { useCallback, useState } from 'react';
 
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import classNames from 'classnames';
 
 import { CaretRightIcon } from '@phosphor-icons/react';
 
-import { useIdentity } from '@/mastodon/identity_context';
-import { languages as preloadedLanguages } from '@/mastodon/initial_state';
 import type {
   ExpandedStatusShape,
   StatusShape,
-  StatusTranslation,
 } from '@/mastodon/models/status';
-import { useAppSelector } from '@/mastodon/store';
 
 import { Button } from '../button/redesign';
 import { EmojiHTML } from '../emoji/html';
@@ -42,12 +38,6 @@ export const StatusContent: React.FC<
   className,
   ...props
 }) => {
-  const { signedIn } = useIdentity();
-  const targetLanguages = useAppSelector(
-    (state) => state.server.translationLanguages.item?.[status.language],
-  );
-  const intl = useIntl();
-
   // Determines if a long post should show the read more button.
   const [collapsed, setCollapsed] = useState(false);
   const onRef = useCallback(
@@ -70,14 +60,6 @@ export const StatusContent: React.FC<
   const language = status.translation?.language ?? status.language;
 
   const isCollapsed = !!onReadMore && collapsible && collapsed;
-  const renderTranslate = !!(
-    onTranslate &&
-    !isCollapsed &&
-    signedIn &&
-    ['public', 'unlisted'].includes(status.visibility) &&
-    status.search_index?.trim().length &&
-    targetLanguages?.includes(intl.locale.replace(/[_-].*/, ''))
-  );
 
   return (
     <div
@@ -102,13 +84,6 @@ export const StatusContent: React.FC<
 
       {children}
 
-      {renderTranslate && (
-        <TranslateButton
-          translation={status.translation}
-          onTranslate={onTranslate}
-        />
-      )}
-
       {isCollapsed && (
         <Button
           size='sm'
@@ -120,51 +95,6 @@ export const StatusContent: React.FC<
           <FormattedMessage id='status.read_more' defaultMessage='Read more' />
         </Button>
       )}
-    </div>
-  );
-};
-
-const TranslateButton: React.FC<{
-  onTranslate: React.MouseEventHandler<HTMLButtonElement>;
-  translation?: StatusTranslation;
-}> = ({ translation, onTranslate }) => {
-  if (!translation) {
-    return (
-      <Button
-        size='sm'
-        variant='ghost'
-        onClick={onTranslate}
-        className={classes.buttonAlign}
-      >
-        <FormattedMessage id='status.translate' defaultMessage='Translate' />
-      </Button>
-    );
-  }
-
-  const language = preloadedLanguages?.find(
-    (lang) => lang[0] === translation.detected_source_language,
-  );
-  const languageName = language
-    ? language[1]
-    : translation.detected_source_language;
-  const provider = translation.provider;
-
-  return (
-    <div className='translate-button'>
-      <Button size='sm' variant='ghost' onClick={onTranslate}>
-        <FormattedMessage
-          id='status.show_original'
-          defaultMessage='Show original'
-        />
-      </Button>
-
-      <div className='translate-button__meta'>
-        <FormattedMessage
-          id='status.translated_from_with'
-          defaultMessage='Translated from {lang} using {provider}'
-          values={{ lang: languageName, provider }}
-        />
-      </div>
     </div>
   );
 };

--- a/app/javascript/mastodon/components/status/content.tsx
+++ b/app/javascript/mastodon/components/status/content.tsx
@@ -87,10 +87,11 @@ export const StatusContent: React.FC<
       {isCollapsed && (
         <Button
           size='sm'
+          clipPadding
           variant='ghost'
           onClick={onReadMore}
           trailingIcon={CaretRightIcon}
-          className={classNames(classes.contentReadMore, classes.buttonAlign)}
+          className={classes.contentReadMore}
         >
           <FormattedMessage id='status.read_more' defaultMessage='Read more' />
         </Button>

--- a/app/javascript/mastodon/components/status/status.tsx
+++ b/app/javascript/mastodon/components/status/status.tsx
@@ -28,6 +28,7 @@ import { StatusMeta } from './meta';
 import { StatusPrepend } from './prepend';
 import { StatusRedesignHeader } from './redesign/header';
 import classes from './styles.module.scss';
+import { TranslateButton } from './translate';
 import type { StatusContainerProps, StatusContextType } from './types';
 
 type StatusRedesignProps = Merge<
@@ -184,6 +185,8 @@ export const StatusRedesign: React.FC<StatusRedesignProps> = ({
             onClick={onExpandedToggle}
           />
         )}
+
+        <TranslateButton status={status} onTranslate={onTranslate} />
 
         {expanded && (
           <StatusContent

--- a/app/javascript/mastodon/components/status/styles.module.scss
+++ b/app/javascript/mastodon/components/status/styles.module.scss
@@ -39,8 +39,21 @@
 .content,
 .footer,
 .root :global(.status__prepend),
-.root :global(.content-warning) {
+.root :global(.content-warning),
+.translate {
   grid-column: var(--content-col);
+}
+
+.translate {
+  display: flex;
+  align-items: center;
+}
+
+.translateInfo {
+  @include mixins.type-label-md;
+
+  color: var(--color-text-secondary);
+  margin-inline-start: auto;
 }
 
 .content {

--- a/app/javascript/mastodon/components/status/styles.module.scss
+++ b/app/javascript/mastodon/components/status/styles.module.scss
@@ -162,7 +162,3 @@
 .actionsButtonGap {
   margin-inline-end: auto;
 }
-
-.buttonAlign {
-  margin-inline-start: calc(-1 * var(--space-sm));
-}

--- a/app/javascript/mastodon/components/status/translate.tsx
+++ b/app/javascript/mastodon/components/status/translate.tsx
@@ -37,11 +37,11 @@ export const TranslateButton: React.FC<{
       <div className={classes.translate}>
         <Button
           size='sm'
+          clipPadding
           color='accent'
           variant='ghost'
           onClick={onTranslate}
           leadingIcon={TranslateIcon}
-          className={classes.buttonAlign}
           loading={translation?.isLoading}
         >
           <FormattedMessage id='status.translate' defaultMessage='Translate' />
@@ -62,11 +62,11 @@ export const TranslateButton: React.FC<{
     <div className={classes.translate}>
       <Button
         size='sm'
+        clipPadding
         color='accent'
         variant='ghost'
         onClick={onTranslate}
         leadingIcon={TranslateIcon}
-        className={classes.buttonAlign}
       >
         <FormattedMessage
           id='status.show_original'

--- a/app/javascript/mastodon/components/status/translate.tsx
+++ b/app/javascript/mastodon/components/status/translate.tsx
@@ -1,0 +1,86 @@
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import { TranslateIcon } from '@phosphor-icons/react';
+
+import { useIdentity } from '@/mastodon/identity_context';
+import { languages as preloadedLanguages } from '@/mastodon/initial_state';
+import type { AnyStatusShape } from '@/mastodon/models/status';
+import { useAppSelector } from '@/mastodon/store';
+
+import { Button } from '../button/redesign';
+
+import classes from './styles.module.scss';
+
+export const TranslateButton: React.FC<{
+  status: AnyStatusShape;
+  onTranslate: React.MouseEventHandler<HTMLButtonElement>;
+}> = ({ status, onTranslate }) => {
+  const { signedIn } = useIdentity();
+  const targetLanguages = useAppSelector(
+    (state) => state.server.translationLanguages.item?.[status.language],
+  );
+  const intl = useIntl();
+
+  const { translation } = status;
+
+  if (
+    !signedIn ||
+    !['public', 'unlisted'].includes(status.visibility) ||
+    status.search_index?.trim().length === 0 ||
+    !targetLanguages?.includes(intl.locale.replace(/[_-].*/, ''))
+  ) {
+    return null;
+  }
+
+  if (!translation || translation.isLoading) {
+    return (
+      <div className={classes.translate}>
+        <Button
+          size='sm'
+          color='accent'
+          variant='ghost'
+          onClick={onTranslate}
+          leadingIcon={TranslateIcon}
+          className={classes.buttonAlign}
+          loading={translation?.isLoading}
+        >
+          <FormattedMessage id='status.translate' defaultMessage='Translate' />
+        </Button>
+      </div>
+    );
+  }
+
+  const language = preloadedLanguages?.find(
+    (lang) => lang[0] === translation.detected_source_language,
+  );
+  const languageName = language
+    ? language[1]
+    : translation.detected_source_language;
+  const provider = translation.provider;
+
+  return (
+    <div className={classes.translate}>
+      <Button
+        size='sm'
+        color='accent'
+        variant='ghost'
+        onClick={onTranslate}
+        leadingIcon={TranslateIcon}
+        className={classes.buttonAlign}
+      >
+        <FormattedMessage
+          id='status.show_original'
+          defaultMessage='Show original'
+        />
+      </Button>
+
+      <div className={classes.translateInfo}>
+        <FormattedMessage
+          id='status.translated_from_with'
+          defaultMessage='Translated from {lang} using {provider}'
+          values={{ lang: languageName, provider }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -41,7 +41,7 @@ class TranslateButton extends PureComponent {
   render () {
     const { translation, onClick } = this.props;
 
-    if (translation) {
+    if (translation && !translation.get('isLoading')) {
       const language     = preloadedLanguages.find(lang => lang[0] === translation.get('detected_source_language'));
       const languageName = language ? language[1] : translation.get('detected_source_language');
       const provider     = translation.get('provider');

--- a/app/javascript/mastodon/models/status.ts
+++ b/app/javascript/mastodon/models/status.ts
@@ -156,4 +156,6 @@ export type FilterResult = Omit<ApiFilterResultJSON, 'filter'> & {
   filter: string;
 };
 
-export type StatusTranslation = Omit<ApiStatusTranslationJSON, 'poll'>;
+export type StatusTranslation = Omit<ApiStatusTranslationJSON, 'poll'> & {
+  isLoading: boolean;
+};

--- a/app/javascript/mastodon/reducers/statuses.js
+++ b/app/javascript/mastodon/reducers/statuses.js
@@ -24,6 +24,7 @@ import {
   STATUS_REVEAL,
   STATUS_HIDE,
   STATUS_COLLAPSE,
+  STATUS_TRANSLATE_REQUEST,
   STATUS_TRANSLATE_SUCCESS,
   STATUS_TRANSLATE_UNDO,
   STATUS_FETCH_REQUEST,
@@ -46,7 +47,7 @@ const deleteStatus = (state, id, references) => {
 
 const statusTranslateSuccess = (state, id, translation) => {
   return state.withMutations(map => {
-    map.setIn([id, 'translation'], fromJS(normalizeStatusTranslation(translation, map.get(id))));
+    map.setIn([id, 'translation'], fromJS(normalizeStatusTranslation(translation, map.get(id))).set('isLoading', false));
 
     const list = map.getIn([id, 'media_attachments']);
     if (translation.media_attachments && list) {
@@ -146,6 +147,8 @@ export default function statuses(state = initialState, action) {
     return state.setIn([action.id, 'collapsed'], action.isCollapsed);
   case timelineDelete.type:
     return deleteStatus(state, action.payload.statusId, action.payload.references);
+  case STATUS_TRANSLATE_REQUEST:
+    return state.setIn([action.id, 'translation', 'isLoading'], true);
   case STATUS_TRANSLATE_SUCCESS:
     return statusTranslateSuccess(state, action.id, action.translation);
   case STATUS_TRANSLATE_UNDO:


### PR DESCRIPTION
> [!NOTE] 
> This is part of work for an upcoming feature that is not complete. This is not ready for testing, feedback, or bug reports. Read more [here](https://blog.joinmastodon.org/2026/08/5.0-laying-the-foundation/).

Fixes WEB-1270.

This moves the translation button outside of the content area, so it appears even if there is a spoiler to allow translation of that before viewing the content itself. It also adds a loading state.

| Caption | Screenshot |
| - | - |
| Before translation | <img width="1200" height="384" alt="image" src="https://github.com/user-attachments/assets/ce254a5d-f164-42d0-8cd6-ca07e568dde0" /> |
| After translation | <img width="1200" height="384" alt="image" src="https://github.com/user-attachments/assets/9985d2f5-4239-4637-9115-8a187d1b0de7" /> |
