### PR TITLE
Fix replies order

### DIFF
--- a/app/javascript/mastodon/reducers/contexts.ts
+++ b/app/javascript/mastodon/reducers/contexts.ts
@@ -55,7 +55,9 @@ const addReply = (
 
   if (!state.inReplyTos[id]) {
     const siblings = (state.replies[in_reply_to_id] ??= []);
-    const index = siblings.findIndex((sibling) => compareId(sibling, id) < 0);
+    const index = siblings.findLastIndex(
+      (sibling) => compareId(sibling, id) < 0,
+    );
     siblings.splice(index + 1, 0, id);
     state.inReplyTos[id] = in_reply_to_id;
   }


### PR DESCRIPTION
Currently, replies 1 2 3 4 will be shown in the order 1 4 3 2.


This bug seems to have been introduced since https://github.com/mastodon/mastodon/pull/34506/ .

https://github.com/mastodon/mastodon/pull/34506/changes#diff-7ffc5437fa6af880551a43e51a86a24c5e5bacba0220f315d3441bd5760a3038R53

Before fix:

<img width="615" height="992" alt="image" src="https://github.com/user-attachments/assets/51b121dd-d0b8-4237-8843-21a233f44e7a" />

After fix:

<img width="825" height="954" alt="image" src="https://github.com/user-attachments/assets/ddb95277-5fbe-440b-877f-dcdc4fe57662" />