### PR TITLE
For Single User mode, set the owner to the configured Site Contact instead of picking the first user.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -231,7 +231,7 @@ module ApplicationHelper
       state_params[:moved_to_account] = current_account.moved_to_account
     end
 
-    state_params[:owner] = Account.local.without_suspended.without_internal.first if single_user_mode?
+    state_params[:owner] = Account.find_local(Setting.site_contact_username.strip.gsub(/\A@/, '')) if single_user_mode?
 
     json = ActiveModelSerializers::SerializableResource.new(InitialStatePresenter.new(state_params), serializer: InitialStateSerializer).to_json
     # rubocop:disable-next Rails/OutputSafety


### PR DESCRIPTION
I have a single-user node. On single-user nodes, accessing the root URL without auth results in a redirect to the owner account, which makes sense.

When I created the node, I had a different username. I "changed" the username - that is, I created a new account on my single-user node and migrated to it. Unfortunately, since the old code only selects the first non-suspended user, the root URL redirect always pointed to my old user, not the new user. Suspending the old account is not a viable workaround since that results in all old links to posts 404'ing. And while there's technically an "easy" way for users to find the new account since there is a "this user has moved to a different account" banner, I kinda don't like that.

This change makes it so that the default root redirect points to whatever user is configured as the site contact. This works for me in my setup and I've run this in a fork for a while, but I'm too lazy to maintain a fork, so I want to get it upstream. However, I don't know if that's a good implementation or if there are any side-effects, so I'd appreciate some insight.

Also, the current redirect behavior seems to have no tests (at least this patch doesn't cause any red tests on my machine). I also didn't add any test, but I am happy to add coverage if you'd prefer.