### PR TITLE
Fix z-index of PIP video player to be above the side panel

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8757,6 +8757,7 @@ noscript {
   bottom: 20px;
   inset-inline-end: 20px;
   width: 300px;
+  z-index: 100;
   background-color: var(--color-bg-primary);
   box-shadow: var(--dropdown-shadow);
 


### PR DESCRIPTION
PIP floating video was hidden behind side panel on single column mode.
Conditions to reproduce this bug:
- Screen is not wide enough to place PIP video on the side panel
- Single column mode