### PR TITLE
Fix relative privacy policy links in subscription emails

### DIFF
--- a/app/views/email_subscription_mailer/confirmation.html.haml
+++ b/app/views/email_subscription_mailer/confirmation.html.haml
@@ -17,6 +17,6 @@
 
 - content_for :footer do
   %p.email-footer-p= t('email_subscription_mailer.notification.footer.reason_for_email_html', name: display_name(@subscription.account), unsubscribe_path: @unsubscribe_url)
-  %p.email-footer-p= t('email_subscription_mailer.notification.footer.privacy_html', domain: @instance, privacy_policy_path: privacy_policy_path)
+  %p.email-footer-p= t('email_subscription_mailer.notification.footer.privacy_html', domain: @instance, privacy_policy_path: privacy_policy_url)
   - if Setting.email_footer_text.present?
     %p.email-footer-p= Setting.email_footer_text

--- a/app/views/email_subscription_mailer/notification.html.haml
+++ b/app/views/email_subscription_mailer/notification.html.haml
@@ -24,6 +24,6 @@
 
 - content_for :footer do
   %p.email-footer-p= t('.footer.reason_for_email_html', name: display_name(@subscription.account), unsubscribe_path: @unsubscribe_url)
-  %p.email-footer-p= t('.footer.privacy_html', domain: @instance, privacy_policy_path: privacy_policy_path)
+  %p.email-footer-p= t('.footer.privacy_html', domain: @instance, privacy_policy_path: privacy_policy_url)
   - if Setting.email_footer_text.present?
     %p.email-footer-p= Setting.email_footer_text

--- a/spec/mailers/email_subscription_mailer_spec.rb
+++ b/spec/mailers/email_subscription_mailer_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe EmailSubscriptionMailer do
           subject: I18n.t('email_subscription_mailer.confirmation.subject')
         )
     end
+
+    it 'includes an absolute URL for the privacy policy' do
+      expect(mail.html_part.body.decoded).to include(
+        "href=\"#{Rails.application.routes.url_helpers.privacy_policy_url(**described_class.default_url_options)}\""
+      )
+    end
   end
 
   describe '.notification' do
@@ -32,6 +38,12 @@ RSpec.describe EmailSubscriptionMailer do
             from: 'notifications@localhost',
             subject: I18n.t('email_subscription_mailer.notification.subject.singular', name: email_subscription.account.display_name, excerpt: statuses.first.text.truncate(17))
           )
+      end
+
+      it 'includes an absolute URL for the privacy policy' do
+        expect(mail.html_part.body.decoded).to include(
+          "href=\"#{Rails.application.routes.url_helpers.privacy_policy_url(**described_class.default_url_options)}\""
+        )
       end
     end
 


### PR DESCRIPTION
Fixes #39542

## Problem
The privacy policy link in subscription confirmation emails uses a relative URL. Depending on the email client, this can resolve against the webmail domain instead of our own, resulting in a broken link or one pointing to the wrong server. The subscription notification email has the same issue.

## Changes
- Updated both email templates so the privacy policy link uses an absolute URL
- Added mailer tests to check that confirmation and notification emails contain the absolute URL

## Verification
- Checked the email preview to confirm the privacy policy link points to the instance domain
- Ran the mailer tests and confirmed they pass